### PR TITLE
Ignore non-boot images in root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-DPRO.*
-DCE.*
-DCORE.*
-DBASE.*
-DBOOT.chg
+*.chg
+*.ERRORS
+*.img7
 *.pac
-*.errors
+*.sml
+!DBOOT.img7
+!DBOOT.sml
 testsGdiplus
 Repository/


### PR DESCRIPTION
Instead of listing specific images to ignore (DBASE.*, DCORE.*, DCE.*, DPRO.*) we can ignore all image-related files (*.chg, *.ERRORS, *.img7, *.sml) and explicitly include (negative ignore) DBOOT.img7 and DBOOT.sml. This allows us to create other images in the Dolphin directory without attracting the attention of Git. 