### PR TITLE
Update IDB Goodies from 6a to 6b

### DIFF
--- a/Core/Contributions/IDB/ChunkBrowser.cls
+++ b/Core/Contributions/IDB/ChunkBrowser.cls
@@ -8,37 +8,24 @@ IdbToolShell subclass: #ChunkBrowser
 ChunkBrowser guid: (GUID fromString: '{625FA0D2-FFC4-4926-9AE7-06FB0998EC4E}')!
 ChunkBrowser comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowser categoriesForClass!IDB Goodies! !
 !ChunkBrowser methodsFor!
 
-about
-	"Display the about view"
-
-	self 
-		idbAbout: '
-Chunk Browser
-for
-Dolphin Smalltalk 6.x
-
-Version 6a
-© 2005 Ian Bartholomew
-http://www.idb.me.uk'!
-
 browseChunk
-	chunkList singleSelection browse!
+	chunkList selection browse!
 
 canBrowse
-	^chunkList hasSingleSelection and: [chunkList singleSelection canBrowse]!
+	^chunkList selections size = 1 and: [chunkList selection canBrowse]!
 
 canPrint
-	^(super respondsTo: #print:) and: [chunkText view textLength ~= 0]!
+	^[super canPrint] on: MessageNotUnderstood do: [:e | false]!
 
 canShowDifferences
-	^(chunkList hasSingleSelection and: [chunkList singleSelection canShowDifferences]) 
-		or: [chunkList selection size = 2]!
+	^(chunkList selections size = 1 and: [chunkList selection canShowDifferences])
+		or: [chunkList selections size = 2]!
 
 chunkSelectAll
 	"Leave all other settings alone"
@@ -62,23 +49,22 @@ clearStatusReport
 	(self presenterNamed: 'statusReport') value: String new!
 
 clipboardOpen
-	| text |
-	text := Clipboard current getText.
-	Cursor wait showWhile: 
-			[model fromStream: text readStream.
+	Cursor wait
+		showWhile:
+			[model loadFromText: Clipboard current getText.
 			chunkList selectionOrNil: nil.
 			self updateChunkList].
 	self caption: 'ChunkBrowser - Clipboard'!
 
 copyText
-	Clipboard current setText: (chunkText hasSelection 
-				ifTrue: [chunkText view selection]
-				ifFalse: [chunkText view text])
-		format: #RichText!
+	Clipboard current
+		setText:
+			(chunkText hasSelection ifTrue: [chunkText view selection] ifFalse: [chunkText view text])
+		format: #String!
 
 createComponents
 	super createComponents.
-	chunkList := self add: MultipleSelectionListPresenter new name: 'chunkList'.
+	chunkList := self add: ListPresenter new name: 'chunkList'.
 	chunkText := self add: SmalltalkWorkspace new name: 'chunkText'.
 	self add: TextPresenter new name: 'statusCount'.
 	self add: TextPresenter new name: 'statusRange'.
@@ -95,61 +81,58 @@ createSchematicWiring
 			send: #onActionPerformed
 			to: self!
 
-differences
-	| differencesPresenter |
-	differencesPresenter := DifferencesPresenter show.
-	chunkList hasSingleSelection 
-		ifTrue: 
-			[differencesPresenter
-				beforeText: chunkList singleSelection sourceText;
-				beforeTitle: 'Current image';
-				afterText: chunkList singleSelection rawText;
-				afterTitle: 'Chunk #' , chunkList singleSelection index printString;
-				refresh]
-		ifFalse: 
-			[differencesPresenter
-				beforeText: chunkList selection first rawText;
-				beforeTitle: 'Chunk #' , chunkList selection first index printString;
-				afterText: chunkList selection last rawText;
-				afterTitle: 'Chunk #' , chunkList selection last index printString;
-				refresh]!
-
 fileOpen
-	| dialog filename |
-	filename ifNil: [filename := SourceManager default changesFileName].
-	dialog := FileOpenDialog on: filename.
-	(dialog
+	| dialog |
+	pathname ifNil: [pathname := SourceManager default changesFileName].
+	(dialog := FileOpenDialog on: pathname)
 		fileTypes: self class fileTypes;
-		defaultExtension: (File splitExtensionFrom: filename);
-		showModal) ifNil: [^self] ifNotNil: [:arg | filename := arg].
-	self openChunkFile: filename!
+		defaultExtension: (File splitExtensionFrom: pathname);
+		showModal.
+	dialog answer ifNil: [^self] ifNotNil: [:arg | pathname := arg].
+	Cursor wait
+		showWhile:
+			[model loadFromFile: pathname.
+			chunkList selectionOrNil: nil.
+			self updateChunkList].
+	self caption: ('ChunkBrowser - <1s>' expandMacrosWith: (File splitFilenameFrom: pathname))!
 
 fileOpenPatch
 	| dialog |
-	dialog := FileOpenDialog on: '*.st'.
-	(dialog
-		fileTypes: (OrderedCollection with: #('Smalltalk Files (*.st)' '*.st')
-					with: #('All Files (*.*)' '*.*'));
+	(dialog := FileOpenDialog on: '*.st')
+		fileTypes: self class stFileTypes;
 		defaultExtension: 'st';
-		showModal) ifNil: [^self] ifNotNil: [:arg | pathname := arg].
-	Cursor wait showWhile: 
-			[model fileOpenPatch: pathname.
+		showModal.
+	dialog answer ifNil: [^self] ifNotNil: [:arg | pathname := arg].
+	Cursor wait
+		showWhile:
+			[model loadFromPatchFile: pathname.
 			chunkList selectionOrNil: nil.
 			self updateChunkList].
-	self caption: 'ChunkBrowser - ' , (File splitFilenameFrom: pathname)!
+	self caption: ('ChunkBrowser - <1s>' expandMacrosWith: (File splitFilenameFrom: pathname))!
+
+idbAbout
+	"Display the about view"
+
+	self
+		idbAbout:
+			'<n>Chunk Browser<n>for<n>Dolphin Smalltalk 6.x<n><n>Version 6b<n>© 2005 Ian Bartholomew<n>http://www.idb.me.uk'
+				expandMacros!
+
+idbHelp
+	self idbHelp: 'idbchunkbrowser'!
 
 onActionPerformed
-	chunkList selection do: [:each | each picked: each picked not].
+	chunkList selections do: [:each | each picked: each picked not].
 	self onRefreshNeeded!
 
 onRefreshNeeded
 	chunkList view updateAll.
-	chunkList hasSingleSelection ifTrue: [chunkList singleSelection showIn: chunkText]!
+	chunkList selections size = 1 ifTrue: [chunkList selection showIn: chunkText]!
 
 onSelectionChanged
-	chunkList hasSingleSelection 
-		ifTrue: [chunkList singleSelection showIn: chunkText]
-		ifFalse: [String new].
+	chunkList selections size = 1
+		ifTrue: [chunkList selection showIn: chunkText]
+		ifFalse: [chunkText text: String new].
 	self clearStatusReport!
 
 onViewClosed
@@ -160,147 +143,122 @@ onViewClosed
 onViewOpened
 	super onViewOpened.
 	filter := ChunkBrowserFilter new.
-	SmalltalkSystem publishedEventsOfInstances do: 
+	SmalltalkSystem publishedEventsOfInstances
+		do:
 			[:each | 
-			SmalltalkSystem current 
+			SmalltalkSystem current
 				when: each
 				send: #onRefreshNeeded
-				to: self].
-	self openDefaultChunkFile!
-
-openChunkFile: filename 
-	Cursor wait showWhile: 
-			[model fileOpen: (pathname := filename).
-			chunkList selectionOrNil: nil.
-			self updateChunkList].
-	self caption: 'ChunkBrowser - ' , (File splitFilenameFrom: pathname)
-!
-
-openDefaultChunkFile
-	self openChunkFile: SourceManager default changesFileName.
-	self restrictionSave.
-	self toggleRestrictingMostRecent!
+				to: self]!
 
 pickSelection
-	chunkList selection do: [:each | each picked: true].
+	chunkList selections do: [:each | each picked: true].
 	self onRefreshNeeded!
 
-print
-	super print: chunkText view!
+printableView
+	^chunkText view!
 
-queryCommand: aCommandQuery 
-	aCommandQuery commandSymbol == #toggleChunkType: 
-		ifTrue: 
+queryCommand: aCommandQuery
+	aCommandQuery commandSymbol == #toggleChunkType:
+		ifTrue:
 			[| argument |
 			aCommandQuery isEnabled: true.
 			argument := aCommandQuery commandDescription command arguments first.
 			aCommandQuery isChecked: (filter isChunkTypeSelected: argument).
 			^true].
-	aCommandQuery commandSymbol == #toggleComparisonType: 
-		ifTrue: 
+	aCommandQuery commandSymbol == #toggleComparisonType:
+		ifTrue:
 			[| argument |
 			aCommandQuery isEnabled: true.
 			argument := aCommandQuery commandDescription command arguments first.
 			aCommandQuery isChecked: (filter isComparisonTypeSelected: argument).
 			^true].
-	aCommandQuery commandSymbol == #restrictionRange 
-		ifTrue: 
+	aCommandQuery commandSymbol == #restrictionRange
+		ifTrue:
 			[aCommandQuery isEnabled: chunkList hasSelection.
 			^true].
-	aCommandQuery commandSymbol == #restrictionSave 
-		ifTrue: 
+	aCommandQuery commandSymbol == #restrictionSave
+		ifTrue:
 			[aCommandQuery isEnabled: model hasChunks.
 			^true].
-	aCommandQuery commandSymbol == #restrictionClear 
-		ifTrue: 
+	aCommandQuery commandSymbol == #restrictionClear
+		ifTrue:
 			[aCommandQuery isEnabled: filter isRestrictingRange.
 			^true].
-	aCommandQuery commandSymbol == #restrictionClass 
-		ifTrue: 
-			[aCommandQuery isEnabled: filter isRestrictingClass 
-						| (chunkList hasSingleSelection and: [chunkList singleSelection chunkClass notNil]).
+	aCommandQuery commandSymbol == #restrictionClass
+		ifTrue:
+			[aCommandQuery
+				isEnabled:
+					filter isRestrictingClass
+						| (chunkList selections size = 1 and: [chunkList selection chunkClass notNil]).
 			aCommandQuery isChecked: filter isRestrictingClass.
 			^true].
-	aCommandQuery commandSymbol == #toggleRestrictingMostRecent 
-		ifTrue: 
+	aCommandQuery commandSymbol == #toggleRestrictingMostRecent
+		ifTrue:
 			[aCommandQuery isEnabled: true.
 			aCommandQuery isChecked: filter isRestrictingMostRecent.
 			^true].
-	aCommandQuery commandSymbol == #toggleRestrictingPicked 
-		ifTrue: 
+	aCommandQuery commandSymbol == #toggleRestrictingPicked
+		ifTrue:
 			[aCommandQuery isEnabled: true.
 			aCommandQuery isChecked: filter isRestrictingPicked.
 			^true].
-	aCommandQuery commandSymbol == #differences 
-		ifTrue: 
+	aCommandQuery commandSymbol == #showDifferences
+		ifTrue:
 			[aCommandQuery isEnabled: self canShowDifferences.
 			^true].
-	aCommandQuery commandSymbol == #copyText 
-		ifTrue: 
-			[aCommandQuery isEnabled: chunkList hasSingleSelection.
+	aCommandQuery commandSymbol == #copyText
+		ifTrue:
+			[aCommandQuery isEnabled: chunkList selections size = 1.
 			^true].
-	aCommandQuery commandSymbol == #browseChunk 
-		ifTrue: 
+	aCommandQuery commandSymbol == #browseChunk
+		ifTrue:
 			[aCommandQuery isEnabled: self canBrowse.
 			^true].
-	(#(#print #printPreview) identityIncludes: aCommandQuery command) 
-		ifTrue: 
+	(#(#print #printPreview) identityIncludes: aCommandQuery command)
+		ifTrue:
 			[aCommandQuery isEnabled: self canPrint.
 			^true].
-	(#(#pickSelection #unpickSelection #restoreSelection) identityIncludes: aCommandQuery command) 
-		ifTrue: 
+	(#(#pickSelection #unpickSelection #restoreSelection) identityIncludes: aCommandQuery command)
+		ifTrue:
 			[aCommandQuery isEnabled: chunkList hasSelection.
 			^true].
-	aCommandQuery commandSymbol == #restorePicked 
-		ifTrue: 
+	aCommandQuery commandSymbol == #restorePicked
+		ifTrue:
 			[aCommandQuery isEnabled: model hasAnyChunksPicked.
 			^true].
-	aCommandQuery commandSymbol == #clipboardOpen 
-		ifTrue: 
+	aCommandQuery commandSymbol == #clipboardOpen
+		ifTrue:
 			[aCommandQuery isEnabled: (Clipboard current isFormatIdAvailable: CF_TEXT).
 			^true].
 	^super queryCommand: aCommandQuery!
 
-restore: aCollection 
+restore: aCollection
 	| failures stream |
 	failures := OrderedCollection new.
 	aCollection do: [:each | each restore ifNotNil: [:arg | failures add: arg]].
 	stream := String writeStream.
-	(self presenterNamed: 'statusReport') 
+	(self presenterNamed: 'statusReport')
 		value: (failures isEmpty ifTrue: ['  Restore suceeded'] ifFalse: ['  Restore may have failed']).
-	failures isEmpty 
-		ifFalse: 
-			[stream
-				nextPutAll: 'The following chunks may have failed to restore:';
-				cr;
-				cr.
-			(failures copyFrom: 1 to: (10 min: failures size)) do: 
-					[:each | 
-					stream
-						print: each key;
-						space;
-						nextPutAll: each value;
-						cr].
-			failures size > 10 
-				ifTrue: 
-					[stream
-						nextPutAll: '.... and ';
-						print: failures size - 10;
-						nextPutAll: ' more'].
-			MessageBox notify: stream contents caption: 'Restore may have failed']!
+	failures isEmpty ifTrue: [^self].
+	stream nextPutAll: 'The following chunks may have failed to restore:<n><n>' expandMacros.
+	(failures copyFrom: 1 to: (10 min: failures size))
+		do: [:each | stream nextPutAll: ('<1p> <2p><n>' expandMacrosWith: each key with: each value)].
+	failures size > 10
+		ifTrue: [stream nextPutAll: ('... and <1d> more' expandMacrosWith: failures size - 10)].
+	MessageBox notify: stream contents caption: 'Restore may have failed'!
 
 restorePicked
 	self restore: model pickedChunks!
 
 restoreSelection
-	self restore: chunkList selection!
+	self restore: chunkList selections!
 
 restrictionClass
-	filter isRestrictingClass 
+	filter isRestrictingClass
 		ifTrue: [filter restrictionClass: nil]
-		ifFalse: 
-			[chunkList hasSingleSelection 
-				ifTrue: [filter restrictionClass: chunkList singleSelection chunkClass]].
+		ifFalse:
+			[chunkList selections size = 1 ifTrue: [filter restrictionClass: chunkList selection chunkClass]].
 	self updateChunkList!
 
 restrictionClear
@@ -308,29 +266,51 @@ restrictionClear
 	self updateChunkList!
 
 restrictionRange
-	chunkList hasSelection 
-		ifTrue: 
-			[| first last |
-			first := 9999999.
-			last := 0.
-			chunkList selection do: 
-					[:each | 
-					first := first min: each index.
-					last := last max: each index].
-			filter restrictionRange: (chunkList hasSingleSelection 
-						ifTrue: [first to: model chunkCount]
-						ifFalse: [first to: last]).
-			self updateChunkList]!
+	| first last |
+	chunkList hasSelection ifFalse: [^self].
+	first := chunkList selections inject: 99999999 into: [:min :each | min min: each index].
+	last := chunkList selections inject: 0 into: [:max :each | max max: each index].
+	filter
+		restrictionRange:
+			(first to: (chunkList selections size = 1 ifTrue: [model chunkCount] ifFalse: [last])).
+	self updateChunkList!
 
 restrictionSave
 	filter restrictionRange: (model indexOfLastImageSave to: model chunkCount).
 	self updateChunkList!
 
-toggleChunkType: aSymbol 
+showDifferences
+	| differencesPresenter |
+	differencesPresenter := DifferencesPresenter show.
+	chunkList selections size = 1
+		ifTrue:
+			[differencesPresenter topShell
+				caption:
+					('Differences between chunk #<1d> and the current image' expandMacrosWith: chunkList selection index).
+			differencesPresenter
+				beforeText: chunkList selection rawText;
+				beforeTitle: ('Chunk #<1d>' expandMacrosWith: chunkList selection index);
+				afterText: chunkList selection sourceFromImage;
+				afterTitle: 'Current image';
+				refresh]
+		ifFalse:
+			[differencesPresenter topShell
+				caption:
+					('Differences between chunk #<1d> and chunk #<2d>'
+						expandMacrosWith: chunkList selections first index
+						with: chunkList selections last index).
+			differencesPresenter
+				beforeText: chunkList selections first rawText;
+				beforeTitle: ('Chunk #<1d>' expandMacrosWith: chunkList selections first index);
+				afterText: chunkList selections last rawText;
+				afterTitle: ('Chunk #<1d>' expandMacrosWith: chunkList selections last index);
+				refresh]!
+
+toggleChunkType: aSymbol
 	filter toggleChunkType: aSymbol.
 	self updateChunkList!
 
-toggleComparisonType: aSymbol 
+toggleComparisonType: aSymbol
 	filter toggleComparisonType: aSymbol.
 	self updateChunkList!
 
@@ -342,52 +322,44 @@ toggleRestrictingPicked
 	filter toggleRestrictingPicked.
 	self updateChunkList!
 
-toggleRestrictionMostPicked
-	filter toggleRestrictingPicked.
-	self updateChunkList!
-
 unpickAll
 	chunkList list do: [:each | each picked: false].
 	self onRefreshNeeded!
 
 unpickSelection
-	chunkList selection do: [:each | each picked: false].
+	chunkList selections do: [:each | each picked: false].
 	self onRefreshNeeded!
 
 updateChunkList
-	| currentSelection |
-	currentSelection := chunkList selectionOrNil.
-	chunkList list: (model filterUsing: filter).
-	currentSelection 
-		ifNotNil: 
-			[:arg | 
-			chunkList selectionOrNil: (arg select: [:each | chunkList list identityIncludes: each]).
-			chunkList view ensureSelectionVisible].
+	| currentSelections |
+	currentSelections := chunkList selections.
+	chunkList list: (model filteredUsing: filter).
+	chunkList selections: currentSelections ifAbsent: [].
+	chunkList view ensureSelectionVisible.
 	self onSelectionChanged.
 	self updateStatus!
 
 updateStatus
-	(self presenterNamed: 'statusCount') value: ((String writeStream)
-				nextPutAll: '  Showing: ';
-				print: chunkList list size;
-				nextPutAll: ' of ';
-				print: (filter isRestrictingRange ifTrue: [filter restrictionRangeSize] ifFalse: [model chunkCount]);
-				contents).
-	(self presenterNamed: 'statusRange') value: (filter isRestrictingRange 
-				ifTrue: 
-					[(String writeStream)
-						nextPutAll: '  Range: ';
-						print: filter restrictionRangeFirst;
-						nextPutAll: ' to ';
-						print: filter restrictionRangeLast;
-						contents]).
-	(self presenterNamed: 'statusRestrict') value: ((String writeStream)
-				nextPutAll: (filter isRestrictingClass ifTrue: [' Cl'] ifFalse: [String new]);
-				nextPutAll: (filter isRestrictingMostRecent ifTrue: [' Re'] ifFalse: [String new]);
-				nextPutAll: (filter isRestrictingPicked ifTrue: [' Pi'] ifFalse: [String new]);
-				contents).
+	(self presenterNamed: 'statusCount')
+		value:
+			('  Showing: <1d> of <2d>'
+				expandMacrosWith: chunkList list size
+				with:
+					(filter isRestrictingRange ifTrue: [filter restrictionRangeSize] ifFalse: [model chunkCount])).
+	(self presenterNamed: 'statusRange')
+		value:
+			(filter isRestrictingRange
+				ifTrue:
+					['  Range: <1d> to <2d>'
+						expandMacrosWith: filter restrictionRangeFirst
+						with: filter restrictionRangeLast]).
+	(self presenterNamed: 'statusRestrict')
+		value:
+			('<1s><2s><3s>'
+				expandMacrosWith: (filter isRestrictingClass ifTrue: [' Cl'] ifFalse: [String new])
+				with: (filter isRestrictingMostRecent ifTrue: [' Re'] ifFalse: [String new])
+				with: (filter isRestrictingPicked ifTrue: [' Pi'] ifFalse: [String new])).
 	self clearStatusReport! !
-!ChunkBrowser categoriesFor: #about!commands!enquiries!public! !
 !ChunkBrowser categoriesFor: #browseChunk!commands!public!testing! !
 !ChunkBrowser categoriesFor: #canBrowse!public!testing! !
 !ChunkBrowser categoriesFor: #canPrint!printing!public!testing! !
@@ -400,18 +372,17 @@ updateStatus
 !ChunkBrowser categoriesFor: #copyText!commands!public! !
 !ChunkBrowser categoriesFor: #createComponents!initializing!public! !
 !ChunkBrowser categoriesFor: #createSchematicWiring!initializing!public! !
-!ChunkBrowser categoriesFor: #differences!commands!public! !
 !ChunkBrowser categoriesFor: #fileOpen!commands!public! !
 !ChunkBrowser categoriesFor: #fileOpenPatch!commands!public! !
+!ChunkBrowser categoriesFor: #idbAbout!commands!enquiries!public! !
+!ChunkBrowser categoriesFor: #idbHelp!commands!enquiries!public! !
 !ChunkBrowser categoriesFor: #onActionPerformed!event handling!public! !
 !ChunkBrowser categoriesFor: #onRefreshNeeded!event handling!public! !
 !ChunkBrowser categoriesFor: #onSelectionChanged!event handling!public! !
 !ChunkBrowser categoriesFor: #onViewClosed!event handling!public! !
 !ChunkBrowser categoriesFor: #onViewOpened!event handling!public! !
-!ChunkBrowser categoriesFor: #openChunkFile:!commands!public! !
-!ChunkBrowser categoriesFor: #openDefaultChunkFile!public! !
 !ChunkBrowser categoriesFor: #pickSelection!commands!public! !
-!ChunkBrowser categoriesFor: #print!accessing!printing!public! !
+!ChunkBrowser categoriesFor: #printableView!accessing!printing!public! !
 !ChunkBrowser categoriesFor: #queryCommand:!commands!public! !
 !ChunkBrowser categoriesFor: #restore:!commands!public! !
 !ChunkBrowser categoriesFor: #restorePicked!commands!public! !
@@ -420,11 +391,11 @@ updateStatus
 !ChunkBrowser categoriesFor: #restrictionClear!commands!public! !
 !ChunkBrowser categoriesFor: #restrictionRange!commands!public! !
 !ChunkBrowser categoriesFor: #restrictionSave!commands!public! !
+!ChunkBrowser categoriesFor: #showDifferences!commands!public! !
 !ChunkBrowser categoriesFor: #toggleChunkType:!commands!public! !
 !ChunkBrowser categoriesFor: #toggleComparisonType:!commands!public! !
 !ChunkBrowser categoriesFor: #toggleRestrictingMostRecent!commands!public! !
 !ChunkBrowser categoriesFor: #toggleRestrictingPicked!commands!public! !
-!ChunkBrowser categoriesFor: #toggleRestrictionMostPicked!commands!public! !
 !ChunkBrowser categoriesFor: #unpickAll!commands!public! !
 !ChunkBrowser categoriesFor: #unpickSelection!commands!public! !
 !ChunkBrowser categoriesFor: #updateChunkList!operations!public! !
@@ -433,18 +404,15 @@ updateStatus
 !ChunkBrowser class methodsFor!
 
 chunkTypeSelection
-	ChunkTypeSelection ifNil: [ChunkTypeSelection := self defaultChunkTypeSelection].
-	^ChunkTypeSelection!
+	^ChunkTypeSelection ifNil: [self defaultChunkTypeSelection]!
 
-chunkTypeSelection: aLookupTable 
+chunkTypeSelection: aLookupTable
 	ChunkTypeSelection := aLookupTable!
 
 compareMethodsUsingParser
-	CompareMethodsUsingParser 
-		ifNil: [CompareMethodsUsingParser := self defaultCompareMethodsUsingParser].
-	^CompareMethodsUsingParser!
+	^CompareMethodsUsingParser ifNil: [self defaultCompareMethodsUsingParser]!
 
-compareMethodsUsingParser: aBoolean 
+compareMethodsUsingParser: aBoolean
 	CompareMethodsUsingParser := aBoolean!
 
 defaultChunkTypeSelection
@@ -459,8 +427,6 @@ defaultChunkTypeSelection
 		at: #'Method Category' put: false;
 		at: #'Method Define' put: true;
 		at: #'Method Delete' put: true;
-		at: #'Resource Define' put: true;
-		at: #'Resource Delete' put: true;
 		at: #System put: true;
 		at: #Other put: false;
 		yourself!
@@ -471,7 +437,7 @@ defaultCompareMethodsUsingParser
 defaultModel
 	^ChunkBrowserModel new!
 
-displayOn: aStream 
+displayOn: aStream
 	aStream nextPutAll: 'Chunk Browser'!
 
 fileTypes
@@ -491,9 +457,11 @@ fileTypes
 icon
 	"Answers an Icon that can be used to represent this class"
 
-	^##(self) instanceClass defaultIcon!
+	^##(self) defaultIcon!
 
 publishedAspects
+	"ss"
+
 	^(super publishedAspects)
 		add: (Aspect dictionary: #chunkTypeSelection);
 		add: (Aspect boolean: #compareMethodsUsingParser);
@@ -507,19 +475,28 @@ resource_Default_view
 	ViewComposer openOn: (ResourceIdentifier class: self selector: #resource_Default_view)
 	"
 
-	^#(#'!!STL' 3 788558 10 ##(Smalltalk.STBViewProxy)  8 ##(Smalltalk.ShellView)  98 27 0 0 98 2 27131905 131073 416 0 721158 ##(Smalltalk.SystemColor)  31 328198 ##(Smalltalk.Point)  1361 1001 519 0 0 0 416 788230 ##(Smalltalk.BorderLayout)  1 1 410 8 ##(Smalltalk.Toolbar)  98 25 0 416 98 2 8 1140853580 131137 576 0 524550 ##(Smalltalk.ColorRef)  8 4278190080 0 519 0 263174 ##(Smalltalk.Font)  0 16 459014 ##(Smalltalk.LOGFONT)  8 #[243 255 255 255 0 0 0 0 0 0 0 0 0 0 0 0 144 1 0 0 0 0 0 0 3 2 1 34 65 114 105 97 108 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 514 193 193 0 576 658 688 8 4294903819 234 256 98 0 234 256 98 30 17807 853766 ##(Smalltalk.ToolbarButton)  17807 0 576 5 1180998 4 ##(Smalltalk.CommandDescription)  459270 ##(Smalltalk.Message)  8 #toggleChunkType: 98 1 8 #'Class Define' 8 'Class Define' 1 1 0 657990 3 ##(Smalltalk.DIBSection)  0 16 1114638 ##(Smalltalk.STBSingletonProxy)  8 ##(Smalltalk.ImageRelativeFileLocator)  8 #current 8 'Idb\Resources\ChunkBrowser.bmp' 0 0 7 514 769 33 9 0 3 17809 898 17809 0 576 5 930 962 992 98 1 8 #'Class Delete' 8 'Class Delete' 1 1 0 1072 5 17811 898 17811 0 576 1 930 962 992 98 1 8 #'Class Comment' 8 'Class Comment' 1 1 0 1072 7 17813 898 17813 0 576 5 930 962 992 98 1 8 #'Class GUID' 8 'Class GUID' 1 1 0 1072 9 17815 898 17815 0 576 1 930 962 992 98 1 8 #'Class Protocol' 8 'Class Protocol' 1 1 0 1072 39 17817 898 17817 0 576 5 930 962 992 98 1 8 #'Method Category' 8 'Method Category' 1 1 0 1072 13 17819 898 17819 0 576 5 930 962 992 98 1 8 #'Method Define' 8 'Method Define' 1 1 0 1072 15 17821 898 17821 0 576 5 930 962 992 98 1 8 #'Method Delete' 8 'Method Delete' 1 1 0 1072 17 17823 898 17823 0 576 1 930 962 992 98 1 8 #System 8 'System' 1 1 0 1072 41 17825 898 17825 0 576 5 930 962 992 98 1 8 #Other 8 'Other' 1 1 0 1072 19 17797 1246982 ##(Smalltalk.ToolbarSystemButton)  17797 0 576 1 930 8 #fileOpen 8 'Open Chunk File' 1 1 0 1 15 17799 2050 17799 0 576 1 930 8 #copyText 8 'Copy Text' 1 1 0 1 3 17801 898 17801 0 576 1 930 8 #differences 8 'Open Differences Browser' 1 1 0 1072 47 17803 2050 17803 0 576 1 930 8 #restoreSelection 8 'Restore Selected Chunk' 1 1 0 1 9 17805 898 17805 0 576 5 930 962 992 98 1 8 #'Class Category' 8 'Class Category' 1 1 0 1072 1 98 17 1050118 ##(Smalltalk.ToolbarSeparator)  0 0 576 3 0 1 2064 2128 2192 2256 2434 0 0 576 3 0 1 2320 912 1184 1280 1376 1472 1568 1664 1760 1856 1952 234 240 98 4 1 1 1072 31 0 1 0 514 33 33 514 45 45 0 656198 1 ##(Smalltalk.FlowLayout)  1 1 1 983302 ##(Smalltalk.MessageSequence)  202 208 98 2 721670 ##(Smalltalk.MessageSend)  8 #createAt:extent: 98 2 514 1 1 514 1345 51 576 2642 8 #updateSize 848 576 983302 ##(Smalltalk.WINDOWPLACEMENT)  8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 160 2 0 0 25 0 0 0] 98 0 514 193 193 0 27 410 8 ##(Smalltalk.StatusBar)  98 18 0 416 98 2 8 1140853004 1 2848 0 482 31 0 7 0 706 0 16 738 8 #[243 255 255 255 0 0 0 0 0 0 0 0 0 0 0 0 144 1 0 0 0 0 0 0 3 2 1 34 65 114 105 97 108 0 159 4 0 134 63 1 0 0 204 53 63 1 2 0 20 59 0 0 0 0 247 0 5 86 111 1] 514 193 193 0 2848 0 8 4294904209 234 256 98 12 853766 ##(Smalltalk.StatusBarItem)  1 321 2848 0 8 ##(Smalltalk.BasicListAbstract)  0 1098 8 ##(Smalltalk.IconImageManager)  1136 8 'statusCount' 3058 1 321 2848 0 3088 0 0 8 'statusRange' 3058 1 161 2848 0 3088 0 0 8 'statusRestrict' 3058 1 181 2848 0 3088 0 0 8 'statusClass' 3058 1 -1 2848 0 3088 0 0 8 'statusReport' 3058 1 221 2848 0 3088 0 0 8 'statusLast' 98 4 3072 3152 3184 3248 1115142 ##(Smalltalk.StatusBarNullItem)  513 1 2848 0 0 2578 202 208 98 1 2642 2672 98 2 514 1 849 514 1345 45 2848 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 168 1 0 0 160 2 0 0 190 1 0 0] 98 0 2832 0 27 0 0 410 8 ##(Smalltalk.ContainerView)  98 15 0 416 98 2 8 1140850688 131073 3520 0 482 31 0 7 0 0 0 3520 1180166 ##(Smalltalk.ProportionalLayout)  234 240 848 16 234 256 848 590342 ##(Smalltalk.Rectangle)  514 1 1 514 1 1 2578 202 208 98 1 2642 2672 98 2 514 1 51 514 1345 799 3520 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 25 0 0 0 160 2 0 0 168 1 0 0] 98 3 410 3536 98 15 0 3520 98 2 8 1140850688 131073 3904 0 482 31 0 7 0 0 0 3904 546 1 1 0 0 0 0 410 8 ##(Smalltalk.MultipleSelectionListView)  98 30 0 3904 98 2 8 1140920393 1025 4000 590662 2 ##(Smalltalk.ListModel)  202 208 848 0 1098 8 ##(Smalltalk.SearchPolicy)  8 #identity 658 688 0 7 265030 4 ##(Smalltalk.Menu)  0 16 98 8 984134 2 ##(Smalltalk.CommandMenuItem)  1 930 8 #pickSelection 8 'Pick selection' 1 1 0 0 0 4242 1 930 8 #unpickSelection 8 'Unpick selection' 1 1 0 0 0 983366 1 ##(Smalltalk.DividerMenuItem)  4097 4242 1 930 8 #restorePicked 8 'Restore picked' 1 1 0 0 0 4242 1 930 2288 8 'Restore selection' 1 1 0 0 0 4386 4097 4242 1 930 2160 8 'Copy' 1 1 0 0 0 4242 1 930 8 #browseChunk 8 'Browse' 1 1 0 0 0 8 '' 0 1 0 0 0 0 0 0 0 4000 0 8 4294904165 3088 0 3104 0 0 0 0 0 0 202 208 98 5 920646 5 ##(Smalltalk.ListViewColumn)  8 'Index' 141 8 #left 787814 3 ##(Smalltalk.BlockClosure)  0 459302 ##(Smalltalk.Context)  1 1 0 0 1180966 ##(Smalltalk.CompiledExpression)  2 9 8 ##(Smalltalk.UndefinedObject)  8 'doIt' 98 2 8 '[:o | o index printString]' 98 1 202 8 ##(Smalltalk.PoolDictionary)  848 8 #[252 1 0 1 1 8 0 17 230 32 228 32 158 159 106 100 105] 8 #index 8 #printString 17 257 0 8 ##(Smalltalk.SortedCollection)  0 0 4000 962 8 #chunkIconIndex 98 0 1 0 0 4722 8 'P' 49 4768 4786 0 4818 1 1 0 0 4850 1 9 4880 8 'doIt' 98 2 8 '[:o | String new]' 98 1 202 4976 848 8 #[252 1 0 1 1 6 0 17 230 32 45 146 106 100 105] 721414 ##(Smalltalk.Association)  8 #String 80 17 257 0 4786 0 4818 2 1 0 0 0 4850 2 13 4880 8 'doIt' 98 2 8 '[:a :b | 
+	^#(#'!!STL' 3 788558 10 ##(Smalltalk.STBViewProxy) 8 ##(Smalltalk.ShellView) 98 27 0 0 98 2 27131905 131073 416 0 721158 ##(Smalltalk.SystemColor) 31 328198 ##(Smalltalk.Point) 1361 1001 551 0 0 0 416 788230 ##(Smalltalk.BorderLayout) 1 1 410 8 ##(Smalltalk.Toolbar) 98 25 0 416 98 2 8 1140853580 131137 576 0 524550 ##(Smalltalk.ColorRef) 8 4278190080 0 519 0 263174 ##(Smalltalk.Font) 0 16 459014 ##(Smalltalk.LOGFONT) 8 #[243 255 255 255 0 0 0 0 0 0 0 0 0 0 0 0 144 1 0 0 0 0 0 0 3 2 1 34 65 114 105 97 108 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 514 193 193 0 576 658 688 8 4294903242 234 256 98 0 234 256 98 30 27095 1246982 ##(Smalltalk.ToolbarSystemButton) 27095 0 576 1 1180998 4 ##(Smalltalk.CommandDescription) 8 #fileOpen 8 'Open Chunk File' 1 1 0 1 15 27097 898 27097 0 576 1 930 8 #copyText 8 'Copy Text' 1 1 0 1 3 27099 853766 ##(Smalltalk.ToolbarButton) 27099 0 576 1 930 8 #showDifferences 8 'Open Differences Browser' 1 1 0 657990 3 ##(Smalltalk.DIBSection) 0 16 1114638 ##(Smalltalk.STBSingletonProxy) 8 ##(Smalltalk.ImageRelativeFileLocator) 8 #current 8 'Idb\Resources\ChunkBrowser.bmp' 0 0 7 514 769 33 9 0 47 27101 898 27101 0 576 1 930 8 #restoreSelection 8 'Restore Selected Chunk' 1 1 0 1 9 27103 1058 27103 0 576 5 930 459270 ##(Smalltalk.Message) 8 #toggleChunkType: 98 1 8 #'Class Category' 8 'Class Category' 1 1 0 1152 1 27105 1058 27105 0 576 5 930 1362 1392 98 1 8 #'Class Define' 8 'Class Define' 1 1 0 1152 3 27107 1058 27107 0 576 5 930 1362 1392 98 1 8 #'Class Delete' 8 'Class Delete' 1 1 0 1152 5 27109 1058 27109 0 576 1 930 1362 1392 98 1 8 #'Class Comment' 8 'Class Comment' 1 1 0 1152 7 27111 1058 27111 0 576 5 930 1362 1392 98 1 8 #'Class GUID' 8 'Class GUID' 1 1 0 1152 9 27113 1058 27113 0 576 1 930 1362 1392 98 1 8 #'Class Protocol' 8 'Class Protocol' 1 1 0 1152 39 27115 1058 27115 0 576 5 930 1362 1392 98 1 8 #'Method Category' 8 'Method Category' 1 1 0 1152 13 27117 1058 27117 0 576 5 930 1362 1392 98 1 8 #'Method Define' 8 'Method Define' 1 1 0 1152 15 27119 1058 27119 0 576 5 930 1362 1392 98 1 8 #'Method Delete' 8 'Method Delete' 1 1 0 1152 17 27121 1058 27121 0 576 1 930 1362 1392 98 1 8 #System 8 'System' 1 1 0 1152 41 27123 1058 27123 0 576 5 930 1362 1392 98 1 8 #Other 8 'Other' 1 1 0 1152 19 98 17 1050118 ##(Smalltalk.ToolbarSeparator) 0 0 576 3 0 1 912 992 1072 1264 2434 0 0 576 3 0 1 1328 1456 1552 1648 1744 1840 1936 2032 2128 2224 2320 234 240 98 4 1 1 1152 31 0 1 0 514 33 33 514 45 45 0 656198 1 ##(Smalltalk.FlowLayout) 1 1 1 983302 ##(Smalltalk.MessageSequence) 202 208 98 2 721670 ##(Smalltalk.MessageSend) 8 #createAt:extent: 98 2 514 1 1 514 1345 51 576 2642 8 #updateSize 848 576 983302 ##(Smalltalk.WINDOWPLACEMENT) 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 160 2 0 0 25 0 0 0] 98 0 514 193 193 0 27 410 8 ##(Smalltalk.StatusBar) 98 18 0 416 98 2 8 1140853004 1 2848 0 482 31 0 7 0 706 0 16 738 8 #[243 255 255 255 0 0 0 0 0 0 0 0 0 0 0 0 144 1 0 0 0 0 0 0 3 2 1 34 65 114 105 97 108 0 159 4 0 134 63 1 0 0 204 53 63 1 2 0 20 59 0 0 0 0 247 0 5 86 111 1] 514 193 193 0 2848 0 8 4294904118 234 256 98 12 853766 ##(Smalltalk.StatusBarItem) 1 321 2848 0 8 ##(Smalltalk.BasicListAbstract) 0 1178 8 ##(Smalltalk.IconImageManager) 1216 8 'statusCount' 3058 1 161 2848 0 3088 0 0 8 'statusRestrict' 3058 1 321 2848 0 3088 0 0 8 'statusRange' 3058 1 221 2848 0 3088 0 0 8 'statusLast' 3058 1 -1 2848 0 3088 0 0 8 'statusReport' 3058 1 181 2848 0 3088 0 0 8 'statusClass' 98 4 3072 3184 3152 3248 1115142 ##(Smalltalk.StatusBarNullItem) 513 1 2848 0 0 2578 202 208 98 1 2642 2672 98 2 514 1 849 514 1345 45 2848 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 168 1 0 0 160 2 0 0 190 1 0 0] 98 0 2832 0 27 0 0 410 8 ##(Smalltalk.ContainerView) 98 15 0 416 98 2 8 1140850688 131073 3520 0 482 31 0 7 0 0 0 3520 1180166 ##(Smalltalk.ProportionalLayout) 234 240 848 16 234 256 848 590342 ##(Smalltalk.Rectangle) 514 1 1 514 1 1 2578 202 208 98 1 2642 2672 98 2 514 1 51 514 1345 799 3520 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 25 0 0 0 160 2 0 0 168 1 0 0] 98 3 410 3536 98 15 0 3520 98 2 8 1140850688 131073 3904 0 482 31 0 7 0 0 0 3904 546 1 1 0 0 0 0 410 8 ##(Smalltalk.ListView) 98 30 0 3904 98 2 8 1140920649 1025 4000 590662 2 ##(Smalltalk.ListModel) 202 208 848 0 1178 8 ##(Smalltalk.SearchPolicy) 8 #identity 658 8 4278190080 0 7 265030 4 ##(Smalltalk.Menu) 0 16 98 8 984134 2 ##(Smalltalk.CommandMenuItem) 1 930 8 #pickSelection 8 'Pick selection' 1 1 0 0 0 4258 1 930 8 #unpickSelection 8 'Unpick selection' 1 1 0 0 0 983366 1 ##(Smalltalk.DividerMenuItem) 4097 4258 1 930 8 #restorePicked 8 'Restore picked' 1 1 0 0 0 4258 1 930 1296 8 'Restore selection' 1 1 0 0 0 4402 4097 4258 1 930 1024 8 'Copy' 1 1 0 0 0 4258 1 930 8 #browseChunk 8 'Browse' 1 1 0 0 0 8 '' 0 1 0 0 0 0 0 0 0 4000 0 8 4294903704 3088 0 3104 0 0 0 514 65 65 0 0 202 208 98 5 920646 5 ##(Smalltalk.ListViewColumn) 8 'Index' 141 8 #left 787814 3 ##(Smalltalk.BlockClosure) 0 459302 ##(Smalltalk.Context) 1 1 0 0 1180966 ##(Smalltalk.CompiledExpression) 2 9 8 ##(Smalltalk.UndefinedObject) 8 'doIt' 98 2 8 '[:o | o index printString]' 98 1 202 8 ##(Smalltalk.PoolDictionary) 848 8 #[252 1 0 1 1 8 0 17 230 32 228 32 158 159 106 100 105] 8 #index 8 #printString 17 257 0 8 ##(Smalltalk.SortedCollection) 0 0 4000 1362 8 #chunkIconIndex 98 0 1 0 0 4754 8 'P' 49 4800 4818 0 4850 1 1 0 0 4882 1 9 4912 8 'doIt' 98 2 8 '[:o | String new]' 98 1 202 5008 848 8 #[252 1 0 1 1 6 0 17 230 32 45 146 106 100 105] 721414 ##(Smalltalk.Association) 8 #String 80 17 257 0 4818 0 4850 2 1 0 0 0 4882 2 13 4912 8 'doIt' 98 2 8 '[:a :b | 
 	a pickedIconIndex = b pickedIconIndex
 		ifTrue: [a index <= b index]
-		ifFalse: [a pickedIconIndex > b pickedIconIndex]]' 98 1 202 4976 848 8 #[252 2 0 1 1 31 0 17 18 230 33 230 32 228 32 158 228 33 158 132 221 8 228 32 159 228 33 159 130 106 228 32 158 228 33 158 129 106 100 105] 8 #pickedIconIndex 5008 17 513 0 0 0 4000 962 5472 98 0 1 0 0 4722 8 'Type' 301 4768 962 8 #chunkType 98 0 4786 0 4818 2 1 0 0 0 4850 2 13 4880 8 'doIt' 98 2 8 '[:a :b | 
+		ifFalse: [a pickedIconIndex > b pickedIconIndex]]' 98 1 202 5008 848 8 #[252 2 0 1 1 31 0 17 18 230 33 230 32 228 32 158 228 33 158 132 221 8 228 32 159 228 33 159 130 106 228 32 158 228 33 158 129 106 100 105] 8 #pickedIconIndex 5040 17 513 0 0 0 4000 1362 5504 98 0 1 0 0 4754 8 'Type' 301 4800 1362 8 #chunkType 98 0 4818 0 4850 2 1 0 0 0 4882 2 13 4912 8 'doIt' 98 2 8 '[:a :b | 
  a chunkType = b chunkType
     ifTrue: [a index <= b index]
-    ifFalse: [a chunkType <= b chunkType]]' 98 1 202 4976 848 8 #[252 2 0 1 1 31 0 17 18 230 33 230 32 228 32 158 228 33 158 132 221 8 228 32 159 228 33 159 130 106 228 32 158 228 33 158 130 106 100 105] 5568 5008 17 513 0 0 0 4000 0 1 0 0 4722 8 'Identity1' 301 4768 962 8 #identity1 98 0 4786 0 4818 2 1 0 0 0 4850 2 13 4880 8 'doIt' 98 2 8 '[:a :b | 
+    ifFalse: [a chunkType <= b chunkType]]' 98 1 202 5008 848 8 #[252 2 0 1 1 31 0 17 18 230 33 230 32 228 32 158 228 33 158 132 221 8 228 32 159 228 33 159 130 106 228 32 158 228 33 158 130 106 100 105] 5600 5040 17 513 0 0 0 4000 0 1 0 0 4754 8 'Identity1' 301 4800 1362 8 #identity1 98 0 4818 0 4850 2 1 0 0 0 4882 2 13 4912 8 'doIt' 98 2 8 '[:a :b | 
  a identity1 = b identity1
 	 ifTrue: [a index <= b index]
-    	ifFalse: [a identity1 <= b identity1]]' 98 1 202 4976 848 8 #[252 2 0 1 1 31 0 17 18 230 33 230 32 228 32 158 228 33 158 132 221 8 228 32 159 228 33 159 130 106 228 32 158 228 33 158 130 106 100 105] 5792 5008 17 513 0 0 0 4000 0 1 0 0 4722 8 'Identity2' 533 4768 962 8 #identity2 5808 4786 0 4818 2 1 0 0 0 4850 2 13 4880 8 'doIt' 98 2 8 '[:a :b | 
+    	ifFalse: [a identity1 <= b identity1]]' 98 1 202 5008 848 8 #[252 2 0 1 1 31 0 17 18 230 33 230 32 228 32 158 228 33 158 132 221 8 228 32 159 228 33 159 130 106 228 32 158 228 33 158 130 106 100 105] 5824 5040 17 513 0 0 0 4000 0 1 0 0 4754 8 'Identity2' 533 4800 1362 8 #identity2 5840 4818 0 4850 2 1 0 0 0 4882 2 13 4912 8 'doIt' 98 2 8 '[:a :b | 
  a identity2 = b identity2
 	ifTrue: [a index <= b index]
-    	ifFalse: [a identity2 <= b identity2]]' 98 1 202 4976 848 8 #[252 2 0 1 1 31 0 17 18 230 33 230 32 228 32 158 228 33 158 132 221 8 228 32 159 228 33 159 130 106 228 32 158 228 33 158 130 106 100 105] 6016 5008 17 513 0 0 0 4000 0 3 0 0 8 #report 848 0 131173 0 0 2578 202 208 98 3 2642 2672 98 2 514 9 9 514 1329 387 4000 2642 8 #contextMenu: 98 1 4208 4000 2642 8 #text: 98 1 8 'Index' 4000 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 4 0 0 0 4 0 0 0 156 2 0 0 197 0 0 0] 98 0 2832 0 27 234 256 98 2 4000 8 'chunkList' 3682 514 9 9 514 9 1 2578 202 208 98 1 2642 2672 98 2 514 1 1 514 1345 395 3904 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 160 2 0 0 197 0 0 0] 98 1 4000 2832 0 27 410 8 ##(Smalltalk.Splitter)  98 12 0 3520 98 2 8 1140850688 1 6720 0 658 688 0 519 0 0 0 6720 2578 202 208 98 1 2642 2672 98 2 514 1 395 514 1345 11 6720 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 197 0 0 0 160 2 0 0 202 0 0 0] 98 0 2832 0 27 410 3536 98 15 0 3520 98 2 8 1140850688 131073 6976 0 482 31 0 7 0 0 0 6976 546 1 1 0 0 0 0 410 8 ##(Smalltalk.ScintillaView)  98 46 0 6976 98 2 8 1174475012 1025 7072 721990 2 ##(Smalltalk.ValueHolder)  0 32 1098 4144 8 #equality 0 196934 1 ##(Smalltalk.RGB)  30277631 0 7 4194 0 16 98 3 4242 1 930 2160 8 'Copy' 1 1 0 0 0 4242 1 930 4448 8 'Restore picked' 1 1 0 0 0 4242 1 930 2288 8 'Restore selection' 1 1 0 0 0 8 '' 0 1 0 0 0 0 0 0 0 7072 0 403526399 852486 ##(Smalltalk.NullConverter)  0 0 11 0 234 256 98 6 8 #lineNumber 1182726 ##(Smalltalk.ScintillaTextStyle)  67 0 0 1 0 0 0 0 7504 0 0 0 8 #indentGuide 7522 75 0 0 1 0 0 0 0 7552 0 0 0 8 #normal 7522 1 0 0 1 0 0 0 0 7584 0 0 0 98 40 7600 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7536 0 0 0 7568 0 0 1377542 ##(Smalltalk.SmalltalkMethodStyler)  1 0 0 32 202 208 848 234 256 98 2 8 #default 1639942 ##(Smalltalk.ScintillaMarkerDefinition)  0 1 786694 ##(Smalltalk.IndexedColor)  33554433 7762 33554471 7072 8 #circle 202 208 848 0 63 0 0 0 0 0 7762 33554447 0 0 0 0 0 234 256 98 6 8 #literalArray 8 '()' 8 #literalBytes 8 '[]' 8 #specialCharacter 8 '()[]<>' 8 '' 1 234 256 848 0 0 0 0 3 0 0 2578 202 208 98 9 2642 2672 98 2 514 9 1 514 1329 395 7072 2642 6320 98 1 7248 7072 2642 8 #selectionRange: 98 1 525062 ##(Smalltalk.Interval)  3 1 3 7072 2642 8 #isTextModified: 98 1 32 7072 2642 8 #modificationEventMask: 98 1 9215 7072 2642 8 #indicatorDefinitions: 98 1 98 2 1836038 ##(Smalltalk.ScintillaIndicatorDefinition)  1 7072 65025 3 8402 3 7072 33423361 5 7072 2642 8 #margins: 98 1 98 3 984582 ##(Smalltalk.ScintillaMargin)  1 7072 1 3 32 1 8514 3 7072 1 1 32 67108863 8514 5 7072 1 1 32 1 7072 2642 8 #markers: 98 1 7824 7072 2642 8 #tabIndents: 98 1 16 7072 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 4 0 0 0 0 0 0 0 156 2 0 0 197 0 0 0] 98 0 2832 0 27 234 256 98 2 7072 8 'chunkText' 3682 514 9 1 514 9 1 2578 202 208 98 1 2642 2672 98 2 514 1 405 514 1345 395 6976 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 202 0 0 0 160 2 0 0 143 1 0 0] 98 1 7072 2832 0 27 2832 0 27 234 256 98 2 576 8 'toolbar' 0 461638 4 ##(Smalltalk.MenuBar)  0 16 98 7 4194 0 16 98 8 4242 1 930 2096 8 '&Open' 8351 1 0 0 0 4242 1 930 8 #fileOpenPatch 8 'Open Patch File' 1 1 0 0 0 4242 1 930 8 #clipboardOpen 8 'Open On Clipboard' 1 1 0 0 0 4386 4097 4242 1 930 8 #pageSetup 8 'Page se&tup...' 1 1 0 0 0 4242 1 930 8 #print 8 '&Print...' 1 1 0 0 0 4386 4097 4242 1 930 8 #exit 8 '&Close' 16615 1 0 0 0 8 '&File' 0 1 0 0 17687 0 0 4194 0 16 98 7 4242 1 930 2160 8 '&Copy' 8327 1 0 0 0 4242 1 930 4624 8 '&Browse' 1 1 0 0 0 4386 4097 4242 1 930 4448 8 'Restore &picked' 1 1 0 0 0 4242 1 930 2288 8 'Restore &selected' 8357 1 0 0 0 4386 4097 4242 1 930 2224 8 'Show &differences' 8355 1 0 0 0 8 '&Edit' 0 1 0 0 17699 0 0 4194 0 16 98 4 4242 1 930 4288 8 '&Pick selected' 1 1 0 0 0 4242 1 930 4352 8 '&Unpick selected' 1 1 0 0 0 4386 4097 4242 1 930 8 #unpickAll 8 'Unpick &all' 1 1 0 0 0 8 '&Pick' 0 1 0 0 17707 0 0 4194 0 16 98 17 4242 1 930 962 992 98 1 2384 8 'Class Category' 1 1 0 0 0 4242 1 930 962 992 98 1 1344 8 'Class Comment' 1 1 0 0 0 4242 1 930 962 992 98 1 1024 8 'Class Define' 1 1 0 0 0 4242 1 930 962 992 98 1 1248 8 'Class Delete' 1 1 0 0 0 4242 1 930 962 992 98 1 1440 8 'Class GUID' 1 1 0 0 0 4242 1 930 962 992 98 1 1536 8 'Class Protocol' 1 1 0 0 0 4386 4097 4242 1 930 962 992 98 1 1632 8 'Method Category' 1 1 0 0 0 4242 1 930 962 992 98 1 1728 8 'Method Define' 1 1 0 0 0 4242 1 930 962 992 98 1 1824 8 'Method Delete' 1 1 0 0 0 4386 4097 4242 1 930 962 992 98 1 2016 8 'Other' 1 1 0 0 0 4242 1 930 962 992 98 1 1920 8 'System' 1 1 0 0 0 4386 4097 4242 1 930 8 #chunkSelectAll 8 'Select All' 1 1 0 0 0 4242 1 930 8 #chunkSelectNone 8 'Select None' 1 1 0 0 0 4242 1 930 8 #chunkSelectDefault 8 'Select Default' 1 1 0 0 0 8 'Chunks' 0 1 0 0 17737 0 0 4194 0 16 98 11 4242 1 930 962 8 #toggleComparisonType: 98 1 8 #Match 8 'Show Matching' 1 1 0 0 0 4242 1 930 962 11312 98 1 8 #Differ 8 'Show Differing' 1 1 0 0 0 4242 1 930 962 11312 98 1 8 #Missing 8 'Show Missing' 1 1 0 0 0 4386 4097 4242 1 930 8 #toggleRestrictingMostRecent 8 'Restrict To Most Recent Only' 1 1 0 0 0 4242 1 930 8 #restrictionClass 8 'Restrict To Selected Class' 1 1 0 0 0 4242 1 930 8 #toggleRestrictingPicked 8 'Restrict To Picked' 1 1 0 0 0 4386 4097 4242 1 930 8 #restrictionRange 8 'Restrict Range - Selection' 1 1 0 0 0 4242 1 930 8 #restrictionSave 8 'Restrict Range - Since Last Save' 1 1 0 0 0 4242 1 930 8 #restrictionClear 8 'Clear Range Restricition' 1 1 0 0 0 8 'Filter' 0 1 0 0 17757 0 0 4194 0 16 98 0 8 '&Tools' 8 #toolsMenu 1 0 0 17759 0 0 4194 0 16 98 19 4242 1 930 8 #helpContents 8 '&Contents' 1025 1 263494 3 ##(Smalltalk.Icon)  0 16 1104 49 1098 8 ##(Smalltalk.ShellLibrary)  7712 0 0 4242 1 930 8 #help 8 'On this &Tool' 1249 1 0 0 0 4242 1 930 8 #helpWhatsThis 8 'What''s This?' 5345 1 0 0 0 4386 4097 4242 1 930 8 #helpFirstSplash 8 'First Splash!!' 1 1 0 0 0 4386 4097 4242 1 930 8 #helpWhatsNew 8 'What''s &New' 1 1 0 0 0 4242 1 930 8 #helpGuidedTour 8 '&Guided Tour' 1 1 0 0 0 4242 1 930 8 #helpTutorials 8 'Tutorials' 1 1 0 0 0 4194 0 16 98 4 4242 2097153 930 8 #tipOfTheDay 8 '&Next Tip of the Day' 9441 1 12162 0 16 1104 8 'TipOfTheDay.ico' 2032142 ##(Smalltalk.STBExternalResourceLibraryProxy)  8 'dolphindr006.dll' 0 0 0 4242 1 930 8 #previousTipOfTheDay 8 '&Previous Tip of the Day' 13537 1 12162 0 16 1104 8 'TipOfTheDay.ico' 12784 0 0 4386 4097 4242 1 930 8 #toggleShowTipsAtStartup 8 '&Show Tips at Startup' 1 1 0 0 0 8 'Tip of the &Day' 0 134217729 0 0 0 0 0 4386 4097 4242 1 930 8 #objectArtsHomePage 8 'Object Arts Homepage' 1 1 0 0 0 4242 1 930 8 #dolphinNewsgroup 8 'Dolphin Newsgroup/Forum' 1 1 0 0 0 4242 1 930 8 #dolphinWikiWeb 8 'Dolphin WikiWeb' 1 1 0 0 0 4242 1 930 8 #myDolphinAccount 8 'My Dolphin Account' 1 1 0 0 0 4386 4097 4242 1 930 8 #dolphinLiveUpdate 8 'Check for Live &Updates...' 1 1 12162 0 16 1104 8 'LiveUpdate.ico' 12784 0 0 4386 4097 4242 1 930 8 #aboutDolphin 8 '&About Dolphin Smalltalk' 1 1 12162 0 16 1104 8 '!!APPLICATION' 12784 0 0 8 '&Help' 0 134217729 0 0 0 0 0 8 '' 0 1 0 0 0 0 0 0 1049350 ##(Smalltalk.AcceleratorTable)  0 16 98 10 5282 8351 9120 5282 16615 9456 5282 8327 9568 5282 8357 9728 5282 8355 9792 5282 1025 930 12128 8 '&Contents' 1025 1 12162 0 16 1104 49 12192 5282 1249 930 12256 8 'On this &Tool' 1249 1 0 5282 5345 930 12320 8 'What''s This?' 5345 1 0 5282 9441 930 12704 8 '&Next Tip of the Day' 9441 1 12162 0 16 1104 8 'TipOfTheDay.ico' 12784 5282 13537 930 12848 8 '&Previous Tip of the Day' 13537 1 12162 0 16 1104 8 'TipOfTheDay.ico' 12784 0 1 0 0 0 0 1 0 0 2578 202 208 98 3 2642 2672 98 2 514 6399 21 514 1361 1001 416 2642 6368 98 1 8 'ChunkBrowser' 416 2642 8 #menuBar: 98 1 9040 416 2770 8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 127 12 0 0 10 0 0 0 39 15 0 0 254 1 0 0] 98 3 576 3520 2848 2832 0 27 )! !
+    	ifFalse: [a identity2 <= b identity2]]' 98 1 202 5008 848 8 #[252 2 0 1 1 31 0 17 18 230 33 230 32 228 32 158 228 33 158 132 221 8 228 32 159 228 33 159 130 106 228 32 158 228 33 158 130 106 100 105] 6048 5040 17 513 0 0 0 4000 0 3 0 0 8 #report 848 0 131173 0 0 2578 202 208 98 3 2642 2672 98 2 514 9 9 514 1329 387 4000 2642 8 #contextMenu: 98 1 4224 4000 2642 8 #text: 98 1 8 'Index' 4000 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 4 0 0 0 4 0 0 0 156 2 0 0 197 0 0 0] 98 0 2832 0 27 234 256 98 2 4000 8 'chunkList' 3682 514 9 9 514 9 1 2578 202 208 98 1 2642 2672 98 2 514 1 1 514 1345 395 3904 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 160 2 0 0 197 0 0 0] 98 1 4000 2832 0 27 410 8 ##(Smalltalk.Splitter) 98 12 0 3520 98 2 8 1140850688 1 6752 0 658 688 0 519 0 0 0 6752 2578 202 208 98 1 2642 2672 98 2 514 1 395 514 1345 11 6752 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 197 0 0 0 160 2 0 0 202 0 0 0] 98 0 2832 0 27 410 3536 98 15 0 3520 98 2 8 1140850688 131073 7008 0 482 31 0 7 0 0 0 7008 546 1 1 0 0 0 0 410 8 ##(Smalltalk.ScintillaView) 98 46 0 7008 98 2 8 1174475012 1025 7104 721990 2 ##(Smalltalk.ValueHolder) 0 32 1178 4144 8 #equality 0 196934 1 ##(Smalltalk.RGB) 30277631 0 7 4210 0 16 98 3 4258 1 930 1024 8 'Copy' 1 1 0 0 0 4258 1 930 4464 8 'Restore picked' 1 1 0 0 0 4258 1 930 1296 8 'Restore selection' 1 1 0 0 0 8 '' 0 1 0 0 0 0 0 0 0 7104 0 460018459 852486 ##(Smalltalk.NullConverter) 0 0 11 0 234 256 98 6 8 #indentGuide 1182726 ##(Smalltalk.ScintillaTextStyle) 75 0 0 1 0 0 0 0 7536 0 0 0 8 #normal 7554 1 0 0 1 0 0 0 0 7584 0 0 0 8 #lineNumber 7554 67 0 0 1 0 0 0 0 7616 0 0 0 98 40 7600 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7632 0 0 0 7568 0 0 1377542 ##(Smalltalk.SmalltalkMethodStyler) 1 0 0 32 202 208 848 234 256 98 2 8 #default 1639942 ##(Smalltalk.ScintillaMarkerDefinition) 0 1 786694 ##(Smalltalk.IndexedColor) 33554433 7794 33554471 7104 8 #circle 202 208 848 0 63 0 0 0 0 0 7794 33554447 0 0 0 0 0 234 256 98 6 8 #specialCharacter 8 '()[]<>' 8 #literalArray 8 '()' 8 #literalBytes 8 '[]' 8 '' 1 234 256 848 0 0 0 0 3 0 0 2578 202 208 98 9 2642 2672 98 2 514 9 1 514 1329 395 7104 2642 6352 98 1 7280 7104 2642 8 #selectionRange: 98 1 525062 ##(Smalltalk.Interval) 3 1 3 7104 2642 8 #isTextModified: 98 1 32 7104 2642 8 #modificationEventMask: 98 1 9215 7104 2642 8 #indicatorDefinitions: 98 1 98 2 1836038 ##(Smalltalk.ScintillaIndicatorDefinition) 1 7104 65025 3 8434 3 7104 33423361 5 7104 2642 8 #margins: 98 1 98 3 984582 ##(Smalltalk.ScintillaMargin) 1 7104 1 3 32 1 8546 3 7104 1 1 32 67108863 8546 5 7104 1 1 32 1 7104 2642 8 #markers: 98 1 7856 7104 2642 8 #tabIndents: 98 1 16 7104 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 4 0 0 0 0 0 0 0 156 2 0 0 197 0 0 0] 98 0 2832 0 27 234 256 98 2 7104 8 'chunkText' 3682 514 9 1 514 9 1 2578 202 208 98 1 2642 2672 98 2 514 1 405 514 1345 395 7008 2770 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 202 0 0 0 160 2 0 0 143 1 0 0] 98 1 7104 2832 0 27 2832 0 27 234 256 98 2 576 8 'toolbar' 0 461638 4 ##(Smalltalk.MenuBar) 0 16 98 7 4210 0 16 98 9 4258 1 930 960 8 '&Open' 8351 1 0 0 0 4258 1 930 8 #fileOpenPatch 8 'Open Patch File' 1 1 0 0 0 4258 1 930 8 #clipboardOpen 8 'Open On Clipboard' 1 1 0 0 0 4402 4097 4258 1 930 8 #pageSetup 8 'Page se&tup...' 1 1 0 0 0 4258 1 930 8 #printPreview 8 'Print preview...' 1 1 0 0 0 4258 1 930 8 #print 8 '&Print...' 1 1 0 0 0 4402 4097 4258 1 930 8 #exit 8 '&Close' 16615 1 0 0 0 8 '&File' 0 1 0 0 27181 0 0 4210 0 16 98 7 4258 1 930 1024 8 '&Copy' 8327 1 0 0 0 4258 1 930 4640 8 '&Browse' 1 1 0 0 0 4402 4097 4258 1 930 4464 8 'Restore &picked' 1 1 0 0 0 4258 1 930 1296 8 'Restore &selected' 9383 1 0 0 0 4402 4097 4258 1 930 1104 8 'Show &differences' 8355 1 0 0 0 8 '&Edit' 0 1 0 0 27193 0 0 4210 0 16 98 4 4258 1 930 4304 8 '&Pick selected' 1 1 0 0 0 4258 1 930 4368 8 '&Unpick selected' 1 1 0 0 0 4402 4097 4258 1 930 8 #unpickAll 8 'Unpick &all' 1 1 0 0 0 8 '&Pick' 0 1 0 0 27201 0 0 4210 0 16 98 17 4258 1 930 1362 1392 98 1 1424 8 'Class Category' 1 1 0 0 0 4258 1 930 1362 1392 98 1 1712 8 'Class Comment' 1 1 0 0 0 4258 1 930 1362 1392 98 1 1520 8 'Class Define' 1 1 0 0 0 4258 1 930 1362 1392 98 1 1616 8 'Class Delete' 1 1 0 0 0 4258 1 930 1362 1392 98 1 1808 8 'Class GUID' 1 1 0 0 0 4258 1 930 1362 1392 98 1 1904 8 'Class Protocol' 1 1 0 0 0 4402 4097 4258 1 930 1362 1392 98 1 2000 8 'Method Category' 1 1 0 0 0 4258 1 930 1362 1392 98 1 2096 8 'Method Define' 1 1 0 0 0 4258 1 930 1362 1392 98 1 2192 8 'Method Delete' 1 1 0 0 0 4402 4097 4258 1 930 1362 1392 98 1 2384 8 'Other' 1 1 0 0 0 4258 1 930 1362 1392 98 1 2288 8 'System' 1 1 0 0 0 4402 4097 4258 1 930 8 #chunkSelectAll 8 'Select All' 1 1 0 0 0 4258 1 930 8 #chunkSelectNone 8 'Select None' 1 1 0 0 0 4258 1 930 8 #chunkSelectDefault 8 'Select Default' 1 1 0 0 0 8 'Chunks' 0 1 0 0 27231 0 0 4210 0 16 98 11 4258 1 930 1362 8 #toggleComparisonType: 98 1 8 #Match 8 'Show Matching' 1 1 0 0 0 4258 1 930 1362 11408 98 1 8 #Differ 8 'Show Differing' 1 1 0 0 0 4258 1 930 1362 11408 98 1 8 #Missing 8 'Show Missing' 1 1 0 0 0 4402 4097 4258 1 930 8 #toggleRestrictingMostRecent 8 'Restrict To Most Recent Only' 1 1 0 0 0 4258 1 930 8 #restrictionClass 8 'Restrict To Selected Class' 1 1 0 0 0 4258 1 930 8 #toggleRestrictingPicked 8 'Restrict To Picked' 1 1 0 0 0 4402 4097 4258 1 930 8 #restrictionRange 8 'Restrict Range - Selection' 1 1 0 0 0 4258 1 930 8 #restrictionSave 8 'Restrict Range - Since Last Save' 1 1 0 0 0 4258 1 930 8 #restrictionClear 8 'Clear Range Restricition' 1 1 0 0 0 8 'Filter' 0 1 0 0 27251 0 0 4210 0 16 98 0 8 '&Tools' 8 #toolsMenu 1 0 0 27253 0 0 4210 0 16 98 2 4258 1 930 8 #idbHelp 8 '&Help' 1 1 0 0 0 4258 1 930 8 #idbAbout 8 '&About' 1 1 0 0 0 8 '&Help' 0 134217729 0 0 27259 0 0 8 '' 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 2578 202 208 98 3 2642 2672 98 2 514 2047 21 514 1361 1001 416 2642 6400 98 1 8 'ChunkBrowser' 416 2642 8 #updateMenuBar 848 416 2770 8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 3 0 0 10 0 0 0 167 6 0 0 254 1 0 0] 98 3 576 3520 2848 2832 0 27)!
+
+stFileTypes
+	"Answer an Array of file types that can be associated with this
+	class of document."
+
+	^(OrderedCollection new)
+		add: #('Smalltalk Files (*.st)' '*.st');
+		add: #('All Files (*.*)' '*.*');
+		yourself! !
 !ChunkBrowser class categoriesFor: #chunkTypeSelection!accessing!public! !
 !ChunkBrowser class categoriesFor: #chunkTypeSelection:!accessing!public! !
 !ChunkBrowser class categoriesFor: #compareMethodsUsingParser!accessing!public! !
@@ -532,4 +509,5 @@ resource_Default_view
 !ChunkBrowser class categoriesFor: #icon!constants!public! !
 !ChunkBrowser class categoriesFor: #publishedAspects!constants!public! !
 !ChunkBrowser class categoriesFor: #resource_Default_view!public!resources-views! !
+!ChunkBrowser class categoriesFor: #stFileTypes!constants!public! !
 

--- a/Core/Contributions/IDB/ChunkBrowserCategoryChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserCategoryChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserSeriesChunk subclass: #ChunkBrowserCategoryChunk
 	instanceVariableNames: ''
@@ -8,14 +8,14 @@ ChunkBrowserSeriesChunk subclass: #ChunkBrowserCategoryChunk
 ChunkBrowserCategoryChunk guid: (GUID fromString: '{C46E27D3-0EF6-4845-9235-CE75B56481F0}')!
 ChunkBrowserCategoryChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserCategoryChunk categoriesForClass!IDB Goodies! !
 !ChunkBrowserCategoryChunk methodsFor!
 
-initializeFrom: aChunkBrowserSeriesStartChunk 
-	super initializeFrom: aChunkBrowserSeriesStartChunk.
+initializeFromSeriesStart: aChunkBrowserSeriesStartChunk
+	super initializeFromSeriesStart: aChunkBrowserSeriesStartChunk.
 	identity2 := aChunkBrowserSeriesStartChunk identity2! !
-!ChunkBrowserCategoryChunk categoriesFor: #initializeFrom:!initializing!public! !
+!ChunkBrowserCategoryChunk categoriesFor: #initializeFromSeriesStart:!initializing!public! !
 

--- a/Core/Contributions/IDB/ChunkBrowserChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 Object subclass: #ChunkBrowserChunk
 	instanceVariableNames: 'rawText index identity1 identity2 picked'
@@ -8,35 +8,52 @@ Object subclass: #ChunkBrowserChunk
 ChunkBrowserChunk guid: (GUID fromString: '{81A73B99-1EF4-4578-B810-1FDB663E27F2}')!
 ChunkBrowserChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserChunk categoriesForClass!IDB Goodies! !
 !ChunkBrowserChunk methodsFor!
 
-<= aChunkBrowserChunk 
+<= aChunkBrowserChunk
 	^index <= aChunkBrowserChunk index!
 
-= aChunk 
+= aChunk
 	^self class == aChunk class and: [identity1 = aChunk identity1 and: [identity2 = aChunk identity2]]!
 
 browse
+	"Open a broser on the receiver"
+
 	self browseTarget browse!
 
+browseTarget
+	self subclassResponsibility!
+
 canBrowse
+	"Answer true if a class browser can be opened on the receiver"
+
 	^self browseTarget notNil!
 
 canCompare
+	"Override if the receiver chunk cannot be compared with another"
+
 	^true!
 
 canShowDifferences
+	"Override if the receiver chunk can be compared with another using a DifferencesPresenter"
+
 	^false!
 
 chunkClass
+	"Answer the name of the class represented by the receiver or nil if it either does not have
+	one or does not exist"
+
 	^self identity1AsClass ifNotNil: [:arg | arg instanceClass name]!
 
 chunkIconIndex
-	^(self isMatch ifNil: [Object] ifNotNil: [:arg | arg ifTrue: [Presenter] ifFalse: [Model]]) icon 
+	"Answer the imageIndex for the icon that represents the match state of the receiver with the
+	current image"
+
+	^(self isMatch ifNil: [Object] ifNotNil: [:arg | arg ifTrue: [Presenter] ifFalse: [Model]]) icon
 		imageIndex!
 
 chunkType
@@ -45,29 +62,9 @@ chunkType
 classNameFromRawText
 	| firstSpaceIndex |
 	firstSpaceIndex := rawText indexOf: Character space.
-	^(rawText indexOfSubCollection: ' class') = firstSpaceIndex 
+	^(rawText indexOfSubCollection: ' class') = firstSpaceIndex
 		ifTrue: [rawText copyFrom: 1 to: firstSpaceIndex + 5]
 		ifFalse: [rawText copyFrom: 1 to: firstSpaceIndex - 1]!
-
-displayTextUsing: aColor 
-	^(RichText rtfConverter)
-		font: SmalltalkWorkspace actualFont;
-		forecolor: aColor;
-		readTextFrom: rawText readStream;
-		richText!
-
-filterUsing: aChunkBrowserFilter 
-	| match |
-	(aChunkBrowserFilter isChunkTypeSelected: self chunkType) ifFalse: [^false].
-	(aChunkBrowserFilter isInRestrictionRange: self index) ifFalse: [^false].
-	(aChunkBrowserFilter isInRestrictionClass: self chunkClass) ifFalse: [^false].
-	(aChunkBrowserFilter isRestrictingPicked and: [picked not]) ifTrue: [^false].
-	self canCompare ifFalse: [^true].
-	aChunkBrowserFilter isCompareNeeded ifFalse: [^true].
-	match := self isMatch.
-	match ifNil: [^aChunkBrowserFilter isComparisonTypeSelected: #Missing].
-	match ifTrue: [^aChunkBrowserFilter isComparisonTypeSelected: #Match].
-	^aChunkBrowserFilter isComparisonTypeSelected: #Differ!
 
 hash
 	^(self class hash bitXor: identity1 hash) bitXor: identity2 hash!
@@ -76,26 +73,16 @@ identity1
 	^identity1!
 
 identity1AndIdentity2AsCompiledMethod
-	^self identity1AsClass 
-		ifNotNil: 
-			[:arg | 
-			(arg includesSelector: identity2 asSymbol) ifTrue: [arg compiledMethodAt: identity2 asSymbol]]!
-
-identity1AndIdentity2AsResourceIdentifier
-	^self identity1AsClass 
-		ifNotNil: 
-			[:arg | 
-			| resourceIdentifier |
-			resourceIdentifier := ResourceIdentifier class: arg name: identity2.
-			(SessionManager current resourceManager resourceAt: resourceIdentifier ifAbsent: []) 
-				ifNotNil: [resourceIdentifier]]!
+	^self identity1AsClass
+		ifNotNil:
+			[:arg | (arg includesSelector: identity2 asSymbol) ifTrue: [arg compiledMethodAt: identity2 asSymbol]]!
 
 identity1AsClass
 	| className metaclass class |
 	className := identity1.
 	metaclass := false.
-	(className includes: Character space) 
-		ifTrue: 
+	(className includes: Character space)
+		ifTrue:
 			[className := className copyFrom: 1 to: (className indexOf: Character space) - 1.
 			metaclass := true].
 	(self class environment includesKey: className) ifFalse: [^nil].
@@ -109,26 +96,47 @@ identity2
 index
 	^index!
 
-index: anInteger 
+index: anInteger
 	index := anInteger!
 
-initialize: aString 
+initialize: aString
 	rawText := aString.
-	picked := false!
+	picked := false.
+	identity1 := String new.
+	identity2 := String new!
 
-isChunkSeriesStart
-	^false!
+isFilteredUsing: aChunkBrowserFilter
+	"Answers true if the receiver passes all the tests in aChunkBrowserFilter"
+
+	| match |
+	(aChunkBrowserFilter isChunkTypeSelected: self chunkType) ifFalse: [^false].
+	(aChunkBrowserFilter isInRestrictionRange: self index) ifFalse: [^false].
+	(aChunkBrowserFilter isInRestrictionClass: self chunkClass) ifFalse: [^false].
+	(aChunkBrowserFilter isRestrictingPicked and: [picked not]) ifTrue: [^false].
+	self canCompare ifFalse: [^true].
+	aChunkBrowserFilter isCompareNeeded ifFalse: [^true].
+	match := self isMatch.
+	match ifNil: [^aChunkBrowserFilter isComparisonTypeSelected: #Missing].
+	match ifTrue: [^aChunkBrowserFilter isComparisonTypeSelected: #Match].
+	^aChunkBrowserFilter isComparisonTypeSelected: #Differ!
 
 isImageSave
+	"Override if the receiver represents an image save"
+
 	^false!
 
 isMatch
 	self subclassResponsibility!
 
+isSeriesStart
+	"Override if the receiver is a chunk representing the start of a series"
+
+	^false!
+
 picked
 	^picked!
 
-picked: aBoolean 
+picked: aBoolean
 	picked := aBoolean!
 
 pickedIconIndex
@@ -140,11 +148,12 @@ rawText
 restore
 	self subclassResponsibility!
 
-showIn: aTextPresenter 
+showIn: aTextPresenter
 	aTextPresenter text: rawText! !
 !ChunkBrowserChunk categoriesFor: #<=!comparing!public! !
 !ChunkBrowserChunk categoriesFor: #=!comparing!public! !
 !ChunkBrowserChunk categoriesFor: #browse!operations!public! !
+!ChunkBrowserChunk categoriesFor: #browseTarget!operations!public! !
 !ChunkBrowserChunk categoriesFor: #canBrowse!public!testing! !
 !ChunkBrowserChunk categoriesFor: #canCompare!public!testing! !
 !ChunkBrowserChunk categoriesFor: #canShowDifferences!public!testing! !
@@ -152,20 +161,18 @@ showIn: aTextPresenter
 !ChunkBrowserChunk categoriesFor: #chunkIconIndex!accessing!public! !
 !ChunkBrowserChunk categoriesFor: #chunkType!accessing!constants!public! !
 !ChunkBrowserChunk categoriesFor: #classNameFromRawText!helpers!public! !
-!ChunkBrowserChunk categoriesFor: #displayTextUsing:!operations!public! !
-!ChunkBrowserChunk categoriesFor: #filterUsing:!operations!public! !
 !ChunkBrowserChunk categoriesFor: #hash!comparing!public! !
 !ChunkBrowserChunk categoriesFor: #identity1!accessing!public! !
 !ChunkBrowserChunk categoriesFor: #identity1AndIdentity2AsCompiledMethod!helpers!public! !
-!ChunkBrowserChunk categoriesFor: #identity1AndIdentity2AsResourceIdentifier!helpers!public! !
 !ChunkBrowserChunk categoriesFor: #identity1AsClass!helpers!public! !
 !ChunkBrowserChunk categoriesFor: #identity2!accessing!public! !
 !ChunkBrowserChunk categoriesFor: #index!accessing!public! !
 !ChunkBrowserChunk categoriesFor: #index:!accessing!public! !
 !ChunkBrowserChunk categoriesFor: #initialize:!initializing!public! !
-!ChunkBrowserChunk categoriesFor: #isChunkSeriesStart!public!testing! !
+!ChunkBrowserChunk categoriesFor: #isFilteredUsing:!operations!public! !
 !ChunkBrowserChunk categoriesFor: #isImageSave!public!testing! !
 !ChunkBrowserChunk categoriesFor: #isMatch!public!testing! !
+!ChunkBrowserChunk categoriesFor: #isSeriesStart!public!testing! !
 !ChunkBrowserChunk categoriesFor: #picked!accessing!public! !
 !ChunkBrowserChunk categoriesFor: #picked:!accessing!public! !
 !ChunkBrowserChunk categoriesFor: #pickedIconIndex!accessing!public! !
@@ -178,33 +185,75 @@ showIn: aTextPresenter
 chunkClasses
 	"A collection of classes that should be tested to decide the type of a chunk"
 
-	ChunkClasses := nil.
-	ChunkClasses 
-		ifNil: 
-			[ChunkClasses := OrderedCollection new.
-			ChunkClasses
+	ChunkClasses
+		ifNil:
+			[ChunkClasses := (OrderedCollection new)
+				add: ChunkBrowserMethodCategorySeriesStartChunk;
+				add: ChunkBrowserMethodDefineSeriesStartChunk;
 				add: ChunkBrowserClassDefineChunk;
 				add: ChunkBrowserClassDeleteChunk;
+				add: ChunkBrowserMethodDeleteChunk;
 				add: ChunkBrowserClassCommentChunk;
 				add: ChunkBrowserClassGUIDChunk;
 				add: ChunkBrowserClassProtocolChunk;
 				add: ChunkBrowserClassCategorySeriesStartChunk;
-				add: ChunkBrowserMethodCategorySeriesStartChunk;
-				add: ChunkBrowserMethodDefineSeriesStartChunk;
-				add: ChunkBrowserMethodDeleteChunk;
-				add: ChunkBrowserSystemChunk].
+				add: ChunkBrowserSystemChunk;
+				yourself].
 	^ChunkClasses!
+
+chunksFromStream: aStream
+	"Answer a collection of subclasses representing the chunks found in aStream"
+
+	| chunks sourceFiler |
+	chunks := OrderedCollection new.
+	sourceFiler := ChunkSourceFiler on: aStream.
+	[aStream atEnd]
+		whileFalse:
+			[| chunkText |
+			chunkText := sourceFiler nextChunk.
+			chunkText isEmpty
+				ifFalse:
+					[| chunkInstance |
+					chunkInstance := self instanceFor: chunkText.
+					chunkInstance isSeriesStart
+						ifTrue:
+							[| seriesChunkText |
+							seriesChunkText := sourceFiler nextChunk.
+							[seriesChunkText isEmpty]
+								whileFalse:
+									[chunks add: (chunkInstance seriesInstanceFor: seriesChunkText).
+									seriesChunkText := sourceFiler nextChunk]]
+						ifFalse: [chunks add: chunkInstance]]].
+	chunks keysAndValuesDo: [:index :each | each index: index].
+	^chunks!
+
+chunksFromText: aString
+	"Answer a collection of subclasses representing the chunks found in aString"
+
+	^self chunksFromStream: aString readStream!
 
 chunkType
 	self subclassResponsibility!
 
-fromText: aString 
-	^self new initialize: aString!
+instanceFor: aString
+	"Detect the correct class for the chunk in aString and answer an instance of it"
 
-isChunkClassFor: aString 
-	self subclassResponsibility! !
+	^(self chunkClasses
+		detect: [:each | each isChunkClassFor: aString]
+		ifNone: [ChunkBrowserOtherChunk]) newFor: aString!
+
+isChunkClassFor: aString
+	self subclassResponsibility!
+
+newFor: aString
+	"Answer an initialized instance of the receiving chunk class"
+
+	^self new initialize: aString! !
 !ChunkBrowserChunk class categoriesFor: #chunkClasses!constants!public! !
+!ChunkBrowserChunk class categoriesFor: #chunksFromStream:!helpers!public! !
+!ChunkBrowserChunk class categoriesFor: #chunksFromText:!helpers!public! !
 !ChunkBrowserChunk class categoriesFor: #chunkType!accessing!constants!public! !
-!ChunkBrowserChunk class categoriesFor: #fromText:!instance creation!public! !
+!ChunkBrowserChunk class categoriesFor: #instanceFor:!instance creation!public! !
 !ChunkBrowserChunk class categoriesFor: #isChunkClassFor:!public!testing! !
+!ChunkBrowserChunk class categoriesFor: #newFor:!instance creation!public! !
 

--- a/Core/Contributions/IDB/ChunkBrowserClassCategoryChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserClassCategoryChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserCategoryChunk subclass: #ChunkBrowserClassCategoryChunk
 	instanceVariableNames: ''
@@ -8,13 +8,13 @@ ChunkBrowserCategoryChunk subclass: #ChunkBrowserClassCategoryChunk
 ChunkBrowserClassCategoryChunk guid: (GUID fromString: '{D294E534-488E-4BCD-91D7-4F3217AE5669}')!
 ChunkBrowserClassCategoryChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserClassCategoryChunk categoriesForClass!IDB Goodies! !
 !ChunkBrowserClassCategoryChunk methodsFor!
 
-= aChunk 
+= aChunk
 	^super = aChunk and: [rawText = aChunk rawText]!
 
 browseTarget
@@ -24,19 +24,22 @@ hash
 	^super hash bitXor: rawText hash!
 
 isMatch
-	^self identity1AsClass 
-		ifNotNil: 
+	^self identity1AsClass
+		ifNotNil:
 			[:arg | 
 			| categories |
 			categories := arg instanceClass categories collect: [:each | each name].
 			categories anySatisfy: [:each | each = rawText]]!
 
 restore
-	| answer |
-	self identity1AsClass 
-		ifNil: [answer := index -> 'Target class missing']
-		ifNotNil: [:arg | (ClassCategory name: rawText) addClass: arg].
-	^answer! !
+	"Answers nil or the error information"
+
+	^self identity1AsClass
+		ifNil: [index -> 'Target class missing']
+		ifNotNil:
+			[:arg | 
+			(ClassCategory name: rawText) addClass: arg.
+			nil]! !
 !ChunkBrowserClassCategoryChunk categoriesFor: #=!comparing!public! !
 !ChunkBrowserClassCategoryChunk categoriesFor: #browseTarget!operations!public! !
 !ChunkBrowserClassCategoryChunk categoriesFor: #hash!comparing!public! !

--- a/Core/Contributions/IDB/ChunkBrowserClassCategorySeriesStartChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserClassCategorySeriesStartChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserSeriesStartChunk subclass: #ChunkBrowserClassCategorySeriesStartChunk
 	instanceVariableNames: ''
@@ -8,30 +8,24 @@ ChunkBrowserSeriesStartChunk subclass: #ChunkBrowserClassCategorySeriesStartChun
 ChunkBrowserClassCategorySeriesStartChunk guid: (GUID fromString: '{515A3FFC-2D8E-45D5-BAC9-8A44EEA67142}')!
 ChunkBrowserClassCategorySeriesStartChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserClassCategorySeriesStartChunk categoriesForClass!IDB Goodies! !
 !ChunkBrowserClassCategorySeriesStartChunk methodsFor!
 
-initialize: aString 
-	"Abc categoriesForClass"
-
-	super initialize: aString.
-	identity2 := String new!
-
-seriesChunkClass
+seriesClass
 	^ChunkBrowserClassCategoryChunk! !
-!ChunkBrowserClassCategorySeriesStartChunk categoriesFor: #initialize:!initializing!public! !
-!ChunkBrowserClassCategorySeriesStartChunk categoriesFor: #seriesChunkClass!constants!public! !
+!ChunkBrowserClassCategorySeriesStartChunk categoriesFor: #seriesClass!constants!public! !
 
 !ChunkBrowserClassCategorySeriesStartChunk class methodsFor!
 
-isChunkClassFor: aString 
+isChunkClassFor: aString
 	"Abc categoriesForClass"
 
 	| firstSpaceIndex |
-	(firstSpaceIndex := aString indexOf: Character space) = 0 ifTrue: [^false].
-	^(aString indexOfSubCollection: ' categoriesForClass') = firstSpaceIndex! !
+	^(firstSpaceIndex := aString indexOf: Character space) = 0
+		ifTrue: [false]
+		ifFalse: [(aString indexOfSubCollection: ' categoriesForClass') = firstSpaceIndex]! !
 !ChunkBrowserClassCategorySeriesStartChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserClassCommentChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserClassCommentChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassCommentChunk
 	instanceVariableNames: 'comment'
@@ -8,7 +8,7 @@ ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassCommentChunk
 ChunkBrowserClassCommentChunk guid: (GUID fromString: '{58B6BE85-0CF0-46AB-954B-B01E2D5B1C24}')!
 ChunkBrowserClassCommentChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserClassCommentChunk categoriesForClass!IDB Goodies! !
@@ -17,14 +17,14 @@ Public Domain Freeware'!
 browseTarget
 	^self identity1AsClass!
 
-initialize: aString 
+initialize: aString
 	"Abc comment: ''"
 
 	super initialize: aString.
 	identity1 := rawText copyFrom: 1 to: (rawText indexOf: $ ).
-	identity2 := String new.
-	comment := rawText copyFrom: (rawText findFirst: [:each | each = $'])
-				to: (rawText findLast: [:each | each = $'])!
+	comment := rawText
+		copyFrom: (rawText findFirst: [:each | each = $'])
+		to: (rawText findLast: [:each | each = $'])!
 
 isMatch
 	^self identity1AsClass ifNotNil: [:arg | arg instanceClass comment printString = comment]! !
@@ -37,14 +37,14 @@ isMatch
 chunkType
 	^#'Class Comment'!
 
-isChunkClassFor: aString 
+isChunkClassFor: aString
 	"Abc comment: ''''
 	Don't check for trailing space in aString as the change log adds multiple entries for class
 	comments - some delimited with a space but some with a crlf"
 
 	| firstSpaceIndex |
-	(firstSpaceIndex := aString indexOf: Character space) = 0 ifTrue: [^false].
-	^(aString indexOfSubCollection: ' comment:') = firstSpaceIndex! !
+	^(firstSpaceIndex := aString indexOf: Character space) ~= 0
+		and: [(aString indexOfSubCollection: ' comment:') = firstSpaceIndex]! !
 !ChunkBrowserClassCommentChunk class categoriesFor: #chunkType!constants!public! !
 !ChunkBrowserClassCommentChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserClassDefineChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserClassDefineChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassDefineChunk
 	instanceVariableNames: ''
@@ -8,7 +8,7 @@ ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassDefineChunk
 ChunkBrowserClassDefineChunk guid: (GUID fromString: '{9A18662B-ED08-4733-BF8B-C22EDE8994E8}')!
 ChunkBrowserClassDefineChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserClassDefineChunk categoriesForClass!IDB Goodies! !
@@ -20,7 +20,7 @@ browseTarget
 canShowDifferences
 	^self identity1AsClass notNil!
 
-initialize: aString 
+initialize: aString
 	"Abd subclass: #Def instanceVariableNames: ''	classVariableNames: '' poolDictionaries: '' classInstanceVariableNames: ''
 	Abd variableSubclass: #Def instanceVariableNames: ''	classVariableNames: '' poolDictionaries: '' classInstanceVariableNames: ''
 	Abd variableByteSubclass: #Def instanceVariableNames: ''	classVariableNames: '' poolDictionaries: '' classInstanceVariableNames: ''"
@@ -28,14 +28,14 @@ initialize: aString
 	| space1 space2 eol |
 	super initialize: aString.
 	space1 := rawText indexOf: $ .
-	space2 := rawText 
-				nextIndexOf: $ 
-				from: space1 + 1
-				to: rawText size.
-	eol := rawText 
-				nextIndexOf: String lineDelimiter first
-				from: space2 + 1
-				to: rawText size.
+	space2 := rawText
+		nextIndexOf: $ 
+		from: space1 + 1
+		to: rawText size.
+	eol := rawText
+		nextIndexOf: String lineDelimiter first
+		from: space2 + 1
+		to: rawText size.
 	identity1 := rawText copyFrom: space2 + 2 to: eol - 1.
 	identity2 := rawText copyFrom: 1 to: space1 - 1!
 
@@ -45,31 +45,33 @@ isMatch
 restore
 	^self restoreAndLog: true!
 
-sourceText
+sourceFromImage
 	^self identity1AsClass instanceClass definition! !
 !ChunkBrowserClassDefineChunk categoriesFor: #browseTarget!operations!public! !
 !ChunkBrowserClassDefineChunk categoriesFor: #canShowDifferences!public!testing! !
 !ChunkBrowserClassDefineChunk categoriesFor: #initialize:!initializing!public! !
 !ChunkBrowserClassDefineChunk categoriesFor: #isMatch!public!testing! !
 !ChunkBrowserClassDefineChunk categoriesFor: #restore!operations!public! !
-!ChunkBrowserClassDefineChunk categoriesFor: #sourceText!accessing!public! !
+!ChunkBrowserClassDefineChunk categoriesFor: #sourceFromImage!accessing!public! !
 
 !ChunkBrowserClassDefineChunk class methodsFor!
 
 chunkType
 	^#'Class Define'!
 
-isChunkClassFor: aString 
+isChunkClassFor: aString
 	"Abd subclass: #Def instanceVariableNames: ''	classVariableNames: '' poolDictionaries: '' classInstanceVariableNames: ''
 	Abd variableSubclass: #Def instanceVariableNames: ''	classVariableNames: '' poolDictionaries: '' classInstanceVariableNames: ''
 	Abd variableByteSubclass: #Def instanceVariableNames: ''	classVariableNames: '' poolDictionaries: '' classInstanceVariableNames: ''"
 
 	| firstSpaceIndex |
-	(firstSpaceIndex := aString indexOf: Character space) = 0 ifTrue: [^false].
-	^(#(' subclass: ' ' variableSubclass: ' ' variableByteSubclass: ') 
-		anySatisfy: [:each | (aString indexOfSubCollection: each) = firstSpaceIndex]) and: 
-				[#('instanceVariableNames: ' 'classVariableNames: ' 'poolDictionaries: ' 'classInstanceVariableNames: ') 
-					allSatisfy: [:each | (aString indexOfSubCollection: each) ~= 0]]! !
+	^(firstSpaceIndex := aString indexOf: Character space) ~= 0
+		and:
+			[(#(' subclass: ' ' variableSubclass: ' ' variableByteSubclass: ')
+				anySatisfy: [:each | (aString indexOfSubCollection: each) = firstSpaceIndex])
+				and:
+					[#('instanceVariableNames: ' 'classVariableNames: ' 'poolDictionaries: ' 'classInstanceVariableNames: ')
+						allSatisfy: [:each | (aString indexOfSubCollection: each) ~= 0]]]! !
 !ChunkBrowserClassDefineChunk class categoriesFor: #chunkType!constants!public! !
 !ChunkBrowserClassDefineChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserClassDeleteChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserClassDeleteChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassDeleteChunk
 	instanceVariableNames: ''
@@ -8,7 +8,7 @@ ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassDeleteChunk
 ChunkBrowserClassDeleteChunk guid: (GUID fromString: '{36C693CE-1906-4999-9626-62D3460757FB}')!
 ChunkBrowserClassDeleteChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserClassDeleteChunk categoriesForClass!IDB Goodies! !
@@ -17,12 +17,11 @@ Public Domain Freeware'!
 browseTarget
 	^self identity1AsClass!
 
-initialize: aString 
+initialize: aString
 	"Abcd removeFromSystem"
 
 	super initialize: aString.
-	identity1 := rawText copyFrom: 1 to: (rawText indexOf: $ ).
-	identity2 := String new!
+	identity1 := rawText copyFrom: 1 to: (rawText indexOf: $ )!
 
 isMatch
 	^self identity1AsClass isNil! !
@@ -35,12 +34,12 @@ isMatch
 chunkType
 	^#'Class Delete'!
 
-isChunkClassFor: aString 
+isChunkClassFor: aString
 	"Abcd removeFromSystem"
 
 	| firstSpaceIndex |
-	(firstSpaceIndex := aString indexOf: Character space) = 0 ifTrue: [^false].
-	^(aString indexOfSubCollection: ' removeFromSystem') = firstSpaceIndex! !
+	^(firstSpaceIndex := aString indexOf: Character space) ~= 0
+		and: [(aString indexOfSubCollection: ' removeFromSystem') = firstSpaceIndex]! !
 !ChunkBrowserClassDeleteChunk class categoriesFor: #chunkType!constants!public! !
 !ChunkBrowserClassDeleteChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserClassGUIDChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserClassGUIDChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassGUIDChunk
 	instanceVariableNames: 'id'
@@ -8,7 +8,7 @@ ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassGUIDChunk
 ChunkBrowserClassGUIDChunk guid: (GUID fromString: '{9B98323B-E586-4209-A7BC-11EAF78617B6}')!
 ChunkBrowserClassGUIDChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserClassGUIDChunk categoriesForClass!IDB Goodies! !
@@ -17,16 +17,16 @@ Public Domain Freeware'!
 browseTarget
 	^self identity1AsClass!
 
-initialize: aString 
+initialize: aString
 	"Abc guid: (GUID fromString: '{6AA41459-4B33-412A-95A7-261C78522521}'
 	Abc guid: (IID fromString: '{6AA41459-4B33-412A-95A7-261C78522521}'
 	Abc guid: (CLSID fromString: '{6AA41459-4B33-412A-95A7-261C78522521}'"
 
 	super initialize: aString.
 	identity1 := rawText copyFrom: 1 to: (rawText indexOf: $ ).
-	identity2 := String new.
-	id := rawText copyFrom: (rawText findFirst: [:each | each = $']) + 1
-				to: (rawText findLast: [:each | each = $']) - 1!
+	id := rawText
+		copyFrom: (rawText findFirst: [:each | each = $']) + 1
+		to: (rawText findLast: [:each | each = $']) - 1!
 
 isMatch
 	^self identity1AsClass ifNotNil: [:arg | arg instanceClass guid asString = id]! !
@@ -39,16 +39,18 @@ isMatch
 chunkType
 	^#'Class GUID'!
 
-isChunkClassFor: aString 
+isChunkClassFor: aString
 	"Abc guid: (GUID fromString: '{6AA41459-4B33-412A-95A7-261C78522521}'
 	Abc guid: (IID fromString: '{6AA41459-4B33-412A-95A7-261C78522521}'
 	Abc guid: (CLSID fromString: '{6AA41459-4B33-412A-95A7-261C78522521}'"
 
 	| firstSpaceIndex |
-	(firstSpaceIndex := aString indexOf: Character space) = 0 ifTrue: [^false].
-	^(aString indexOfSubCollection: ' guid: (GUID fromString: ''{') = firstSpaceIndex or: 
-			[(aString indexOfSubCollection: ' guid: (IID fromString: ''{') = firstSpaceIndex 
-				or: [(aString indexOfSubCollection: ' guid: (CLSID fromString: ''{') = firstSpaceIndex]]! !
+	^(firstSpaceIndex := aString indexOf: Character space) ~= 0
+		and:
+			[(aString indexOfSubCollection: ' guid: (GUID fromString: ''{') = firstSpaceIndex
+				or:
+					[(aString indexOfSubCollection: ' guid: (IID fromString: ''{') = firstSpaceIndex
+						or: [(aString indexOfSubCollection: ' guid: (CLSID fromString: ''{') = firstSpaceIndex]]]! !
 !ChunkBrowserClassGUIDChunk class categoriesFor: #chunkType!constants!public! !
 !ChunkBrowserClassGUIDChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserClassProtocolChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserClassProtocolChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassProtocolChunk
 	instanceVariableNames: 'attributes selectors'
@@ -8,7 +8,7 @@ ChunkBrowserExpressionChunk subclass: #ChunkBrowserClassProtocolChunk
 ChunkBrowserClassProtocolChunk guid: (GUID fromString: '{C8986897-7417-46B9-A404-28A5AB21EA14}')!
 ChunkBrowserClassProtocolChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserClassProtocolChunk categoriesForClass!IDB Goodies! !
@@ -17,7 +17,7 @@ Public Domain Freeware'!
 browseTarget
 	^self identity1AsClass!
 
-initialize: aString 
+initialize: aString
 	"Abc methodProtocol: aSymbol attributes: anArrayOfSymbols selectors: anArrayOfSymbols
 	Abc class methodProtocol: aSymbol attributes: anArrayOfSymbols selectors: anArrayOfSymbols"
 
@@ -28,20 +28,19 @@ initialize: aString
 	target2 := aString indexOfSubCollection: 'attributes:'.
 	target3 := aString indexOfSubCollection: 'selectors:'.
 	identity2 := ((aString copyFrom: target1 to: target2 - 1) copyWithoutAll: '#''') trimBlanks.
-	attributes := ((aString copyFrom: target2 + 'attributes:' size to: target3 - 1) 
-				copyWithoutAll: '#()') trimBlanks 
-				subStrings collect: [:each | each asSymbol].
-	selectors := ((aString copyFrom: target3 + 'selectors:' size to: aString size) 
-				copyWithoutAll: '#()') trimBlanks 
-				subStrings collect: [:each | each asSymbol]!
+	attributes := ((aString copyFrom: target2 + 'attributes:' size to: target3 - 1)
+		copyWithoutAll: '#()') trimBlanks subStrings collect: [:each | each asSymbol].
+	selectors := ((aString copyFrom: target3 + 'selectors:' size to: aString size)
+		copyWithoutAll: '#()') trimBlanks subStrings collect: [:each | each asSymbol]!
 
 isMatch
-	^self identity1AsClass 
-		ifNotNil: 
-			[(MethodProtocol exists: identity2) and: 
+	^self identity1AsClass
+		ifNotNil:
+			[(MethodProtocol exists: identity2)
+				and:
 					[| protocol |
 					protocol := MethodProtocol name: identity2.
-					(protocol selectors symmetricDifference: selectors) isEmpty 
+					(protocol selectors symmetricDifference: selectors) isEmpty
 						and: [(protocol attributes symmetricDifference: attributes) isEmpty]]]! !
 !ChunkBrowserClassProtocolChunk categoriesFor: #browseTarget!operations!public! !
 !ChunkBrowserClassProtocolChunk categoriesFor: #initialize:!initializing!public! !
@@ -52,14 +51,15 @@ isMatch
 chunkType
 	^#'Class Protocol'!
 
-isChunkClassFor: aString 
+isChunkClassFor: aString
 	"Abc methodProtocol: aSymbol attributes: anArrayOfSymbols selectors: anArrayOfSymbols
 	Abc class methodProtocol: aSymbol attributes: anArrayOfSymbols selectors: anArrayOfSymbols"
 
 	| firstSpaceIndex |
-	(firstSpaceIndex := aString indexOf: Character space) = 0 ifTrue: [^false].
-	^#(' methodProtocol: #' ' class methodProtocol: #') 
-		anySatisfy: [:each | (aString indexOfSubCollection: each) = firstSpaceIndex]! !
+	^(firstSpaceIndex := aString indexOf: Character space) ~= 0
+		and:
+			[#(' methodProtocol: #' ' class methodProtocol: #')
+				anySatisfy: [:each | (aString indexOfSubCollection: each) = firstSpaceIndex]]! !
 !ChunkBrowserClassProtocolChunk class categoriesFor: #chunkType!constants!public! !
 !ChunkBrowserClassProtocolChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserExpressionChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserExpressionChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserChunk subclass: #ChunkBrowserExpressionChunk
 	instanceVariableNames: ''
@@ -8,7 +8,7 @@ ChunkBrowserChunk subclass: #ChunkBrowserExpressionChunk
 ChunkBrowserExpressionChunk guid: (GUID fromString: '{0F9C053E-F249-49B6-9DA5-FCECE45BE89F}')!
 ChunkBrowserExpressionChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserExpressionChunk categoriesForClass!IDB Goodies! !
@@ -19,10 +19,13 @@ restore
 
 	^self restoreAndLog: false!
 
-restoreAndLog: aBoolean 
+restoreAndLog: aBoolean
+	"Answers nil or the error information"
+
 	| answer |
-	[Compiler evaluate: self rawText logged: aBoolean] on: CompilerNotification
-		do: 
+	[Compiler evaluate: self rawText logged: aBoolean]
+		on: CompilerNotification
+		do:
 			[:e | 
 			answer := index -> e errorMessage.
 			e resume].

--- a/Core/Contributions/IDB/ChunkBrowserFilter.cls
+++ b/Core/Contributions/IDB/ChunkBrowserFilter.cls
@@ -8,19 +8,19 @@ Model subclass: #ChunkBrowserFilter
 ChunkBrowserFilter guid: (GUID fromString: '{CCA89E53-EEE3-495A-915F-463F69C7009A}')!
 ChunkBrowserFilter comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserFilter categoriesForClass!IDB Goodies! !
 !ChunkBrowserFilter methodsFor!
 
 chunkSelectAll
-	selectedChunkTypes := #(#'Class Category' #'Class Comment' #'Class Define' #'Class Delete' #'Class GUID' #'Class Protocol' #'Method Category' #'Method Define' #'Method Delete' #System #Other) 
-				asSet!
+	selectedChunkTypes := #(#'Class Category' #'Class Comment' #'Class Define' #'Class Delete' #'Class GUID' #'Class Protocol' #'Method Category' #'Method Define' #'Method Delete' #System #Other)
+		asSet!
 
 chunkSelectDefault
 	selectedChunkTypes := Set new.
-	ChunkBrowser chunkTypeSelection 
+	ChunkBrowser chunkTypeSelection
 		keysAndValuesDo: [:key :value | value ifTrue: [selectedChunkTypes add: key]]!
 
 chunkSelectNone
@@ -31,22 +31,21 @@ initialize
 	self chunkSelectDefault.
 	selectedComparisonTypes := #(#Match #Differ #Missing) asSet.
 	restrictionRange := restrictionClass := nil.
-	restrictingMostRecent := false.
-	restrictingPicked := false!
+	restrictingMostRecent := restrictingPicked := false!
 
-isChunkTypeSelected: aSymbol 
+isChunkTypeSelected: aSymbol
 	^selectedChunkTypes includes: aSymbol!
 
 isCompareNeeded
 	^selectedComparisonTypes size ~= 3!
 
-isComparisonTypeSelected: aSymbol 
+isComparisonTypeSelected: aSymbol
 	^selectedComparisonTypes includes: aSymbol!
 
-isInRestrictionClass: aSymbol 
+isInRestrictionClass: aSymbol
 	^self isRestrictingClass not or: [restrictionClass == aSymbol]!
 
-isInRestrictionRange: anInteger 
+isInRestrictionRange: anInteger
 	^self isRestrictingRange not or: [restrictionRange includes: anInteger]!
 
 isRestrictingClass
@@ -61,10 +60,10 @@ isRestrictingPicked
 isRestrictingRange
 	^restrictionRange notNil!
 
-restrictionClass: aSymbolOrNil 
+restrictionClass: aSymbolOrNil
 	restrictionClass := aSymbolOrNil!
 
-restrictionRange: aRangeOrNil 
+restrictionRange: aRangeOrNil
 	restrictionRange := aRangeOrNil!
 
 restrictionRangeFirst
@@ -76,13 +75,13 @@ restrictionRangeLast
 restrictionRangeSize
 	^restrictionRange size!
 
-toggleChunkType: aSymbol 
-	(self isChunkTypeSelected: aSymbol) 
+toggleChunkType: aSymbol
+	(self isChunkTypeSelected: aSymbol)
 		ifTrue: [selectedChunkTypes remove: aSymbol]
 		ifFalse: [selectedChunkTypes add: aSymbol]!
 
-toggleComparisonType: aSymbol 
-	(self isComparisonTypeSelected: aSymbol) 
+toggleComparisonType: aSymbol
+	(self isComparisonTypeSelected: aSymbol)
 		ifTrue: [selectedComparisonTypes remove: aSymbol]
 		ifFalse: [selectedComparisonTypes add: aSymbol]!
 

--- a/Core/Contributions/IDB/ChunkBrowserMethodCategoryChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserMethodCategoryChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserCategoryChunk subclass: #ChunkBrowserMethodCategoryChunk
 	instanceVariableNames: ''
@@ -8,7 +8,7 @@ ChunkBrowserCategoryChunk subclass: #ChunkBrowserMethodCategoryChunk
 ChunkBrowserMethodCategoryChunk guid: (GUID fromString: '{9D242F9C-C429-483D-848B-80FBC1B52DB7}')!
 ChunkBrowserMethodCategoryChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserMethodCategoryChunk categoriesForClass!IDB Goodies! !
@@ -18,19 +18,22 @@ browseTarget
 	^self identity1AndIdentity2AsCompiledMethod!
 
 isMatch
-	^self identity1AndIdentity2AsCompiledMethod 
-		ifNotNil: 
+	^self identity1AndIdentity2AsCompiledMethod
+		ifNotNil:
 			[:arg | 
 			| categories |
 			categories := arg categories collect: [:each | each name].
 			categories anySatisfy: [:each | each = rawText]]!
 
 restore
-	| answer |
-	self identity1AndIdentity2AsCompiledMethod 
-		ifNil: [answer := index -> 'Target class or method missing']
-		ifNotNil: [:arg | (MethodCategory name: rawText) addMethod: arg].
-	^answer! !
+	"Answers nil or the error information"
+
+	^self identity1AndIdentity2AsCompiledMethod
+		ifNil: [index -> 'Target class or method missing']
+		ifNotNil:
+			[:arg | 
+			(MethodCategory name: rawText) addMethod: arg.
+			nil]! !
 !ChunkBrowserMethodCategoryChunk categoriesFor: #browseTarget!operations!public! !
 !ChunkBrowserMethodCategoryChunk categoriesFor: #isMatch!public!testing! !
 !ChunkBrowserMethodCategoryChunk categoriesFor: #restore!operations!public! !

--- a/Core/Contributions/IDB/ChunkBrowserMethodCategorySeriesStartChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserMethodCategorySeriesStartChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserSeriesStartChunk subclass: #ChunkBrowserMethodCategorySeriesStartChunk
 	instanceVariableNames: ''
@@ -8,31 +8,33 @@ ChunkBrowserSeriesStartChunk subclass: #ChunkBrowserMethodCategorySeriesStartChu
 ChunkBrowserMethodCategorySeriesStartChunk guid: (GUID fromString: '{F8439B0F-CAEC-4C70-81AC-875F0941E0D9}')!
 ChunkBrowserMethodCategorySeriesStartChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserMethodCategorySeriesStartChunk categoriesForClass!IDB Goodies! !
 !ChunkBrowserMethodCategorySeriesStartChunk methodsFor!
 
-initialize: aString 
+initialize: aString
 	"'Abc categoriesFor: #abc' or 'Abc class categoriesFor: #abc'"
 
 	super initialize: aString.
 	identity2 := aString copyFrom: (aString indexOf: $#) + 1!
 
-seriesChunkClass
+seriesClass
 	^ChunkBrowserMethodCategoryChunk! !
 !ChunkBrowserMethodCategorySeriesStartChunk categoriesFor: #initialize:!initializing!public! !
-!ChunkBrowserMethodCategorySeriesStartChunk categoriesFor: #seriesChunkClass!constants!public! !
+!ChunkBrowserMethodCategorySeriesStartChunk categoriesFor: #seriesClass!constants!public! !
 
 !ChunkBrowserMethodCategorySeriesStartChunk class methodsFor!
 
-isChunkClassFor: aString 
+isChunkClassFor: aString
 	"'Abc categoriesFor: #abc' or 'Abc class categoriesFor: #abc'"
 
 	| firstSpaceIndex |
-	(firstSpaceIndex := aString indexOf: Character space) = 0 ifTrue: [^false].
-	^(aString indexOfSubCollection: ' categoriesFor: #') = firstSpaceIndex 
-		or: [(aString indexOfSubCollection: ' class categoriesFor: #') = firstSpaceIndex]! !
+	^(firstSpaceIndex := aString indexOf: Character space) = 0
+		ifTrue: [false]
+		ifFalse:
+			[(aString indexOfSubCollection: ' categoriesFor: #') = firstSpaceIndex
+				or: [(aString indexOfSubCollection: ' class categoriesFor: #') = firstSpaceIndex]]! !
 !ChunkBrowserMethodCategorySeriesStartChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserMethodDefineChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserMethodDefineChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserSeriesChunk subclass: #ChunkBrowserMethodDefineChunk
 	instanceVariableNames: ''
@@ -8,7 +8,7 @@ ChunkBrowserSeriesChunk subclass: #ChunkBrowserMethodDefineChunk
 ChunkBrowserMethodDefineChunk guid: (GUID fromString: '{1F404FDA-A397-4D69-B6AF-F3BC30E06DF4}')!
 ChunkBrowserMethodDefineChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserMethodDefineChunk categoriesForClass!IDB Goodies! !
@@ -20,42 +20,63 @@ browseTarget
 canShowDifferences
 	^self identity1AndIdentity2AsCompiledMethod notNil!
 
-initializeFrom: aChunkBrowserSeriesStartChunk 
-	super initializeFrom: aChunkBrowserSeriesStartChunk.
+initializeFromSeriesStart: aChunkBrowserSeriesStartChunk
+	super initializeFromSeriesStart: aChunkBrowserSeriesStartChunk.
 	identity2 := SelectorParser parse: rawText!
 
 isMatch
-	^self identity1AndIdentity2AsCompiledMethod 
-		ifNotNil: 
-			[:arg | 
-			arg getSource = rawText or: 
-					[ChunkBrowser compareMethodsUsingParser and: 
-							[arg parseTree = (SmalltalkParser 
-										parseMethod: rawText
-										in: self identity1AsClass
-										onError: [:aString :pos | ^nil])]]]!
+	"Answers nil if no comparison is possible, true if the current image matches the chunk and
+	false if it doesn't. If the source code is not identical then it has the option of a further
+	test for equality using a parse tree"
+
+	| compiledMethod currentTree chunkTree |
+	compiledMethod := self identity1AndIdentity2AsCompiledMethod.
+	compiledMethod
+		ifNil:
+			["unable to compare as method not available"
+			^nil].
+	compiledMethod getSource = rawText
+		ifTrue:
+			["chunk source is the same as image so must match"
+			^true].
+	ChunkBrowser compareMethodsUsingParser
+		ifFalse:
+			["don't want to compare using parser and the sources differs"
+			^false].
+	(currentTree := compiledMethod parseTreeNoError)
+		ifNil:
+			["failed to parse current and sources differs"
+			^false].
+	(chunkTree := SmalltalkParser parseMethod: rawText in: self identity1AsClass)
+		ifNil:
+			["failed to parse chunk and source differs"
+			^false].
+	^currentTree = chunkTree!
 
 restore
-	| answer |
-	self identity1AsClass 
-		ifNil: [answer := index -> 'Target class missing']
-		ifNotNil: 
+	"Answers nil or the error information"
+
+	self identity1AsClass
+		ifNil: [^index -> 'Target class missing']
+		ifNotNil:
 			[:arg | 
-			[arg compile: self rawText] on: CompilerNotification
-				do: 
+			| answer |
+			[arg compile: self rawText]
+				on: CompilerNotification
+				do:
 					[:e | 
 					answer := index -> e errorMessage.
-					e resume]].
-	^answer!
+					e resume].
+			^answer]!
 
-sourceText
+sourceFromImage
 	^self identity1AndIdentity2AsCompiledMethod getSource! !
 !ChunkBrowserMethodDefineChunk categoriesFor: #browseTarget!operations!public! !
 !ChunkBrowserMethodDefineChunk categoriesFor: #canShowDifferences!public!testing! !
-!ChunkBrowserMethodDefineChunk categoriesFor: #initializeFrom:!initializing!public! !
+!ChunkBrowserMethodDefineChunk categoriesFor: #initializeFromSeriesStart:!initializing!public! !
 !ChunkBrowserMethodDefineChunk categoriesFor: #isMatch!public!testing! !
 !ChunkBrowserMethodDefineChunk categoriesFor: #restore!operations!public! !
-!ChunkBrowserMethodDefineChunk categoriesFor: #sourceText!accessing!public! !
+!ChunkBrowserMethodDefineChunk categoriesFor: #sourceFromImage!accessing!public! !
 
 !ChunkBrowserMethodDefineChunk class methodsFor!
 

--- a/Core/Contributions/IDB/ChunkBrowserMethodDefineSeriesStartChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserMethodDefineSeriesStartChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserSeriesStartChunk subclass: #ChunkBrowserMethodDefineSeriesStartChunk
 	instanceVariableNames: ''
@@ -8,31 +8,26 @@ ChunkBrowserSeriesStartChunk subclass: #ChunkBrowserMethodDefineSeriesStartChunk
 ChunkBrowserMethodDefineSeriesStartChunk guid: (GUID fromString: '{D788A393-1FE6-4B1B-AE26-CFBAC04DB82A}')!
 ChunkBrowserMethodDefineSeriesStartChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserMethodDefineSeriesStartChunk categoriesForClass!IDB Goodies! !
 !ChunkBrowserMethodDefineSeriesStartChunk methodsFor!
 
-initialize: aString 
-	"'Abc methodsFor' or 'Abc class methodsFor'"
-
-	super initialize: aString.
-	identity2 := String new!
-
-seriesChunkClass
+seriesClass
 	^ChunkBrowserMethodDefineChunk! !
-!ChunkBrowserMethodDefineSeriesStartChunk categoriesFor: #initialize:!initializing!public! !
-!ChunkBrowserMethodDefineSeriesStartChunk categoriesFor: #seriesChunkClass!constants!public! !
+!ChunkBrowserMethodDefineSeriesStartChunk categoriesFor: #seriesClass!constants!public! !
 
 !ChunkBrowserMethodDefineSeriesStartChunk class methodsFor!
 
-isChunkClassFor: aString 
+isChunkClassFor: aString
 	"'Abc methodsFor' or 'Abc class methodsFor'"
 
 	| firstSpaceIndex |
-	(firstSpaceIndex := aString indexOf: Character space) = 0 ifTrue: [^false].
-	^(aString indexOfSubCollection: ' methodsFor') = firstSpaceIndex 
-		or: [(aString indexOfSubCollection: ' class methodsFor') = firstSpaceIndex]! !
+	^(firstSpaceIndex := aString indexOf: Character space) = 0
+		ifTrue: [false]
+		ifFalse:
+			[(aString indexOfSubCollection: ' methodsFor') = firstSpaceIndex
+				or: [(aString indexOfSubCollection: ' class methodsFor') = firstSpaceIndex]]! !
 !ChunkBrowserMethodDefineSeriesStartChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserMethodDeleteChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserMethodDeleteChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserExpressionChunk subclass: #ChunkBrowserMethodDeleteChunk
 	instanceVariableNames: ''
@@ -8,7 +8,7 @@ ChunkBrowserExpressionChunk subclass: #ChunkBrowserMethodDeleteChunk
 ChunkBrowserMethodDeleteChunk guid: (GUID fromString: '{DEB9428A-51F1-4A3F-A73F-D6CB2C444D99}')!
 ChunkBrowserMethodDeleteChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserMethodDeleteChunk categoriesForClass!IDB Goodies! !
@@ -20,15 +20,15 @@ browseTarget
 identity1AndIdentity2AsCompiledMethod
 	"Overridden for browse"
 
-	^self identity1AsClass 
-		ifNotNil: 
+	^self identity1AsClass
+		ifNotNil:
 			[:arg | 
 			| selectors |
 			selectors := identity2 subStrings.
-			(selectors notEmpty and: [arg includesSelector: selectors first asSymbol]) 
+			(selectors notEmpty and: [arg includesSelector: selectors first asSymbol])
 				ifTrue: [arg compiledMethodAt: selectors first asSymbol]]!
 
-initialize: aString 
+initialize: aString
 	"	ClassName removeSelector: #SelectorSymbol
 		ClassName class removeSelector: #SelectorSymbol
 		ClassName removeSelector: #SelectorSymbol ifAbsent: []
@@ -40,29 +40,31 @@ initialize: aString
 	super initialize: aString.
 	identity1 := self classNameFromRawText.
 	hashIndex := aString indexOf: $#.
-	identity2 := (aString indexOfSubCollection: #removeSelectors:) == 0 
-				ifTrue: 
-					[| stop |
-					stop := aString 
-								nextIndexOf: Character space
-								from: hashIndex
-								to: aString size.
-					aString copyFrom: hashIndex + 1 to: (stop == 0 ifTrue: [aString size] ifFalse: [stop])]
-				ifFalse: 
-					[(aString copyFrom: hashIndex + 1
-						to: (aString 
-								nextIndexOf: $)
-								from: hashIndex
-								to: aString size)) 
-							copyWithoutAll: '#()'].
+	identity2 := (aString indexOfSubCollection: #removeSelectors:) == 0
+		ifTrue:
+			[| stop |
+			stop := aString
+				nextIndexOf: Character space
+				from: hashIndex
+				to: aString size.
+			aString copyFrom: hashIndex + 1 to: (stop == 0 ifTrue: [aString size] ifFalse: [stop])]
+		ifFalse:
+			[(aString
+				copyFrom: hashIndex + 1
+				to:
+					(aString
+						nextIndexOf: $)
+						from: hashIndex
+						to: aString size)) copyWithoutAll: '#()'].
 	identity2 := identity2 trimBlanks	"PE/27/05/2004: remove trailing blank (thanks Pieter)"!
 
 isMatch
 	"Answer true if class missing as the method must be deleted?"
 
-	^self identity1AsClass 
+	^self identity1AsClass
 		ifNil: [true]
-		ifNotNil: [:arg | (identity2 subStrings anySatisfy: [:each | arg includesSelector: each asSymbol]) not]! !
+		ifNotNil:
+			[:arg | (identity2 subStrings anySatisfy: [:each | arg includesSelector: each asSymbol]) not]! !
 !ChunkBrowserMethodDeleteChunk categoriesFor: #browseTarget!operations!public! !
 !ChunkBrowserMethodDeleteChunk categoriesFor: #identity1AndIdentity2AsCompiledMethod!helpers!public! !
 !ChunkBrowserMethodDeleteChunk categoriesFor: #initialize:!initializing!public! !
@@ -73,7 +75,7 @@ isMatch
 chunkType
 	^#'Method Delete'!
 
-isChunkClassFor: aString 
+isChunkClassFor: aString
 	"	ClassName removeSelector: #SelectorSymbol
 		ClassName class removeSelector: #SelectorSymbol
 		ClassName removeSelector: #SelectorSymbol ifAbsent: []
@@ -82,9 +84,10 @@ isChunkClassFor: aString
 		ClassName class removeSelectors: #(SelectorSymbols)"
 
 	| firstSpaceIndex |
-	(firstSpaceIndex := aString indexOf: Character space) = 0 ifTrue: [^false].
-	^#(' removeSelector: #' ' class removeSelector: #' ' removeSelectors: #(' ' class removeSelectors: #(') 
-		anySatisfy: [:each | (aString indexOfSubCollection: each) = firstSpaceIndex]! !
+	^(firstSpaceIndex := aString indexOf: Character space) ~= 0
+		and:
+			[#(' removeSelector: #' ' class removeSelector: #' ' removeSelectors: #(' ' class removeSelectors: #(')
+				anySatisfy: [:each | (aString indexOfSubCollection: each) = firstSpaceIndex]]! !
 !ChunkBrowserMethodDeleteChunk class categoriesFor: #chunkType!constants!public! !
 !ChunkBrowserMethodDeleteChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserModel.cls
+++ b/Core/Contributions/IDB/ChunkBrowserModel.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 Model subclass: #ChunkBrowserModel
 	instanceVariableNames: 'chunks'
@@ -8,102 +8,25 @@ Model subclass: #ChunkBrowserModel
 ChunkBrowserModel guid: (GUID fromString: '{806C497C-FE7E-440D-A6EB-4E4AE9D6ACED}')!
 ChunkBrowserModel comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserModel categoriesForClass!IDB Goodies! !
 !ChunkBrowserModel methodsFor!
 
+chunkClass
+	^ChunkBrowserChunk!
+
 chunkCount
 	^chunks size!
 
-decodeChunkFromText: aString 
-	| chunkClass |
-	chunkClass := ChunkBrowserChunk chunkClasses detect: [:each | each isChunkClassFor: aString]
-				ifNone: [ChunkBrowserOtherChunk].
-	^chunkClass fromText: aString!
-
-fileInChunkSeriesFrom: aChunkSourceFiler after: aChunk 
-	| chunk chunkSeries |
-	chunkSeries := OrderedCollection new.
-	chunk := aChunkSourceFiler nextChunk.
-	[chunk isEmpty] whileFalse: 
-			[chunkSeries add: (aChunk seriesChunk: chunk).
-			chunk := aChunkSourceFiler nextChunk].
-	^chunkSeries!
-
-fileInChunksFrom: aStream 
-	| chunksLoaded sourceFiler |
-	chunksLoaded := OrderedCollection new.
-	sourceFiler := ChunkSourceFiler on: aStream.
-	[aStream atEnd] whileFalse: 
-			[| chunkSource |
-			chunkSource := sourceFiler nextChunk.
-			chunkSource isEmpty 
-				ifFalse: 
-					[| chunk |
-					chunk := self decodeChunkFromText: chunkSource.
-					chunk isChunkSeriesStart 
-						ifTrue: [chunksLoaded addAll: (self fileInChunkSeriesFrom: sourceFiler after: chunk)]
-						ifFalse: [chunksLoaded add: chunk]]].
-	chunksLoaded keysAndValuesDo: [:index :each | each index: index].
-	^chunksLoaded!
-
-fileOpen: aString 
-	| stream |
-	stream := FileStream read: aString.
-	[self fromStream: stream] ensure: [stream close]!
-
-fileOpenPatch: aString 
-	"Dolphin LiveUpdate file.
-	Assumes 6 chunks, the first 5 contain information about the patch and
-	the sixth contains all the new sorce code"
-
-	| stream |
-	stream := FileStream read: aString.
-	
-	[| loadedChunks sourceChunks |
-	loadedChunks := self fileInChunksFrom: stream.
-	self assert: [loadedChunks size = 6].
-	sourceChunks := self fileInChunksFrom: (loadedChunks at: 6) rawText readStream.
-	sourceChunks do: [:each | each index: each index + 5].
-	chunks := (loadedChunks copyFrom: 1 to: 5) , sourceChunks] 
-			ensure: [stream close]!
-
-filteredChunksUsing: aChunkBrowserFilter 
+filteredUsing: aChunkBrowserFilter
 	| filtered mostRecent |
-	filtered := OrderedCollection new.
+	filtered := chunks select: [:each | each isFilteredUsing: aChunkBrowserFilter].
+	aChunkBrowserFilter isRestrictingMostRecent ifFalse: [^filtered asSortedCollection].
 	mostRecent := Set new.
-	chunks do: 
-			[:each | 
-			(each filterUsing: aChunkBrowserFilter) 
-				ifTrue: 
-					[filtered add: each.
-					aChunkBrowserFilter isRestrictingMostRecent 
-						ifTrue: 
-							[(mostRecent includes: each) ifTrue: [mostRecent remove: each].
-							mostRecent add: each]]].
-	^(aChunkBrowserFilter isRestrictingMostRecent ifTrue: [mostRecent] ifFalse: [filtered]) 
-		asSortedCollection!
-
-filterUsing: aChunkBrowserFilter 
-	| filtered mostRecent |
-	filtered := OrderedCollection new.
-	mostRecent := Set new.
-	chunks do: 
-			[:each | 
-			(each filterUsing: aChunkBrowserFilter) 
-				ifTrue: 
-					[filtered add: each.
-					aChunkBrowserFilter isRestrictingMostRecent 
-						ifTrue: 
-							[(mostRecent includes: each) ifTrue: [mostRecent remove: each].
-							mostRecent add: each]]].
-	^(aChunkBrowserFilter isRestrictingMostRecent ifTrue: [mostRecent] ifFalse: [filtered]) 
-		asSortedCollection!
-
-fromStream: aStream 
-	chunks := self fileInChunksFrom: aStream!
+	filtered reverseDo: [:each | (mostRecent includes: each) ifFalse: [mostRecent add: each]].
+	^mostRecent asSortedCollection!
 
 hasAnyChunksPicked
 	^chunks anySatisfy: [:each | each picked]!
@@ -121,24 +44,39 @@ initialize
 	super initialize.
 	chunks := OrderedCollection new!
 
+loadFromFile: aString
+	| stream |
+	stream := FileStream read: aString.
+	chunks := [self chunkClass chunksFromStream: stream] ensure: [stream close]!
+
+loadFromPatchFile: aString
+	"Dolphin LiveUpdate file.
+	Assumes 6 chunks, the first 5 contain information about the patch and
+	the sixth contains all the new source code"
+
+	self loadFromFile: aString.
+	chunks size = 6 ifFalse: [^MessageBox notify: 'Not a patch file'].
+	chunks addAll: (self chunkClass chunksFromText: chunks removeLast rawText).
+	chunks keysAndValuesDo: [:index :each | each index: index]!
+
+loadFromText: aString
+	chunks := self chunkClass chunksFromText: aString!
+
 pickedChunks
 	^chunks select: [:each | each picked]!
 
 unpickAll
 	chunks do: [:each | each picked: false]! !
+!ChunkBrowserModel categoriesFor: #chunkClass!accessing!public! !
 !ChunkBrowserModel categoriesFor: #chunkCount!helpers!public! !
-!ChunkBrowserModel categoriesFor: #decodeChunkFromText:!operations!public! !
-!ChunkBrowserModel categoriesFor: #fileInChunkSeriesFrom:after:!operations!public! !
-!ChunkBrowserModel categoriesFor: #fileInChunksFrom:!operations!public! !
-!ChunkBrowserModel categoriesFor: #fileOpen:!operations!public! !
-!ChunkBrowserModel categoriesFor: #fileOpenPatch:!operations!public! !
-!ChunkBrowserModel categoriesFor: #filteredChunksUsing:!operations!public! !
-!ChunkBrowserModel categoriesFor: #filterUsing:!operations!public! !
-!ChunkBrowserModel categoriesFor: #fromStream:!operations!public! !
+!ChunkBrowserModel categoriesFor: #filteredUsing:!operations!public! !
 !ChunkBrowserModel categoriesFor: #hasAnyChunksPicked!public!testing! !
 !ChunkBrowserModel categoriesFor: #hasChunks!public!testing! !
 !ChunkBrowserModel categoriesFor: #indexOfLastImageSave!helpers!public! !
 !ChunkBrowserModel categoriesFor: #initialize!initializing!public! !
+!ChunkBrowserModel categoriesFor: #loadFromFile:!operations!public! !
+!ChunkBrowserModel categoriesFor: #loadFromPatchFile:!operations!public! !
+!ChunkBrowserModel categoriesFor: #loadFromText:!operations!public! !
 !ChunkBrowserModel categoriesFor: #pickedChunks!accessing!public! !
 !ChunkBrowserModel categoriesFor: #unpickAll!operations!public! !
 

--- a/Core/Contributions/IDB/ChunkBrowserOtherChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserOtherChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserExpressionChunk subclass: #ChunkBrowserOtherChunk
 	instanceVariableNames: ''
@@ -8,14 +8,17 @@ ChunkBrowserExpressionChunk subclass: #ChunkBrowserOtherChunk
 ChunkBrowserOtherChunk guid: (GUID fromString: '{593D449B-5B54-4990-9DB8-1925EA103E40}')!
 ChunkBrowserOtherChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserOtherChunk categoriesForClass!IDB Goodies! !
 !ChunkBrowserOtherChunk methodsFor!
 
-= aChunk 
+= aChunk
 	^super = aChunk and: [rawText = aChunk rawText]!
+
+browseTarget
+	self shouldNotImplement!
 
 canBrowse
 	^false!
@@ -34,24 +37,27 @@ chunkIconIndex
 hash
 	^super hash bitXor: rawText hash!
 
-initialize: aString 
+initialize: aString
 	super initialize: aString.
 	identity1 := String new.
-	identity2 := String new.
 	self initializeIdentity!
 
 initializeIdentity
 	| tidy |
-	identity1 := (rawText first = $" and: [rawText last = $"]) 
-				ifTrue: ['comment']
-				ifFalse: ['evaluation'].
+	identity1 := (rawText first = $" and: [rawText last = $"])
+		ifTrue: ['comment']
+		ifFalse: ['evaluation'].
 	tidy := rawText copyReplacing: Character cr withObject: $_.
 	tidy := tidy copyWithout: Character lf.
 	identity2 := tidy copyFrom: 1 to: (tidy size min: 100)!
 
 isMatch
+	^nil!
+
+restore
 	^nil! !
 !ChunkBrowserOtherChunk categoriesFor: #=!comparing!public! !
+!ChunkBrowserOtherChunk categoriesFor: #browseTarget!operations!public! !
 !ChunkBrowserOtherChunk categoriesFor: #canBrowse!public!testing! !
 !ChunkBrowserOtherChunk categoriesFor: #canCompare!public!testing! !
 !ChunkBrowserOtherChunk categoriesFor: #chunkClass!accessing!public! !
@@ -60,6 +66,7 @@ isMatch
 !ChunkBrowserOtherChunk categoriesFor: #initialize:!initializing!public! !
 !ChunkBrowserOtherChunk categoriesFor: #initializeIdentity!initializing!public! !
 !ChunkBrowserOtherChunk categoriesFor: #isMatch!public!testing! !
+!ChunkBrowserOtherChunk categoriesFor: #restore!operations!public! !
 
 !ChunkBrowserOtherChunk class methodsFor!
 

--- a/Core/Contributions/IDB/ChunkBrowserSeriesChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserSeriesChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserChunk subclass: #ChunkBrowserSeriesChunk
 	instanceVariableNames: ''
@@ -8,13 +8,19 @@ ChunkBrowserChunk subclass: #ChunkBrowserSeriesChunk
 ChunkBrowserSeriesChunk guid: (GUID fromString: '{5FC81BCC-8654-4219-898E-4F08511DD311}')!
 ChunkBrowserSeriesChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserSeriesChunk categoriesForClass!IDB Goodies! !
 !ChunkBrowserSeriesChunk methodsFor!
 
-initializeFrom: aChunkBrowserSeriesStartChunk 
+initializeFromSeriesStart: aChunkBrowserSeriesStartChunk
 	identity1 := aChunkBrowserSeriesStartChunk identity1! !
-!ChunkBrowserSeriesChunk categoriesFor: #initializeFrom:!initializing!public! !
+!ChunkBrowserSeriesChunk categoriesFor: #initializeFromSeriesStart:!initializing!public! !
+
+!ChunkBrowserSeriesChunk class methodsFor!
+
+isChunkClassFor: aString
+	self shouldNotImplement! !
+!ChunkBrowserSeriesChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 

--- a/Core/Contributions/IDB/ChunkBrowserSeriesStartChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserSeriesStartChunk.cls
@@ -1,32 +1,53 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserChunk subclass: #ChunkBrowserSeriesStartChunk
-	instanceVariableNames: 'owningClass'
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ChunkBrowserSeriesStartChunk guid: (GUID fromString: '{24F42E2C-7A1F-4252-BDFE-4584ED820429}')!
 ChunkBrowserSeriesStartChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserSeriesStartChunk categoriesForClass!IDB Goodies! !
 !ChunkBrowserSeriesStartChunk methodsFor!
 
-initialize: aString 
+browseTarget
+	self shouldNotImplement!
+
+initialize: aString
 	super initialize: aString.
 	identity1 := self classNameFromRawText!
 
-isChunkSeriesStart
+isMatch
+	self shouldNotImplement!
+
+isSeriesStart
 	^true!
 
-seriesChunk: aString 
-	| chunk |
-	chunk := self seriesChunkClass fromText: aString.
-	chunk initializeFrom: self.
-	^chunk! !
+restore
+	self shouldNotImplement!
+
+seriesClass
+	self subclassResponsibility!
+
+seriesInstanceFor: aString
+	^(self seriesClass newFor: aString)
+		initializeFromSeriesStart: self;
+		yourself! !
+!ChunkBrowserSeriesStartChunk categoriesFor: #browseTarget!operations!public! !
 !ChunkBrowserSeriesStartChunk categoriesFor: #initialize:!initializing!public! !
-!ChunkBrowserSeriesStartChunk categoriesFor: #isChunkSeriesStart!public!testing! !
-!ChunkBrowserSeriesStartChunk categoriesFor: #seriesChunk:!initializing!public! !
+!ChunkBrowserSeriesStartChunk categoriesFor: #isMatch!public!testing! !
+!ChunkBrowserSeriesStartChunk categoriesFor: #isSeriesStart!public!testing! !
+!ChunkBrowserSeriesStartChunk categoriesFor: #restore!operations!public! !
+!ChunkBrowserSeriesStartChunk categoriesFor: #seriesClass!constants!public! !
+!ChunkBrowserSeriesStartChunk categoriesFor: #seriesInstanceFor:!initializing!public! !
+
+!ChunkBrowserSeriesStartChunk class methodsFor!
+
+chunkType
+	self shouldNotImplement! !
+!ChunkBrowserSeriesStartChunk class categoriesFor: #chunkType!constants!public! !
 

--- a/Core/Contributions/IDB/ChunkBrowserSystemChunk.cls
+++ b/Core/Contributions/IDB/ChunkBrowserSystemChunk.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 ChunkBrowserOtherChunk subclass: #ChunkBrowserSystemChunk
 	instanceVariableNames: ''
@@ -8,7 +8,7 @@ ChunkBrowserOtherChunk subclass: #ChunkBrowserSystemChunk
 ChunkBrowserSystemChunk guid: (GUID fromString: '{E2344DF7-4685-46A5-A350-969184292B80}')!
 ChunkBrowserSystemChunk comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkBrowserSystemChunk categoriesForClass!IDB Goodies! !
@@ -39,7 +39,8 @@ initializeIdentity
 
 	| terminate |
 	self perform: (self class symbolFor: rawText).
-	(identity2 isEmpty and: [(terminate := rawText indexOfSubCollection: ': ') ~= 0]) 
+	terminate := rawText indexOfSubCollection: ': '.
+	(identity2 isEmpty and: [terminate ~= 0])
 		ifTrue: [identity2 := rawText copyFrom: 2 to: terminate - 1]!
 
 isImageSave
@@ -54,14 +55,13 @@ loadPackage
 packageName
 	| quoteIndex |
 	quoteIndex := (rawText indexOf: $') + 1.
-	^rawText copyFrom: quoteIndex
-		to: (rawText 
+	^rawText
+		copyFrom: quoteIndex
+		to:
+			(rawText
 				nextIndexOf: $'
 				from: quoteIndex
 				to: rawText size) - 1!
-
-restore
-	^nil!
 
 uninstallPackage
 	"15:15:09, 07 April 2002: Uninstalling package 'ChunkBrowser'"
@@ -76,7 +76,6 @@ uninstallPackage
 !ChunkBrowserSystemChunk categoriesFor: #isImageSave!public!testing! !
 !ChunkBrowserSystemChunk categoriesFor: #loadPackage!operations!public! !
 !ChunkBrowserSystemChunk categoriesFor: #packageName!helpers!public! !
-!ChunkBrowserSystemChunk categoriesFor: #restore!operations!public! !
 !ChunkBrowserSystemChunk categoriesFor: #uninstallPackage!operations!public! !
 
 !ChunkBrowserSystemChunk class methodsFor!
@@ -84,7 +83,32 @@ uninstallPackage
 chunkType
 	^#System!
 
-isChunkClassFor: aString 
+hasText: aString
+	^(self symbolFor: aString) notNil!
+
+hasTime: aString
+	"''11:06:39, 03 April 2002: Image saved''
+	Got to be pretty unlucky if this fails and it's a lot faster than trying
+	to convert aString to a Time"
+
+	^aString fourth = $:
+		and:
+			[(aString at: 7) = $:
+				and:
+					[(aString at: 10) = $,
+						and:
+							[| bits |
+							bits := (aString copyFrom: 2 to: 35) subStrings.
+							bits size >= 4
+								and:
+									[bits first size = 9
+										and:
+											[bits second size = 2
+												and:
+													[(bits third allSatisfy: [:each | each isLetter])
+														and: [bits fourth size = 5 and: [bits fourth last = $:]]]]]]]]!
+
+isChunkClassFor: aString
 	"
 	''11:06:39, 03 April 2002: Dolphin Smalltalk
 	''11:06:39, 03 April 2002: Loading package
@@ -96,27 +120,28 @@ isChunkClassFor: aString
 	''11:06:39, 03 April 2002: Compressing sources...
 	"
 
-	| stream |
-	(aString size > 10 and: [aString first = $" and: [aString last = $"]]) ifFalse: [^false].
-	stream := aString readStream.
-	[Time readFrom: stream] on: InvalidFormat do: [:e | ^false].
-	^(self symbolFor: aString) notNil!
+	^aString size > 30
+		and:
+			[aString first = $"
+				and: [aString last = $" and: [(self hasTime: aString) and: [self hasText: aString]]]]!
 
-symbolFor: aString 
+symbolFor: aString
 	| lookup |
 	lookup := ##((Dictionary new)
-				at: ': Dolphin Smalltalk' put: #imageStart;
-				at: ': Loading package' put: #loadPackage;
-				at: ': Loading source package' put: #loadPackage;
-				at: ': Uninstalling package' put: #uninstallPackage;
-				at: ': Image saved' put: #imageSave;
-				at: ': Compressed sources' put: #compressedSources;
-				at: ': Compressed changes' put: #compressedChanges;
-				at: ': Compressing sources...' put: #compressedSources;
-				yourself).
-	^(lookup associations detect: [:each | (aString indexOfSubCollection: each key) ~= 0] ifNone: [^nil]) 
-		value! !
+			at: ': Dolphin Smalltalk' put: #imageStart;
+			at: ': Loading package' put: #loadPackage;
+			at: ': Loading source package' put: #loadPackage;
+			at: ': Uninstalling package' put: #uninstallPackage;
+			at: ': Image saved' put: #imageSave;
+			at: ': Compressed sources' put: #compressedSources;
+			at: ': Compressed changes' put: #compressedChanges;
+			at: ': Compressing sources...' put: #compressedSources;
+			yourself).
+	^(lookup associations detect: [:each | (aString indexOfSubCollection: each key) ~= 0] ifNone: [nil])
+		ifNotNil: [:arg | arg value]! !
 !ChunkBrowserSystemChunk class categoriesFor: #chunkType!constants!public! !
+!ChunkBrowserSystemChunk class categoriesFor: #hasText:!public!testing! !
+!ChunkBrowserSystemChunk class categoriesFor: #hasTime:!public!testing! !
 !ChunkBrowserSystemChunk class categoriesFor: #isChunkClassFor:!public!testing! !
 !ChunkBrowserSystemChunk class categoriesFor: #symbolFor:!constants!public! !
 

--- a/Core/Contributions/IDB/ChunkFileMethodScanner.cls
+++ b/Core/Contributions/IDB/ChunkFileMethodScanner.cls
@@ -6,9 +6,22 @@ Object subclass: #ChunkFileMethodScanner
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ChunkFileMethodScanner guid: (GUID fromString: '{B8B83C19-E601-4265-B607-2A0B2122144B}')!
-ChunkFileMethodScanner comment: 'See [DolphinImageFolder]/Idb/Documentation for details
+ChunkFileMethodScanner comment: 'Scans the sources and changes file and answers a collection of either...
+- all the method versions for a specified class
+- all the method versions for a specified method in a class
 
-(C) 2006-2008 Ian Bartholomew
+Usage
+ChunkFileMethodScanner forMethodsInClass: aClass
+ChunkFileMethodScanner forMethod: aSymbol inClass: aClass
+
+The answer is a collection of Arrays, one for each method version found.  
+Each entry in the Array contains 3 items
+
+at: 1 = the source of the chunk, either #changes or #sources 
+at: 2 = the selector the method was saved as, a Symbol 
+at: 3 = the method source
+
+(C) 2005 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ChunkFileMethodScanner categoriesForClass!IDB Goodies! !
@@ -84,14 +97,12 @@ scan: aStream for: aString source: aSymbol
 scanChangesFileFor: aString
 	"Scan the changes file for method definition chunks preceded by aString"
 
-	#idbToDo.	"Temporary fix for Dolphin bug.  Do not attempt to read change log if it is less than one buffer in size"
-	SourceManager default changesStream size <= FileStream bufferSize ifTrue: [^OrderedCollection new].
 	^self
 		scan: SourceManager default changesStream
 		for: aString
 		source: #changes!
 
-scanForMethodChunks: aMethodSelector inClass: aClass
+scanForMethodChunks: aMethodSelector inClass: aClass 
 	"Answers a collection of Arrays containing all the method definitions for
 	aClass>>aMethodSelector from both the sources and change files.
 
@@ -100,9 +111,9 @@ scanForMethodChunks: aMethodSelector inClass: aClass
 		at: 2 = selector as Symbol 
 		at: 3 = method source"
 
-	^(self scanForMethodChunksInClass: aClass) select: [:each | aMethodSelector = each second]!
+	^(self scanForMethodChunksInClass: aClass) select: [:each | aMethodSelector = (each at: 2)]!
 
-scanForMethodChunksInClass: aClass
+scanForMethodChunksInClass: aClass 
 	"Answers a collection of Arrays containing all the method definitions, from both the sources
 	and change files, belonging to aClass
 
@@ -112,7 +123,12 @@ scanForMethodChunksInClass: aClass
 		at: 3 = method source"
 
 	| target |
-	target := '!!<1s> methodsFor!!' expandMacrosWith: aClass name.
+	target := (String writeStream)
+				nextPut: $!!;
+				nextPutAll: aClass name;
+				nextPutAll: ' methodsFor!!';
+				cr;
+				contents.
 	^(self scanSourcesFileFor: target) , (self scanChangesFileFor: target)!
 
 scanSourcesFileFor: aString
@@ -136,13 +152,13 @@ forMethod: aMethodSelector inClass: aClass
 	"Answers a collection containing all the method definitions for aClass>>aMethodSelector from
 	both the sources and change files"
 
-	^self new scanForMethodChunks: aMethodSelector inClass: aClass!
+	^super new scanForMethodChunks: aMethodSelector inClass: aClass!
 
 forMethodsInClass: aClass
 	"Answers a collection containing all the method definitions, from both the sources and
 	change files, belonging to aClass"
 
-	^self new scanForMethodChunksInClass: aClass! !
+	^super new scanForMethodChunksInClass: aClass! !
 !ChunkFileMethodScanner class categoriesFor: #forMethod:inClass:!instance creation!public! !
 !ChunkFileMethodScanner class categoriesFor: #forMethodsInClass:!instance creation!public! !
 

--- a/Core/Contributions/IDB/ClassHistoryBrowser.cls
+++ b/Core/Contributions/IDB/ClassHistoryBrowser.cls
@@ -1,30 +1,61 @@
 "Filed out from Dolphin Smalltalk X6.1"!
 
-HistoryBrowserAbstract subclass: #ClassHistoryBrowser
-	instanceVariableNames: 'list'
+HistoryBrowser subclass: #ClassHistoryBrowser
+	instanceVariableNames: 'class list'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ClassHistoryBrowser guid: (GUID fromString: '{30A97C72-065A-4C23-9F8E-DC13497F6EDA}')!
-ClassHistoryBrowser comment: 'See [DolphinImageFolder]/Idb/Documentation for details
+ClassHistoryBrowser comment: 'Searches the sources and changes files to provide a change history for a class and opens a browser on the results.
 
-(C) 2006-2008 Ian Bartholomew
+Usage:
+ClassHistoryBrowser showOnClass: aClass
+
+All methods in the class are displayed in the browser with 4 fields.
+
+- The selector used when the method was saved.
+- The status of the method
+	- original......The method is in the image and only present in the sources file
+	- added......The method is in the image and only present in the changes file
+	- modified......The method is in the image and present in both the sources and changes file
+	- deleted......The method is not in the image but is present in either the sources or changes file
+- The number of times the method appears in the sources file (always 0 or 1)
+- The number of times the method appears in the changes file
+
+Double clicking in the list will open a MethodHistoryBrowser on the selection.  Note that although the ClassHistoryBrowser
+might show multiple versions of a method the MethodHistoryBrowser may display fewer versions.  This is because the 
+MethodHistoryBrowser automatically removes duplicate consecutive entries.
+
+(C) 2005 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !ClassHistoryBrowser categoriesForClass!IDB Goodies! !
 !ClassHistoryBrowser methodsFor!
 
+about
+	"Display the about view"
+
+	self 
+		about: '
+Class History Browser
+for
+Dolphin Smalltalk 6.x
+
+Version 6b
+© 2005 Ian Bartholomew
+http://www.idb.me.uk'!
+
 browseHistory
 	"Private - Open up a MethodHistoryBrowser on the selected method to allow
 	a previous version to be located and, optionally restored"
 
-	MethodHistoryBrowser showOnClass: class selector: list selection first!
+	MethodHistoryBrowser showOnClass: class selector: (list selection at: 1)!
 
 browseMethod
 	"Private - Open up a ClassBrowser on the selected method"
 
-	(class includesSelector: list selection first)
-		ifTrue: [(class compiledMethodAt: list selection first) browse]!
+	(class includesSelector: (list selection at: 1)) 
+		ifTrue: [(class compiledMethodAt: (list selection at: 1)) browse]!
 
 createComponents
 	super createComponents.
@@ -32,7 +63,7 @@ createComponents
 
 createSchematicWiring
 	super createSchematicWiring.
-	list
+	list 
 		when: #actionPerformed
 		send: #browseHistory
 		to: self.
@@ -50,18 +81,11 @@ createSchematicWiring
 historyStatusFor: aSymbol in: aCollection
 	| inSources inChanges |
 	(class includesSelector: aSymbol) ifFalse: [^'deleted'].
-	inSources := aCollection anySatisfy: [:each | each first = #sources].
-	inChanges := aCollection anySatisfy: [:each | each first = #changes].
+	inSources := aCollection anySatisfy: [:each | (each at: 1) = #sources].
+	inChanges := aCollection anySatisfy: [:each | (each at: 1) = #changes].
 	inSources & inChanges ifTrue: [^'modified'].
 	inSources not & inChanges ifTrue: [^'added'].
 	^'original'!
-
-idbAbout
-	"Display the about view"
-
-	self 
-		idbAbout: '<n>Class History Browser<n>for<n>Dolphin Smalltalk 6.x<n><n>Version 6c<n>© 2005-2008 Ian Bartholomew<n>http://www.idb.me.uk' 
-				expandMacros!
 
 onImageChanged: aCompiledMethod
 	"Private - The image has changed. If it is a method in the class we are displaying
@@ -69,10 +93,19 @@ onImageChanged: aCompiledMethod
 
 	| currentSelection |
 	aCompiledMethod methodClass == class ifFalse: [^self].
-	currentSelection := list hasSelection ifTrue: [list selection first].
+	list hasSelection ifTrue: [currentSelection := list selection at: 1].
 	self setClass: class.
-	currentSelection ifNil: [^self].
-	list selection: (list list detect: [:each | each first == currentSelection])!
+	currentSelection isNil ifTrue: [^self].
+	list selection: (list list detect: [:each | (each at: 1) == currentSelection])!
+
+onMethodAdded: aCompilationResult
+	self onImageChanged: aCompilationResult method!
+
+onMethodRemoved: aCompiledMethod 
+	self onImageChanged: aCompiledMethod!
+
+onMethodUpdated: aCompilationResult 
+	self onImageChanged: aCompilationResult method!
 
 onViewClosed
 	"Private - This is needed to prevent events trying to access this shell
@@ -81,14 +114,14 @@ onViewClosed
 	super onViewClosed.
 	SmalltalkSystem current removeEventsTriggeredFor: self!
 
-queryCommand: aCommandQuery
-	aCommandQuery command = #browseHistory
-		ifTrue:
+queryCommand: aCommandQuery 
+	aCommandQuery command = #browseHistory 
+		ifTrue: 
 			[aCommandQuery isEnabled: list hasSelection.
 			^true].
-	aCommandQuery command = #browseMethod
-		ifTrue:
-			[aCommandQuery isEnabled: (list hasSelection and: [class includesSelector: list selection first]).
+	aCommandQuery command = #browseMethod 
+		ifTrue: 
+			[aCommandQuery isEnabled: (list hasSelection and: [class includesSelector: (list selection at: 1)]).
 			^true].
 	^super queryCommand: aCommandQuery!
 
@@ -97,32 +130,35 @@ setClass: aClass
 	also whenever a method in the selected class is edivted/deleted"
 
 	class := aClass.
-	self caption: ('Method History for <1s>' expandMacrosWith: class printString).
+	self caption: 'Method History for ' , class printString.
 	self updateHistory!
 
 updateHistory
 	| chunks selectors methodHistory |
-	chunks := Cursor wait showWhile: [self scanner forMethodsInClass: class].
-	selectors := (chunks collect: [:each | each second]) asSet asSortedCollection asOrderedCollection.
-	methodHistory := selectors
-		collect:
+	Cursor wait showWhile: [chunks := self scanner forMethodsInClass: class].
+	selectors := (chunks collect: [:each | each at: 2]) asSet asSortedCollection.
+	methodHistory := OrderedCollection new.
+	selectors do: 
 			[:eachSelector | 
 			| selectorChunks |
-			selectorChunks := chunks select: [:each | each second = eachSelector].
-			(Array new: 4)
-				at: 1 put: eachSelector;
-				at: 2 put: (self historyStatusFor: eachSelector in: selectorChunks);
-				at: 3 put: (selectorChunks select: [:each | each first = #sources]) size;
-				at: 4 put: (selectorChunks select: [:each | each first = #changes]) size;
-				yourself].
+			selectorChunks := chunks select: [:each | (each at: 2) = eachSelector].
+			methodHistory add: ((Array new: 4)
+						at: 1 put: eachSelector;
+						at: 2 put: (self historyStatusFor: eachSelector in: selectorChunks);
+						at: 3 put: (selectorChunks select: [:each | (each at: 1) = #sources]) size;
+						at: 4 put: (selectorChunks select: [:each | (each at: 1) = #changes]) size;
+						yourself)].
 	list list: methodHistory! !
+!ClassHistoryBrowser categoriesFor: #about!commands!public! !
 !ClassHistoryBrowser categoriesFor: #browseHistory!commands!public! !
 !ClassHistoryBrowser categoriesFor: #browseMethod!commands!public! !
 !ClassHistoryBrowser categoriesFor: #createComponents!initializing!public! !
 !ClassHistoryBrowser categoriesFor: #createSchematicWiring!initializing!public! !
 !ClassHistoryBrowser categoriesFor: #historyStatusFor:in:!helpers!public! !
-!ClassHistoryBrowser categoriesFor: #idbAbout!commands!public! !
 !ClassHistoryBrowser categoriesFor: #onImageChanged:!event handling!public! !
+!ClassHistoryBrowser categoriesFor: #onMethodAdded:!event handling!public! !
+!ClassHistoryBrowser categoriesFor: #onMethodRemoved:!event handling!public! !
+!ClassHistoryBrowser categoriesFor: #onMethodUpdated:!event handling!public! !
 !ClassHistoryBrowser categoriesFor: #onViewClosed!event handling!public! !
 !ClassHistoryBrowser categoriesFor: #queryCommand:!commands!public! !
 !ClassHistoryBrowser categoriesFor: #setClass:!initializing!public! !
@@ -138,7 +174,7 @@ resource_Default_view
 	ViewComposer openOn: (ResourceIdentifier class: self selector: #resource_Default_view)
 	"
 
-	^#(#'!!STL' 3 788558 10 ##(Smalltalk.STBViewProxy)  8 ##(Smalltalk.ShellView)  98 27 0 0 98 2 27131905 131073 416 0 721158 ##(Smalltalk.SystemColor)  31 328198 ##(Smalltalk.Point)  1001 701 551 0 0 0 416 788230 ##(Smalltalk.BorderLayout)  1 1 0 0 0 0 410 8 ##(Smalltalk.ListView)  98 30 0 416 98 2 8 1140920397 1025 576 590662 2 ##(Smalltalk.ListModel)  202 208 98 0 0 1310726 ##(Smalltalk.IdentitySearchPolicy)  524550 ##(Smalltalk.ColorRef)  8 4278190080 0 7 265030 4 ##(Smalltalk.Menu)  0 16 98 2 984134 2 ##(Smalltalk.CommandMenuItem)  1 1180998 4 ##(Smalltalk.CommandDescription)  8 #browseHistory 8 'Method history' 1 1 0 0 0 850 1 882 8 #browseMethod 8 'Method browser' 1 1 0 0 0 8 '' 0 1 0 0 0 0 0 0 0 576 0 8 4294903419 8 ##(Smalltalk.BasicListAbstract)  0 1049670 1 ##(Smalltalk.IconImageManager)  0 0 0 0 0 0 202 208 98 4 920646 5 ##(Smalltalk.ListViewColumn)  8 'Selector' 497 8 #left 1040 8 ##(Smalltalk.SortedCollection)  787814 3 ##(Smalltalk.BlockClosure)  0 459302 ##(Smalltalk.Context)  1 1 0 0 1180966 ##(Smalltalk.CompiledExpression)  0 9 8 ##(Smalltalk.UndefinedObject)  8 'doIt' 98 2 8 '[:o | o at: 1]' 98 1 202 8 ##(Smalltalk.PoolDictionary)  704 8 #[252 1 0 1 1 8 0 17 230 32 228 32 63 148 106 100 105] 17 257 0 0 576 0 3 0 0 1122 8 'Status' 161 8 #center 1040 1184 1202 0 1234 1 1 0 0 1266 0 9 1296 8 'doIt' 98 2 8 '[:o | o at: 2]' 98 1 202 1392 704 8 #[252 1 0 1 1 8 0 17 230 32 228 32 64 148 106 100 105] 17 257 0 0 576 0 1 0 0 1122 8 'Sources' 161 1456 1040 1184 1202 0 1234 1 1 0 0 1266 0 9 1296 8 'doIt' 98 2 8 '[:o | o at: 3]' 98 1 202 1392 704 8 #[252 1 0 1 1 9 0 17 230 32 228 32 214 3 148 106 100 105] 17 257 0 0 576 0 1 0 0 1122 8 'Changes' 161 1456 1040 1184 1202 0 1234 1 1 0 0 1266 0 9 1296 8 'doIt' 98 2 8 '[:o | o at: 4]' 98 1 202 1392 704 8 #[252 1 0 1 1 9 0 17 230 32 228 32 214 4 148 106 100 105] 17 257 0 0 576 0 1 0 0 8 #report 704 0 131169 0 0 983302 ##(Smalltalk.MessageSequence)  202 208 98 3 721670 ##(Smalltalk.MessageSend)  8 #createAt:extent: 98 2 514 1 1 514 985 593 576 2050 8 #contextMenu: 98 1 816 576 2050 8 #text: 98 1 8 'Selector' 576 983302 ##(Smalltalk.WINDOWPLACEMENT)  8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 236 1 0 0 40 1 0 0] 98 0 514 193 193 0 27 234 256 98 2 576 8 'list' 0 461638 4 ##(Smalltalk.MenuBar)  0 16 98 2 802 0 16 98 1 850 1 882 8 #exit 8 '&Close' 16615 1 0 0 0 8 '&File' 0 134217729 0 0 9693 0 0 802 0 16 98 2 850 1 882 8 #idbHelp 8 '&Help' 1 1 0 0 0 850 1 882 8 #idbAbout 8 '&About' 1 1 0 0 0 8 '&Help' 0 134217729 0 0 9699 0 0 8 '' 0 134217729 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 1986 202 208 98 3 2050 2080 98 2 514 2047 21 514 1001 701 416 2050 2208 98 1 8 'Class History' 416 2050 8 #updateMenuBar 704 416 2258 8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 3 0 0 10 0 0 0 243 5 0 0 104 1 0 0] 98 1 576 2320 0 27 )!
+	^#(#'!!STL' 3 788558 10 ##(Smalltalk.STBViewProxy)  8 ##(Smalltalk.ShellView)  98 27 0 0 98 2 27131905 131073 416 0 721158 ##(Smalltalk.SystemColor)  31 328198 ##(Smalltalk.Point)  1001 701 551 0 0 0 416 788230 ##(Smalltalk.BorderLayout)  1 1 0 0 0 0 410 8 ##(Smalltalk.ListView)  98 30 0 416 98 2 8 1140920397 1025 576 590662 2 ##(Smalltalk.ListModel)  202 208 98 0 0 1114638 ##(Smalltalk.STBSingletonProxy)  8 ##(Smalltalk.SearchPolicy)  8 #identity 524550 ##(Smalltalk.ColorRef)  8 4278190080 0 7 265030 4 ##(Smalltalk.Menu)  0 16 98 2 984134 2 ##(Smalltalk.CommandMenuItem)  1 1180998 4 ##(Smalltalk.CommandDescription)  8 #browseHistory 8 'Method history' 1 1 0 0 0 882 1 914 8 #browseMethod 8 'Method browser' 1 1 0 0 0 8 '' 0 1 0 0 0 0 0 0 0 576 0 8 4294903223 8 ##(Smalltalk.BasicListAbstract)  0 730 8 ##(Smalltalk.IconImageManager)  8 #current 0 0 0 0 0 0 202 208 98 4 920646 5 ##(Smalltalk.ListViewColumn)  8 'Selector' 547 8 #left 1072 8 ##(Smalltalk.SortedCollection)  787814 3 ##(Smalltalk.BlockClosure)  0 459302 ##(Smalltalk.Context)  1 1 0 0 1180966 ##(Smalltalk.CompiledExpression)  0 9 8 ##(Smalltalk.UndefinedObject)  8 'doIt' 98 2 8 '[:o | o at: 1]' 98 1 202 8 ##(Smalltalk.PoolDictionary)  704 8 #[252 1 0 1 1 8 0 17 230 32 228 32 63 148 106 100 105] 17 257 0 0 576 0 3 0 0 1170 8 'Status' 161 8 #center 1072 1232 1250 0 1282 1 1 0 0 1314 0 9 1344 8 'doIt' 98 2 8 '[:o | o at: 2]' 98 1 202 1440 704 8 #[252 1 0 1 1 8 0 17 230 32 228 32 64 148 106 100 105] 17 257 0 0 576 0 1 0 0 1170 8 'Sources' 161 1504 1072 1232 1250 0 1282 1 1 0 0 1314 0 9 1344 8 'doIt' 98 2 8 '[:o | o at: 3]' 98 1 202 1440 704 8 #[252 1 0 1 1 9 0 17 230 32 228 32 214 3 148 106 100 105] 17 257 0 0 576 0 1 0 0 1170 8 'Changes' 161 1504 1072 1232 1250 0 1282 1 1 0 0 1314 0 9 1344 8 'doIt' 98 2 8 '[:o | o at: 4]' 98 1 202 1440 704 8 #[252 1 0 1 1 9 0 17 230 32 228 32 214 4 148 106 100 105] 17 257 0 0 576 0 1 0 0 8 #report 704 0 131169 0 0 983302 ##(Smalltalk.MessageSequence)  202 208 98 3 721670 ##(Smalltalk.MessageSend)  8 #createAt:extent: 98 2 514 1 1 514 1035 593 576 2098 8 #contextMenu: 98 1 848 576 2098 8 #text: 98 1 8 'Selector' 576 983302 ##(Smalltalk.WINDOWPLACEMENT)  8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 5 2 0 0 40 1 0 0] 98 0 514 193 193 0 27 234 256 98 2 576 8 'list' 0 461638 4 ##(Smalltalk.MenuBar)  0 16 98 2 834 0 16 98 1 882 1 914 8 #exit 8 '&Close' 16615 1 0 0 0 8 '&File' 0 134217729 0 0 22147 0 0 882 1 914 8 #about 8 '&About' 1 1 0 0 0 8 '' 0 134217729 0 0 0 0 0 0 1049350 ##(Smalltalk.AcceleratorTable)  0 16 98 1 721414 ##(Smalltalk.Association)  16615 2528 0 1 0 0 0 0 1 0 0 2034 202 208 98 3 2098 2128 98 2 514 2047 21 514 1051 701 416 2098 2256 98 1 8 'Class History' 416 2098 8 #menuBar: 98 1 2448 416 2306 8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 3 0 0 10 0 0 0 12 6 0 0 104 1 0 0] 98 1 576 2368 0 27 )!
 
 showOnClass: aClass
 	^self show setClass: aClass! !

--- a/Core/Contributions/IDB/DEVNAMES.cls
+++ b/Core/Contributions/IDB/DEVNAMES.cls
@@ -1,6 +1,6 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
-Win32Structure subclass: #DEVNAMES
+ExternalStructure subclass: #DEVNAMES
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -8,10 +8,27 @@ Win32Structure subclass: #DEVNAMES
 DEVNAMES guid: (GUID fromString: '{776A9E91-190A-4EA6-969C-92BC7B280AD9}')!
 DEVNAMES comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
-!DEVNAMES categoriesForClass!External-Data-Structured-Win32!IDB Goodies! !
+!DEVNAMES categoriesForClass!IDB Goodies! !
+!DEVNAMES methodsFor!
+
+deviceName
+	#JamesFoster.
+	^String fromAddress: bytes yourAddress + self wDeviceOffset!
+
+driverName
+	#JamesFoster.
+	^String fromAddress: bytes yourAddress + self wDriverOffset!
+
+outputName
+	#JamesFoster.
+	^String fromAddress: bytes yourAddress + self wOutputOffset! !
+!DEVNAMES categoriesFor: #deviceName!accessing!public! !
+!DEVNAMES categoriesFor: #driverName!accessing!public! !
+!DEVNAMES categoriesFor: #outputName!accessing!public! !
+
 !DEVNAMES class methodsFor!
 
 defineFields

--- a/Core/Contributions/IDB/HistoryBrowserAbstract.cls
+++ b/Core/Contributions/IDB/HistoryBrowserAbstract.cls
@@ -11,7 +11,7 @@ HistoryBrowserAbstract comment: 'See [DolphinImageFolder]/Idb/Documentation for 
 (C) 2006-2008 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
-!HistoryBrowserAbstract categoriesForClass!Unclassified! !
+!HistoryBrowserAbstract categoriesForClass!IDB Goodies! !
 !HistoryBrowserAbstract methodsFor!
 
 idbAbout

--- a/Core/Contributions/IDB/IDB Chunk Browser.pax
+++ b/Core/Contributions/IDB/IDB Chunk Browser.pax
@@ -2,15 +2,18 @@
 package := Package name: 'IDB Chunk Browser'.
 package paxVersion: 1;
 	basicComment: 'Chunk Browser
-Version 6a - May 2005
+Version 6b - October 2005
 For Version 6 of Dolphin Smalltalk
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware
+
+6b - October 2005
+	- removed Help menu and added About menu
 '.
 
-package basicPackageVersion: 'IDB$PACKAGE$VERSION 6a'.
+package basicPackageVersion: 'IDB$PACKAGE$VERSION 6b JGF.1'.
 
 
 package classNames
@@ -36,12 +39,6 @@ package classNames
 	add: #ChunkBrowserSeriesChunk;
 	add: #ChunkBrowserSeriesStartChunk;
 	add: #ChunkBrowserSystemChunk;
-	add: #MultipleSelectionListPresenter;
-	yourself.
-
-package methodNames
-	add: 'Toolbar class' -> #resource_ChunkBrowser_chunk_tools;
-	add: 'Toolbar class' -> #resource_ChunkBrowser_file_tools;
 	yourself.
 
 package binaryGlobalNames: (Set new
@@ -59,9 +56,7 @@ package setPrerequisites: (IdentitySet new
 	add: '..\Object Arts\Dolphin\MVP\Presenters\Difference\Dolphin Differences Presenter';
 	add: '..\Object Arts\Dolphin\MVP\Models\List\Dolphin List Models';
 	add: '..\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter';
-	add: '..\Object Arts\Dolphin\MVP\Deprecated\Dolphin MVP (Deprecated)';
 	add: '..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base';
-	add: '..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Rich Text Presenter';
 	add: '..\Object Arts\Dolphin\MVP\Views\Scintilla\Dolphin Scintilla View';
 	add: '..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter';
 	add: '..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters';
@@ -69,7 +64,6 @@ package setPrerequisites: (IdentitySet new
 	add: 'IDB Common';
 	add: 'IDB Method History';
 	add: '..\Object Arts\Dolphin\System\Compiler\Smalltalk Parser';
-	add: '..\Object Arts\Dolphin\ActiveX\Shell\Windows Shell';
 	yourself).
 
 package!
@@ -92,7 +86,7 @@ ChunkBrowserChunk subclass: #ChunkBrowserSeriesChunk
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ChunkBrowserChunk subclass: #ChunkBrowserSeriesStartChunk
-	instanceVariableNames: 'owningClass'
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -181,11 +175,6 @@ Model subclass: #ChunkBrowserModel
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-ListPresenter subclass: #MultipleSelectionListPresenter
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
 IdbToolShell subclass: #ChunkBrowser
 	instanceVariableNames: 'chunkList chunkText pathname filter'
 	classVariableNames: 'ChunkTypeSelection CompareMethodsUsingParser'
@@ -196,30 +185,6 @@ IdbToolShell subclass: #ChunkBrowser
 
 
 "Loose Methods"!
-
-!Toolbar class methodsFor!
-
-resource_ChunkBrowser_chunk_tools
-	"Answer the literal data from which the 'ChunkBrowser chunk tools' resource can be reconstituted.
-	DO NOT EDIT OR RECATEGORIZE THIS METHOD.
-
-	If you wish to modify this resource evaluate:
-	ViewComposer openOn: (ResourceIdentifier class: self selector: #resource_ChunkBrowser_chunk_tools)
-	"
-
-	^#(#'!!STL' 3 788558 10 ##(STBViewProxy)  8 ##(Toolbar)  98 25 0 0 98 2 8 1140853516 131137 416 0 524550 ##(ColorRef)  8 4278190080 0 517 0 263174 ##(Font)  0 16 459014 ##(LOGFONT)  8 #[243 255 255 255 0 0 0 0 0 0 0 0 0 0 0 0 144 1 0 0 0 0 0 0 3 2 1 34 65 114 105 97 108 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 328198 ##(Point)  193 193 0 416 498 528 8 4294904585 234 256 98 0 234 256 98 40 37585 853766 ##(ToolbarButton)  37585 0 416 1 1180998 4 ##(CommandDescription)  459270 ##(Message)  8 #toggleInclusionOfChunkType: 98 1 8 #'Class Protocol' 8 'Class Protocol' 1 1 0 657990 3 ##(DIBSection)  0 16 1114638 ##(STBSingletonProxy)  8 ##(ImageRelativeFileLocator)  8 #current 8 'Ian Bartholomew\Resources\ChunkBrowser.bmp' 2032142 ##(STBExternalResourceLibraryProxy)  8 'dolphindr006.dll' 0 0 7 626 737 33 9 0 39 37587 754 37587 0 416 5 786 818 848 98 1 8 #'Method Category' 8 'Method Category' 1 1 0 928 13 37589 754 37589 0 416 5 786 818 848 98 1 8 #'Method Define' 8 'Method Define' 1 1 0 928 15 37591 754 37591 0 416 5 786 818 848 98 1 8 #'Method Delete' 8 'Method Delete' 1 1 0 928 17 37593 754 37593 0 416 5 786 818 848 98 1 8 #'Resource Define' 8 'Resource Define' 1 1 0 928 11 37595 754 37595 0 416 1 786 818 848 98 1 8 #'Resource Delete' 8 'Resource Delete' 1 1 0 928 37 37597 754 37597 0 416 1 786 818 848 98 1 8 #System 8 'System' 1 1 0 928 41 37599 754 37599 0 416 5 786 818 848 98 1 8 #Other 8 'Other' 1 1 0 928 19 37601 754 37601 0 416 1 786 8 #selectDefault 8 'Select default chunk types' 1 1 0 928 21 37603 754 37603 0 416 1 786 8 #selectNone 8 'Deselect all chunk types' 1 1 0 928 23 37605 754 37605 0 416 1 786 8 #selectRange 8 'Set range limits' 1 1 0 928 25 37607 754 37607 0 416 1 786 8 #lastOnly 8 'Last' 1 1 0 928 27 37609 754 37609 0 416 5 786 818 8 #toggleComparison: 98 1 8 #Match 8 'Match' 1 1 0 928 29 37611 754 37611 0 416 5 786 818 2064 98 1 8 #Differ 8 'Differ' 1 1 0 928 31 37613 754 37613 0 416 5 786 818 2064 98 1 8 #Missing 8 'Missing' 1 1 0 928 33 37575 754 37575 0 416 5 786 818 848 98 1 8 #'Class Category' 8 'Class Category' 1 1 0 928 1 37577 754 37577 0 416 5 786 818 848 98 1 8 #'Class Define' 8 'Class Define' 1 1 0 928 3 37579 754 37579 0 416 5 786 818 848 98 1 8 #'Class Delete' 8 'Class Delete' 1 1 0 928 5 37581 754 37581 0 416 1 786 818 848 98 1 8 #'Class Comment' 8 'Class Comment' 1 1 0 928 7 37583 754 37583 0 416 5 786 818 848 98 1 8 #'Class GUID' 8 'Class GUID' 1 1 0 928 9 98 24 1050118 ##(ToolbarSeparator)  0 0 416 3 0 1 2320 2416 2512 2608 2704 768 1088 1184 1280 1376 1472 1568 1664 2818 0 0 416 3 0 1 1760 1824 2818 0 0 416 3 0 1 1888 1952 2818 0 0 416 3 0 1 2016 2128 2224 234 240 98 2 928 1 0 1 0 626 33 33 626 45 45 0 656198 1 ##(FlowLayout)  1 1 1 983302 ##(MessageSequence)  202 208 98 2 721670 ##(MessageSend)  8 #createAt:extent: 98 2 626 11 11 626 991 51 416 3058 8 #updateSize 704 416 983302 ##(WINDOWPLACEMENT)  8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 5 0 0 0 5 0 0 0 244 1 0 0 30 0 0 0] 98 0 626 193 193 0 27 )!
-
-resource_ChunkBrowser_file_tools
-	"Answer the literal data from which the 'ChunkBrowser file tools' resource can be reconstituted.
-	DO NOT EDIT OR RECATEGORIZE THIS METHOD.
-
-	If you wish to modify this resource evaluate:
-	ViewComposer openOn: (ResourceIdentifier class: self selector: #resource_ChunkBrowser_file_tools)
-	"
-
-	^#(#'!!STL' 3 788558 10 ##(STBViewProxy)  8 ##(Toolbar)  98 25 0 0 98 2 8 1140853516 131137 416 0 524550 ##(ColorRef)  8 4278190080 0 517 0 263174 ##(Font)  0 16 459014 ##(LOGFONT)  8 #[243 255 255 255 0 0 0 0 0 0 0 0 0 0 0 0 144 1 0 0 0 0 0 0 3 2 1 34 65 114 105 97 108 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 328198 ##(Point)  193 193 0 416 498 528 8 4294904585 234 256 98 0 234 256 98 12 37621 853766 ##(ToolbarButton)  37621 0 416 1 1180998 4 ##(CommandDescription)  8 #differences 8 'Differences' 1 1 0 657990 3 ##(DIBSection)  0 16 1114638 ##(STBSingletonProxy)  8 ##(ImageRelativeFileLocator)  8 #current 8 'Ian Bartholomew\Resources\ChunkBrowser.bmp' 2032142 ##(STBExternalResourceLibraryProxy)  8 'dolphindr006.dll' 0 0 7 626 737 33 9 0 35 37623 754 37623 0 416 1 786 8 #restoreSelection 8 'Restore selection' 1 1 0 864 43 37625 754 37625 0 416 1 786 8 #restorePicked 8 'Restore picked' 1 1 0 864 45 37615 1246982 ##(ToolbarSystemButton)  37615 0 416 1 786 8 #fileOpen 8 'Open' 1 1 0 1 15 37617 1154 37617 0 416 1 786 8 #copyText 8 'Copy text' 1 1 0 1 3 37619 1154 37619 0 416 1 786 8 #print 8 'Print' 1 1 0 1 29 98 9 1050118 ##(ToolbarSeparator)  0 0 416 3 0 1 1168 1378 0 0 416 3 0 1 1232 1296 1378 0 0 416 3 0 1 768 1024 1088 234 240 98 4 1 1 864 31 0 1 0 626 33 33 626 45 45 0 656198 1 ##(FlowLayout)  1 1 1 983302 ##(MessageSequence)  202 208 98 2 721670 ##(MessageSend)  8 #createAt:extent: 98 2 626 11 11 626 325 51 416 1602 8 #updateSize 704 416 983302 ##(WINDOWPLACEMENT)  8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 5 0 0 0 5 0 0 0 167 0 0 0 30 0 0 0] 98 0 626 193 193 0 27 )! !
-!Toolbar class categoriesFor: #resource_ChunkBrowser_chunk_tools!public!resources-views! !
-!Toolbar class categoriesFor: #resource_ChunkBrowser_file_tools!public!resources-views! !
 
 "End of package definition"!
 

--- a/Core/Contributions/IDB/IDB Common.pax
+++ b/Core/Contributions/IDB/IDB Common.pax
@@ -2,15 +2,18 @@
 package := Package name: 'IDB Common'.
 package paxVersion: 1;
 	basicComment: 'Common classes and methods for IDB Goodies
-Version 6a - May 2005
+Version 6b - October 2005
 For Version 6 of Dolphin Smalltalk
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware
+
+6b - October 2005
+	- removed #idbHelp
 '.
 
-package basicPackageVersion: 'IDB$PACKAGE$VERSION 6a'.
+package basicPackageVersion: 'IDB$PACKAGE$VERSION 6b jgf.1'.
 
 
 package classNames
@@ -65,7 +68,7 @@ idbDefaultIconName
 	the /packages/idb folder."
 
 	#idbAdded.
-	^File 
+	^File
 		composePath: SessionManager current idbResourcesFolder
 		stem: self name
 		extension: 'ico'! !

--- a/Core/Contributions/IDB/IDB Method History.pax
+++ b/Core/Contributions/IDB/IDB Method History.pax
@@ -2,26 +2,24 @@
 package := Package name: 'IDB Method History'.
 package paxVersion: 1;
 	basicComment: 'Extracts and presents class/method history from the change log
-Version 6c - January 2008
+Version 6b - October 2005
 For Version 6 of Dolphin Smalltalk
 
-(C) 2006-2008 Ian Bartholomew
+(C) 2005 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware
 
-6c - January 2008
-	- Updated for 6.1
-	- Removed DiffBrowser class (now uses Dolphins)
 6b - October 2005
 	- extensive rewrite'.
 
-package basicPackageVersion: 'IDB$PACKAGE$VERSION 6c'.
+package basicPackageVersion: 'IDB$PACKAGE$VERSION 6b'.
 
 
 package classNames
 	add: #ChunkFileMethodScanner;
 	add: #ClassHistoryBrowser;
-	add: #HistoryBrowserAbstract;
+	add: #DiffBrowser;
+	add: #HistoryBrowser;
 	add: #MethodHistoryBrowser;
 	add: #SelectorParser;
 	yourself.
@@ -45,19 +43,20 @@ package globalAliases: (Set new
 	yourself).
 
 package setPrerequisites: (IdentitySet new
-	add: '..\..\Object Arts\Dolphin\IDE\Base\Development System';
-	add: '..\..\Object Arts\Dolphin\Base\Dolphin';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Common Controls\Dolphin Common Controls';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\Difference\Dolphin Differences Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Models\List\Dolphin List Models';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\Number\Dolphin Number Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Scintilla\Dolphin Scintilla View';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Slider\Dolphin Slider Control';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters';
-	add: '..\..\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models';
+	add: '..\Object Arts\Dolphin\IDE\Base\Development System';
+	add: '..\Object Arts\Dolphin\Base\Dolphin';
+	add: '..\Object Arts\Dolphin\MVP\Views\Common Controls\Dolphin Common Controls';
+	add: '..\Object Arts\Dolphin\MVP\Dialogs\Common\Dolphin Common Dialogs';
+	add: '..\Object Arts\Dolphin\MVP\Presenters\Difference\Dolphin Differences Presenter';
+	add: '..\Object Arts\Dolphin\MVP\Models\List\Dolphin List Models';
+	add: '..\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter';
+	add: '..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base';
+	add: '..\Object Arts\Dolphin\MVP\Presenters\Number\Dolphin Number Presenter';
+	add: '..\Object Arts\Dolphin\MVP\Views\Scintilla\Dolphin Scintilla View';
+	add: '..\Object Arts\Dolphin\MVP\Views\Slider\Dolphin Slider Control';
+	add: '..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter';
+	add: '..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters';
+	add: '..\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models';
 	yourself).
 
 package!
@@ -74,18 +73,23 @@ Object subclass: #SelectorParser
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-SmalltalkToolShell subclass: #HistoryBrowserAbstract
-	instanceVariableNames: 'class'
+SmalltalkToolShell subclass: #DiffBrowser
+	instanceVariableNames: 'diffsPresenter'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-HistoryBrowserAbstract subclass: #ClassHistoryBrowser
-	instanceVariableNames: 'list'
+SmalltalkToolShell subclass: #HistoryBrowser
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-HistoryBrowserAbstract subclass: #MethodHistoryBrowser
-	instanceVariableNames: 'history selector debugger selection slider source'
+HistoryBrowser subclass: #ClassHistoryBrowser
+	instanceVariableNames: 'class list'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+HistoryBrowser subclass: #MethodHistoryBrowser
+	instanceVariableNames: 'history class selector debugger selection slider source'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -116,10 +120,10 @@ canBrowseMethodHistory
 canBrowseMethodHistoryForClass
 	#idbAdded.
 	^self hasClassSelected! !
-!ClassBrowserAbstract categoriesFor: #browseMethodHistory!accessing!commands!idb goodies!public! !
+!ClassBrowserAbstract categoriesFor: #browseMethodHistory!accessing!commands!idb goodies!private! !
 !ClassBrowserAbstract categoriesFor: #browseMethodHistoryForClass!commands!idb goodies!public! !
-!ClassBrowserAbstract categoriesFor: #canBrowseMethodHistory!idb goodies!public!testing! !
-!ClassBrowserAbstract categoriesFor: #canBrowseMethodHistoryForClass!idb goodies!public!testing! !
+!ClassBrowserAbstract categoriesFor: #canBrowseMethodHistory!idb goodies!private!testing! !
+!ClassBrowserAbstract categoriesFor: #canBrowseMethodHistoryForClass!idb goodies!private!testing! !
 
 !Debugger methodsFor!
 
@@ -135,38 +139,37 @@ browseMethodHistory
 canBrowseMethodHistory
 	#idbAdded.
 	^self hasEditableMethodSelected! !
-!Debugger categoriesFor: #browseMethodHistory!commands!idb goodies!public! !
-!Debugger categoriesFor: #canBrowseMethodHistory!accessing!idb goodies!public!testing! !
+!Debugger categoriesFor: #browseMethodHistory!commands!idb goodies!private! !
+!Debugger categoriesFor: #canBrowseMethodHistory!accessing!idb goodies!private!testing! !
 
 !MethodBrowserShell methodsFor!
 
 browseMethodHistory
 	#idbAdded.
-	MethodHistoryBrowser
-		showOnClass: self selectedMethod methodClass
+	MethodHistoryBrowser showOnClass: self selectedMethod methodClass
 		selector: self selectedMethod selector!
 
 canBrowseMethodHistory
 	#idbAdded.
 	^self browser hasMethodSelected! !
-!MethodBrowserShell categoriesFor: #browseMethodHistory!accessing!commands!idb goodies!public! !
-!MethodBrowserShell categoriesFor: #canBrowseMethodHistory!accessing!idb goodies!public!testing! !
+!MethodBrowserShell categoriesFor: #browseMethodHistory!accessing!commands!idb goodies!private! !
+!MethodBrowserShell categoriesFor: #canBrowseMethodHistory!accessing!idb goodies!private!testing! !
 
 !SmalltalkToolShell methodsFor!
 
-queryMethodHistoryCommand: aCommandQuery
+queryMethodHistoryCommand: aCommandQuery 
 	| selector |
 	selector := aCommandQuery commandSymbol.
-	selector == #browseMethodHistory
-		ifTrue:
+	selector == #browseMethodHistory 
+		ifTrue: 
 			[aCommandQuery isEnabled: self canBrowseMethodHistory.
 			^true].
-	selector == #browseMethodHistoryForClass
-		ifTrue:
+	selector == #browseMethodHistoryForClass 
+		ifTrue: 
 			[aCommandQuery isEnabled: self canBrowseMethodHistoryForClass.
 			^true].
 	^false! !
-!SmalltalkToolShell categoriesFor: #queryMethodHistoryCommand:!commands!idb goodies!public! !
+!SmalltalkToolShell categoriesFor: #queryMethodHistoryCommand:!commands!private! !
 
 "End of package definition"!
 

--- a/Core/Contributions/IDB/IDB Printer.pax
+++ b/Core/Contributions/IDB/IDB Printer.pax
@@ -2,45 +2,60 @@
 package := Package name: 'IDB Printer'.
 package paxVersion: 1;
 	basicComment: 'Printing
-Version 6a - May 2005
+Version 6b - November 2005
 For Version 6 of Dolphin Smalltalk
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware
+
+6b - November 2005
+	- Added methods contributed by James Foster.  Thanks.
 '.
 
-package basicPackageVersion: 'IDB$PACKAGE$VERSION 6a'.
+package basicPackageVersion: 'IDB$PACKAGE$VERSION 6b JGF.1'.
 
+package basicScriptAt: #preinstall put: 'Win32Constants
+	at: ''PHYSICALWIDTH'' put: 110;
+	at: ''PHYSICALHEIGHT'' put: 111;
+	at: ''PHYSICALOFFSETX'' put: 112;
+	at: ''PHYSICALOFFSETY'' put: 113
+'.
 
 package classNames
 	add: #DEVNAMES;
-	add: #IdeBrowserPrinterExtension;
-	add: #IdePrinter;
-	add: #IdePrinterExtensions;
 	add: #PAGESETUPDLG;
 	add: #Printer;
+	add: #PrintPreviewShell;
 	yourself.
 
 package methodNames
-	add: #ClassBrowserAbstract -> #canPrint;
-	add: #ClassBrowserAbstract -> #print;
+	add: #Bitmap -> #canvasCompatibleWith:;
 	add: #ComDlgLibrary -> #pageSetupDlg:;
+	add: #DEVMODE -> #deviceName;
 	add: #FORMATRANGE -> #cpMax;
 	add: #FORMATRANGE -> #cpMin;
-	add: #MethodBrowserShell -> #canPrint;
-	add: #MethodBrowserShell -> #print;
-	add: #MultilineTextEdit -> #printOn:margins:selectionRange:pageRange:titleBlock:;
-	add: #Notepad -> #filePageSetup;
-	add: #Notepad -> #filePrint;
-	add: #RichTextEdit -> #printOn:margins:selectionRange:pageRange:titleBlock:;
-	add: #ScintillaView -> #printOn:margins:selectionRange:pageRange:titleBlock:;
-	add: #Shell -> #pageSetup;
-	add: #Shell -> #print:;
-	add: #SmalltalkWorkspaceDocument -> #canPrint;
-	add: #SmalltalkWorkspaceDocument -> #print;
-	add: #WordPad -> #filePageSetup;
-	add: #WordPad -> #filePrint;
+	add: #FORMATRANGE -> #hdcTarget;
+	add: #KernelLibrary -> #getProfileString:keyName:default:returnedString:size:;
+	add: #MultilineTextEdit -> #printDocumentTo:;
+	add: #MultilineTextEdit -> #printPreviewDocumentTo:for:;
+	add: #PRINTDLG -> #deviceNameFromDevMode;
+	add: #PRINTDLG -> #deviceNameFromDevNames;
+	add: #PRINTDLG -> #devModeDo:;
+	add: #PRINTDLG -> #devNamesDo:;
+	add: #PRINTDLG -> #driverName;
+	add: #PRINTDLG -> #outputName;
+	add: #PRINTDLGEX -> #deviceNameFromDevMode;
+	add: #PRINTDLGEX -> #deviceNameFromDevNames;
+	add: #PRINTDLGEX -> #devModeDo:;
+	add: #PRINTDLGEX -> #devNamesDo:;
+	add: #PRINTDLGEX -> #driverName;
+	add: #PRINTDLGEX -> #outputName;
+	add: #RichTextEdit -> #printDocumentTo:;
+	add: #RichTextEdit -> #printPreviewDocumentTo:for:;
+	add: #ScintillaView -> #printDocumentTo:;
+	add: #ScintillaView -> #printPreviewDocumentTo:for:;
+	add: 'PrinterCanvas class' -> #forPrinterNamed:;
 	yourself.
 
 package globalNames
@@ -54,17 +69,19 @@ package globalAliases: (Set new
 	yourself).
 
 package setPrerequisites: (IdentitySet new
-	add: '..\Object Arts\Dolphin\IDE\Base\Development System';
 	add: '..\Object Arts\Dolphin\Base\Dolphin';
+	add: '..\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Choice Prompter';
 	add: '..\Object Arts\Dolphin\MVP\Dialogs\Common\Dolphin Common Dialogs';
 	add: '..\Object Arts\Dolphin\MVP\Dialogs\Common\Dolphin Common Print Dialog';
+	add: '..\Object Arts\Dolphin\MVP\Presenters\Image\Dolphin Image Presenter';
 	add: '..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base';
+	add: '..\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Prompter';
 	add: '..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Rich Text Presenter';
 	add: '..\Object Arts\Dolphin\MVP\Views\Scintilla\Dolphin Scintilla View';
+	add: '..\Object Arts\Dolphin\MVP\Views\Scrollbars\Dolphin Scrollbars';
 	add: '..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter';
-	add: 'IDB IDE Extensions';
-	add: '..\Object Arts\Samples\MVP\Notepad\Notepad';
-	add: '..\Object Arts\Samples\MVP\Wordpad\Wordpad';
+	add: '..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters';
+	add: '..\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models';
 	yourself).
 
 package!
@@ -72,11 +89,11 @@ package!
 "Class Definitions"!
 
 Object subclass: #Printer
-	instanceVariableNames: 'hDevNames hDevMode rtMargin margins selectionRange pageRange titleBlock'
-	classVariableNames: 'Default'
-	poolDictionaries: 'PrintingConstants ScintillaConstants Win32Constants'
+	instanceVariableNames: 'hDevNames hDevMode rtMargin margins selectionRange pageRange pageRangeLimits titleBlock printerCanvas'
+	classVariableNames: ''
+	poolDictionaries: 'PrintingConstants Win32Constants'
 	classInstanceVariableNames: ''!
-Win32Structure subclass: #DEVNAMES
+ExternalStructure subclass: #DEVNAMES
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -86,18 +103,8 @@ Win32Structure subclass: #PAGESETUPDLG
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-IdeExtensions subclass: #IdePrinterExtensions
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
-IdePrinterExtensions subclass: #IdeBrowserPrinterExtension
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
-Printer subclass: #IdePrinter
-	instanceVariableNames: ''
+Shell subclass: #PrintPreviewShell
+	instanceVariableNames: 'image documentView printer currentPage bitmap lastPage'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -107,21 +114,22 @@ Printer subclass: #IdePrinter
 
 "Loose Methods"!
 
-!ClassBrowserAbstract methodsFor!
+!Bitmap methodsFor!
 
-canPrint
-	#idbAdded.
-	^#('source' 'definition' 'comment') includes: self currentCard view name!
+canvasCompatibleWith: aPrinterCanvas
+	"Private - Answer a Canvas to access the bitmap"
 
-print
 	#idbAdded.
-	super print: self currentCard view referee! !
-!ClassBrowserAbstract categoriesFor: #canPrint!idb goodies!printing!public!testing! !
-!ClassBrowserAbstract categoriesFor: #print!idb goodies!printing!public! !
+	hdc
+		ifNil:
+			[hdc := GDILibrary default createCompatibleDC: aPrinterCanvas handle.
+			GDILibrary default selectObject: hdc hgdiobj: self asParameter].
+	^Canvas withNonOwnedDC: hdc! !
+!Bitmap categoriesFor: #canvasCompatibleWith:!idb goodies!printing!public! !
 
 !ComDlgLibrary methodsFor!
 
-pageSetupDlg: aWinPAGESETUPDLG 
+pageSetupDlg: aWinPAGESETUPDLG
 	"Private - Displays a Page Setup dialog box.
 
 		BOOL PageSetupDlg(
@@ -133,6 +141,14 @@ pageSetupDlg: aWinPAGESETUPDLG
 	^self invalidCall! !
 !ComDlgLibrary categoriesFor: #pageSetupDlg:!idb goodies!primitives!public!win32 functions-common dialog box! !
 
+!DEVMODE methodsFor!
+
+deviceName
+	#idbAdded.
+	#JamesFoster.
+	^String fromAddress: self dmDeviceName yourAddress! !
+!DEVMODE categoriesFor: #deviceName!accessing!idb goodies!public! !
+
 !FORMATRANGE methodsFor!
 
 cpMax
@@ -141,171 +157,389 @@ cpMax
 
 cpMin
 	#idbAdded.
-	^bytes sdwordAtOffset: 40! !
+	^bytes sdwordAtOffset: 40!
+
+hdcTarget
+	#idbAdded.
+	^bytes dwordAtOffset: 4! !
 !FORMATRANGE categoriesFor: #cpMax!accessing!idb goodies!public! !
 !FORMATRANGE categoriesFor: #cpMin!accessing!idb goodies!public! !
+!FORMATRANGE categoriesFor: #hdcTarget!accessing!idb goodies!public! !
 
-!MethodBrowserShell methodsFor!
+!KernelLibrary methodsFor!
 
-canPrint
+getProfileString: appName keyName: keyName default: defaultStr returnedString: retStr size: anInt
+	<stdcall: dword GetProfileStringA lpvoid lpvoid lpvoid lpvoid dword>
 	#idbAdded.
-	^true!
-
-print
-	#idbAdded.
-	super print: browserPresenter sourcePresenter view! !
-!MethodBrowserShell categoriesFor: #canPrint!idb goodies!printing!public!testing! !
-!MethodBrowserShell categoriesFor: #print!idb goodies!printing!public! !
+	#JamesFoster.
+	self invalidCall! !
+!KernelLibrary categoriesFor: #getProfileString:keyName:default:returnedString:size:!idb goodies!public!win32 functions-system information! !
 
 !MultilineTextEdit methodsFor!
 
-printOn: aPrinterCanvas margins: aRectangle selectionRange: selectionIntervalOrNil pageRange: pageIntervalOrNil titleBlock: aBlockOrNil 
+printDocumentTo: aPrinter
 	| richTextEdit |
 	#idbAdded.
 	richTextEdit := (RichTextEdit new)
-				parentView: View desktop;
-				create;
-				yourself.
+		parentView: View desktop;
+		create;
+		yourself.
 	richTextEdit
 		replaceSelection: self text;
-		printOn: aPrinterCanvas
-			margins: aRectangle
-			selectionRange: selectionIntervalOrNil
-			pageRange: pageIntervalOrNil
-			titleBlock: aBlockOrNil! !
-!MultilineTextEdit categoriesFor: #printOn:margins:selectionRange:pageRange:titleBlock:!idb goodies!printing!private! !
+		printDocumentTo: aPrinter!
 
-!Notepad methodsFor!
+printPreviewDocumentTo: aPrinter for: aPrintPreviewShell
+	| richTextEdit |
+	#idbAdded.
+	richTextEdit := (RichTextEdit new)
+		parentView: View desktop;
+		create;
+		yourself.
+	richTextEdit
+		replaceSelection: self text;
+		printPreviewDocumentTo: aPrinter for: aPrintPreviewShell! !
+!MultilineTextEdit categoriesFor: #printDocumentTo:!idb goodies!printing!public! !
+!MultilineTextEdit categoriesFor: #printPreviewDocumentTo:for:!idb goodies!printing!public! !
 
-filePageSetup
-	self pageSetup!
+!PRINTDLG methodsFor!
 
-filePrint
-	self print: documentPresenter view! !
-!Notepad categoriesFor: #filePageSetup!idb goodies!Printing!public! !
-!Notepad categoriesFor: #filePrint!idb goodies!Printing!public! !
+deviceNameFromDevMode
+	#idbAdded.
+	#JamesFoster.
+	^self devModeDo: [:devMode | devMode deviceName]!
+
+deviceNameFromDevNames
+	#idbAdded.
+	#JamesFoster.
+	^self devNamesDo: [:devMode | devMode deviceName]!
+
+devModeDo: aBlock
+	| hDevMode pDevMode |
+	#idbAdded.
+	#JamesFoster.
+	hDevMode := self hDevMode.
+	(pDevMode := KernelLibrary default globalLock: hDevMode) ifNil: [^nil].
+	^[aBlock value: (DEVMODE fromAddress: pDevMode)]
+		ensure: [KernelLibrary default globalUnlock: hDevMode]!
+
+devNamesDo: aBlock
+	| hDevNames pDevNames |
+	#idbAdded.
+	#JamesFoster.
+	hDevNames := self hDevNames.
+	(pDevNames := KernelLibrary default globalLock: hDevNames) ifNil: [^self].
+	^[aBlock value: (DEVNAMES fromAddress: pDevNames)]
+		ensure: [KernelLibrary default globalUnlock: hDevNames]!
+
+driverName
+	#idbAdded.
+	#JamesFoster.
+	^self devNamesDo: [:devMode | devMode driverName]!
+
+outputName
+	#idbAdded.
+	#JamesFoster.
+	^self devNamesDo: [:devNames | devNames outputName]! !
+!PRINTDLG categoriesFor: #deviceNameFromDevMode!accessing!idb goodies!public! !
+!PRINTDLG categoriesFor: #deviceNameFromDevNames!accessing!idb goodies!public! !
+!PRINTDLG categoriesFor: #devModeDo:!accessing!idb goodies!public! !
+!PRINTDLG categoriesFor: #devNamesDo:!accessing!idb goodies!public! !
+!PRINTDLG categoriesFor: #driverName!accessing!idb goodies!public! !
+!PRINTDLG categoriesFor: #outputName!accessing!idb goodies!public! !
+
+!PRINTDLGEX methodsFor!
+
+deviceNameFromDevMode
+	#idbAdded.
+	#JamesFoster.
+	^self devModeDo: [:devMode | devMode deviceName]!
+
+deviceNameFromDevNames
+	#idbAdded.
+	#JamesFoster.
+	^self devNamesDo: [:devMode | devMode deviceName]!
+
+devModeDo: aBlock
+	| hDevMode pDevMode |
+	#idbAdded.
+	#JamesFoster.
+	hDevMode := self hDevMode.
+	(pDevMode := KernelLibrary default globalLock: hDevMode) ifNil: [^nil].
+	^[aBlock value: (DEVMODE fromAddress: pDevMode)]
+		ensure: [KernelLibrary default globalUnlock: hDevMode]!
+
+devNamesDo: aBlock
+	| hDevNames pDevNames |
+	#idbAdded.
+	#JamesFoster.
+	hDevNames := self hDevNames.
+	(pDevNames := KernelLibrary default globalLock: hDevNames) ifNil: [^self].
+	^[aBlock value: (DEVNAMES fromAddress: pDevNames)]
+		ensure: [KernelLibrary default globalUnlock: hDevNames]!
+
+driverName
+	#idbAdded.
+	#JamesFoster.
+	^self devNamesDo: [:devMode | devMode driverName]!
+
+outputName
+	#idbAdded.
+	#JamesFoster.
+	^self devNamesDo: [:devNames | devNames outputName]! !
+!PRINTDLGEX categoriesFor: #deviceNameFromDevMode!accessing!idb goodies!public! !
+!PRINTDLGEX categoriesFor: #deviceNameFromDevNames!accessing!idb goodies!public! !
+!PRINTDLGEX categoriesFor: #devModeDo:!helpers!idb goodies!public! !
+!PRINTDLGEX categoriesFor: #devNamesDo:!helpers!idb goodies!public! !
+!PRINTDLGEX categoriesFor: #driverName!accessing!idb goodies!public! !
+!PRINTDLGEX categoriesFor: #outputName!accessing!idb goodies!public! !
+
+!PrinterCanvas class methodsFor!
+
+forPrinterNamed: aString
+	| hDC |
+	#idbAdded.
+	#JamesFoster.
+	hDC := GDILibrary default
+		createDC: nil
+		lpszDevice: aString asParameter
+		lpszOutput: nil
+		lpInitData: nil.	"lpdvminit: nil."
+	#idbToDo.	"Check GDI call"
+	hDC ifNil: [^nil].
+	^self withOwnedDC: hDC asInteger! !
+!PrinterCanvas class categoriesFor: #forPrinterNamed:!idb goodies!instance creation!public! !
 
 !RichTextEdit methodsFor!
 
-printOn: aPrinterCanvas margins: aRectangle selectionRange: selectionIntervalOrNil pageRange: pageIntervalOrNil titleBlock: aBlockOrNil 
-	| formatRange pageRect renderRect currentPage |
-	#idbAdded.
-	"All measurements in TWIPS"
-	pageRect := Point zero extent: (aPrinterCanvas extent * 1440 / aPrinterCanvas resolution) truncated.
-	renderRect := pageRect origin + (aRectangle topLeft * 1.44) truncated 
-				corner: pageRect corner - (aRectangle bottomRight * 1.44) truncated.
+printDocumentTo: aPrinter
+	"I know the print and printPreview metods could be amalgamated but 
+	there are enough differences to make it messy"
+
+	| formatRange pageRect renderRect page |
+	#idbAdded.	"All measurements in pixels"	"All the documentation implies that the origin in the next statement should be the offset (see printPreview)
+	If you use that then the page is printed too far to the right??"
+	pageRect := (0 @ 0 * 1440 / aPrinter printerCanvas resolution) truncated
+		extent: (aPrinter printerCanvas extent * 1440 / aPrinter printerCanvas resolution) truncated.	"margins are in 0.001 of an inch"
+	renderRect := pageRect origin + (aPrinter margins topLeft * 1.44) truncated
+		corner: pageRect corner - (aPrinter margins bottomRight * 1.44) truncated.
 	formatRange := FORMATRANGE new.
 	formatRange
-		hdc: aPrinterCanvas handle;
-		hdcTarget: aPrinterCanvas handle;
-		rc: (RECT fromRectangle: renderRect);
+		hdc: aPrinter printerCanvas handle;
+		hdcTarget: aPrinter printerCanvas handle;
 		rcPage: (RECT fromRectangle: pageRect);
-		cpMin: (selectionIntervalOrNil ifNil: [0] ifNotNil: [selectionIntervalOrNil start]);
-		cpMax: (selectionIntervalOrNil ifNil: [self textLength] ifNotNil: [selectionIntervalOrNil stop]).
-	currentPage := 1.
-	aPrinterCanvas startDocNamed: 'Dolphin'.
-	[formatRange cpMin < formatRange cpMax] whileTrue: 
-			[formatRange cpMin: (self 
-						sendMessage: EM_FORMATRANGE
-						wParam: 0
-						lParam: formatRange yourAddress).
-			(pageIntervalOrNil isNil or: [pageIntervalOrNil includes: currentPage]) 
-				ifTrue: 
-					[aPrinterCanvas startPage.
-					aBlockOrNil 
-						ifNotNil: 
+		cpMin: (aPrinter selectionRange ifNil: [0] ifNotNil: [:arg | arg start]);
+		cpMax: (aPrinter selectionRange ifNil: [self textLength] ifNotNil: [:arg | arg stop]).
+	page := 1.
+	aPrinter printerCanvas startDocNamed: 'Dolphin'.
+	[formatRange cpMin < formatRange cpMax]
+		whileTrue:
+			["We need to refresh the renderRect every page"
+			formatRange rc: (RECT fromRectangle: renderRect).
+			(aPrinter pageRange isNil or: [aPrinter pageRange includes: page])
+				ifTrue:
+					[aPrinter printerCanvas startPage.	"Insert the title (if needed)"
+					aPrinter titleBlock
+						ifNotNil:
 							[:arg | 
-							arg 
-								value: aPrinterCanvas
-								value: currentPage
-								value: (renderRect left / 1440 * aPrinterCanvas resolution x) truncated
-								value: (renderRect right / 1440 * aPrinterCanvas resolution x) truncated].
-					self 
+							arg
+								value: aPrinter printerCanvas
+								value: page
+								value: (renderRect left / 1440 * aPrinter printerCanvas resolution x) truncated
+								value: (renderRect right / 1440 * aPrinter printerCanvas resolution x) truncated].	"Render it"
+					formatRange
+						cpMin:
+							(self
+								sendMessage: EM_FORMATRANGE
+								wParam: 0
+								lParam: formatRange yourAddress).	"Display it"
+					self
 						sendMessage: EM_DISPLAYBAND
 						wParam: 0
 						lParam: formatRange rc yourAddress.
-					aPrinterCanvas endPage].
-			currentPage := currentPage + 1].
-	self 
+					aPrinter printerCanvas endPage]
+				ifFalse:
+					["No need to render so just format the page and continue"
+					formatRange
+						cpMin:
+							(self
+								sendMessage: EM_FORMATRANGE
+								wParam: 0
+								lParam: formatRange yourAddress)].
+			page := page + 1].
+	self
 		sendMessage: EM_FORMATRANGE
 		wParam: 0
 		lParam: 0.
-	aPrinterCanvas endDoc! !
-!RichTextEdit categoriesFor: #printOn:margins:selectionRange:pageRange:titleBlock:!idb goodies!printing!private! !
+	aPrinter printerCanvas endDoc!
+
+printPreviewDocumentTo: aPrinter for: aPrintPreviewShell
+	"I know the print and printPreview metods could be amalgamated but 
+	there are enough differences to make it messy"
+
+	| formatRange offset pageRect renderRect page bitmap bitmapCanvas |
+	#idbAdded.	"All measurements in pixels"
+	bitmap := Bitmap compatible: aPrinter printerCanvas extent: aPrinter pageSize.
+	bitmapCanvas := (bitmap canvasCompatibleWith: aPrinter printerCanvas)
+		fillRectangle: (0 @ 0 extent: aPrinter pageSize) brush: Brush white;
+		yourself.
+	offset := (aPrinter printerCanvas getDeviceCaps: PHYSICALOFFSETX)
+		@ (aPrinter printerCanvas getDeviceCaps: PHYSICALOFFSETY).
+	pageRect := (offset * 1440 / aPrinter printerCanvas resolution) truncated
+		extent: (aPrinter printerCanvas extent * 1440 / aPrinter printerCanvas resolution) truncated.	"margins are in 0.001 of an inch"
+	renderRect := pageRect origin + (aPrinter margins topLeft * 1.44) truncated
+		corner: pageRect corner - (aPrinter margins bottomRight * 1.44) truncated.
+	formatRange := FORMATRANGE new.
+	formatRange
+		hdc: bitmapCanvas handle;
+		hdcTarget: aPrinter printerCanvas handle;
+		rcPage: (RECT fromRectangle: pageRect);
+		cpMin: (aPrinter selectionRange ifNil: [0] ifNotNil: [:arg | arg start]);
+		cpMax: (aPrinter selectionRange ifNil: [self textLength] ifNotNil: [:arg | arg stop]).
+	page := 1.
+	[formatRange cpMin < formatRange cpMax]
+		whileTrue:
+			["We need to refresh the renderRect every page"
+			formatRange rc: (RECT fromRectangle: renderRect).
+			aPrintPreviewShell currentPage = page
+				ifTrue:
+					["Insert the title (if needed)"
+					aPrinter titleBlock
+						ifNotNil:
+							[:arg | 
+							arg
+								value: bitmapCanvas
+								value: page
+								value: (renderRect left / 1440 * aPrinter printerCanvas resolution x) truncated
+								value: (renderRect right / 1440 * aPrinter printerCanvas resolution x) truncated].	"Render it"
+					formatRange
+						cpMin:
+							(self
+								sendMessage: EM_FORMATRANGE
+								wParam: 0
+								lParam: formatRange yourAddress).	"Display it"
+					self
+						sendMessage: EM_DISPLAYBAND
+						wParam: 0
+						lParam: formatRange rc yourAddress]
+				ifFalse:
+					["No need to render so just format the page and continue"
+					formatRange
+						cpMin:
+							(self
+								sendMessage: EM_FORMATRANGE
+								wParam: 0
+								lParam: formatRange yourAddress)].
+			page := page + 1].
+	self
+		sendMessage: EM_FORMATRANGE
+		wParam: 0
+		lParam: 0.
+	aPrintPreviewShell
+		bitmap: bitmap;
+		lastPage: page - 1! !
+!RichTextEdit categoriesFor: #printDocumentTo:!idb goodies!printing!public! !
+!RichTextEdit categoriesFor: #printPreviewDocumentTo:for:!idb goodies!printing!public! !
 
 !ScintillaView methodsFor!
 
-printOn: aPrinterCanvas margins: aRectangle selectionRange: selectionIntervalOrNil pageRange: pageIntervalOrNil titleBlock: aBlockOrNil 
-	| formatRange pageRect renderRect currentPage |
-	#idbAdded.
-	"All measurements in pixels"
-	pageRect := Point zero extent: aPrinterCanvas extent.
-	renderRect := pageRect origin + (aRectangle topLeft / 1000 * aPrinterCanvas resolution) truncated 
-				corner: pageRect corner - (aRectangle bottomRight / 1000 * aPrinterCanvas resolution) truncated.
+printDocumentTo: aPrinter
+	"I know the print and printPreview metods could be amalgamated but 
+	there are enough differences to make it messy"
+
+	| formatRange pageRect renderRect page |
+	#idbAdded.	"All measurements in pixels"	"All the documentation implies that the origin in the next statement should be the offset (see printPreview)
+	If you use that then the page is printed too far to the right??"
+	pageRect := 0 @ 0 extent: aPrinter printerCanvas extent.	"margins are in 0.001 of an inch"
+	renderRect := pageRect origin
+		+ (aPrinter margins topLeft / 1000 * aPrinter printerCanvas resolution) truncated
+		corner:
+			pageRect corner
+				- (aPrinter margins bottomRight / 1000 * aPrinter printerCanvas resolution) truncated.
 	formatRange := FORMATRANGE new.
 	formatRange
-		hdc: aPrinterCanvas handle;
-		hdcTarget: aPrinterCanvas handle;
+		hdc: aPrinter printerCanvas handle;
+		hdcTarget: aPrinter printerCanvas handle;
 		rc: (RECT fromRectangle: renderRect);
 		rcPage: (RECT fromRectangle: pageRect);
-		cpMin: (selectionIntervalOrNil ifNil: [0] ifNotNil: [selectionIntervalOrNil start]);
-		cpMax: (selectionIntervalOrNil ifNil: [self textLength] ifNotNil: [selectionIntervalOrNil stop]).
+		cpMin: (aPrinter selectionRange ifNil: [0] ifNotNil: [:arg | arg start]);
+		cpMax: (aPrinter selectionRange ifNil: [self textLength] ifNotNil: [:arg | arg stop]).
 	self printColourMode: SC_PRINT_COLOURONWHITE.
-	currentPage := 1.
-	aPrinterCanvas startDocNamed: 'Dolphin'.
-	[formatRange cpMin < formatRange cpMax] whileTrue: 
-			[(pageIntervalOrNil isNil or: [pageIntervalOrNil includes: currentPage]) 
-				ifTrue: 
-					[aPrinterCanvas startPage.
-					aBlockOrNil 
-						ifNotNil: 
+	page := 1.
+	aPrinter printerCanvas startDocNamed: 'Dolphin'.
+	[formatRange cpMin < formatRange cpMax]
+		whileTrue:
+			[(aPrinter pageRange isNil or: [aPrinter pageRange includes: page])
+				ifTrue:
+					[aPrinter printerCanvas startPage.	"Insert the title (if needed)"
+					aPrinter titleBlock
+						ifNotNil:
 							[:arg | 
-							arg 
-								value: aPrinterCanvas
-								value: currentPage
+							arg
+								value: aPrinter printerCanvas
+								value: page
 								value: renderRect left
-								value: renderRect right].
+								value: renderRect right].	"Render it"
 					formatRange cpMin: (self sciFormatRange: true fr: formatRange).
-					aPrinterCanvas endPage]
-				ifFalse: [formatRange cpMin: (self sciFormatRange: false fr: formatRange)].
-			currentPage := currentPage + 1].
+					aPrinter printerCanvas endPage]
+				ifFalse:
+					["No need to render so just format the page and continue"
+					formatRange cpMin: (self sciFormatRange: false fr: formatRange)].
+			page := page + 1].
 	self sciFormatRange: false fr: 0.
-	aPrinterCanvas endDoc! !
-!ScintillaView categoriesFor: #printOn:margins:selectionRange:pageRange:titleBlock:!idb goodies!printing!private! !
+	aPrinter printerCanvas endDoc!
 
-!Shell methodsFor!
+printPreviewDocumentTo: aPrinter for: aPrintPreviewShell
+	"I know the print and printPreview metods could be amalgamated but 
+	there are enough differences to make it messy"
 
-pageSetup
-	#idbAdded.
-	IdePrinter default showPageSetupDialog: true!
-
-print: aView 
-	#idbAdded.
-	IdePrinter default print: aView showDialog: true! !
-!Shell categoriesFor: #pageSetup!idb goodies!printing!public! !
-!Shell categoriesFor: #print:!idb goodies!printing!public! !
-
-!SmalltalkWorkspaceDocument methodsFor!
-
-canPrint
-	#idbAdded.
-	^true!
-
-print
-	#idbAdded.
-	super print: workspacePresenter view! !
-!SmalltalkWorkspaceDocument categoriesFor: #canPrint!idb goodies!printing!public!testing! !
-!SmalltalkWorkspaceDocument categoriesFor: #print!idb goodies!printing!public! !
-
-!WordPad methodsFor!
-
-filePageSetup
-	self pageSetup!
-
-filePrint
-	self print: documentPresenter view! !
-!WordPad categoriesFor: #filePageSetup!idb goodies!Printing!public! !
-!WordPad categoriesFor: #filePrint!idb goodies!Printing!public! !
+	| formatRange offset pageRect renderRect page bitmap bitmapCanvas |
+	#idbAdded.	"All measurements in pixels"
+	bitmap := Bitmap compatible: aPrinter printerCanvas extent: aPrinter pageSize.
+	bitmapCanvas := (bitmap canvasCompatibleWith: aPrinter printerCanvas)
+		fillRectangle: (0 @ 0 extent: aPrinter pageSize) brush: Brush white;
+		yourself.
+	offset := (aPrinter printerCanvas getDeviceCaps: PHYSICALOFFSETX)
+		@ (aPrinter printerCanvas getDeviceCaps: PHYSICALOFFSETY).
+	pageRect := offset extent: aPrinter printerCanvas extent.	"margins are in 0.001 of an inch"
+	renderRect := pageRect origin
+		+ (aPrinter margins topLeft / 1000 * aPrinter printerCanvas resolution) truncated
+		corner:
+			pageRect corner
+				- (aPrinter margins bottomRight / 1000 * aPrinter printerCanvas resolution) truncated.
+	formatRange := FORMATRANGE new.
+	formatRange
+		hdc: bitmapCanvas handle;
+		hdcTarget: aPrinter printerCanvas handle;
+		rc: (RECT fromRectangle: renderRect);
+		rcPage: (RECT fromRectangle: pageRect);
+		cpMin: (aPrinter selectionRange ifNil: [0] ifNotNil: [:arg | arg start]);
+		cpMax: (aPrinter selectionRange ifNil: [self textLength] ifNotNil: [:arg | arg stop]).
+	self printColourMode: SC_PRINT_COLOURONWHITE.
+	page := 1.
+	[formatRange cpMin < formatRange cpMax]
+		whileTrue:
+			[aPrintPreviewShell currentPage = page
+				ifTrue:
+					["Insert the title (if needed)"
+					aPrinter titleBlock
+						ifNotNil:
+							[:arg | 
+							arg
+								value: bitmapCanvas
+								value: page
+								value: renderRect left
+								value: renderRect right].	"Render it"
+					formatRange cpMin: (self sciFormatRange: true fr: formatRange)]
+				ifFalse:
+					["No need to render so just format the page and continue"
+					formatRange cpMin: (self sciFormatRange: false fr: formatRange)].
+			page := page + 1].
+	self sciFormatRange: false fr: 0.
+	aPrintPreviewShell
+		bitmap: bitmap;
+		lastPage: page - 1! !
+!ScintillaView categoriesFor: #printDocumentTo:!idb goodies!printing!public! !
+!ScintillaView categoriesFor: #printPreviewDocumentTo:for:!idb goodies!printing!public! !
 
 "End of package definition"!
 

--- a/Core/Contributions/IDB/IdbShell.cls
+++ b/Core/Contributions/IDB/IdbShell.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 SmalltalkToolShell subclass: #IdbShell
 	instanceVariableNames: ''
@@ -8,37 +8,56 @@ SmalltalkToolShell subclass: #IdbShell
 IdbShell guid: (GUID fromString: '{D143E0F5-FB16-48B9-999E-C66F61C6FD3E}')!
 IdbShell comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !IdbShell categoriesForClass!IDB Goodies! !
 !IdbShell methodsFor!
 
-idbAbout: aString 
-	(Splash bitmap: (Bitmap fromFile: SessionManager current idbResourcesFolder , '\about.bmp')
-		overlayWith: 
-			[:canvas | 
-			Processor sleep: 1000.
-			canvas
-				setBkMode: TRANSPARENT;
-				forecolor: Color blue;
-				font: (Font name: 'Arial' pointSize: 11) beBold;
-				formatText: aString
-					in: ((0 @ 0 extent: 250 @ 180) insetBy: 8 @ 8)
-					flags: DT_CENTER]) 
-			show!
+idbAbout
+	self subclassResponsibility!
+
+idbAbout: aString
+	self class idbAbout: aString!
 
 idbHelp
-	"Open up the index page for help on idb tools"
+	self subclassResponsibility!
 
-	ShellLibrary default shellOpen: (File composePath: SessionManager current idbDocumentationFolder
-				subPath: self class name asLowercase , '.html')! !
-!IdbShell categoriesFor: #idbAbout:!commands!public! !
-!IdbShell categoriesFor: #idbHelp!commands!public! !
+idbHelp: aFileNameStem
+	self class idbHelp: aFileNameStem! !
+!IdbShell categoriesFor: #idbAbout!public! !
+!IdbShell categoriesFor: #idbAbout:!operations!public! !
+!IdbShell categoriesFor: #idbHelp!public! !
+!IdbShell categoriesFor: #idbHelp:!operations!public! !
 
 !IdbShell class methodsFor!
 
 defaultIconName
-	^self idbDefaultIconName! !
+	^self idbDefaultIconName!
+
+idbAbout: aString
+	(Splash
+		bitmap:
+			(Bitmap fromFile: (File composePath: SessionManager current idbResourcesFolder subPath: 'about.bmp'))
+		overlayWith:
+			[:canvas | 
+			Processor sleep: 1000.
+			canvas
+				backgroundMode: TRANSPARENT;
+				forecolor: Color blue;
+				font: (Font name: 'Arial' pointSize: 11) beBold;
+				formatText: aString
+					in: ((0 @ 0 extent: 250 @ 180) insetBy: 8 @ 8)
+					flags: DT_CENTER]) show!
+
+idbHelp: aFileNameStem
+	ShellLibrary default
+		shellOpen:
+			(File
+				composePath: SessionManager current idbDocumentationFolder
+				stem: aFileNameStem
+				extension: 'html')! !
 !IdbShell class categoriesFor: #defaultIconName!constants!public! !
+!IdbShell class categoriesFor: #idbAbout:!operations!public! !
+!IdbShell class categoriesFor: #idbHelp:!operations!public! !
 

--- a/Core/Contributions/IDB/IdbToolShell.cls
+++ b/Core/Contributions/IDB/IdbToolShell.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 IdbShell subclass: #IdbToolShell
 	instanceVariableNames: ''
@@ -8,13 +8,13 @@ IdbShell subclass: #IdbToolShell
 IdbToolShell guid: (GUID fromString: '{D5A39E13-1A86-4F66-B67F-C7875188C304}')!
 IdbToolShell comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !IdbToolShell categoriesForClass!IDB Goodies! !
 !IdbToolShell methodsFor!
 
-addToCommandRoute: route 
+addToCommandRoute: route
 	super addToCommandRoute: route.
 	route appendTarget: Smalltalk developmentSystem! !
 !IdbToolShell categoriesFor: #addToCommandRoute:!commands!public! !
@@ -22,16 +22,16 @@ addToCommandRoute: route
 !IdbToolShell class methodsFor!
 
 initializeAfterLoad
-	self == ##(self) 
-		ifFalse: 
+	self == ##(self)
+		ifFalse:
 			[(Smalltalk developmentSystem)
 				addAdditionalToolsFolderIcon: self toolsFolderIcon;
 				registerTool: self].
 	super initializeAfterLoad!
 
 uninitializeBeforeRemove
-	self == ##(self) 
-		ifFalse: 
+	self == ##(self)
+		ifFalse:
 			[(Smalltalk developmentSystem)
 				removeSystemFolderIcon: self toolsFolderIcon;
 				unregisterTool: self].

--- a/Core/Contributions/IDB/MethodHistoryBrowser.cls
+++ b/Core/Contributions/IDB/MethodHistoryBrowser.cls
@@ -1,18 +1,47 @@
 "Filed out from Dolphin Smalltalk X6.1"!
 
-HistoryBrowserAbstract subclass: #MethodHistoryBrowser
-	instanceVariableNames: 'history selector debugger selection slider source'
+HistoryBrowser subclass: #MethodHistoryBrowser
+	instanceVariableNames: 'history class selector debugger selection slider source'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 MethodHistoryBrowser guid: (GUID fromString: '{58D8A262-AC1F-455C-AD71-5EBAB63F34E3}')!
-MethodHistoryBrowser comment: 'See [DolphinImageFolder]/Idb/Documentation for details
+MethodHistoryBrowser comment: 'Searches the sources and changes files to provide a change history for a method and opens a browser on the results.
 
-(C) 2006-2008 Ian Bartholomew
+Usage:
+ClassHistoryBrowser showOnClass: aClass selector: aSelectorSymbol
+
+Versions of the method can be selected by using the controls at the top of the browser.
+
+Versions are in the correct order but sequential duplicates have been removed.  If an method appears in the sources file 
+and the changes file then the version from the sources file will be the first in the list.
+
+The current version of the method can be
+- copied.  To the clipboard
+- restored.  The newly restored method will be added to the end of the list
+- diffed.  A DifferencesPresenter will be opend comparing the current selection with the last version
+
+If the IDB IDE Printer package is installed then the current version can be printed.
+
+
+(C) 2005 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !MethodHistoryBrowser categoriesForClass!IDB Goodies! !
 !MethodHistoryBrowser methodsFor!
+
+about
+	"Display the about view"
+
+	self 
+		about: '
+Method History Browser
+for
+Dolphin Smalltalk 6.x
+
+Version 6b
+© 2005 Ian Bartholomew
+http://www.idb.me.uk'!
 
 canPrint
 	^[super canPrint] on: MessageNotUnderstood do: [:e | false]!
@@ -24,7 +53,7 @@ createComponents
 
 createSchematicWiring
 	super createSchematicWiring.
-	slider
+	slider 
 		when: #valueChanged
 		send: #onSliderValueChanged
 		to: self.
@@ -39,14 +68,15 @@ createSchematicWiring
 			send: #onMethodRemoved:
 			to: self!
 
-idbAbout
-	"Display the about view"
+diff
+	(DiffBrowser show)
+		caption: class name , '>>' , selector;
+		compare: ((history at: selection) at: 3)
+			id: 'Version #' , selection printString
+			and: ((history at: history size) at: 3)
+			id: 'Current image'!
 
-	self 
-		idbAbout: '<n>Method History Browser<n>for<n>Dolphin Smalltalk 6.x<n><n>Version 6c<n>© 2005-2008 Ian Bartholomew<n>http://www.idb.me.uk' 
-				expandMacros!
-
-moveTo: anInteger
+moveTo: anInteger 
 	selection := anInteger.
 	self updateSelection!
 
@@ -66,6 +96,15 @@ onImageChanged: aCompiledMethod
 	aCompiledMethod methodClass == class & (aCompiledMethod selector == selector)
 		ifTrue: [self updateHistory]!
 
+onMethodAdded: aCompilationResult
+	self onImageChanged: aCompilationResult method!
+
+onMethodRemoved: aCompiledMethod 
+	self onImageChanged: aCompiledMethod!
+
+onMethodUpdated: aCompilationResult 
+	self onImageChanged: aCompilationResult method!
+
 onSliderValueChanged
 	self moveTo: slider model value!
 
@@ -76,32 +115,32 @@ onViewClosed
 	super onViewClosed.
 	SmalltalkSystem current removeEventsTriggeredFor: self!
 
-onViewOpened
+onViewOpened	
 	super onViewOpened.
 	selection := history size!
 
 printableView
 	^source view!
 
-queryCommand: aCommandQuery
-	(#(#print #printPreview) identityIncludes: aCommandQuery command)
-		ifTrue:
+queryCommand: aCommandQuery 
+	(#(#print #printPreview) identityIncludes: aCommandQuery command) 
+		ifTrue: 
 			[aCommandQuery isEnabled: self canPrint.
 			^true].
-	aCommandQuery command == #moveToFirst
-		ifTrue:
+	aCommandQuery command == #moveToFirst 
+		ifTrue: 
 			[aCommandQuery isEnabled: selection ~= 1.
 			^true].
-	(#(#showDifferences #restoreMethod #moveToLast) identityIncludes: aCommandQuery command)
-		ifTrue:
+	(#(#diff #restoreMethod #moveToLast) identityIncludes: aCommandQuery command) 
+		ifTrue: 
 			[aCommandQuery isEnabled: selection ~= history size.
 			^true].
-	aCommandQuery command == #moveToPrevious
-		ifTrue:
+	aCommandQuery command == #moveToPrevious 
+		ifTrue: 
 			[aCommandQuery isEnabled: history size ~= 1 & (selection > 1).
 			^true].
-	aCommandQuery command == #moveToNext
-		ifTrue:
+	aCommandQuery command == #moveToNext 
+		ifTrue: 
 			[aCommandQuery isEnabled: history size ~= 1 & (selection < history size).
 			^true].
 	^super queryCommand: aCommandQuery!
@@ -112,17 +151,22 @@ restoreMethod
 	let this go without a warning. The history browser will be updated by the 
 	normal event mechanism"
 
-	(class compile: (history at: selection) third) ifNil: [^MessageBox warning: 'Restore failed'].
+	(class compile: ((history at: selection) at: 3)) isNil
+		ifTrue: [^MessageBox warning: 'Restore failed'].
 	debugger ifNotNil: [debugger restartMethod]!
 
 setCaption
-	self
-		caption:
-			('MethodHistory - <1s>>><2s>  (<3d> of <4d>)'
-				expandMacrosWith: class name
-				with: selector asString
-				with: selection
-				with: history size)!
+	self caption: ((String writeStream)
+				nextPutAll: 'MethodHistory - ';
+				nextPutAll: class name;
+				nextPutAll: '>>';
+				nextPutAll: selector asString;
+				nextPutAll: '  (';
+				print: selection;
+				nextPutAll: ' of ';
+				print: history size;
+				nextPut: $);
+				contents)!
 
 setClass: aClass selector: aSymbol debugger: aDebuggerOrNil
 	"Initialze the list by locating the source for all the historical methods for the selected
@@ -134,34 +178,21 @@ setClass: aClass selector: aSymbol debugger: aDebuggerOrNil
 	debugger := aDebuggerOrNil.
 	self updateHistory!
 
-showDifferences
-	| differencesPresenter |
-	differencesPresenter := DifferencesPresenter show.
-	differencesPresenter topShell
-		caption: ('Differences between version #<1d> and the current image' expandMacrosWith: selection).
-	differencesPresenter
-		beforeText: (history at: selection) third;
-		beforeTitle: ('Version #<1d>' expandMacrosWith: selection);
-		afterText: history last third;
-		afterTitle: 'Current image';
-		refresh!
-
 updateHistory
 	"Get the historic information for the method. Purge consecutive duplicates from the list"
 
 	| temp |
-	temp := Cursor wait showWhile: [self scanner forMethod: selector inClass: class].
+	Cursor wait showWhile: [temp := self scanner forMethod: selector inClass: class].
 	history := OrderedCollection with: temp first.
-	temp
-		do:
-			[:each | history last first = each first & (history last third = each third) ifFalse: [history add: each]].
+	temp do: 
+			[:each | 
+			(history last at: 1) = (each at: 1) & ((history last at: 3) = (each at: 3)) 
+				ifFalse: [history add: each]].
 	self setCaption.
 	self moveToLast!
 
 updateSelection
-	source
-		text: (history at: selection) third;
-		setFocus.
+	source text: ((history at: selection) at: 3).
 	history size = 1
 		ifTrue:
 			[(slider view)
@@ -174,16 +205,20 @@ updateSelection
 				isEnabled: true.
 			slider value: selection].
 	self setCaption! !
+!MethodHistoryBrowser categoriesFor: #about!commands!public! !
 !MethodHistoryBrowser categoriesFor: #canPrint!printing!public!testing! !
 !MethodHistoryBrowser categoriesFor: #createComponents!initializing!public! !
 !MethodHistoryBrowser categoriesFor: #createSchematicWiring!initializing!public! !
-!MethodHistoryBrowser categoriesFor: #idbAbout!commands!public! !
+!MethodHistoryBrowser categoriesFor: #diff!commands!public! !
 !MethodHistoryBrowser categoriesFor: #moveTo:!operations!public! !
 !MethodHistoryBrowser categoriesFor: #moveToFirst!commands!public! !
 !MethodHistoryBrowser categoriesFor: #moveToLast!commands!public! !
 !MethodHistoryBrowser categoriesFor: #moveToNext!commands!public! !
 !MethodHistoryBrowser categoriesFor: #moveToPrevious!commands!public! !
 !MethodHistoryBrowser categoriesFor: #onImageChanged:!event handling!public! !
+!MethodHistoryBrowser categoriesFor: #onMethodAdded:!event handling!public! !
+!MethodHistoryBrowser categoriesFor: #onMethodRemoved:!event handling!public! !
+!MethodHistoryBrowser categoriesFor: #onMethodUpdated:!event handling!public! !
 !MethodHistoryBrowser categoriesFor: #onSliderValueChanged!initializing!public! !
 !MethodHistoryBrowser categoriesFor: #onViewClosed!event handling!public! !
 !MethodHistoryBrowser categoriesFor: #onViewOpened!event handling!public! !
@@ -192,7 +227,6 @@ updateSelection
 !MethodHistoryBrowser categoriesFor: #restoreMethod!commands!public! !
 !MethodHistoryBrowser categoriesFor: #setCaption!operations!public! !
 !MethodHistoryBrowser categoriesFor: #setClass:selector:debugger:!accessing!public! !
-!MethodHistoryBrowser categoriesFor: #showDifferences!commands!public! !
 !MethodHistoryBrowser categoriesFor: #updateHistory!operations!public! !
 !MethodHistoryBrowser categoriesFor: #updateSelection!event handling!public! !
 
@@ -206,7 +240,7 @@ resource_Default_view
 	ViewComposer openOn: (ResourceIdentifier class: self selector: #resource_Default_view)
 	"
 
-	^#(#'!!STL' 3 788558 10 ##(Smalltalk.STBViewProxy)  8 ##(Smalltalk.ShellView)  98 27 0 0 98 2 27131905 131073 416 0 721158 ##(Smalltalk.SystemColor)  31 328198 ##(Smalltalk.Point)  1261 601 551 0 0 0 416 852230 ##(Smalltalk.FramingLayout)  234 240 98 4 410 8 ##(Smalltalk.ScintillaView)  98 46 0 416 98 2 8 1174475012 1025 608 721990 2 ##(Smalltalk.ValueHolder)  0 32 1310726 ##(Smalltalk.EqualitySearchPolicy)  0 196934 1 ##(Smalltalk.RGB)  30277631 0 7 0 0 0 608 0 8 4294903303 852486 ##(Smalltalk.NullConverter)  0 0 11 0 234 256 98 6 8 #lineNumber 1182726 ##(Smalltalk.ScintillaTextStyle)  67 0 0 1 0 0 0 0 864 0 0 0 8 #normal 882 1 0 0 1 0 0 0 0 912 0 0 0 8 #indentGuide 882 75 0 0 1 0 0 0 0 944 0 0 0 98 40 928 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 896 0 0 0 960 0 0 1377542 ##(Smalltalk.SmalltalkMethodStyler)  1 0 0 32 202 208 98 0 234 256 98 2 8 #default 1639942 ##(Smalltalk.ScintillaMarkerDefinition)  0 1 786694 ##(Smalltalk.IndexedColor)  33554433 1138 33554471 608 8 #circle 202 208 1040 0 63 9215 0 0 0 0 1138 33554447 0 0 0 0 0 234 256 98 6 8 #literalArray 8 '()' 8 #literalBytes 8 '[]' 8 #specialCharacter 8 '()[]<>' 8 '' 1 234 256 1040 0 0 0 0 3 0 234 256 98 4 8 'indicator1' 1509190 1 ##(Smalltalk.ScintillaIndicatorStyle)  3 608 33423361 5 32 0 0 8 'indicator0' 1442 1 608 65025 3 32 0 0 983302 ##(Smalltalk.MessageSequence)  202 208 98 7 721670 ##(Smalltalk.MessageSend)  8 #createAt:extent: 98 2 514 1 73 514 1245 421 608 1570 8 #selectionRange: 98 1 525062 ##(Smalltalk.Interval)  3 1 3 608 1570 8 #isTextModified: 98 1 32 608 1570 8 #modificationEventMask: 98 1 9215 608 1570 8 #margins: 98 1 98 3 984582 ##(Smalltalk.ScintillaMargin)  1 608 1 3 32 1 1906 3 608 1 1 32 67108863 1906 5 608 1 1 32 1 608 1570 8 #indentationGuides: 98 1 0 608 1570 8 #tabIndents: 98 1 16 608 983302 ##(Smalltalk.WINDOWPLACEMENT)  8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 36 0 0 0 110 2 0 0 246 0 0 0] 98 0 514 193 193 0 27 1181766 2 ##(Smalltalk.FramingConstraints)  1180678 ##(Smalltalk.FramingCalculation)  8 #fixedParentLeft 1 2178 8 #fixedParentRight 1 2178 8 #fixedPreviousBottom 1 2178 8 #fixedParentBottom 1 410 8 ##(Smalltalk.ContainerView)  98 15 0 416 98 2 8 1140850688 131073 2320 0 0 0 7 0 0 0 2320 546 234 240 98 6 410 2336 98 15 0 2320 98 2 8 1140850688 131073 2448 0 0 0 7 0 0 0 2448 546 234 240 98 10 410 8 ##(Smalltalk.PushButton)  98 20 0 2448 98 2 8 1140924416 1 2560 0 0 0 7 0 0 0 2560 0 8 4294903329 1180998 4 ##(Smalltalk.CommandDescription)  8 #moveToPrevious 8 '<' 1 1 0 0 32 0 0 0 1506 202 208 98 3 1570 1600 98 2 514 65 9 514 49 57 2560 1570 8 #isEnabled: 98 1 32 2560 1570 8 #text: 98 1 8 '<' 2560 2066 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 32 0 0 0 4 0 0 0 56 0 0 0 32 0 0 0] 98 0 2128 0 29 2146 2178 8 #fixedPreviousRight 9 2178 8 #fixedViewLeft 49 2178 8 #fixedParentTop 9 2288 -7 410 2576 98 20 0 2448 98 2 8 1140924416 1 3104 0 0 0 7 0 0 0 3104 0 8 4294903329 2658 8 #moveToFirst 8 '|<' 1 1 0 0 32 0 0 0 1506 202 208 98 3 1570 1600 98 2 514 9 9 514 49 57 3104 1570 2848 98 1 32 3104 1570 2896 98 1 8 '|<' 3104 2066 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 4 0 0 0 4 0 0 0 28 0 0 0 32 0 0 0] 98 0 2128 0 29 2146 2192 9 3040 49 3072 9 2288 -7 410 8 ##(Smalltalk.Slider)  98 18 0 2448 98 2 8 1140916485 1 3488 690 0 32 1376774 ##(Smalltalk.PluggableSearchPolicy)  459270 ##(Smalltalk.Message)  8 #= 98 0 3618 8 #hash 98 0 3 0 0 7 0 0 0 3488 0 8 4294903429 802 0 0 3 0 0 1506 202 208 98 3 1570 1600 98 2 514 121 1 514 361 71 3488 1570 8 #pageSize: 98 1 3 3488 1570 8 #range: 98 1 1714 1 3 3 3488 2066 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 60 0 0 0 0 0 0 0 240 0 0 0 35 0 0 0] 98 0 2128 0 27 2146 2192 121 2224 -119 3072 1 2178 8 #fixedViewTop 71 410 2576 98 20 0 2448 98 2 8 1140924416 1 4080 0 0 0 7 0 0 0 4080 0 8 4294903329 2658 8 #moveToLast 8 '>|' 1 1 0 0 32 0 0 0 1506 202 208 98 3 1570 1600 98 2 514 545 9 514 49 57 4080 1570 2848 98 1 32 4080 1570 2896 98 1 8 '>|' 4080 2066 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 16 1 0 0 4 0 0 0 40 1 0 0 32 0 0 0] 98 0 2128 0 29 2146 2178 8 #fixedViewRight -47 2224 -7 3072 9 2288 -7 410 2576 98 20 0 2448 98 2 8 1140924416 1 4496 0 0 0 7 0 0 0 4496 0 8 4294903329 2658 8 #moveToNext 8 '>' 1 1 0 0 32 0 0 0 1506 202 208 98 3 1570 1600 98 2 514 489 9 514 49 57 4496 1570 2848 98 1 32 4496 1570 2896 98 1 8 '>' 4496 2066 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 244 0 0 0 4 0 0 0 12 1 0 0 32 0 0 0] 98 0 2128 0 29 2146 4464 -47 2178 8 #fixedPreviousLeft -7 3072 9 2288 -7 234 256 98 2 3488 8 'slider' 0 1506 202 208 98 1 1570 1600 98 2 514 323 1 514 601 73 2448 2066 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 161 0 0 0 0 0 0 0 205 1 0 0 36 0 0 0] 98 5 3104 2560 4080 4496 3488 2128 0 27 2146 3008 51 3040 601 3072 1 2288 1 410 2576 98 20 0 2320 98 2 8 1140924416 1 5136 0 0 0 7 0 0 0 5136 0 8 4294903329 2658 8 #restoreMethod 8 'Restore' 1 1 0 0 32 0 0 0 1506 202 208 98 3 1570 1600 98 2 514 17 9 514 121 57 5136 1570 2848 98 1 32 5136 1570 2896 98 1 8 'Restore' 5136 2066 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 8 0 0 0 4 0 0 0 68 0 0 0 32 0 0 0] 98 0 2128 0 29 2146 2192 17 3040 121 3072 9 2288 -7 410 2576 98 20 0 2320 98 2 8 1140924416 1 5520 0 0 0 7 0 0 0 5520 0 8 4294903329 2658 8 #showDifferences 8 'Diff' 1 1 0 0 32 0 0 0 1506 202 208 98 3 1570 1600 98 2 514 153 9 514 121 57 5520 1570 2848 98 1 32 5520 1570 2896 98 1 8 'Diff' 5520 2066 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 76 0 0 0 4 0 0 0 136 0 0 0 32 0 0 0] 98 0 2128 0 29 2146 3008 17 3040 121 3072 9 2288 -7 234 256 1040 0 1506 202 208 98 1 1570 1600 98 2 514 1 1 514 1245 73 2320 2066 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 110 2 0 0 36 0 0 0] 98 3 5136 5520 2448 2128 0 27 2146 2192 1 2224 1 3072 1 4048 73 234 256 98 2 608 8 'source' 590342 ##(Smalltalk.Rectangle)  514 1 1 514 1 1 461638 4 ##(Smalltalk.MenuBar)  0 16 98 4 265030 4 ##(Smalltalk.Menu)  0 16 98 5 984134 2 ##(Smalltalk.CommandMenuItem)  1 2658 8 #pageSetup 8 'Page &setup...' 1 1 0 0 0 6306 1 2658 8 #printPreview 8 'Print p&review...' 1 1 0 0 0 6306 1 2658 8 #print 8 '&Print...' 1 1 0 0 0 983366 1 ##(Smalltalk.DividerMenuItem)  4097 6306 1 2658 8 #exit 8 '&Close' 16615 1 0 0 0 8 '&File' 0 1 0 0 10069 0 0 6258 0 16 98 3 6306 1 2658 8 #copySelection 8 '&Copy' 1 1 0 0 0 6306 1 2658 5232 8 '&Restore' 9381 1 0 0 0 6306 1 2658 5616 8 '&Differences' 9353 1 0 0 0 8 '&Edit' 0 1 0 0 10077 0 0 6258 0 16 98 4 6306 1 2658 3200 8 '&First' 1605 1 0 0 0 6306 1 2658 2688 8 '&Previous' 1611 1 0 0 0 6306 1 2658 4592 8 '&Next' 1615 1 0 0 0 6306 1 2658 4176 8 '&Last' 1603 1 0 0 0 8 '&Selection' 0 134217729 0 0 10087 0 0 6258 0 16 98 2 6306 1 2658 8 #idbHelp 8 '&Help' 1 1 0 0 0 6306 1 2658 8 #idbAbout 8 '&About' 1 1 0 0 0 8 '&Help' 0 134217729 0 0 10093 0 0 8 '' 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 1506 202 208 98 3 1570 1600 98 2 514 2047 21 514 1261 601 416 1570 2896 98 1 8 'Method History' 416 1570 8 #updateMenuBar 1040 416 2066 8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 3 0 0 10 0 0 0 117 6 0 0 54 1 0 0] 98 2 2320 608 2128 0 27 )!
+	^#(#'!!STL' 3 788558 10 ##(Smalltalk.STBViewProxy)  8 ##(Smalltalk.ShellView)  98 27 0 0 98 2 27131905 131073 416 0 721158 ##(Smalltalk.SystemColor)  31 328198 ##(Smalltalk.Point)  1261 601 551 0 0 0 416 852230 ##(Smalltalk.FramingLayout)  234 240 98 4 410 8 ##(Smalltalk.ContainerView)  98 15 0 416 98 2 8 1140850688 131073 608 0 0 0 7 0 0 0 608 546 234 240 98 6 410 624 98 15 0 608 98 2 8 1140850688 131073 736 0 0 0 7 0 0 0 736 546 234 240 98 10 410 8 ##(Smalltalk.PushButton)  98 17 0 736 98 2 8 1140924416 1 848 0 0 0 7 0 0 0 848 0 8 4294902643 1180998 4 ##(Smalltalk.CommandDescription)  8 #moveToPrevious 8 '<' 1 1 0 0 32 983302 ##(Smalltalk.MessageSequence)  202 208 98 3 721670 ##(Smalltalk.MessageSend)  8 #createAt:extent: 98 2 514 65 9 514 49 57 848 1074 8 #isEnabled: 98 1 32 848 1074 8 #text: 98 1 8 '<' 848 983302 ##(Smalltalk.WINDOWPLACEMENT)  8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 32 0 0 0 4 0 0 0 56 0 0 0 32 0 0 0] 98 0 514 193 193 0 27 1181766 2 ##(Smalltalk.FramingConstraints)  1114638 ##(Smalltalk.STBSingletonProxy)  8 ##(Smalltalk.FramingCalculation)  8 #fixedPreviousRight 9 1402 1424 8 #fixedViewLeft 49 1402 1424 8 #fixedParentTop 9 1402 1424 8 #fixedParentBottom -7 410 8 ##(Smalltalk.Slider)  98 18 0 736 98 2 8 1140916485 1 1552 721990 2 ##(Smalltalk.ValueHolder)  0 32 1376774 ##(Smalltalk.PluggableSearchPolicy)  459270 ##(Smalltalk.Message)  8 #= 98 0 1698 8 #hash 98 0 3 0 0 7 0 0 0 1552 0 8 4294905329 852486 ##(Smalltalk.NullConverter)  0 0 3 0 0 1010 202 208 98 3 1074 1104 98 2 514 121 1 514 361 71 1552 1074 8 #pageSize: 98 1 3 1552 1074 8 #range: 98 1 525062 ##(Smalltalk.Interval)  1 3 3 1552 1282 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 60 0 0 0 0 0 0 0 240 0 0 0 35 0 0 0] 98 0 1344 0 27 1362 1402 1424 8 #fixedParentLeft 121 1402 1424 8 #fixedParentRight -119 1488 1 1402 1424 8 #fixedViewTop 71 410 864 98 17 0 736 98 2 8 1140924416 1 2256 0 0 0 7 0 0 0 2256 0 8 4294902643 946 8 #moveToFirst 8 '|<' 1 1 0 0 32 1010 202 208 98 3 1074 1104 98 2 514 9 9 514 49 57 2256 1074 1184 98 1 32 2256 1074 1232 98 1 8 '|<' 2256 1282 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 4 0 0 0 4 0 0 0 28 0 0 0 32 0 0 0] 98 0 1344 0 27 1362 2160 9 1456 49 1488 9 1520 -7 410 864 98 17 0 736 98 2 8 1140924416 1 2640 0 0 0 7 0 0 0 2640 0 8 4294902643 946 8 #moveToLast 8 '>|' 1 1 0 0 32 1010 202 208 98 3 1074 1104 98 2 514 545 9 514 49 57 2640 1074 1184 98 1 32 2640 1074 1232 98 1 8 '>|' 2640 1282 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 16 1 0 0 4 0 0 0 40 1 0 0 32 0 0 0] 98 0 1344 0 27 1362 1402 1424 8 #fixedViewRight -47 2192 -7 1488 9 1520 -7 410 864 98 17 0 736 98 2 8 1140924416 1 3056 0 0 0 7 0 0 0 3056 0 8 4294902643 946 8 #moveToNext 8 '>' 1 1 0 0 32 1010 202 208 98 3 1074 1104 98 2 514 489 9 514 49 57 3056 1074 1184 98 1 32 3056 1074 1232 98 1 8 '>' 3056 1282 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 244 0 0 0 4 0 0 0 12 1 0 0 32 0 0 0] 98 0 1344 0 27 1362 3024 -47 1402 1424 8 #fixedPreviousLeft -7 1488 9 1520 -7 234 256 98 2 1552 8 'slider' 0 1010 202 208 98 1 1074 1104 98 2 514 323 1 514 601 73 736 1282 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 161 0 0 0 0 0 0 0 205 1 0 0 36 0 0 0] 98 5 2256 848 2640 3056 1552 1344 0 27 1362 1408 51 1456 601 1488 1 1520 1 410 864 98 17 0 608 98 2 8 1140924416 1 3696 0 0 0 7 0 0 0 3696 0 8 4294902643 946 8 #restoreMethod 8 'Restore' 1 1 0 0 32 1010 202 208 98 3 1074 1104 98 2 514 17 9 514 121 57 3696 1074 1184 98 1 32 3696 1074 1232 98 1 8 'Restore' 3696 1282 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 8 0 0 0 4 0 0 0 68 0 0 0 32 0 0 0] 98 0 1344 0 27 1362 2160 17 1456 121 1488 9 1520 -7 410 864 98 17 0 608 98 2 8 1140924416 1 4080 0 0 0 7 0 0 0 4080 0 8 4294902643 946 8 #diff 8 'Diff' 1 1 0 0 32 1010 202 208 98 3 1074 1104 98 2 514 153 9 514 121 57 4080 1074 1184 98 1 32 4080 1074 1232 98 1 8 'Diff' 4080 1282 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 76 0 0 0 4 0 0 0 136 0 0 0 32 0 0 0] 98 0 1344 0 27 1362 1408 17 1456 121 1488 9 1520 -7 234 256 98 0 0 1010 202 208 98 1 1074 1104 98 2 514 1 1 514 1245 73 608 1282 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 110 2 0 0 36 0 0 0] 98 3 3696 4080 736 1344 0 27 1362 2160 1 2192 1 1488 1 2224 73 410 8 ##(Smalltalk.ScintillaView)  98 46 0 416 98 2 8 1174475012 1025 4672 1634 0 32 1402 8 ##(Smalltalk.SearchPolicy)  8 #equality 0 196934 1 ##(Smalltalk.RGB)  30277631 0 7 0 0 0 4672 0 72569627 1826 0 0 11 0 234 256 98 6 8 #indentGuide 1182726 ##(Smalltalk.ScintillaTextStyle)  75 0 0 1 0 0 0 0 4896 0 0 0 8 #lineNumber 4914 67 0 0 1 0 0 0 0 4944 0 0 0 8 #normal 4914 1 0 0 1 0 0 0 0 4976 0 0 0 98 40 4992 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 4960 0 0 0 4928 0 0 1377542 ##(Smalltalk.SmalltalkMethodStyler)  1 0 0 32 202 208 4480 234 256 98 2 8 #default 1639942 ##(Smalltalk.ScintillaMarkerDefinition)  0 1 786694 ##(Smalltalk.IndexedColor)  33554433 5154 33554471 4672 8 #circle 202 208 4480 0 63 0 0 0 0 0 5154 33554447 0 0 0 0 0 234 256 98 6 8 #literalBytes 8 '[]' 8 #literalArray 8 '()' 8 #specialCharacter 8 '()[]<>' 8 '' 1 234 256 4480 0 0 0 0 3 0 0 1010 202 208 98 8 1074 1104 98 2 514 1 73 514 1245 421 4672 1074 8 #selectionRange: 98 1 2066 3 1 3 4672 1074 8 #isTextModified: 98 1 32 4672 1074 8 #modificationEventMask: 98 1 9215 4672 1074 8 #indicatorDefinitions: 98 1 98 2 1836038 ##(Smalltalk.ScintillaIndicatorDefinition)  1 4672 65025 3 5746 3 4672 33423361 5 4672 1074 8 #margins: 98 1 98 3 984582 ##(Smalltalk.ScintillaMargin)  1 4672 1 3 32 1 5858 3 4672 1 1 32 67108863 5858 5 4672 1 1 32 1 4672 1074 8 #markers: 98 1 5216 4672 1074 8 #tabIndents: 98 1 16 4672 1282 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 36 0 0 0 110 2 0 0 246 0 0 0] 98 0 1344 0 27 1362 2160 1 2192 1 1402 1424 8 #fixedPreviousBottom 1 1520 1 234 256 98 2 4672 8 'source' 590342 ##(Smalltalk.Rectangle)  514 1 1 514 1 1 461638 4 ##(Smalltalk.MenuBar)  0 16 98 4 265030 4 ##(Smalltalk.Menu)  0 16 98 5 984134 2 ##(Smalltalk.CommandMenuItem)  1 946 8 #pageSetup 8 'Page &setup...' 1 1 0 0 0 6322 1 946 8 #printPreview 8 'Print p&review...' 1 1 0 0 0 6322 1 946 8 #print 8 '&Print...' 1 1 0 0 0 983366 1 ##(Smalltalk.DividerMenuItem)  4097 6322 1 946 8 #exit 8 '&Close' 16615 1 0 0 0 8 '&File' 0 1 0 0 49303 0 0 6274 0 16 98 3 6322 1 946 8 #copySelection 8 '&Copy' 1 1 0 0 0 6322 1 946 3792 8 '&Restore' 9381 1 0 0 0 6322 1 946 4176 8 '&Diff' 9353 1 0 0 0 8 '&Edit' 0 1 0 0 49311 0 0 6274 0 16 98 4 6322 1 946 2352 8 '&First' 1605 1 0 0 0 6322 1 946 976 8 '&Previous' 1611 1 0 0 0 6322 1 946 3152 8 '&Next' 1615 1 0 0 0 6322 1 946 2736 8 '&Last' 1603 1 0 0 0 8 '&Position' 0 134217729 0 0 49321 0 0 6322 1 946 8 #about 8 '&About!!' 1 1 0 0 0 8 '' 0 1 0 0 0 0 0 0 1049414 1 ##(Smalltalk.AcceleratorTable)  0 16 234 256 98 14 9353 6800 16615 6576 1611 6944 9381 6752 1615 6992 1603 7040 1605 6896 0 1 0 0 0 0 1 0 0 1010 202 208 98 3 1074 1104 98 2 514 2799 21 514 1261 601 416 1074 1232 98 1 8 'Method History' 416 1074 8 #menuBar: 98 1 6240 416 1282 8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 119 5 0 0 10 0 0 0 237 7 0 0 54 1 0 0] 98 2 608 4672 1344 0 27 )!
 
 showOnClass: aClass selector: aSymbol
 	^self
@@ -221,5 +255,5 @@ showOnClass: aClass selector: aSymbol debugger: aDebuggerOrNil
 		debugger: aDebuggerOrNil! !
 !MethodHistoryBrowser class categoriesFor: #resource_Default_view!public!resources-views! !
 !MethodHistoryBrowser class categoriesFor: #showOnClass:selector:!instance creation!public! !
-!MethodHistoryBrowser class categoriesFor: #showOnClass:selector:debugger:!instance creation!public! !
+!MethodHistoryBrowser class categoriesFor: #showOnClass:selector:debugger:!instance creation!private! !
 

--- a/Core/Contributions/IDB/PAGESETUPDLG.cls
+++ b/Core/Contributions/IDB/PAGESETUPDLG.cls
@@ -8,25 +8,78 @@ Win32Structure subclass: #PAGESETUPDLG
 PAGESETUPDLG guid: (GUID fromString: '{C96162D4-5DD4-43D1-A305-E90D67357D91}')!
 PAGESETUPDLG comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !PAGESETUPDLG categoriesForClass!IDB Goodies! !
 !PAGESETUPDLG methodsFor!
 
-dwSize: anObject 
+defaultFlag
+	#JamesFoster.
+	^self devNamesDo: [:devNames | devNames wDefault]!
+
+deviceNameFromDevMode
+	#JamesFoster.
+	^self devModeDo: [:devMode | devMode deviceName]!
+
+deviceNameFromDevNames
+	#JamesFoster.
+	^self devNamesDo: [:devMode | devMode deviceName]!
+
+devModeDo: aBlock
+	| hDevMode pDevMode |
+	#JamesFoster.
+	hDevMode := self hDevMode.
+	(pDevMode := KernelLibrary default globalLock: hDevMode) ifNil: [^nil].
+	^[aBlock value: (DEVMODE fromAddress: pDevMode)]
+		ensure: [KernelLibrary default globalUnlock: hDevMode]!
+
+devNamesDo: aBlock
+	| hDevNames pDevNames |
+	#JamesFoster.
+	hDevNames := self hDevNames.
+	(pDevNames := KernelLibrary default globalLock: hDevNames) ifNil: [^self].
+	^[aBlock value: (DEVNAMES fromAddress: pDevNames)]
+		ensure: [KernelLibrary default globalUnlock: hDevNames]!
+
+driverName
+	#JamesFoster.
+	^self devNamesDo: [:devMode | devMode driverName]!
+
+dwSize: anObject
 	"Set the receiver's dwSize field to the value of anObject."
 
 	bytes dwordAtOffset: 0 put: anObject!
 
-ownerView: aView 
+orientation
+	#JamesFoster.
+	^self devModeDo: [:devMode | devMode dmOrientation]!
+
+outputName
+	#JamesFoster.
+	^self devNamesDo: [:devNames | devNames outputName]!
+
+ownerView: aView
 	"Set the parent window for the dialog to aView."
 
 	| hWnd |
 	hWnd := aView asParameter.
-	hWnd isNull ifFalse: [self hwndOwner: hWnd]! !
+	hWnd isNull ifFalse: [self hwndOwner: hWnd]!
+
+paperSize
+	#JamesFoster.
+	^self devModeDo: [:devMode | devMode dmPaperSize]! !
+!PAGESETUPDLG categoriesFor: #defaultFlag!accessing!public! !
+!PAGESETUPDLG categoriesFor: #deviceNameFromDevMode!accessing!public! !
+!PAGESETUPDLG categoriesFor: #deviceNameFromDevNames!accessing!public! !
+!PAGESETUPDLG categoriesFor: #devModeDo:!helpers!public! !
+!PAGESETUPDLG categoriesFor: #devNamesDo:!helpers!public! !
+!PAGESETUPDLG categoriesFor: #driverName!accessing!public! !
 !PAGESETUPDLG categoriesFor: #dwSize:!**compiled accessors**!public! !
+!PAGESETUPDLG categoriesFor: #orientation!accessing!public! !
+!PAGESETUPDLG categoriesFor: #outputName!accessing!public! !
 !PAGESETUPDLG categoriesFor: #ownerView:!accessing!public! !
+!PAGESETUPDLG categoriesFor: #paperSize!accessing!public! !
 
 !PAGESETUPDLG class methodsFor!
 
@@ -62,7 +115,7 @@ defineFields
 		defineField: #rtMinMargin type: (StructureField type: RECT);
 		defineField: #rtMargin type: (StructureField type: RECT);
 		defineField: #hInstance type: DWORDField filler;
-		defineField: #lCustData type: INT_PTRField filler;
+		defineField: #lCustData type: DWORDField filler;
 		defineField: #lpfnPageSetupHook type: (PointerField type: ExternalAddress) beFiller;
 		defineField: #lpfnPagePaintHook type: (PointerField type: ExternalAddress) beFiller;
 		defineField: #lpPageSetupTemplateName type: (PointerField type: String) beFiller;

--- a/Core/Contributions/IDB/PrintPreviewShell.cls
+++ b/Core/Contributions/IDB/PrintPreviewShell.cls
@@ -1,0 +1,145 @@
+"Filed out from Dolphin Smalltalk X6.1"!
+
+Shell subclass: #PrintPreviewShell
+	instanceVariableNames: 'image documentView printer currentPage bitmap lastPage'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+PrintPreviewShell guid: (GUID fromString: '{9BC31592-F010-4EB2-952D-C7FB44733B01}')!
+PrintPreviewShell comment: 'See [DolphinImageFolder]/Idb/Documentation for details
+
+(C) 2006 Ian Bartholomew
+ian@idb.me.uk
+Public Domain Freeware'!
+!PrintPreviewShell categoriesForClass!IDB Goodies! !
+!PrintPreviewShell methodsFor!
+
+bitmap: anObject
+	bitmap := anObject!
+
+centreImage
+	image view parentView scrollOffset: (image view width // 2 - (view getWindowRect width // 2)) @ 0!
+
+createComponents
+	super createComponents.
+	image := self add: ImagePresenter new name: 'image'!
+
+currentPage
+	^currentPage!
+
+displayCurrentPage
+	printer printPreview: documentView for: self.
+	currentPage > lastPage
+		ifTrue:
+			[currentPage := lastPage.
+			printer printPreview: documentView for: self].
+	image value: bitmap.
+	self
+		caption:
+			((String writeStream)
+				print: currentPage;
+				nextPutAll: ' of ';
+				print: lastPage;
+				contents)!
+
+lastPage: anObject
+	lastPage := anObject!
+
+moveToFirstPage
+	currentPage := 1.
+	self displayCurrentPage!
+
+moveToLastPage
+	currentPage := lastPage.
+	self displayCurrentPage!
+
+moveToNextPage
+	currentPage := currentPage + 1.
+	self displayCurrentPage!
+
+moveToPreviousPage
+	currentPage := currentPage - 1.
+	self displayCurrentPage!
+
+onPositionChanged: aPositionEvent
+	super onPositionChanged: aPositionEvent.
+	self centreImage!
+
+onViewClosed
+	printer pageRangeLimits: nil.
+	super onViewClosed!
+
+pageSetup
+	printer showPageSetupDialog: true.
+	self displayCurrentPage!
+
+print
+	printer pageRangeLimits: (1 to: lastPage).
+	printer print: documentView selectionRange: (1 to: 0).
+	self displayCurrentPage!
+
+printer: aPrinter documentView: aView
+	printer := aPrinter.
+	documentView := aView.
+	currentPage := 1.
+	[self displayCurrentPage] postToInputQueue!
+
+queryCommand: aCommandQuery
+	(#(#moveToPreviousPage #moveToFirstPage) identityIncludes: aCommandQuery commandSymbol)
+		ifTrue:
+			[aCommandQuery isEnabled: (currentPage notNil and: [currentPage > 1]).
+			^true].
+	(#(#moveToNextPage #moveToLastPage) identityIncludes: aCommandQuery commandSymbol)
+		ifTrue:
+			[aCommandQuery isEnabled: (currentPage notNil and: [lastPage notNil and: [currentPage < lastPage]]).
+			^true].
+	^super queryCommand: aCommandQuery!
+
+selectPage
+	| text |
+	text := Prompter prompt: 'Enter required page number (1 to ' , lastPage printString , ')'.
+	(text isNil or: [(text := text trimBlanks) = 0 or: [text anySatisfy: [:each | each isDigit not]]])
+		ifTrue: [^self].
+	currentPage := Integer fromString: text.
+	self displayCurrentPage!
+
+zoomIn
+	image view extent: (image view extent * 1.5) rounded.
+	self centreImage!
+
+zoomOut
+	image view extent: (image view extent * 0.666) rounded.
+	self centreImage! !
+!PrintPreviewShell categoriesFor: #bitmap:!accessing!public! !
+!PrintPreviewShell categoriesFor: #centreImage!commands!public! !
+!PrintPreviewShell categoriesFor: #createComponents!initializing!public! !
+!PrintPreviewShell categoriesFor: #currentPage!accessing!public! !
+!PrintPreviewShell categoriesFor: #displayCurrentPage!displaying!public! !
+!PrintPreviewShell categoriesFor: #lastPage:!accessing!public! !
+!PrintPreviewShell categoriesFor: #moveToFirstPage!commands!public! !
+!PrintPreviewShell categoriesFor: #moveToLastPage!commands!public! !
+!PrintPreviewShell categoriesFor: #moveToNextPage!commands!public! !
+!PrintPreviewShell categoriesFor: #moveToPreviousPage!commands!public! !
+!PrintPreviewShell categoriesFor: #onPositionChanged:!event handling!public! !
+!PrintPreviewShell categoriesFor: #onViewClosed!event handling!public! !
+!PrintPreviewShell categoriesFor: #pageSetup!commands!public! !
+!PrintPreviewShell categoriesFor: #print!commands!public! !
+!PrintPreviewShell categoriesFor: #printer:documentView:!initializing!public! !
+!PrintPreviewShell categoriesFor: #queryCommand:!commands!public! !
+!PrintPreviewShell categoriesFor: #selectPage!commands!public! !
+!PrintPreviewShell categoriesFor: #zoomIn!commands!public! !
+!PrintPreviewShell categoriesFor: #zoomOut!commands!public! !
+
+!PrintPreviewShell class methodsFor!
+
+resource_Default_view
+	"Answer the literal data from which the 'Default view' resource can be reconstituted.
+	DO NOT EDIT OR RECATEGORIZE THIS METHOD.
+
+	If you wish to modify this resource evaluate:
+	ViewComposer openOn: (ResourceIdentifier class: self selector: #resource_Default_view)
+	"
+
+	^#(#'!!STL' 3 788558 10 ##(STBViewProxy) 8 ##(ShellView) 98 27 0 0 98 2 27131905 131073 416 0 524550 ##(ColorRef) 8 4278190080 0 551 0 0 0 416 852230 ##(FramingLayout) 234 240 98 4 410 8 ##(ScrollingDecorator) 98 18 0 416 98 2 8 1143996416 131073 592 0 0 0 7 0 0 0 592 1573190 1 ##(ScrollingDecoratorLayout) 16 234 256 98 2 410 8 ##(ImageView) 98 21 0 592 98 2 8 1149239552 1 736 721990 2 ##(ValueHolder) 0 0 1376774 ##(PluggableSearchPolicy) 459270 ##(Message) 8 #= 98 0 882 8 #hash 98 0 0 482 8 4278190080 0 7 0 0 0 736 0 8 4294903431 852486 ##(NullConverter) 0 0 0 0 8 #scaleToFit 1 0 0 983302 ##(MessageSequence) 202 208 98 1 721670 ##(MessageSend) 8 #createAt:extent: 98 2 328198 ##(Point) 1 1 1218 1185 685 736 983302 ##(WINDOWPLACEMENT) 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 80 2 0 0 86 1 0 0] 98 0 1218 193 193 0 27 8 'image' 0 1218 1 1 16 1218 17 17 1090 202 208 98 1 1154 1184 98 2 1218 1 49 1218 1185 685 592 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 24 0 0 0 80 2 0 0 110 1 0 0] 98 1 736 1328 0 27 1181766 2 ##(FramingConstraints) 1114638 ##(STBSingletonProxy) 8 ##(FramingCalculation) 8 #fixedParentLeft 1 1594 1616 8 #fixedParentRight 1 1594 1616 8 #fixedPreviousBottom 1 1594 1616 8 #fixedParentBottom 1 410 8 ##(ContainerView) 98 15 0 416 98 2 8 1140850688 131073 1744 0 0 0 7 0 0 0 1744 530 234 240 98 20 410 8 ##(PushButton) 98 17 0 1744 98 2 8 1140924416 1 1872 0 0 0 7 0 0 0 1872 0 8 4294906413 1180998 4 ##(CommandDescription) 8 #pageSetup 8 'Page Setup' 1 1 0 0 32 1090 202 208 98 3 1154 1184 98 2 1218 149 1 1218 141 49 1872 1154 8 #isEnabled: 98 1 32 1872 1154 8 #text: 98 1 8 'Page Setup' 1872 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 74 0 0 0 0 0 0 0 144 0 0 0 24 0 0 0] 98 0 1328 0 27 1554 1594 1616 8 #fixedPreviousRight 9 1594 1616 8 #fixedViewLeft 141 1594 1616 8 #fixedParentTop 1 1712 1 410 1888 98 17 0 1744 98 2 8 1140924416 1 2416 0 0 0 7 0 0 0 2416 0 8 4294906413 1970 8 #zoomOut 8 'Out' 1 1 0 0 32 1090 202 208 98 3 1154 1184 98 2 1218 737 1 1218 61 49 2416 1154 2160 98 1 32 2416 1154 2208 98 1 8 'Out' 2416 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 112 1 0 0 0 0 0 0 142 1 0 0 24 0 0 0] 98 0 1328 0 27 1554 2320 9 2352 61 2384 1 1712 1 410 1888 98 17 0 1744 98 2 8 1140924416 1 2800 0 0 0 7 0 0 0 2800 0 8 4294906413 1970 8 #moveToFirstPage 8 'I<' 1 1 0 0 32 1090 202 208 98 3 1154 1184 98 2 1218 313 1 1218 61 49 2800 1154 2160 98 1 32 2800 1154 2208 98 1 8 'I<' 2800 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 156 0 0 0 0 0 0 0 186 0 0 0 24 0 0 0] 98 0 1328 0 27 1554 2320 25 2352 61 2384 1 1712 1 410 1888 98 17 0 1744 98 2 8 1140924416 1 3184 0 0 0 7 0 0 0 3184 0 8 4294906413 1970 8 #moveToLastPage 8 '>I' 1 1 0 0 32 1090 202 208 98 3 1154 1184 98 2 1218 585 1 1218 61 49 3184 1154 2160 98 1 32 3184 1154 2208 98 1 8 '>I' 3184 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 36 1 0 0 0 0 0 0 66 1 0 0 24 0 0 0] 98 0 1328 0 27 1554 2320 9 2352 61 2384 1 1712 1 410 1888 98 17 0 1744 98 2 8 1140924416 1 3568 0 0 0 7 0 0 0 3568 0 8 4294906413 1970 8 #selectPage 8 'Go' 1 1 0 0 32 1090 202 208 98 3 1154 1184 98 2 1218 449 1 1218 61 49 3568 1154 2160 98 1 32 3568 1154 2208 98 1 8 'Go' 3568 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 224 0 0 0 0 0 0 0 254 0 0 0 24 0 0 0] 98 0 1328 0 27 1554 2320 9 2352 61 2384 1 1712 1 410 1888 98 17 0 1744 98 2 8 1140924416 1 3952 0 0 0 7 0 0 0 3952 0 8 4294906413 1970 8 #moveToPreviousPage 8 '<' 1 1 0 0 32 1090 202 208 98 3 1154 1184 98 2 1218 381 1 1218 61 49 3952 1154 2160 98 1 32 3952 1154 2208 98 1 8 '<' 3952 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 190 0 0 0 0 0 0 0 220 0 0 0 24 0 0 0] 98 0 1328 0 27 1554 2320 9 2352 61 2384 1 1712 1 410 1888 98 17 0 1744 98 2 8 1140924416 1 4336 0 0 0 7 0 0 0 4336 0 8 4294906413 1970 8 #exit 8 'Close' 1 1 0 0 32 1090 202 208 98 2 1154 1184 98 2 1218 821 1 1218 141 49 4336 1154 2208 98 1 8 'Close' 4336 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 154 1 0 0 0 0 0 0 224 1 0 0 24 0 0 0] 98 0 1328 0 27 1554 2320 25 2352 141 1594 1616 8 #fixedPreviousTop 1 1680 1 410 1888 98 17 0 1744 98 2 8 1140924416 1 4720 0 0 0 7 0 0 0 4720 0 8 4294906413 1970 8 #print 8 'Print' 1 1 0 0 32 1090 202 208 98 3 1154 1184 98 2 1218 1 1 1218 141 49 4720 1154 2160 98 1 32 4720 1154 2208 98 1 8 'Print' 4720 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 70 0 0 0 24 0 0 0] 98 0 1328 0 27 1554 1600 1 2352 141 2384 1 1712 1 410 1888 98 17 0 1744 98 2 8 1140924416 1 5104 0 0 0 7 0 0 0 5104 0 8 4294906413 1970 8 #moveToNextPage 8 '>' 1 1 0 0 32 1090 202 208 98 3 1154 1184 98 2 1218 517 1 1218 61 49 5104 1154 2160 98 1 32 5104 1154 2208 98 1 8 '>' 5104 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 2 1 0 0 0 0 0 0 32 1 0 0 24 0 0 0] 98 0 1328 0 27 1554 2320 9 2352 61 2384 1 1712 1 410 1888 98 17 0 1744 98 2 8 1140924416 1 5488 0 0 0 7 0 0 0 5488 0 8 4294906413 1970 8 #zoomIn 8 'In' 1 1 0 0 32 1090 202 208 98 3 1154 1184 98 2 1218 669 1 1218 61 49 5488 1154 2160 98 1 32 5488 1154 2208 98 1 8 'In' 5488 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 78 1 0 0 0 0 0 0 108 1 0 0 24 0 0 0] 98 0 1328 0 27 1554 2320 25 2352 61 2384 1 1712 1 234 256 98 0 0 1090 202 208 98 1 1154 1184 98 2 1218 1 1 1218 1185 49 1744 1266 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 80 2 0 0 24 0 0 0] 98 10 4720 1872 2800 3952 3568 5104 3184 5488 2416 4336 1328 0 27 1554 1600 1 1648 1 2384 1 1594 1616 8 #fixedViewTop 49 234 256 5888 0 0 0 0 4336 1 0 0 0 0 1 0 0 1090 202 208 98 2 1154 1184 98 2 1218 20001 20001 1218 1201 801 416 1154 8 #menuBar: 98 1 0 416 1266 8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 16 39 0 0 16 39 0 0 104 41 0 0 160 40 0 0] 98 2 1744 592 1328 0 27)! !
+!PrintPreviewShell class categoriesFor: #resource_Default_view!public!resources-views! !
+

--- a/Core/Contributions/IDB/Printer.cls
+++ b/Core/Contributions/IDB/Printer.cls
@@ -1,40 +1,82 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk X6.1"!
 
 Object subclass: #Printer
-	instanceVariableNames: 'hDevNames hDevMode rtMargin margins selectionRange pageRange titleBlock'
-	classVariableNames: 'Default'
-	poolDictionaries: 'PrintingConstants ScintillaConstants Win32Constants'
+	instanceVariableNames: 'hDevNames hDevMode rtMargin margins selectionRange pageRange pageRangeLimits titleBlock printerCanvas'
+	classVariableNames: ''
+	poolDictionaries: 'PrintingConstants Win32Constants'
 	classInstanceVariableNames: ''!
 Printer guid: (GUID fromString: '{38D2291D-3137-45FF-9573-B92AE401F1A8}')!
 Printer comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
-(C) 2005 Ian Bartholomew
+(C) 2006 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
-!Printer categoriesForClass!IDB Goodies!Kernel-Objects! !
+!Printer categoriesForClass!IDB Goodies! !
 !Printer methodsFor!
 
 defaultTitleBlock
-	^self subclassResponsibility!
+	^nil!
 
 initialize
 	super initialize.
-	hDevMode := hDevNames := 0.
+	hDevMode := hDevNames := printerCanvas := 0.
 	titleBlock := self defaultTitleBlock.
-	self showPageSetupDialog: false!
+	self showPageSetupDialog: false.
+	self showPrintDialog: false selectionRange: (1 to: 0)!
 
-print: aView showDialog: aBoolean 
-	(self showPrintDialog: aBoolean selectionRange: aView selectionRange) 
-		ifNotNil: 
-			[:arg | 
-			aView 
-				printOn: arg
-				margins: margins
-				selectionRange: selectionRange
-				pageRange: pageRange
-				titleBlock: titleBlock]!
+margins
+	^margins!
 
-showPageSetupDialog: aBoolean 
+pageRange
+	^pageRange!
+
+pageRangeLimits: anObject
+	pageRangeLimits := anObject!
+
+pageSize
+	^(printerCanvas getDeviceCaps: PHYSICALWIDTH) @ (printerCanvas getDeviceCaps: PHYSICALHEIGHT)!
+
+print: aView
+	self print: aView selectionRange: aView selectionRange!
+
+print: aView selectionRange: anInterval
+	(self showPrintDialog: true selectionRange: anInterval)
+		ifNotNil:
+			[self setPrinterCanvas.
+			aView printDocumentTo: self]!
+
+printerCanvas
+	^printerCanvas!
+
+printPreview: aView
+	| printPreviewShell |
+	printPreviewShell := PrintPreviewShell show.
+	printPreviewShell printer: self documentView: aView!
+
+printPreview: aView for: aPrintPreviewShell
+	self setPrinterCanvas.
+	aView printPreviewDocumentTo: self for: aPrintPreviewShell!
+
+selectionRange
+	^selectionRange!
+
+setPrinterCanvas
+	| devModeAddr devNamesAddr devMode devNames hDC |
+	devModeAddr := KernelLibrary default globalLock: hDevMode.
+	devMode := DEVMODE new initializeAtAddress: devModeAddr.
+	devNamesAddr := KernelLibrary default globalLock: hDevNames.
+	devNames := DEVNAMES new initializeAtAddress: devNamesAddr.
+	hDC := GDILibrary default
+		createDC: (String fromAddress: devNamesAddr yourAddress + devNames wDriverOffset)
+		lpszDevice: (String fromAddress: devNamesAddr yourAddress + devNames wDeviceOffset)
+		lpszOutput: (String fromAddress: devNamesAddr yourAddress + devNames wOutputOffset)
+		lpInitData: devMode.
+	KernelLibrary default globalUnlock: hDevNames.
+	KernelLibrary default globalUnlock: hDevMode.
+	self assert: [hDC notNil].
+	printerCanvas := PrinterCanvas withOwnedDC: hDC asInteger!
+
+showPageSetupDialog: aBoolean
 	"aBoolean is false if we don't want the dialog to be displayed, just set the defaults"
 
 	| pageSetupDlg active apiResult |
@@ -44,37 +86,37 @@ showPageSetupDialog: aBoolean
 		ownerView: active;
 		hDevMode: hDevMode;
 		hDevNames: hDevNames.
-	rtMargin 
-		ifNotNil: 
+	rtMargin
+		ifNotNil:
 			[pageSetupDlg
 				rtMargin: rtMargin;
 				flags: pageSetupDlg flags | PSD_MARGINS].
-	aBoolean 
-		ifFalse: 
+	aBoolean
+		ifFalse:
 			[pageSetupDlg
 				flags: pageSetupDlg flags | PSD_RETURNDEFAULT;
 				hDevMode: 0;
 				hDevNames: 0].
-	
-	[SessionManager inputState startIdleTimer: active.
-	apiResult := ComDlgLibrary default pageSetupDlg: pageSetupDlg asParameter] 
-			ensure: [SessionManager inputState stopIdleTimer: active].
-	apiResult 
-		ifTrue: 
+	apiResult := [SessionManager inputState startIdleTimer: active.
+	ComDlgLibrary default pageSetupDlg: pageSetupDlg asParameter]
+		ensure: [SessionManager inputState stopIdleTimer: active].
+	apiResult
+		ifTrue:
 			[rtMargin := pageSetupDlg rtMargin copy.
-			margins := (pageSetupDlg flags anyMask: PSD_INHUNDREDTHSOFMILLIMETERS) 
-						ifTrue: 
-							["convert mm margin to inches"
-							(rtMargin topLeft / 2.54 corner: rtMargin bottomRight / 2.54) truncated]
-						ifFalse: [rtMargin asRectangle].
+			margins := (pageSetupDlg flags anyMask: PSD_INHUNDREDTHSOFMILLIMETERS)
+				ifTrue:
+					["convert mm margin to inches"
+					(rtMargin topLeft / 2.54 corner: rtMargin bottomRight / 2.54) truncated]
+				ifFalse: [rtMargin asRectangle].
 			hDevMode := pageSetupDlg hDevMode copy.
 			hDevNames := pageSetupDlg hDevNames copy]
-		ifFalse: 
+		ifFalse:
 			[| error |
-			(error := ComDlgLibrary default commDlgExtendedError) = 0 
-				ifFalse: [self error: 'PageSetupDialog error: ' , error printString]]!
+			(error := ComDlgLibrary default commDlgExtendedError) = 0
+				ifFalse: [self error: 'PageSetupDialog error: ' , error printString].
+			^nil]!
 
-showPrintDialog: showBoolean selectionRange: anInterval 
+showPrintDialog: showBoolean selectionRange: anInterval
 	"aBoolean is false if we don't want the dialog to be displayed, just set the defaults"
 
 	| printDlg active apiResult |
@@ -82,57 +124,95 @@ showPrintDialog: showBoolean selectionRange: anInterval
 	active := View active.
 	printDlg
 		ownerView: active;
-		flags: ##(PD_USEDEVMODECOPIES | PD_ALLPAGES | PD_RETURNDC);
+		flags: ##(PD_USEDEVMODECOPIES | PD_ALLPAGES);
 		nFromPage: 1;
 		nToPage: 1;
 		nMinPage: 1;
-		nMaxPage: 16rFFFF;
+		nMaxPage: (pageRangeLimits ifNil: [16rFFFF] ifNotNil: [pageRangeLimits stop]);
 		nCopies: 1;
 		hDC: 0;
 		hDevMode: hDevMode;
 		hDevNames: hDevNames.
 	anInterval isEmpty ifTrue: [printDlg flags: printDlg flags | PD_NOSELECTION].
-	showBoolean 
-		ifFalse: 
+	showBoolean
+		ifFalse:
 			[printDlg
 				flags: printDlg flags | PD_RETURNDEFAULT;
 				hDevMode: 0;
 				hDevNames: 0].
-	
-	[SessionManager inputState startIdleTimer: active.
-	apiResult := ComDlgLibrary default printDlg: printDlg asParameter] 
-			ensure: [SessionManager inputState stopIdleTimer: active].
-	apiResult 
-		ifTrue: 
+	apiResult := [SessionManager inputState startIdleTimer: active.
+	ComDlgLibrary default printDlg: printDlg asParameter]
+		ensure: [SessionManager inputState stopIdleTimer: active].
+	apiResult
+		ifTrue:
 			[selectionRange := (printDlg flags anyMask: PD_SELECTION) ifTrue: [anInterval].
-			pageRange := (printDlg flags anyMask: PD_PAGENUMS) 
-						ifTrue: [printDlg nFromPage to: printDlg nToPage].
+			pageRange := (printDlg flags anyMask: PD_PAGENUMS)
+				ifTrue: [printDlg nFromPage to: printDlg nToPage].
 			hDevMode := printDlg hDevMode copy.
-			hDevNames := printDlg hDevNames copy.
-			^PrinterCanvas withOwnedDC: printDlg hDC]
-		ifFalse: 
+			hDevNames := printDlg hDevNames copy]
+		ifFalse:
 			[| error |
-			(error := ComDlgLibrary default commDlgExtendedError) = 0 
-				ifFalse: [self error: 'PrintSetupDialog error: ' , error printString].
+			(error := ComDlgLibrary default commDlgExtendedError) = 0
+				ifFalse:
+					[printerCanvas := nil.
+					self error: 'PrintSetupDialog error: ' , error printString].
 			^nil]!
 
 titleBlock
 	^titleBlock!
 
 titleBlock: anObject
+	"
+	[:printerCanvas :pageNumber :leftMargin :rightMargin | 
+		]"
+
 	titleBlock := anObject! !
-!Printer categoriesFor: #defaultTitleBlock!defaults!private! !
-!Printer categoriesFor: #initialize!initializing!private! !
-!Printer categoriesFor: #print:showDialog:!operations!printing!private! !
-!Printer categoriesFor: #showPageSetupDialog:!operations!private! !
-!Printer categoriesFor: #showPrintDialog:selectionRange:!operations!private! !
-!Printer categoriesFor: #titleBlock!accessing!private! !
-!Printer categoriesFor: #titleBlock:!accessing!private! !
+!Printer categoriesFor: #defaultTitleBlock!accessing!defaults!public! !
+!Printer categoriesFor: #initialize!initializing!public! !
+!Printer categoriesFor: #margins!accessing!public! !
+!Printer categoriesFor: #pageRange!accessing!public! !
+!Printer categoriesFor: #pageRangeLimits:!accessing!public! !
+!Printer categoriesFor: #pageSize!accessing!public! !
+!Printer categoriesFor: #print:!operations!printing!public! !
+!Printer categoriesFor: #print:selectionRange:!operations!printing!public! !
+!Printer categoriesFor: #printerCanvas!accessing!public! !
+!Printer categoriesFor: #printPreview:!operations!public! !
+!Printer categoriesFor: #printPreview:for:!operations!public! !
+!Printer categoriesFor: #selectionRange!accessing!public! !
+!Printer categoriesFor: #setPrinterCanvas!operations!printing!public! !
+!Printer categoriesFor: #showPageSetupDialog:!operations!public! !
+!Printer categoriesFor: #showPrintDialog:selectionRange:!operations!public! !
+!Printer categoriesFor: #titleBlock!accessing!public! !
+!Printer categoriesFor: #titleBlock:!accessing!public! !
 
 !Printer class methodsFor!
 
-default
-	Default ifNil: [Default := self new initialize].
-	^Default! !
-!Printer class categoriesFor: #default!accessing!instance creation!public! !
+new
+	^super new initialize!
+
+printerNames
+	| printerInfo |
+	#JamesFoster.
+	printerInfo := (String new: 1024) asParameter.
+	KernelLibrary default
+		getProfileString: 'devices' asParameter
+		keyName: nil
+		default: String new asParameter
+		returnedString: printerInfo
+		size: printerInfo size.
+	^(printerInfo subStrings: Character null) select: [:each | each notEmpty]!
+
+selectPrinterNameWithPrompt: promptString default: defaultString
+	| list |
+	#JamesFoster.
+	list := self printerNames asOrderedCollection.
+	(list includes: defaultString)
+		ifTrue:
+			[list
+				remove: defaultString;
+				addFirst: defaultString].
+	^ChoicePrompter choices: list caption: promptString! !
+!Printer class categoriesFor: #new!object creation!public! !
+!Printer class categoriesFor: #printerNames!accessing!public! !
+!Printer class categoriesFor: #selectPrinterNameWithPrompt:default:!helpers!public! !
 

--- a/Core/Contributions/IDB/SelectorParser.cls
+++ b/Core/Contributions/IDB/SelectorParser.cls
@@ -6,109 +6,122 @@ Object subclass: #SelectorParser
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 SelectorParser guid: (GUID fromString: '{BCEF9177-1432-4EB4-80D9-6197B30BC4AB}')!
-SelectorParser comment: 'See [DolphinImageFolder]/Idb/Documentation for details
+SelectorParser comment: 'Parse a method definition string to obtain the method''s selector.
 
-(C) 2006-2008 Ian Bartholomew
+Usage:
+SelectorParser parse: aString
+
+Advantages over using the compiler to obtain the selector...
+- faster
+- will work on methods that don''t compile correctly
+
+(C) 2005 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !SelectorParser categoriesForClass!IDB Goodies! !
 !SelectorParser methodsFor!
 
-binaryTokenFrom: aStream
+binaryTokenFrom: aStream 
 	"Answer the binary token from aStream"
 
 	| start stop |
 	start := aStream position.
-	[aStream atEnd
-		ifTrue:
+	
+	[aStream atEnd 
+		ifTrue: 
 			[aStream position: start.
 			^aStream upToEnd].
-	(self isBinaryDelimiter: aStream next)
-		ifTrue:
+	(self isBinaryDelimiter: aStream next) 
+		ifTrue: 
 			[stop := aStream position.
 			aStream position: start.
-			^aStream next: stop - start - 1]] repeat!
+			^aStream next: stop - start - 1]] 
+			repeat!
 
-firstTokenFrom: aStream
+firstTokenFrom: aStream 
 	"Answer the first token from the current position in the stream. After skipping 
 	separators and (recursively) comment we know the next token will be either a 
 	binary selector or unary/keyword selector"
 
 	aStream skipSeparators ifFalse: [^String new].
-	(aStream peekFor: $")
-		ifTrue:
+	(aStream peekFor: $") 
+		ifTrue: 
 			[aStream skipTo: $".
 			^self firstTokenFrom: aStream].
-	^(self isBinaryStarter: aStream peek)
+	^(self isBinaryStarter: aStream peek) 
 		ifTrue: [self binaryTokenFrom: aStream]
 		ifFalse: [self keywordOrUnaryTokenFrom: aStream]!
 
-isBinaryDelimiter: aCharacter
+isBinaryDelimiter: aCharacter 
 	"Answer true is aCharacter cannot be part of a binary selector"
 
-	^##(' "_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' , Character tab asString
-			, Character cr asString , Character nl asString , Character newPage asString)
-		includes: aCharacter!
+	^(##(' "_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' , Character tab asString 
+		, Character cr asString , Character nl asString 
+		, Character newPage asString) indexOf: aCharacter) 
+		~= 0!
 
-isBinaryStarter: aCharacter
+isBinaryStarter: aCharacter 
 	"Answer true is aCharacter can be the first character in a binary selector.
 	Defined with regard to the current image. Adding binary selectors to the
 	image may also require modifications here. See class comment"
 
-	^##('<=>\@|~&%*+,-/') includes: aCharacter!
+	^(##('<=>\@|~&%*+,-/') indexOf: aCharacter) ~= 0!
 
-isKeyword: aString
+isKeyword: aString 
 	"Answer true if aString is a valid keyword token"
 
 	^aString size >= 2 and: [aString last = $: and: [self isKeywordStarter: aString first]]!
 
-isKeywordStarter: aCharacter
+isKeywordStarter: aCharacter 
 	"Answer true is aCharacter is the first character of a keyword selector"
 
-	^##('_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ') includes: aCharacter!
+	^(##('_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ') indexOf: aCharacter) ~= 0!
 
-isNonBinaryDelimiter: aCharacter
+isNonBinaryDelimiter: aCharacter 
 	"Answer true is aCharacter cannot be part of a unary selector, keyword
 	selector or the arguments in a selector string"
 
-	^##(' "#''^([<|-' , Character tab asString , Character cr asString , Character nl asString
-			, Character newPage asString) includes: aCharacter!
+	^(##(' "#''^([<|-' , Character tab asString , Character cr asString , Character nl asString 
+		, Character newPage asString) indexOf: aCharacter) 
+		~= 0!
 
-keywordOrArgumentTokenFrom: aStream
+keywordOrArgumentTokenFrom: aStream 
 	"Answer the next token from aStream. Once we have got past separators
 	and (possibly recursive) comments we can treat it in the same way (in terms 
 	of character sequences) as the initial unary/keyword token. "
 
 	aStream skipSeparators ifFalse: [^String new].
-	(aStream peekFor: $")
-		ifTrue:
+	(aStream peekFor: $") 
+		ifTrue: 
 			[aStream skipTo: $".
 			^self keywordOrArgumentTokenFrom: aStream].
 	^self keywordOrUnaryTokenFrom: aStream!
 
-keywordOrUnaryTokenFrom: aStream
+keywordOrUnaryTokenFrom: aStream 
 	"Answer the unary or keyword token from aStream. The only difference
 	is that the unary token needs to be answered without it's delimiter but the
 	keyword tokens needs to include it's delimiter - a colon"
 
 	| start stop char |
 	start := aStream position.
-	[aStream atEnd
-		ifTrue:
+	
+	[aStream atEnd 
+		ifTrue: 
 			[aStream position: start.
 			^aStream upToEnd].
-	(char := aStream next) = $:
-		ifTrue:
+	(char := aStream next) = $: 
+		ifTrue: 
 			[stop := aStream position.
 			aStream position: start.
 			^aStream next: stop - start].
-	(self isNonBinaryDelimiter: char)
-		ifTrue:
+	(self isNonBinaryDelimiter: char) 
+		ifTrue: 
 			[stop := aStream position.
 			aStream position: start.
-			^aStream next: stop - start - 1]] repeat!
+			^aStream next: stop - start - 1]] 
+			repeat!
 
-parse: aString
+parse: aString 
 	"Answer the Smalltalk selector parsed from aString. If the first token
 	is a binary or unary token we need do no more, otherwise we have to
 	get keyword tokens but omit the intervening arguments"
@@ -118,8 +131,7 @@ parse: aString
 	token := self firstTokenFrom: readStream.
 	(self isKeyword: token) ifFalse: [^token].
 	writeStream := String writeStream: 100.
-	[self isKeyword: token]
-		whileTrue:
+	[self isKeyword: token] whileTrue: 
 			[writeStream nextPutAll: token.
 			self keywordOrArgumentTokenFrom: readStream.
 			token := self keywordOrArgumentTokenFrom: readStream].
@@ -137,7 +149,7 @@ parse: aString
 
 !SelectorParser class methodsFor!
 
-parse: aString
+parse: aString 
 	"Shortcut to create the receiver and perform the parsing "
 
 	^self new parse: aString! !


### PR DESCRIPTION
With the exception of two files (IDB Method History.pax and MethodHistoryBrowser.cls), the IDB goodies appear to be based on version 6a from 2005. This pull request provides version 6b from 2006 (including the two aforementioned files to keep things consistent). Note that Ian's web site and email are no longer valid so I'm submitting what I have since it seems later and I've been using it consistently for almost a decade.