### PR TITLE
Delete DBOOT.chg file since it otherwise keeps growing with every boot

### DIFF
--- a/Boot.st
+++ b/Boot.st
@@ -76,8 +76,9 @@ VMLibrary default unlockVM: 0 expireAfter: 0 flags: 0!
 SourceManager default basicCompressSources: 0 asValue.
 SessionManager current saveImage!
 
-"Remove rogue .img file"
-File delete: (File default: SessionManager current imagePath extension: 'img')!
+"Remove rogue .img and unnecessary .chg files"
+File delete: (File default: SessionManager current imagePath extension: 'img').
+File delete: 'DBOOT.chg'!
 
 SessionManager current quit!
 


### PR DESCRIPTION
By the time we are at this point in the script, the new product's change log is open and this one is closed.