### PR TITLE
Boot in subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.chg
 *.ERRORS
+*.img
 *.img7
 *.pac
 *.sml

--- a/Boot.st
+++ b/Boot.st
@@ -8,6 +8,7 @@ prefix := ''.
 count timesRepeat: [
 	(File exists: prefix, 'Dolphin7.exe') ifTrue: [
 		Smalltalk at: #bootPathPrefix put: prefix.
+		prefix notEmpty ifTrue: [Notification signal: 'bootPathPrefix = ', prefix printString].
 		^prefix
 	] ifFalse: [
 		prefix := '..\', prefix.
@@ -19,7 +20,7 @@ self error: 'Dolphin7.exe not found'!
 loaded from there. Fix up the package pathname here."
 | dolphinPackage |
 dolphinPackage := (Package manager packageNamed: 'Dolphin').
-dolphinPackage packagePathname: bootPathPrefix, 'Core\', dolphinPackage packagePathname!
+dolphinPackage packageFileName: bootPathPrefix, 'Core\', dolphinPackage packagePathname!
 
 "MemoryManager guid is corrupted during boot for some reason (that needs looking into)"
 MemoryManager guid: (GUID fromString: '{703BD0AD-FBFF-4D00-866B-B80387F7B1D7}')!
@@ -81,6 +82,8 @@ Notification signal: 'Booting ', product name.
 product boot] on: Error do: [:ex | 
 	"isPrompted==true ifFalse: [SessionManager current quit: -2]."
 	ex pass ] !
+
+Smalltalk removeKey: #bootPathPrefix!
 
 DevelopmentSessionManager installNew!
 

--- a/Boot.st
+++ b/Boot.st
@@ -1,12 +1,25 @@
 "Boot a workable Dolphin from the boot image"
 
-"
-DBOOT was created in the Core folder and had the raw Dolphin package
-loaded from there. Fix up the package pathname here.
-"
+"Allow for boot in a child directory"
+| count prefix |
+count := ((SessionManager current imageBase subStrings: $\) 
+	reject: [:each | each isEmpty or: [each includes: $:]]) size.
+prefix := ''.
+count timesRepeat: [
+	(File exists: prefix, 'Dolphin7.exe') ifTrue: [
+		Smalltalk at: #bootPathPrefix put: prefix.
+		^prefix
+	] ifFalse: [
+		prefix := '..\', prefix.
+	].
+].
+self error: 'Dolphin7.exe not found'!
+
+"DBOOT was created in the Core folder and had the raw Dolphin package
+loaded from there. Fix up the package pathname here."
 | dolphinPackage |
 dolphinPackage := (Package manager packageNamed: 'Dolphin').
-dolphinPackage packagePathname: 'Core\', dolphinPackage packagePathname!
+dolphinPackage packagePathname: bootPathPrefix, 'Core\', dolphinPackage packagePathname!
 
 "MemoryManager guid is corrupted during boot for some reason (that needs looking into)"
 MemoryManager guid: (GUID fromString: '{703BD0AD-FBFF-4D00-866B-B80387F7B1D7}')!
@@ -20,26 +33,26 @@ Package fileIn.
 File fileIn !
 
 "Install some bare bones packages to get the Installation Management system working"
-Package manager install: 'Core\Object Arts\Dolphin\Registry\Dolphin Registry Access.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\Registry\Dolphin Registry Access.pax'!
 
 "We need this to install any packages containing binaries"
-Package manager install: 'Core\Object Arts\Dolphin\System\Base64\Dolphin Base64.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\System\Base64\Dolphin Base64.pax'!
 
 "We'll need MVP bits in order to be able to display the choice prompter for the image version to boot"
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\Installation Manager\Dolphin Products.pax'!
-Package manager  	install: 'Core\Object Arts\Dolphin\MVP\Dialogs\Common\Dolphin Common Dialogs.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Presenters\Choice\Dolphin Choice Presenter.pax'!
-Package manager  	install: 'Core\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Choice Prompter.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\Installation Manager\Dolphin Products.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Dialogs\Common\Dolphin Common Dialogs.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Presenters\Choice\Dolphin Choice Presenter.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter.pax'!
+Package manager install: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Choice Prompter.pax'!
 
 "It was a crap idea to have classes whose names only differed by case wasn't it - hence we need this bodge even now"
-SourceManager default fileIn: 'Core\Object Arts\Dolphin\MVP\Base\BITMAP_Struct.cls'!
+SourceManager default fileIn: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Base\BITMAP_Struct.cls'!
 BITMAP initializeAfterLoad!
-SourceManager default fileIn: 'Core\Object Arts\Dolphin\MVP\Base\DIBSECTION_Struct.cls'!
+SourceManager default fileIn: bootPathPrefix, 'Core\Object Arts\Dolphin\MVP\Base\DIBSECTION_Struct.cls'!
 DIBSECTION initializeAfterLoad!
 
 "Set Dolphin package version and about operation"
@@ -61,7 +74,7 @@ productName := SessionManager current argv at: 3 ifAbsent: [ | p |
 
 [product := Smalltalk at: productName asSymbol ifAbsent: [ | path |
 	path := SessionManager current argv at: 4.
-	Package manager install: path.
+	Package manager install: bootPathPrefix, path.
 	Smalltalk at: productName asSymbol].
 SessionManager current saveImage: (File fullPathOf: product shortProductName).
 Notification signal: 'Booting ', product name.

--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinProduct.cls
@@ -30,7 +30,8 @@ basicLoad
 
 	"Inform the development system of it's new product state"
 
-	| packageManager |
+	| packageManager prefix |
+	prefix := Smalltalk at: #bootPathPrefix ifAbsent: [''].
 	self installProductDetails.
 	packageManager := Package manager.
 	self packagePaths do: 
@@ -39,7 +40,7 @@ basicLoad
 			name := File splitStemFrom: each.
 			packageManager packageNamed: name
 				ifNone: 
-					[[packageManager install: each] on: packageManager prerequisiteNotFoundSignal
+					[[packageManager install: prefix, each] on: packageManager prerequisiteNotFoundSignal
 						do: [:ex | ex resume: (File splitPathFrom: each)]]].
 	Smalltalk developmentSystem beNotChanged!
 

--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinProduct.cls
@@ -40,7 +40,10 @@ basicLoad
 			name := File splitStemFrom: each.
 			packageManager packageNamed: name
 				ifNone: 
-					[[packageManager install: prefix, each] on: packageManager prerequisiteNotFoundSignal
+					[[ | path |
+					path := each.
+					(File exists: path) ifFalse: [path := prefix, path].
+					packageManager install: path] on: packageManager prerequisiteNotFoundSignal
 						do: [:ex | ex resume: (File splitPathFrom: each)]]].
 	Smalltalk developmentSystem beNotChanged!
 


### PR DESCRIPTION
These changes allow a **userdev** to boot a development image in a subdirectory of Dolphin's root directory. Now all application development activity can be isolated from **coredev** activity. 