### PR TITLE
Parse command line options

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Command Line.pax
+++ b/Core/Object Arts/Dolphin/Base/Command Line.pax
@@ -1,0 +1,44 @@
+| package |
+package := Package name: 'Command Line'.
+package paxVersion: 1;
+	basicComment: ''.
+
+
+package classNames
+	add: #CommandLine;
+	add: #CommandLineTestCase;
+	yourself.
+
+package binaryGlobalNames: (Set new
+	yourself).
+
+package globalAliases: (Set new
+	yourself).
+
+package setPrerequisites: (IdentitySet new
+	add: 'Dolphin';
+	add: '..\..\..\Contributions\Camp Smalltalk\SUnit\SUnit';
+	yourself).
+
+package!
+
+"Class Definitions"!
+
+Object subclass: #CommandLine
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+TestCase subclass: #CommandLineTestCase
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+
+"Global Aliases"!
+
+
+"Loose Methods"!
+
+"End of package definition"!
+

--- a/Core/Object Arts/Dolphin/Base/Command Line.pax
+++ b/Core/Object Arts/Dolphin/Base/Command Line.pax
@@ -25,7 +25,7 @@ package!
 "Class Definitions"!
 
 Object subclass: #CommandLine
-	instanceVariableNames: 'arguments argv optArg optInd optionPrefixChars options'
+	instanceVariableNames: 'arguments argv optArg optInd optOpt optionPrefixChars options'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Base/Command Line.pax
+++ b/Core/Object Arts/Dolphin/Base/Command Line.pax
@@ -25,7 +25,7 @@ package!
 "Class Definitions"!
 
 Object subclass: #CommandLine
-	instanceVariableNames: 'argv index optionPrefixChars'
+	instanceVariableNames: 'arguments argv optArg optInd optionPrefixChars options'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Base/Command Line.pax
+++ b/Core/Object Arts/Dolphin/Base/Command Line.pax
@@ -25,7 +25,7 @@ package!
 "Class Definitions"!
 
 Object subclass: #CommandLine
-	instanceVariableNames: ''
+	instanceVariableNames: 'argv index optionPrefixChars'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Base/Command Line.pax
+++ b/Core/Object Arts/Dolphin/Base/Command Line.pax
@@ -25,7 +25,7 @@ package!
 "Class Definitions"!
 
 Object subclass: #CommandLine
-	instanceVariableNames: 'arguments argv optArg optInd optOpt optionPrefixChars options'
+	instanceVariableNames: 'arguments argv optArg optIndex optOpt optionPrefixChars options parsingArg parsingArgStream parsingOptionStream parsingRules'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Base/CommandLine.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLine.cls
@@ -1,15 +1,66 @@
 "Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #CommandLine
-	instanceVariableNames: ''
+	instanceVariableNames: 'argv index optionPrefixChars'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 CommandLine guid: (GUID fromString: '{4E9D5C42-1049-4F31-862C-CB56225AA08A}')!
 CommandLine comment: ''!
 !CommandLine categoriesForClass!Kernel-Objects! !
+!CommandLine methodsFor!
+
+getOpt: aString
+
+	self options: aString.
+	^nil!
+
+initialize: anArray
+
+	argv := anArray.
+	self assert: [2 <= argv size].
+	index := 3.
+	optionPrefixChars := '-/'.!
+
+options: aString
+
+	| argStream options optionsStream |
+	optionsStream := ReadStream on: aString.
+	options := OrderedCollection new.
+	[optionsStream atEnd] whileFalse: [
+		| argRequired char |
+		argRequired := nil.	"argument not allowed"
+		char := optionsStream next. 
+		 optionsStream peek == $: ifTrue: [
+			argRequired := (optionsStream next; peek) == $:.
+		].
+		options add: char -> argRequired.
+	].
+	argStream := (ReadStream on: argv) next; next; yourself.
+	[argStream atEnd] whileFalse: [
+		| arg |
+		arg := argStream next.
+		(optionPrefixChars includes: arg first) ifTrue: [
+			| argRequired char |
+			char := arg at: 2.
+			argRequired := (options detect: [:each | each key == char] ifNone: [self error: 'unexpected option']) value.
+			argRequired halt.
+		] ifFalse: [
+			arg halt.
+		].
+	].
+	self halt.
+! !
+!CommandLine categoriesFor: #getOpt:!public! !
+!CommandLine categoriesFor: #initialize:!public! !
+!CommandLine categoriesFor: #options:!public! !
+
 !CommandLine class methodsFor!
 
