### PR TITLE
Remove non distributable check

### DIFF
--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinBaseProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinBaseProduct.cls
@@ -174,7 +174,7 @@ isAbstract
 productName
 	"Answer the product name"
 	
-	^'Base' Edition!
+	^'Base Edition'!
 
 shortProductName
 	"Answer the abbreviated product name"

--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinCommunityEdition.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinCommunityEdition.cls
@@ -49,27 +49,6 @@ productName
 	
 	^'Community Edition'!
 
-redistHeaderText
-	"Answer the blah which forms the fixed part of REDIST.TXT"
-
-^'This file details the Redistributable Components of DOLPHIN SMALLTALK
-COMMUNITY EDITION (the SOFTWARE PRODUCT) that you are permitted
-to redistribute. 
-
-This file is an addendum to the DOLPHIN SMALKLTALK License Agreement, and should be 
-read in conjunction with that document in its entirety.  The full text of the License
-Agreement is available in the file "License.rtf" in the installation directory.
-
-Redistributable Components
-==========================
-
-THERE ARE NO REDISTRIBUTABLE COMPONENTS IN DOLPHIN SMALLTALK
-COMMUNITY EDITION.
-
-This implies that you are NOT allowed to create redistibutable applications with this
-version of the SOFTWARE PRODUCT. If you wish to create redistributable applications
-with DOLPHIN SMALLTALK you must purchase the PROFESSIONAL EDITION.'!
-
 shortProductName
 	"Answer the abbreviated product name"
 	
@@ -77,6 +56,5 @@ shortProductName
 !DolphinCommunityEdition class categoriesFor: #isAbstract!operations!public!testing! !
 !DolphinCommunityEdition class categoriesFor: #productLevel!constants!private! !
 !DolphinCommunityEdition class categoriesFor: #productName!accessing!public! !
-!DolphinCommunityEdition class categoriesFor: #redistHeaderText!constants!public! !
 !DolphinCommunityEdition class categoriesFor: #shortProductName!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinProduct.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #DolphinProduct
 	instanceVariableNames: 'versionMask encryptedClasses'
@@ -484,25 +484,6 @@ fromString: aString
 	sub := stm upToEnd.
 	^(EditionsMap at: sub) version: version!
 
-generateLicenseAddendum
-	"Write the addendum to the License Agreement, REDIST.TXT, which details redistribution rights.
-		ShellLibrary default shellOpen: self generateLicenseAddendum
-	"
-
-	"Assume that one is running an image in the development tree"
-
-	| path target |
-	path := self redistFilename.
-	File createDirectoryPath: (File splitPathFrom: path).
-	target := FileStream write: path.
-	target
-		nextPutAll: self redistHeaderText;
-		cr;
-		cr.
-	self redistWriteClassesOn: target.
-	target close.
-	^path!
-
 icon
 	"Answers an Icon that can be used to represent this class"
 
@@ -596,19 +577,6 @@ productPrefix
 
 	^'Dolphin Smalltalk'!
 
-redistFilename
-	"Answer the full path of Redist.txt"
-
-	^FileLocator imageRelative localFileSpecFor: 'Redist.txt'!
-
-redistHeaderText
-	"Answer the blah which forms the fixed part of REDIST.TXT"
-
-	^self subclassResponsibility!
-
-redistWriteClassesOn: target 
-!
-
 release
 	"Release an instance of the receiver"
 
@@ -637,7 +605,6 @@ versionMask: versionMask
 !DolphinProduct class categoriesFor: #current!accessing!public! !
 !DolphinProduct class categoriesFor: #errorInvalidProductDescription:!exceptions!public! !
 !DolphinProduct class categoriesFor: #fromString:!instance creation!public! !
-!DolphinProduct class categoriesFor: #generateLicenseAddendum!public! !
 !DolphinProduct class categoriesFor: #icon!constants!public! !
 !DolphinProduct class categoriesFor: #initialize!initializing!private! !
 !DolphinProduct class categoriesFor: #isAbstract!operations!public!testing! !
@@ -652,9 +619,6 @@ versionMask: versionMask
 !DolphinProduct class categoriesFor: #productMask!accessing!private! !
 !DolphinProduct class categoriesFor: #productName!accessing!public! !
 !DolphinProduct class categoriesFor: #productPrefix!instance creation!public! !
-!DolphinProduct class categoriesFor: #redistFilename!public! !
-!DolphinProduct class categoriesFor: #redistHeaderText!constants!public! !
-!DolphinProduct class categoriesFor: #redistWriteClassesOn:!public! !
 !DolphinProduct class categoriesFor: #release!operations!public! !
 !DolphinProduct class categoriesFor: #shortProductName!accessing!public! !
 !DolphinProduct class categoriesFor: #version:!instance creation!public! !

