### PR TITLE
CommandLine fix for runtime

### DIFF
--- a/Core/Object Arts/Dolphin/Base/CommandLine.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLine.cls
@@ -112,7 +112,6 @@ getOpt: aString
 initialize: anArray
 
 	argv := anArray.
-	self assert: [2 <= argv size].
 	optIndex := 1.
 	optionPrefixChars := '-/'.
 	parsingRules := OrderedCollection new.!
@@ -155,7 +154,6 @@ parse
 	parsingErrors := WriteStream on: String new.
 	parsingArgStream := (ReadStream on: argv) 
 		next; 	"exe"
-		next; 	"img7"
 		yourself.
 	[parsingArgStream atEnd] whileFalse: [	"iterate over the argv array"
 		self parseNextArg.

--- a/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
@@ -417,7 +417,7 @@ processCommandLine
 	| commandLine options arguments |
 	commandLine := self commandLineParser.
 	options := commandLine options.
-	arguments := commandLine arguments.
+	arguments := commandLine arguments copyFrom: 2. "leave off image name"
 	"File in a given file"
 	options at: $f ifPresent: [:fileInFile | SourceManager default fileIn: fileInFile].
 	"Clone a new image to the given path"


### PR DESCRIPTION
The original implementation of CommandLine ignored the first argument (image name) and started processing with second argument. This doesn't work in a runtime image since the first argument should not be ignored. Also, the requirement that argv have at least two elements is not applicable in the runtime when we might have nothing more than the executable name causing a walkback when launching a runtime.