-test: anArray! !
-!CommandLine class categoriesFor: #test:!public! !
+argv: anArray
+
+	^super new
+		initialize: anArray;
+		yourself! !
+!CommandLine class categoriesFor: #argv:!public! !
 

--- a/Core/Object Arts/Dolphin/Base/CommandLine.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLine.cls
@@ -1,0 +1,15 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+Object subclass: #CommandLine
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+CommandLine guid: (GUID fromString: '{4E9D5C42-1049-4F31-862C-CB56225AA08A}')!
+CommandLine comment: ''!
+!CommandLine categoriesForClass!Kernel-Objects! !
+!CommandLine class methodsFor!
+
+test: anArray! !
+!CommandLine class categoriesFor: #test:!public! !
+

--- a/Core/Object Arts/Dolphin/Base/CommandLine.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLine.cls
@@ -1,14 +1,33 @@
 "Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #CommandLine
-	instanceVariableNames: 'arguments argv optArg optInd optionPrefixChars options'
+	instanceVariableNames: 'arguments argv optArg optInd optOpt optionPrefixChars options'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 CommandLine guid: (GUID fromString: '{4E9D5C42-1049-4F31-862C-CB56225AA08A}')!
-CommandLine comment: ''!
+CommandLine comment: 'Instances of CommandLine can be used to parse command line options and arguments. 
+
+The implementation is guided by and modeled on getopt() in Unix (http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html), but also has a simpler API. 
+
+The description of the options is similar to getopt(), basically a string of characters that are allowed options with a $: following those that require an arguments.
+
+From a CMD shell in the Dolphin directory, launch the development image with the following:
+
+C:\Dolphin>Dolphin7 DPRO.img7 -a -b -c foo bar
+
+Then, in a workspace evalute the following:
+
+| commandLine options arguments |
+commandLine := CommandLine options: ''abc:''.
+options := commandLine options.	"a Dictionary($c -> ''foo'' $a -> nil $b -> nil)"
+arguments := commandLine arguments. "#(''bar'')"'!
 !CommandLine categoriesForClass!Kernel-Objects! !
 !CommandLine methodsFor!
+
+arguments
+
+	^arguments!
 
 getOpt: aString
 
@@ -21,7 +40,13 @@ getOpt: aString
 		option := options at: optInd.
 	].
 	optInd := optInd + 1.
-	optArg := option value.
+	option key == $? ifTrue: [
+		optArg := nil.
+		optOpt := option value.
+	] ifFalse: [
+		optArg := option value.
+		optOpt := nil.
+	].
 	^option key!
 
 initialize: anArray
@@ -39,6 +64,17 @@ optInd
 
 	^optInd + 2!
 
+options
+
+	| dict |
+	dict := Dictionary new.
+	options do: [:each | 
+		(each notNil and: [each key notNil and: [each key ~~ $?]]) ifTrue: [
+			dict at: each key put: each value.
+		].
+	].
+	^dict!
+
 options: aString
 
 	| argStream optionsStream rules |
@@ -51,7 +87,7 @@ options: aString
 		argRequired := nil.	"argument not allowed"
 		char := optionsStream next. 
 		 optionsStream peek == $: ifTrue: [
-			argRequired := (optionsStream next; peek) == $:.
+			argRequired := (optionsStream next; peek) ~~ $:.
 		].
 		rules add: char -> argRequired.
 	].
