### PR TITLE
Maintain accurate references to packages when image is moved

### DIFF
--- a/Core/Object Arts/Dolphin/Base/SessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SessionManager.cls
@@ -338,6 +338,9 @@ imageFileName
 
 	^File default: self imagePath extension: self imageExtension!
 
+imageMovedFrom: oldBase to: newBase
+	"Private - Available for subclasses to override"!
+
 imagePath
 	"Answer the base file path on which the image, source and changes
 	file names are based. An example might be: c:\Program Files\Dolphin\Dolphin."
@@ -624,8 +627,10 @@ onStartup: args
 	just saved BEFORE closing down. Walkbacks will work at just about any stage,
 	but other windows will not open if View>>onStartup has not been run."
 
+	| oldBase newBase |
 	state := 0.
 	eventLogHandle := stdioStreams := consoleHandler := nil.
+	oldBase := self imageBase.
 
 	"Save away the Array of startup arguments, passed in by the VM, for later use"
 	startupArgs := args.
@@ -653,6 +658,8 @@ onStartup: args
 		 development image if the startup has progressed sufficiently far."
 		self forkMain.
 				state := 4	"Full of strange oaths and bearded like the pard"].
+
+	oldBase ~= (newBase := self imageBase) ifTrue: [self imageMovedFrom: oldBase to: newBase].
 
 	"We must terminate the active process to prevent it from continuing from where it left
 	off when the image was saved and running onExit processing, or whatever it would have
@@ -1085,6 +1092,7 @@ windowsDirectory
 !SessionManager categoriesFor: #imageBase!accessing!public! !
 !SessionManager categoriesFor: #imageExtension!constants!private! !
 !SessionManager categoriesFor: #imageFileName!accessing!public! !
+!SessionManager categoriesFor: #imageMovedFrom:to:!event handling!private! !
 !SessionManager categoriesFor: #imagePath!accessing!public! !
 !SessionManager categoriesFor: #imagePath:!accessing!private! !
 !SessionManager categoriesFor: #imageVersion!accessing!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
@@ -132,8 +132,24 @@ helpWhatsNewTopic
 
 imageMovedFrom: oldBase to: newBase
 
-	Notification signal: 'imageMovedFrom: ' , oldBase printString , ' to: ' , newBase printString.
-!
+	| oldPath newPath fullPath alternatePath |
+	(self isSourceVisibleFrom: oldBase) ifFalse: [^self].	"No sense in moving to new base"
+	PackageManager current packages do: [:each | 
+		oldPath := each packagePathname.
+		(File exists: oldPath) ifFalse: [
+			fullPath := File fullPathOf: oldPath relativeTo: oldBase.
+			(File exists: fullPath) ifFalse: [
+				alternatePath := File 
+					change: fullPath 
+					extension: (each isUsingPAX ifTrue: ['pac'] ifFalse: ['pax']).
+				(File exists: alternatePath) ifTrue: [
+					fullPath := alternatePath.
+				].
+			].
+			newPath := File relativePathOf: fullPath to: newBase.
+			each packageFileName: newPath.
+		].
+	]!
 
 imageStamp
 	"Answer the TimeStamp at which the image was saved."
@@ -208,6 +224,16 @@ isOAD
 	"Private - Is this an Object Arts Development image?"
 
 	^(self productDetails at: 6) = 'OAE'!
+
+isSourceVisibleFrom: oldBase
+
+	| samplePackage oldPath fullPath |
+	samplePackage := PackageManager current packageNamed: 'Development System'.
+	oldPath := samplePackage packagePathname.
+	fullPath :=  File fullPathOf: oldPath relativeTo: oldBase.
+	(File exists: fullPath) ifTrue: [^true].
+	fullPath := File change: fullPath extension: (samplePackage isUsingPAX ifTrue: ['pac'] ifFalse: ['pax']).
+	^File exists: fullPath!
 
 keepAlive
 	"The inputState has determined that there are no live windows.
@@ -321,10 +347,10 @@ onStartup: args
 	just saved BEFORE closing down. Walkbacks will work at just about any stage,
 	but other windows will not open if View>>onStartup has not been run."
 
-	| oldBase newBase |
+	| oldPath oldBase newBase |
 	state := 0.
 	eventLogHandle := stdioStreams := consoleHandler := nil.
-	oldBase := self imageBase.
+	oldPath := imagePath.
 
 	"Save away the Array of startup arguments, passed in by the VM, for later use"
 	startupArgs := args.
@@ -353,6 +379,7 @@ onStartup: args
 		self forkMain.
 				state := 4	"Full of strange oaths and bearded like the pard"].
 
+	oldBase := File splitPathFrom: oldPath.
 	oldBase ~= (newBase := self imageBase) ifTrue: [self imageMovedFrom: oldBase to: newBase].
 
 	"We must terminate the active process to prevent it from continuing from where it left
@@ -751,7 +778,7 @@ versionString
 !DevelopmentSessionManager categoriesFor: #helpRootUrl!constants!public! !
 !DevelopmentSessionManager categoriesFor: #helpTutorialsTopic!constants!public! !
 !DevelopmentSessionManager categoriesFor: #helpWhatsNewTopic!constants!public! !
-!DevelopmentSessionManager categoriesFor: #imageMovedFrom:to:!event handling!public! !
+!DevelopmentSessionManager categoriesFor: #imageMovedFrom:to:!event handling!private! !
 !DevelopmentSessionManager categoriesFor: #imageStamp!accessing!public! !
 !DevelopmentSessionManager categoriesFor: #imageStamp:!accessing!private! !
 !DevelopmentSessionManager categoriesFor: #imageVersionMinor:!accessing!private! !
