### PR TITLE
Support creation of another product

### DIFF
--- a/Boot.st
+++ b/Boot.st
@@ -53,7 +53,10 @@ productName := SessionManager current argv at: 3 ifAbsent: [ | p |
 	isPrompted := true.
 	p name].
 
-[product := Smalltalk at: productName asSymbol.
+[product := Smalltalk at: productName asSymbol ifAbsent: [ | path |
+	path := SessionManager current argv at: 4.
+	Package manager install: path.
+	Smalltalk at: productName asSymbol].
 SessionManager current saveImage: (File fullPathOf: product shortProductName).
 Notification signal: 'Booting ', product name.
 product boot] on: Error do: [:ex | 


### PR DESCRIPTION
There are three subclasses of DolphinProduct included as part of the boot image and any of these three can be built with a command-line argument. To build another product using the same process requires loading a new subclass of DolphinProduct before the build can proceed. This pull request provides one such way of doing so. If the named product (argument 3) isn't found then argument 4 is treated as the path to a package to be loaded and then the search for the product is repeated. I've been able to build a Jade development image using this approach and it seems pretty simply. I'm not sure, however, if it is the recommended approach. Like all my contributions, I'd welcome feedback and guidance.