--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinProfessional.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinProfessional.cls
@@ -125,54 +125,6 @@ productName
 	
 	^'Professional'!
 
-redistHeaderText
-	"Answer the blah which forms the fixed part of REDIST.TXT"
-
-^'This file details the Redistributable Components of DOLPHIN SMALLTALK
-PROFESSIONAL EDITION (the SOFTWARE PRODUCT) that you are permitted
-to redistribute with your Applications. It also lists the Development System
-Components of the SOFTWARE PRODUCT that you must NOT distribute with
-your applications without express written permission from Object Arts Ltd.
-
-This file is an addendum to the DOLPHIN SMALLTALK License Agreement, and should be 
-read in conjunction with this document in its entirety.  The full text of the License
-Agreement is available in the file "License.rtf" in the installation directory.
-
-Redistributable Components
-==========================
-
-The following files may be redistributed as an integral part of executable applications
-created by you utilising the SOFTWARE PRODUCT:
-
-DOLPHIN.EXE
-DOLPHINVM006.DLL
-DOLPHINCR006.DLL
-DOLPHINDR006.DLL
-DOLPHINSURECRYPTO.DLL
-
-Non-redistributable (Development System) Components
-===================================================
-
-The following files are solely Development System components of the SOFTWARE 
-PRODUCT and you must NOT redistribute them in any form:
-
-GUISTUB.EXE
-GUITOGO.EXE
-CONSOLESTUB.EXE
-CONSOLETOGO.EXE
-
-The following classes are Development System Components of the SOFTWARE
-PRODUCT and you must NOT redistribute them in any form, as either source or 
-object code, either independently or as part of an Application:'.
-!
-
-redistWriteClassesOn: target 
-	self developmentClasses asSortedCollection do: 
-			[:e | 
-			target
-				print: e;
-				cr]!
-
 shortProductName
 	"Answer the abbreviated product name"
 	
@@ -181,7 +133,5 @@ shortProductName
 !DolphinProfessional class categoriesFor: #isAbstract!operations!public!testing! !
 !DolphinProfessional class categoriesFor: #productLevel!constants!private! !
 !DolphinProfessional class categoriesFor: #productName!accessing!public! !
-!DolphinProfessional class categoriesFor: #redistHeaderText!constants!public! !
-!DolphinProfessional class categoriesFor: #redistWriteClassesOn:!public! !
 !DolphinProfessional class categoriesFor: #shortProductName!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/Lagoon/BasicImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/BasicImageStripper.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Model subclass: #BasicImageStripper
 	instanceVariableNames: ''
@@ -539,8 +539,6 @@ stripRedundantPackagesNotifying: notifier
 	self stripRedundantPackages ifFalse: [^0].
 	required := self actualRequiredPackages.
 	pacman := self systemPackageManager.
-	requiredDevPkgs := required select: [:each | self developmentPackageNames includes: each name].
-	requiredDevPkgs notEmpty ifTrue: [self warnDependentOnDevPackages: requiredDevPkgs].
 	redundantPackages := pacman packages difference: required.
 	"Turn off events to prevent repeated tracing of pre-reqs as each of the redundant packages
 	 is uninstalled."

--- a/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
@@ -349,9 +349,6 @@ developmentMethods
 	self developmentMethodCategoryNames do: [:name | devMethods addAll: (catClass name: name) contents].
 	^devMethods!
 
-developmentPackageNames
-	^#('Value Edition Tools' 'Standard Edition Tools' 'Development System' 'Dolphin Refactoring Browser' 'ActiveX Automation Development')!
-
 developmentResources
 	"Answer a <collection> of <ResourceIdentifier>s representing any development system resources that
 	are not owned directly by development classes."
@@ -560,7 +557,7 @@ initialTidy
 
 	versionResource := nil.
 	self 