@@ -762,6 +789,7 @@ versionString
 !DevelopmentSessionManager categoriesFor: #isDLL!private!testing! !
 !DevelopmentSessionManager categoriesFor: #isEmbedded!public!testing! !
 !DevelopmentSessionManager categoriesFor: #isOAD!accessing!private!product! !
+!DevelopmentSessionManager categoriesFor: #isSourceVisibleFrom:!event handling!private! !
 !DevelopmentSessionManager categoriesFor: #keepAlive!idling!operations-shutdown!public! !
 !DevelopmentSessionManager categoriesFor: #lastSerialNumberRegistryKeyFor:!accessing!private!product! !
 !DevelopmentSessionManager categoriesFor: #lastSerialNumberRegistryKeyPre61!accessing!private!product! !

--- a/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
@@ -130,6 +130,11 @@ helpTutorialsTopic
 helpWhatsNewTopic
 	^'Whats_New'!
 
+imageMovedFrom: oldBase to: newBase
+
+	Notification signal: 'imageMovedFrom: ' , oldBase printString , ' to: ' , newBase printString.
+!
+
 imageStamp
 	"Answer the TimeStamp at which the image was saved."
 
@@ -694,6 +699,7 @@ versionString
 !DevelopmentSessionManager categoriesFor: #helpRootUrl!constants!public! !
 !DevelopmentSessionManager categoriesFor: #helpTutorialsTopic!constants!public! !
 !DevelopmentSessionManager categoriesFor: #helpWhatsNewTopic!constants!public! !
+!DevelopmentSessionManager categoriesFor: #imageMovedFrom:to:!event handling!public! !
 !DevelopmentSessionManager categoriesFor: #imageStamp!accessing!public! !
 !DevelopmentSessionManager categoriesFor: #imageStamp:!accessing!private! !
 !DevelopmentSessionManager categoriesFor: #imageVersionMinor:!accessing!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
@@ -308,6 +308,58 @@ onQueryWindowsShutdown
 	self saveImage.
 	self quit: 0!
 
+onStartup: args
+	"NOTE: when this method matches that in SessionManager, 
+	this one should be removed. (We override because we can't modify it easily.)"
+
+	"Initialize the receiver immediately following system startup.
+	This is the main system initialization routine, and is responsible
+	for starting the windowing system, the process system, etc.
+	WARNING: If you break the early startup process (especially before prestart.st)
+	then you will not be able to load your image. It is recommended, therefore, that
+	if changing startup code, you should attempt to run up a new copy of the image
+	just saved BEFORE closing down. Walkbacks will work at just about any stage,
+	but other windows will not open if View>>onStartup has not been run."
+
+	| oldBase newBase |
+	state := 0.
+	eventLogHandle := stdioStreams := consoleHandler := nil.
+	oldBase := self imageBase.
+
+	"Save away the Array of startup arguments, passed in by the VM, for later use"
+	startupArgs := args.
+	imagePath := args class == Array ifTrue: [args first] ifFalse: [args].
+	cmdLineFlags := argv := nil.
+
+	[self primaryStartup.
+	state := 1.		"Mewling and puking in the nurse's arms"
+
+	"Before the secondary startup, lets have an opportunity of getting
+	in and fixing and possible problems with the image (only required in Development?)"
+	self preStart.
+	self secondaryStartup.
+	state := 2.		"The whining schoolboy with shining morning face"
+
+	"We are now in a position to claim ownership of the image file, if relevant."
+	self registerRunning.
+
+	"Trigger any user startup processing"
+	[self trigger: #sessionStarted] ensure: [self tertiaryStartup].
+	state := 3	"The Lover sighing like furnace"] 
+			ensure: 
+				["Always attempt to start the main process (must place into state 5)
+		 even if earlier startup failed. This may help recover a damaged
+		 development image if the startup has progressed sufficiently far."
+		self forkMain.
+				state := 4	"Full of strange oaths and bearded like the pard"].
+
+	oldBase ~= (newBase := self imageBase) ifTrue: [self imageMovedFrom: oldBase to: newBase].
+
+	"We must terminate the active process to prevent it from continuing from where it left
+	off when the image was saved and running onExit processing, or whatever it would have
+	done next. We also kill it to prevent any invalid termination running."
+	Processor activeProcess kill!
+
 onUnhandledWarning: aWarning
 	"The unhandled Warning, aWarning, occurred in the active Process.
 	Override the superclass implementation in order to give the user
@@ -722,6 +774,7 @@ versionString
 !DevelopmentSessionManager categoriesFor: #onExit!event handling!public! !
 !DevelopmentSessionManager categoriesFor: #onQueryEndSession:!event handling!public! !
 !DevelopmentSessionManager categoriesFor: #onQueryWindowsShutdown!event handling!public! !
+!DevelopmentSessionManager categoriesFor: #onStartup:!event handling!public! !
 !DevelopmentSessionManager categoriesFor: #onUnhandledWarning:!event handling!public! !
 !DevelopmentSessionManager categoriesFor: #open:!operations-startup!private! !
 !DevelopmentSessionManager categoriesFor: #openPackage:!operations-startup!private! !


### PR DESCRIPTION
If the paths to the packages were valid before an image was moved, modify the paths so that they are still valid. (Offered for consideration of the workflow options.)