@@ -69,27 +105,32 @@ options: aString
 					options add: nil.
 					arguments addAll: argStream upToEnd.
 				] ifFalse: [
-					rule := rules detect: [:each | each key == char] ifNone: [self error: 'unexpected option: ' , char printString].
-					argRequired := rule value.
-					argRequired ifNil: [
-						options add: char -> nil.
+					rule := rules detect: [:each | each key == char] ifNone: [nil -> nil].
+					rule key ifNil: [
+						options add: $? -> char.
 					] ifNotNil: [
-						| optionArg |
-						(optionArg := optionStream upToEnd) isEmpty ifTrue: [
-							argStream atEnd ifTrue: [
-								self halt.
-							] ifFalse: [
-								optionArg := argStream peek.
-								(optionPrefixChars includes: optionArg first) ifTrue: [
-									optionArg := ''.
-								] ifFalse: [
-									argStream next.
-									options add: nil.
+						argRequired := rule value.
+						argRequired ifNil: [
+							options add: char -> nil.
+						] ifNotNil: [
+							| optionArg |
+							(optionArg := optionStream upToEnd) isEmpty ifTrue: [
+								argStream atEnd ifFalse: [
+									optionArg := argStream peek.
+									(optionPrefixChars includes: optionArg first) ifTrue: [
+										optionArg := ''.
+									] ifFalse: [
+										argStream next.
+										options add: nil.
+									].
 								].
 							].
+							(argRequired and: [optionArg isEmpty]) ifTrue: [
+								optionArg := char. 
+								char := $?.
+							].
+							options add: char -> optionArg.
 						].
-						(argRequired and: [optionArg isEmpty]) ifTrue: [self error: 'Argument required for option: ' , char printString].
-						options add: char -> optionArg.
 					].
 				].
 			].
@@ -97,19 +138,39 @@ options: aString
 			arguments add: arg.
 		].
 	].
-! !
+	arguments := arguments asArray.!
+
+optOpt
+
+	^optOpt! !
+!CommandLine categoriesFor: #arguments!public! !
 !CommandLine categoriesFor: #getOpt:!public! !
 !CommandLine categoriesFor: #initialize:!public! !
 !CommandLine categoriesFor: #optArg!public! !
 !CommandLine categoriesFor: #optInd!public! !
+!CommandLine categoriesFor: #options!public! !
 !CommandLine categoriesFor: #options:!public! !
+!CommandLine categoriesFor: #optOpt!public! !
 
 !CommandLine class methodsFor!
 
 argv: anArray
+	"Constructor used primarily for testing"
 
 	^super new
 		initialize: anArray;
+		yourself!
+
+new
+
+	^self argv: SessionManager current argv!
+
+options: aString
+
+	^self new
+		options: aString;
 		yourself! !
 !CommandLine class categoriesFor: #argv:!public! !
+!CommandLine class categoriesFor: #new!public! !
+!CommandLine class categoriesFor: #options:!public! !
 

--- a/Core/Object Arts/Dolphin/Base/CommandLine.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLine.cls
@@ -1,7 +1,7 @@
 "Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #CommandLine
-	instanceVariableNames: 'argv index optionPrefixChars'
+	instanceVariableNames: 'arguments argv optArg optInd optionPrefixChars options'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -12,21 +12,40 @@ CommandLine comment: ''!
 
 getOpt: aString
 
+	| option |
 	self options: aString.
-	^nil!
+	options size < optInd ifTrue: [^nil].
+	(option := options at: optInd) ifNil: [
+		optInd := optInd + 1.
+		options size < optInd ifTrue: [^nil].
+		option := options at: optInd.
+	].
+	optInd := optInd + 1.
+	optArg := option value.
+	^option key!
 
 initialize: anArray
 
 	argv := anArray.
 	self assert: [2 <= argv size].
-	index := 3.
+	optInd := 1.
 	optionPrefixChars := '-/'.!
+
+optArg
+
+	^optArg!
+
+optInd
+
+	^optInd + 2!
 
 options: aString
 
-	| argStream options optionsStream |
+	| argStream optionsStream rules |
 	optionsStream := ReadStream on: aString.
+	arguments := OrderedCollection new.
 	options := OrderedCollection new.
+	rules := OrderedCollection new.
 	[optionsStream atEnd] whileFalse: [
 		| argRequired char |
 		argRequired := nil.	"argument not allowed"
@@ -34,25 +53,55 @@ options: aString
 		 optionsStream peek == $: ifTrue: [
 			argRequired := (optionsStream next; peek) == $:.
 		].
-		options add: char -> argRequired.
+		rules add: char -> argRequired.
 	].
 	argStream := (ReadStream on: argv) next; next; yourself.
 	[argStream atEnd] whileFalse: [
 		| arg |
 		arg := argStream next.
-		(optionPrefixChars includes: arg first) ifTrue: [
-			| argRequired char |
-			char := arg at: 2.
-			argRequired := (options detect: [:each | each key == char] ifNone: [self error: 'unexpected option']) value.
-			argRequired halt.
+		(1 < arg size and: [optionPrefixChars includes: arg first]) ifTrue: [
+			| optionStream |
+			optionStream := (ReadStream on: arg) next; yourself.
+			[optionStream atEnd] whileFalse: [
+				| argRequired char rule |
+				char := optionStream next.
+				(arg size == 2 and: [(arg at: 1) == (arg at: 2)]) ifTrue: [
+					options add: nil.
+					arguments addAll: argStream upToEnd.
+				] ifFalse: [
+					rule := rules detect: [:each | each key == char] ifNone: [self error: 'unexpected option: ' , char printString].
+					argRequired := rule value.
+					argRequired ifNil: [
+						options add: char -> nil.
+					] ifNotNil: [
+						| optionArg |
+						(optionArg := optionStream upToEnd) isEmpty ifTrue: [
+							argStream atEnd ifTrue: [
+								self halt.
+							] ifFalse: [
+								optionArg := argStream peek.
+								(optionPrefixChars includes: optionArg first) ifTrue: [
+									optionArg := ''.
+								] ifFalse: [
+									argStream next.
+									options add: nil.
+								].
+							].
+						].
+						(argRequired and: [optionArg isEmpty]) ifTrue: [self error: 'Argument required for option: ' , char printString].
+						options add: char -> optionArg.
+					].
+				].
+			].
 		] ifFalse: [
-			arg halt.
+			arguments add: arg.
 		].
 	].
-	self halt.
 ! !
 !CommandLine categoriesFor: #getOpt:!public! !
 !CommandLine categoriesFor: #initialize:!public! !
+!CommandLine categoriesFor: #optArg!public! !
+!CommandLine categoriesFor: #optInd!public! !
 !CommandLine categoriesFor: #options:!public! !
 
 !CommandLine class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/CommandLine.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLine.cls
@@ -1,7 +1,7 @@
 "Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #CommandLine
-	instanceVariableNames: 'arguments argv optArg optInd optOpt optionPrefixChars options'
+	instanceVariableNames: 'arguments argv optArg optIndex optOpt optionPrefixChars options parsingArg parsingArgStream parsingOptionStream parsingRules'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -30,16 +30,17 @@ arguments
 	^arguments!
 
 getOpt: aString
+	"http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html"
 
 	| option |
 	self options: aString.
-	options size < optInd ifTrue: [^nil].
-	(option := options at: optInd) ifNil: [
-		optInd := optInd + 1.
-		options size < optInd ifTrue: [^nil].
-		option := options at: optInd.
+	options size < optIndex ifTrue: [^nil].
+	(option := options at: optIndex) ifNil: [
+		optIndex := optIndex + 1.
+		options size < optIndex ifTrue: [^nil].
+		option := options at: optIndex.
 	].
-	optInd := optInd + 1.
+	optIndex := optIndex + 1.
 	option key == $? ifTrue: [
 		optArg := nil.
 		optOpt := option value.
@@ -53,119 +54,146 @@ initialize: anArray
 
 	argv := anArray.
 	self assert: [2 <= argv size].
-	optInd := 1.
+	optIndex := 1.
 	optionPrefixChars := '-/'.!
 
 optArg
 
 	^optArg!
 
-optInd
-
-	^optInd + 2!
-
 options
+	"Answers a dictionary where key is the option and value is
+		nil if no argument allowed
+		empty if optional argument missing
+		otherwise value of optional or required argument"
 
 	| dict |
 	dict := Dictionary new.
 	options do: [:each | 
-		(each notNil and: [each key notNil and: [each key ~~ $?]]) ifTrue: [
+		each key ~~ $? ifTrue: [
 			dict at: each key put: each value.
 		].
 	].
 	^dict!
 
 options: aString
+	"http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html"
 
-	| argStream optionsStream rules |
-	optionsStream := ReadStream on: aString.
-	arguments := OrderedCollection new.
-	options := OrderedCollection new.
-	rules := OrderedCollection new.
-	[optionsStream atEnd] whileFalse: [
-		| argRequired char |
-		argRequired := nil.	"argument not allowed"
-		char := optionsStream next. 
-		 optionsStream peek == $: ifTrue: [
-			argRequired := (optionsStream next; peek) ~~ $:.
-		].
-		rules add: char -> argRequired.
-	].
-	argStream := (ReadStream on: argv) next; next; yourself.
-	[argStream atEnd] whileFalse: [
-		| arg |
-		arg := argStream next.
-		(1 < arg size and: [optionPrefixChars includes: arg first]) ifTrue: [
-			| optionStream |
-			optionStream := (ReadStream on: arg) next; yourself.
-			[optionStream atEnd] whileFalse: [
-				| argRequired char rule |
-				char := optionStream next.
-				(arg size == 2 and: [(arg at: 1) == (arg at: 2)]) ifTrue: [
-					options add: nil.
-					arguments addAll: argStream upToEnd.
-				] ifFalse: [
-					rule := rules detect: [:each | each key == char] ifNone: [nil -> nil].
-					rule key ifNil: [
-						options add: $? -> char.
-					] ifNotNil: [
-						argRequired := rule value.
-						argRequired ifNil: [
-							options add: char -> nil.
-						] ifNotNil: [
-							| optionArg |
-							(optionArg := optionStream upToEnd) isEmpty ifTrue: [
-								argStream atEnd ifFalse: [
-									optionArg := argStream peek.
-									(optionPrefixChars includes: optionArg first) ifTrue: [
-										optionArg := ''.
-									] ifFalse: [
-										argStream next.
-										options add: nil.
-									].
-								].
-							].
-							(argRequired and: [optionArg isEmpty]) ifTrue: [
-								optionArg := char. 
-								char := $?.
-							].
-							options add: char -> optionArg.
-						].
-					].
-				].
-			].
-		] ifFalse: [
-			arguments add: arg.
-		].
-	].
-	arguments := arguments asArray.!
+	parsingRules := self rulesFrom: aString.
+	self parse.!
 
 optOpt
 
-	^optOpt! !
-!CommandLine categoriesFor: #arguments!public! !
-!CommandLine categoriesFor: #getOpt:!public! !
-!CommandLine categoriesFor: #initialize:!public! !
-!CommandLine categoriesFor: #optArg!public! !
-!CommandLine categoriesFor: #optInd!public! !
-!CommandLine categoriesFor: #options!public! !
+	^optOpt!
+
+parse
+
+	arguments := OrderedCollection new.
+	options := OrderedCollection new.
+	parsingArgStream := (ReadStream on: argv) 
+		next; 	"exe"
+		next; 	"img7"
+		yourself.
+	[parsingArgStream atEnd] whileFalse: [	"iterate over the argv array"
+		self parseNextArg.
+	].
+	arguments := arguments asArray.!
+
+parseNextArg
+
+	parsingArg := parsingArgStream next.
+	(1 < parsingArg size and: [optionPrefixChars includes: parsingArg first]) ifFalse: [	"no prefix means treat as an argument rather than as an option"
+		arguments add: parsingArg.
+		^self
+	].
+	parsingOptionStream := (ReadStream on: parsingArg) 
+		next; 	"Prefix character ($/ or $-)"
+		yourself.
+	[parsingOptionStream atEnd] whileFalse: [	"one argv can have multiple options (-ab is equivalent to -a -b)"
+		self parseNextOption.
+	].
+!
+
+parseNextOption
+
+	| argRequired char optionArg rule |
+	char := parsingOptionStream next.
+	(parsingArg size == 2 and: [(parsingArg at: 1) == (parsingArg at: 2)]) ifTrue: [	"-- is a signal to treat everything following as arguments, not options"
+		arguments addAll: parsingArgStream upToEnd.
+		^self
+	].
+	rule := parsingRules 
+		detect: [:each | each key == char] 
+		ifNone: [	"Unrecognized option"
+			options add: $? -> char.
+			^self
+		].
+	argRequired := rule value.
+	argRequired ifNil: [	"simple option without an argument"
+		options add: char -> nil.
+		^self
+	].
+	"option has an optional or required argument"
+	optionArg := parsingOptionStream upToEnd.	"option argument can follow immediately (-xabc)"
+	(optionArg isEmpty and: [parsingArgStream atEnd not]) ifTrue: [	"look for option argument in next argv"
+		optionArg := parsingArgStream peek.
+		(optionPrefixChars includes: optionArg first) ifTrue: [	"next argument begins with prefix character, so another option"
+			optionArg := ''.		"option does not have an argument"
+		] ifFalse: [
+			parsingArgStream next.	"argument associated with option"
+		].
+	].
+	(argRequired and: [optionArg isEmpty]) ifTrue: [	"error if required argument is not present"
+		optionArg := char. 
+		char := $?.
+	].
+	options add: char -> optionArg.	"save option and argument"!
+
+rulesFrom: aString
+	"Answer an array "
+
+	| optionsStream rules |
+	optionsStream := ReadStream on: aString.
+	rules := OrderedCollection new.
+	[optionsStream atEnd] whileFalse: [
+		| argRequired char |
+		argRequired := nil.	"initially assume that argument not allowed"
+		char := optionsStream next. 
+		 optionsStream peek == $: ifTrue: [
+			argRequired := (optionsStream next; peek) ~~ $:.	": means argument is required; :: means argument is optional"
+		].
+		rules add: char -> argRequired.
+	].
+	^rules
+! !
+!CommandLine categoriesFor: #arguments!accessing!public! !
+!CommandLine categoriesFor: #getOpt:!getopt protocol!public! !
+!CommandLine categoriesFor: #initialize:!private! !
+!CommandLine categoriesFor: #optArg!getopt protocol!public! !
+!CommandLine categoriesFor: #options!accessing!public! !
 !CommandLine categoriesFor: #options:!public! !
-!CommandLine categoriesFor: #optOpt!public! !
+!CommandLine categoriesFor: #optOpt!getopt protocol!public! !
+!CommandLine categoriesFor: #parse!private! !
+!CommandLine categoriesFor: #parseNextArg!private! !
+!CommandLine categoriesFor: #parseNextOption!private! !
+!CommandLine categoriesFor: #rulesFrom:!private! !
 
 !CommandLine class methodsFor!
 
 argv: anArray
-	"Constructor used primarily for testing"
+	"Constructor called directly only in testing"
 
 	^super new
 		initialize: anArray;
 		yourself!
 
 new
+	"Generally the #options: constructor should be used"
 
 	^self argv: SessionManager current argv!
 
 options: aString
+	"http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html"
 
 	^self new
 		options: aString;

--- a/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
@@ -10,7 +10,7 @@ CommandLineTestCase comment: ''!
 !CommandLineTestCase categoriesForClass!SUnit! !
 !CommandLineTestCase methodsFor!
 
-test_getOpt_1
+test_getOpt_01
 	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
 
 	| commandLine optionChar |
@@ -18,15 +18,119 @@ test_getOpt_1
 	optionChar := commandLine getOpt: 'abc:'.
 	self assert: optionChar isNil.	"No options provided"!
 
-test_getOpt_2
+test_getOpt_02
 	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
 
-	| commandLine optionChar |
+	| commandLine |
 	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-a' '-b').
-	optionChar := commandLine getOpt: 'abc:'.
 	self 
-		assert: optionChar == $a;
+		assert: (commandLine getOpt: 'abc:') == $a;
+		assert: commandLine optArg isNil;
+		assert: (commandLine getOpt: 'abc:') == $b;
+		assert: commandLine optArg isNil;
+		assert: (commandLine getOpt: 'abc:') isNil;
+		yourself.!
+
+test_getOpt_03
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-ab').
+	self 
+		assert: (commandLine getOpt: 'abc:') == $a;
+		assert: commandLine optArg isNil;
+		assert: (commandLine getOpt: 'abc:') == $b;
+		assert: commandLine optArg isNil;
+		assert: (commandLine getOpt: 'abc:') isNil;
+		yourself.!
+
+test_getOpt_04
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-c' 'foo').
+	self 
+		assert: (commandLine getOpt: 'abc:') == $c;
+		assert: commandLine optArg = 'foo';
+		assert: (commandLine getOpt: 'abc:') isNil;
+		yourself.!
+
+test_getOpt_05
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-cfoo').
+	self 
+		assert: (commandLine getOpt: 'abc:') == $c;
+		assert: commandLine optArg = 'foo';
+		assert: (commandLine getOpt: 'abc:') isNil;
+		yourself.!
+
+test_getOpt_06
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' 'arg1').
+	self 
+		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine optInd == 3;
+		yourself.!
+
+test_getOpt_07
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-a' 'arg1').
+	self 
+		assert: (commandLine getOpt: 'abc:') == $a;
+		assert: commandLine optArg isNil;
+		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine optInd == 4;
+		yourself.!
+
+test_getOpt_08
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-c' 'foo' 'arg1').
+	self 
+		assert: (commandLine getOpt: 'abc:') == $c;
+		assert: commandLine optArg = 'foo';
+		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine optInd == 5;
+		yourself.!
+
+test_getOpt_09
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-a' '--' '-b').
+	self 
+		assert: (commandLine getOpt: 'abc:') == $a;
+		assert: commandLine optArg isNil;
+		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine optInd == 5;
+		yourself.!
+
+test_getOpt_10
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-a' '-').
+	self 
+		assert: (commandLine getOpt: 'abc:') == $a;
+		assert: commandLine optArg isNil;
+		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine optInd == 4;
 		yourself.! !
-!CommandLineTestCase categoriesFor: #test_getOpt_1!public! !
-!CommandLineTestCase categoriesFor: #test_getOpt_2!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_01!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_02!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_03!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_04!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_05!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_06!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_07!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_08!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_09!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_10!public! !
 

--- a/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
@@ -10,11 +10,23 @@ CommandLineTestCase comment: ''!
 !CommandLineTestCase categoriesForClass!SUnit! !
 !CommandLineTestCase methodsFor!
 
-test_getopt
+test_getOpt_1
 	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
 
-	| commandLine |
-	commandLine := CommandLine test: #('Dolphin7.exe' 'DPRO.img7').
-	! !
-!CommandLineTestCase categoriesFor: #test_getopt!public! !
+	| commandLine optionChar |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7').
+	optionChar := commandLine getOpt: 'abc:'.
+	self assert: optionChar isNil.	"No options provided"!
+
+test_getOpt_2
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine optionChar |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-a' '-b').
+	optionChar := commandLine getOpt: 'abc:'.
+	self 
+		assert: optionChar == $a;
+		yourself.! !
+!CommandLineTestCase categoriesFor: #test_getOpt_1!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_2!public! !
 

--- a/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
@@ -122,6 +122,79 @@ test_getOpt_10
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
 		assert: commandLine optInd == 4;
+		yourself.!
+
+test_getOpt_11
+	"http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html
+	Unexected option"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-x').
+	self 
+		assert: (commandLine getOpt: 'abc:') == $?;
+		assert: commandLine optOpt = $x;
+		assert: commandLine optArg isNil;
+		assert: (commandLine getOpt: 'abc:') isNil;
+		yourself.!
+
+test_getOpt_12
+	"http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html
+	Missing required option argument"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-c').
+	self 
+		assert: (commandLine getOpt: 'abc:') == $?;
+		assert: commandLine optOpt = $c;
+		assert: commandLine optArg isNil;
+		assert: (commandLine getOpt: 'abc:') isNil;
+		yourself.!
+
+test_getOpt_13
+	"http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html
+	Missing optional option argument"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-c').
+	self 
+		assert: (commandLine getOpt: 'abc::') == $c;
+		assert: commandLine optOpt isNil;
+		assert: commandLine optArg isEmpty;
+		assert: (commandLine getOpt: 'abc:') isNil;
+		yourself.!
+
+testAccessors
+
+	| commandLine options arguments |
+	commandLine := (CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-a' '-b' '-c' 'foo' 'bar'))
+		options: 'abc:';
+		yourself.
+	options := commandLine options.
+	arguments := commandLine arguments.
+	self 
+		assert: options class == Dictionary;
+		assert: options keys asSortedCollection asArray = #($a $b $c);
+		assert: (options at: $a) isNil;
+		assert: (options at: $b) isNil;
+		assert: (options at: $c) = 'foo';
+		assert: arguments = #('bar');
+		yourself.!
+
+testSlashPrefix
+
+	| commandLine options arguments |
+	commandLine := (CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '/a' '/b' '/c' 'foo' 'bar'))
+		options: 'abc:';
+		yourself.
+	options := commandLine options.
+	arguments := commandLine arguments.
+	self 
+		assert: options class == Dictionary;
+		assert: options keys asSortedCollection asArray = #($a $b $c);
+		assert: (options at: $a) isNil;
+		assert: (options at: $b) isNil;
+		assert: (options at: $c) = 'foo';
+		assert: arguments = #('bar');
 		yourself.! !
 !CommandLineTestCase categoriesFor: #test_getOpt_01!public! !
 !CommandLineTestCase categoriesFor: #test_getOpt_02!public! !
@@ -133,4 +206,9 @@ test_getOpt_10
 !CommandLineTestCase categoriesFor: #test_getOpt_08!public! !
 !CommandLineTestCase categoriesFor: #test_getOpt_09!public! !
 !CommandLineTestCase categoriesFor: #test_getOpt_10!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_11!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_12!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_13!public! !
+!CommandLineTestCase categoriesFor: #testAccessors!public! !
+!CommandLineTestCase categoriesFor: #testSlashPrefix!public! !
 

--- a/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
@@ -29,6 +29,7 @@ test_getOpt_02
 		assert: (commandLine getOpt: 'abc:') == $b;
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine arguments isEmpty;
 		yourself.!
 
 test_getOpt_03
@@ -42,6 +43,7 @@ test_getOpt_03
 		assert: (commandLine getOpt: 'abc:') == $b;
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine arguments isEmpty;
 		yourself.!
 
 test_getOpt_04
@@ -53,6 +55,7 @@ test_getOpt_04
 		assert: (commandLine getOpt: 'abc:') == $c;
 		assert: commandLine optArg = 'foo';
 		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine arguments isEmpty;
 		yourself.!
 
 test_getOpt_05
@@ -64,6 +67,7 @@ test_getOpt_05
 		assert: (commandLine getOpt: 'abc:') == $c;
 		assert: commandLine optArg = 'foo';
 		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine arguments isEmpty;
 		yourself.!
 
 test_getOpt_06
@@ -73,7 +77,7 @@ test_getOpt_06
 	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' 'arg1').
 	self 
 		assert: (commandLine getOpt: 'abc:') isNil;
-		assert: commandLine optInd == 3;
+		assert: commandLine arguments = #('arg1');
 		yourself.!
 
 test_getOpt_07
@@ -85,7 +89,7 @@ test_getOpt_07
 		assert: (commandLine getOpt: 'abc:') == $a;
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
-		assert: commandLine optInd == 4;
+		assert: commandLine arguments = #('arg1');
 		yourself.!
 
 test_getOpt_08
@@ -97,7 +101,7 @@ test_getOpt_08
 		assert: (commandLine getOpt: 'abc:') == $c;
 		assert: commandLine optArg = 'foo';
 		assert: (commandLine getOpt: 'abc:') isNil;
-		assert: commandLine optInd == 5;
+		assert: commandLine arguments = #('arg1');
 		yourself.!
 
 test_getOpt_09
@@ -109,7 +113,7 @@ test_getOpt_09
 		assert: (commandLine getOpt: 'abc:') == $a;
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
-		assert: commandLine optInd == 5;
+		assert: commandLine arguments = #('-b');
 		yourself.!
 
 test_getOpt_10
@@ -121,7 +125,7 @@ test_getOpt_10
 		assert: (commandLine getOpt: 'abc:') == $a;
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
-		assert: commandLine optInd == 4;
+		assert: commandLine arguments = #('-');
 		yourself.!
 
 test_getOpt_11
@@ -135,6 +139,7 @@ test_getOpt_11
 		assert: commandLine optOpt = $x;
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine arguments isEmpty;
 		yourself.!
 
 test_getOpt_12
@@ -148,6 +153,7 @@ test_getOpt_12
 		assert: commandLine optOpt = $c;
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine arguments isEmpty;
 		yourself.!
 
 test_getOpt_13
@@ -161,6 +167,18 @@ test_getOpt_13
 		assert: commandLine optOpt isNil;
 		assert: commandLine optArg isEmpty;
 		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine arguments isEmpty;
+		yourself.!
+
+test_getOpt_14
+	"http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html
+	Double dash indicates to treat remainder as arguments, not options"
+
+	| commandLine |
+	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '--' '-a' '-b' '-c').
+	self 
+		assert: (commandLine getOpt: 'abc:') isNil;
+		assert: commandLine arguments = #('-a' '-b' '-c');
 		yourself.!
 
 testAccessors
@@ -209,6 +227,7 @@ testSlashPrefix
 !CommandLineTestCase categoriesFor: #test_getOpt_11!public! !
 !CommandLineTestCase categoriesFor: #test_getOpt_12!public! !
 !CommandLineTestCase categoriesFor: #test_getOpt_13!public! !
+!CommandLineTestCase categoriesFor: #test_getOpt_14!public! !
 !CommandLineTestCase categoriesFor: #testAccessors!public! !
 !CommandLineTestCase categoriesFor: #testSlashPrefix!public! !
 

--- a/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTestCase.cls
@@ -1,0 +1,20 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+TestCase subclass: #CommandLineTestCase
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+CommandLineTestCase guid: (GUID fromString: '{3A8A3BC5-3EF6-46C1-933B-754C6B06457E}')!
+CommandLineTestCase comment: ''!
+!CommandLineTestCase categoriesForClass!SUnit! !
+!CommandLineTestCase methodsFor!
+
+test_getopt
+	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
+
+	| commandLine |
+	commandLine := CommandLine test: #('Dolphin7.exe' 'DPRO.img7').
+	! !
+!CommandLineTestCase categoriesFor: #test_getopt!public! !
+


### PR DESCRIPTION
This is a proposal to address Issue #34. While any feedback is welcome, I'm primarily interested in what API is needed. Also, if it gets to the point of being considered for inclusion, then I'd welcome guidance on the packaging (I assume that it doesn't warrant a separate package and tests should go somewhere else). This does not yet support long options nor multiple options with the same name. In any case, the API is what is interesting and since all the tests pass, I'm throwing it open for discussion.

Note that I haven't modified the boot script to include this so it needs to be loaded manually.