-		finishedWithAll: #(#actualRequiredPackages #buildMessageMap #buildPreservedMessages #buildRootClasses #canDeploy #checkedStubFilePath #closeAllDevelopmentTools #closeChangeLog #buildManifest:description:version: #appendManifestContent: #copyAndUpdateStub:to: #defaultStubFilePath #developmentClasses #developmentMethodCategoryNames #developmentMethods #developmentPackageNames #disableDevelopmentSystem #executableName #executableName: #executablePath #exeFileExtension #ignoreViewReferences: #includeManifestResource #initialize #initialTidy #installRuntimeSessionManager #isResourceUpdatingPossible #isResourceUpdatingRequired #isToGo #logConfiguration #logFileExtension #logFileName #logPreservedClasses #logPreservedMessages #logReferencesToClasses: #logRemainingPackages #manifestResourceId #notifyClassesOfImminentStrip: #notifyClassesOfStrip #notRequiredMethodCategories #openLogFile #prepareToStrip #preStripCheck #preStripScript #preStripScript: #referencesFromObjectsInClasses: #requiredClasses #requiredMethodCategories #requiredPackageNames #resizeStubFile: #retainInstVarNames: #rootClasses: #rootPackage #rootPackage: #runPreStripScript #runtimeSessionManagerClass #runtimeSessionManagerClass: #snapshotType: #stripAndSave #stripAndSaveWithProgress #stripNotRequiredMethodsNotifying: #stripRedundantPackages #stripRedundantPackagesNotifying: #stripShouldNotImplement #stubFile #stubFilePath #updateIconResource: #updateStringTableResource: #updateStubResources: #updateVersionResource: #updateXPManifestResource: #vmReferencedClasses #warnDependentOnDevPackages: #writeLogFile)!
+		finishedWithAll: #(#actualRequiredPackages #buildMessageMap #buildPreservedMessages #buildRootClasses #canDeploy #checkedStubFilePath #closeAllDevelopmentTools #closeChangeLog #buildManifest:description:version: #appendManifestContent: #copyAndUpdateStub:to: #defaultStubFilePath #developmentClasses #developmentMethodCategoryNames #developmentMethods #disableDevelopmentSystem #executableName #executableName: #executablePath #exeFileExtension #ignoreViewReferences: #includeManifestResource #initialize #initialTidy #installRuntimeSessionManager #isResourceUpdatingPossible #isResourceUpdatingRequired #isToGo #logConfiguration #logFileExtension #logFileName #logPreservedClasses #logPreservedMessages #logReferencesToClasses: #logRemainingPackages #manifestResourceId #notifyClassesOfImminentStrip: #notifyClassesOfStrip #notRequiredMethodCategories #openLogFile #prepareToStrip #preStripCheck #preStripScript #preStripScript: #referencesFromObjectsInClasses: #requiredClasses #requiredMethodCategories #requiredPackageNames #resizeStubFile: #retainInstVarNames: #rootClasses: #rootPackage #rootPackage: #runPreStripScript #runtimeSessionManagerClass #runtimeSessionManagerClass: #snapshotType: #stripAndSave #stripAndSaveWithProgress #stripNotRequiredMethodsNotifying: #stripRedundantPackages #stripRedundantPackagesNotifying: #stripShouldNotImplement #stubFile #stubFilePath #updateIconResource: #updateStringTableResource: #updateStubResources: #updateVersionResource: #updateXPManifestResource: #vmReferencedClasses #writeLogFile)!
 
 installRuntimeSessionManager
 	"Private - Install the application <SessionManager>. For an application deployed with its
@@ -2038,25 +2035,6 @@ vmReferencedClasses
 	^VMLibrary default registry 
 		select: [:each | each class isMeta and: [(#('GUID' 'PoolConstantsDictionary') includes: each name asString) not]]!
 
-warnDependentOnDevPackages: aCollectionOfPackages 
-	| stm |
-	stm := String writeStream.
-	stm
-		nextPutAll: 'The application may be dependent upon non-distributable development tools or classes in the following packages:';
-		cr.
-	aCollectionOfPackages do: 
-			[:each | 
-			stm
-				crtab;
-				nextPutAll: each name].
-	stm 
-		nextPutAll: '
-
-You can use the Package Browser''s ''Prerequisites'' pane to track down the source of the dependencies.
-
-Before deploying this application you must check the image stripping log to be sure that all development tools have been removed.'.
-	MessageBox notify: stm contents!
-
 writeLogFile
 	"Answer true if the receiver will write a log file during
 	its stripping process"
@@ -2098,7 +2076,6 @@ writeLogFile: aBoolean
 !ImageStripper categoriesFor: #developmentClasses!configuration!public! !
 !ImageStripper categoriesFor: #developmentMethodCategoryNames!constants!public! !
 !ImageStripper categoriesFor: #developmentMethods!configuration!public! !
-!ImageStripper categoriesFor: #developmentPackageNames!constants!private! !
 !ImageStripper categoriesFor: #developmentResources!configuration!public! !
 !ImageStripper categoriesFor: #disableClassChangeFlagging!operations!private! !
 !ImageStripper categoriesFor: #disableDevelopmentSystem!operations!private! !
@@ -2250,7 +2227,6 @@ writeLogFile: aBoolean
 !ImageStripper categoriesFor: #versionResource!accessing!private! !
 !ImageStripper categoriesFor: #versionResource:!accessing!private! !
 !ImageStripper categoriesFor: #vmReferencedClasses!constants!public! !
-!ImageStripper categoriesFor: #warnDependentOnDevPackages:!operations!public! !
 !ImageStripper categoriesFor: #writeLogFile!accessing!public!testing! !
 !ImageStripper categoriesFor: #writeLogFile:!accessing!development!public! !
 


### PR DESCRIPTION
Various methods refer to the old license and distribution restrictions. This removes those references without affecting the image stripping process. 