### PR TITLE
Allow code block to be part of CommandLineOption

### DIFF
--- a/Core/Object Arts/Dolphin/Base/CommandLine.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLine.cls
@@ -56,14 +56,29 @@ addOptionAllowingArgumentNamed: aString
 	parsingRules add: (CommandLineOption allowingArgumentNamed: aString).
 !
 
+addOptionAllowingArgumentNamed: aString  whenPresentDo: aBlock
+
+	parsingRules add: (CommandLineOption allowingArgumentNamed: aString block: aBlock).
+!
+
 addOptionNamed: aString
 
 	parsingRules add: (CommandLineOption named: aString).
 !
 
+addOptionNamed: aString whenPresentDo: aBlock
+
+	parsingRules add: (CommandLineOption named: aString block: aBlock).
+!
+
 addOptionRequiringArgumentNamed: aString
 
 	parsingRules add: (CommandLineOption requiringArgumentNamed: aString).
+!
+
+addOptionRequiringArgumentNamed: aString  whenPresentDo: aBlock
+
+	parsingRules add: (CommandLineOption requiringArgumentNamed: aString block: aBlock).
 !
 
 addRulesFrom: aString
@@ -100,14 +115,14 @@ getOpt: aString
 		option := options at: optIndex.
 	].
 	optIndex := optIndex + 1.
-	option key == $? ifTrue: [
+	option key ifNil: [
 		optArg := nil.
 		optOpt := option value.
-	] ifFalse: [
-		optArg := option value.
-		optOpt := nil.
+		^$?
 	].
-	^option key!
+	optArg := option value.
+	optOpt := nil.
+	^option key name!
 
 initialize: anArray
 
@@ -131,8 +146,8 @@ options
 	self checkForErrors.
 	dict := Dictionary new.
 	options do: [:each | 
-		each key ~~ $? ifTrue: [
-			dict at: each key put: each value.
+		each key ifNotNil: [
+			dict at: each key name put: each value.
 		].
 	].
 	^dict!
@@ -158,7 +173,8 @@ parse
 	[parsingArgStream atEnd] whileFalse: [	"iterate over the argv array"
 		self parseNextArg.
 	].
-	arguments := arguments asArray.!
+	arguments := arguments asArray.
+!
 
 parseLongOption: aString
 
@@ -189,7 +205,7 @@ parseLongOption: aString
 		].
 	rule isArgumentAllowed ifFalse: [
 		argument ifNil: [
-			options add: rule name -> nil.
+			options add: rule -> nil.
 		] ifNotNil: [
 			parsingErrors nextPutAll: 'Option ' , rule name printString , ' has unexpected argument of ' , argument printString; cr.
 		].
@@ -208,10 +224,10 @@ parseLongOption: aString
 		
 	].
 	(rule isArgumentRequired and: [argument isNil]) ifTrue: [
-		options add: $? -> key.
+		options add: nil -> key.
 		parsingErrors nextPutAll: 'Missing required argument for option ' , key printString; cr.
 	] ifFalse: [
-		options add: rule name -> argument.
+		options add: rule -> argument.
 	].
 !
 
@@ -245,33 +261,44 @@ parseNextOption
 	rule := parsingRules 
 		detect: [:each | each name == char] 
 		ifNone: [	"Unrecognized option"
-			options add: $? -> char.
+			options add: nil -> char.
 			parsingErrors nextPutAll: 'Unrecognized option: ' , char printString; cr.
 			^self
 		].
 	rule isArgumentAllowed ifFalse: [	"simple option without an argument"
-		options add: char -> nil.
+		options add: rule -> nil.
 		^self
 	].
 	"option has an optional or required argument"
 	optionArg := parsingOptionStream upToEnd.	"option argument can follow immediately (-xabc)"
-	(optionArg isEmpty and: [parsingArgStream atEnd not]) ifTrue: [	"look for option argument in next argv"
+	optionArg isEmpty ifTrue: [optionArg := nil].
+	(optionArg isNil and: [parsingArgStream atEnd not]) ifTrue: [	"look for option argument in next argv"
 		optionArg := parsingArgStream peek.
 		(optionPrefixChars includes: optionArg first) ifTrue: [	"next argument begins with prefix character, so another option"
-			optionArg := ''.		"option does not have an argument"
+			optionArg := nil.		"option does not have an argument"
 		] ifFalse: [
 			parsingArgStream next.	"argument associated with option"
 		].
 	].
-	(rule isArgumentRequired and: [optionArg isEmpty]) ifTrue: [	"error if required argument is not present"
+	(rule isArgumentRequired and: [optionArg isNil]) ifTrue: [	"error if required argument is not present"
 		parsingErrors nextPutAll: 'Missing required argument for option ' , char printString; cr.
 		optionArg := char. 
-		char := $?.
+		rule := nil.
 	].
-	options add: char -> optionArg.	"save option and argument"! !
+	options add: rule -> optionArg.	"save option and argument"!
+
+valueBlocks
+
+	options ifNil: [self parse].
+	options do: [:each | 
+		each key ifNotNil: [:rule | rule value: each value].
+	].! !
 !CommandLine categoriesFor: #addOptionAllowingArgumentNamed:!public! !
+!CommandLine categoriesFor: #addOptionAllowingArgumentNamed:whenPresentDo:!public! !
 !CommandLine categoriesFor: #addOptionNamed:!public! !
+!CommandLine categoriesFor: #addOptionNamed:whenPresentDo:!public! !
 !CommandLine categoriesFor: #addOptionRequiringArgumentNamed:!public! !
+!CommandLine categoriesFor: #addOptionRequiringArgumentNamed:whenPresentDo:!public! !
 !CommandLine categoriesFor: #addRulesFrom:!private! !
 !CommandLine categoriesFor: #arguments!accessing!public! !
 !CommandLine categoriesFor: #checkForErrors!private! !
@@ -285,6 +312,7 @@ parseNextOption
 !CommandLine categoriesFor: #parseLongOption:!private! !
 !CommandLine categoriesFor: #parseNextArg!private! !
 !CommandLine categoriesFor: #parseNextOption!private! !
+!CommandLine categoriesFor: #valueBlocks!public! !
 
 !CommandLine class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/CommandLineOption.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineOption.cls
@@ -1,7 +1,7 @@
 "Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #CommandLineOption
-	instanceVariableNames: 'name isArgumentAllowed isArgumentRequired'
+	instanceVariableNames: 'name isArgumentAllowed isArgumentRequired block'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -29,17 +29,40 @@ initializeOptionAllowingArgumentNamed: aString
 	isArgumentAllowed := true.
 	isArgumentRequired := false.!
 
+initializeOptionAllowingArgumentNamed: aString block: aBlock
+
+	name :=aString.
+	isArgumentAllowed := true.
+	isArgumentRequired := false.
+	block := aBlock.
+!
+
 initializeOptionNamed: aString
 
 	name :=aString.
 	isArgumentAllowed := false.
 	isArgumentRequired := false.!
 
+initializeOptionNamed: aString block: aBlock
+
+	name :=aString.
+	isArgumentAllowed := false.
+	isArgumentRequired := false.
+	block := aBlock.
+!
+
 initializeOptionRequiringArgumentNamed: aString
 
 	name :=aString.
 	isArgumentAllowed := true.
 	isArgumentRequired := true.!
+
+initializeOptionRequiringArgumentNamed: aString block: aBlock
+
+	name :=aString.
+	isArgumentAllowed := true.
+	isArgumentRequired := true.
+	block := aBlock.!
 
 isArgumentAllowed
 	^isArgumentAllowed!
@@ -61,11 +84,22 @@ name
 	^name!
 
 name: anObject
-	name := anObject! !
+	name := anObject!
+
+value: anObject
+
+	block ifNil: [^self].
+	isArgumentAllowed
+		ifTrue: [block value: anObject]
+		ifFalse: [block value].
+! !
 !CommandLineOption categoriesFor: #initializeFromStream:!private! !
 !CommandLineOption categoriesFor: #initializeOptionAllowingArgumentNamed:!private! !
+!CommandLineOption categoriesFor: #initializeOptionAllowingArgumentNamed:block:!private! !
 !CommandLineOption categoriesFor: #initializeOptionNamed:!private! !
+!CommandLineOption categoriesFor: #initializeOptionNamed:block:!private! !
 !CommandLineOption categoriesFor: #initializeOptionRequiringArgumentNamed:!private! !
+!CommandLineOption categoriesFor: #initializeOptionRequiringArgumentNamed:block:!private! !
 !CommandLineOption categoriesFor: #isArgumentAllowed!accessing!public! !
 !CommandLineOption categoriesFor: #isArgumentAllowed:!accessing!public! !
 !CommandLineOption categoriesFor: #isArgumentRequired!accessing!public! !
@@ -73,6 +107,7 @@ name: anObject
 !CommandLineOption categoriesFor: #isLongOption!public! !
 !CommandLineOption categoriesFor: #name!accessing!public! !
 !CommandLineOption categoriesFor: #name:!accessing!public! !
+!CommandLineOption categoriesFor: #value:!public! !
 
 !CommandLineOption class methodsFor!
 
@@ -80,6 +115,12 @@ allowingArgumentNamed: aString
 
 	^self new
 		initializeOptionAllowingArgumentNamed: aString;
+		yourself!
+
+allowingArgumentNamed: aString block: aBlock
+
+	^self new
+		initializeOptionAllowingArgumentNamed: aString block: aBlock;
 		yourself!
 
 fromStream: aStream
@@ -94,13 +135,28 @@ named: aString
 		initializeOptionNamed: aString;
 		yourself!
 
+named: aString block: aBlock
+
+	^self new
+		initializeOptionNamed: aString block: aBlock;
+		yourself!
+
 requiringArgumentNamed: aString
 
 	^self new
 		initializeOptionRequiringArgumentNamed: aString;
+		yourself!
+
+requiringArgumentNamed: aString block: aBlock
+
+	^self new
+		initializeOptionRequiringArgumentNamed: aString block: aBlock;
 		yourself! !
 !CommandLineOption class categoriesFor: #allowingArgumentNamed:!public! !
+!CommandLineOption class categoriesFor: #allowingArgumentNamed:block:!public! !
 !CommandLineOption class categoriesFor: #fromStream:!public! !
 !CommandLineOption class categoriesFor: #named:!public! !
+!CommandLineOption class categoriesFor: #named:block:!public! !
 !CommandLineOption class categoriesFor: #requiringArgumentNamed:!public! !
+!CommandLineOption class categoriesFor: #requiringArgumentNamed:block:!public! !
 

--- a/Core/Object Arts/Dolphin/Base/CommandLineTest.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTest.cls
@@ -21,10 +21,10 @@ test_getOpt_01
 test_getOpt_02
 	"http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html"
 
-	| commandLine |
+	| commandLine x |
 	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-a' '-b').
 	self 
-		assert: (commandLine getOpt: 'abc:') == $a;
+		assert: (x := commandLine getOpt: 'abc:') == $a;
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') == $b;
 		assert: commandLine optArg isNil;
@@ -146,10 +146,10 @@ test_getOpt_12
 	"http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html
 	Missing required option argument"
 
-	| commandLine |
+	| commandLine x |
 	commandLine := CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-c').
 	self 
-		assert: (commandLine getOpt: 'abc:') == $?;
+		assert: (x := commandLine getOpt: 'abc:') == $?;
 		assert: commandLine optOpt = $c;
 		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
@@ -165,7 +165,7 @@ test_getOpt_13
 	self 
 		assert: (commandLine getOpt: 'abc::') == $c;
 		assert: commandLine optOpt isNil;
-		assert: commandLine optArg isEmpty;
+		assert: commandLine optArg isNil;
 		assert: (commandLine getOpt: 'abc:') isNil;
 		assert: commandLine arguments = #('DPRO.img7');
 		yourself.!
@@ -197,6 +197,45 @@ testAccessors
 		assert: (options at: $c) = 'foo';
 		assert: arguments = #('DPRO.img7' 'bar');
 		yourself.!
+
+testBlockNoArgument
+
+	| foundFoo |
+	foundFoo := false.
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '--foo' 'bar'))
+		addOptionNamed: 'foo' whenPresentDo: [foundFoo := true];
+		valueBlocks.
+	self assert: foundFoo.
+!
+
+testBlockOptionalArgumentAbsent
+
+	| fooValue barValue |
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '--foo' '--bar'))
+		addOptionAllowingArgumentNamed: 'foo' whenPresentDo: [:value | fooValue := value];
+		addOptionAllowingArgumentNamed: 'bar' whenPresentDo: [:value | barValue := value];
+		valueBlocks.
+	self
+		assert: fooValue isNil;
+		assert: barValue isNil;
+		yourself.!
+
+testBlockOptionalArgumentPresent
+
+	| fooValue |
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '--foo' 'bar'))
+		addOptionAllowingArgumentNamed: 'foo' whenPresentDo: [:value | fooValue := value];
+		valueBlocks.
+	self assert: fooValue = 'bar'.!
+
+testBlockRequiredArgumentPresent
+
+	| fooValue |
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '--foo' 'bar'))
+		addOptionRequiringArgumentNamed: 'foo' whenPresentDo: [:value | fooValue := value];
+		valueBlocks.
+	self assert: fooValue = 'bar'.
+!
 
 testLongAmbiguousOption
 
@@ -361,6 +400,72 @@ testPartialLong
 		assert: arguments = #('DPRO.img7');
 		yourself.!
 
+testRepeatBlockOptionalArgumentAbsent
+
+	| fooCount barCount |
+	fooCount := 0.
+	barCount := 0.
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '--foo' '--bar' '--foo'))
+		addOptionAllowingArgumentNamed: 'foo' whenPresentDo: [:value | fooCount := fooCount + 1];
+		addOptionAllowingArgumentNamed: 'bar' whenPresentDo: [:value | barCount := barCount + 1];
+		valueBlocks.
+	self
+		assert: fooCount = 2;
+		assert: barCount = 1;
+		yourself.!
+
+testRepeatBlockOptionalArgumentPresent
+
+	| fooValue |
+	fooValue := ''.
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '--foo' 'bar' '--foo' 'BAR'))
+		addOptionAllowingArgumentNamed: 'foo' whenPresentDo: [:value | fooValue := fooValue , value];
+		valueBlocks.
+	self assert: fooValue = 'barBAR'.!
+
+testRepeatShortBlockNoArgument
+
+	| fooCount |
+	fooCount := 0.
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-f' 'bar' '-f'))
+		addOptionNamed: $f whenPresentDo: [fooCount := fooCount + 1];
+		valueBlocks.
+	self assert: fooCount = 2.
+!
+
+testShortBlockNoArgument
+
+	| foundFoo |
+	foundFoo := false.
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-f' 'bar'))
+		addOptionNamed: $f whenPresentDo: [foundFoo := true];
+		valueBlocks.
+	self assert: foundFoo.
+!
+
+testShortBlockOptionalArgumentAbsent
+
+	| fooValue barValue |
+	fooValue := Object new.
+	barValue := Object new.
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-f' '-b'))
+		addOptionAllowingArgumentNamed: $f whenPresentDo: [:value | fooValue := value];
+		addOptionAllowingArgumentNamed: $b whenPresentDo: [:value | barValue := value];
+		valueBlocks.
+	self
+		assert: fooValue isNil;
+		assert: barValue isNil;
+		yourself.!
+
+testShortBlockRequiredArgumentPresent
+
+	| fooValue |
+	(CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '-f' 'bar'))
+		addOptionRequiringArgumentNamed: $f whenPresentDo: [:value | fooValue := value];
+		valueBlocks.
+	self assert: fooValue = 'bar'.
+!
+
 testSlashPrefix
 
 	| commandLine options arguments |
@@ -406,6 +511,10 @@ testUnrecognizedOption
 !CommandLineTest categoriesFor: #test_getOpt_13!getopt protocol!public! !
 !CommandLineTest categoriesFor: #test_getOpt_14!getopt protocol!public! !
 !CommandLineTest categoriesFor: #testAccessors!public! !
+!CommandLineTest categoriesFor: #testBlockNoArgument!block!public! !
+!CommandLineTest categoriesFor: #testBlockOptionalArgumentAbsent!block!public! !
+!CommandLineTest categoriesFor: #testBlockOptionalArgumentPresent!block!public! !
+!CommandLineTest categoriesFor: #testBlockRequiredArgumentPresent!block!public! !
 !CommandLineTest categoriesFor: #testLongAmbiguousOption!errors!public! !
 !CommandLineTest categoriesFor: #testLongEquals!long tests!public! !
 !CommandLineTest categoriesFor: #testLongMissingRequiredArgument!errors!public! !
@@ -417,6 +526,12 @@ testUnrecognizedOption
 !CommandLineTest categoriesFor: #testLongUnexpectedOption!errors!public! !
 !CommandLineTest categoriesFor: #testMissingRequiredArgument!errors!public! !
 !CommandLineTest categoriesFor: #testPartialLong!long tests!public! !
+!CommandLineTest categoriesFor: #testRepeatBlockOptionalArgumentAbsent!block!public! !
+!CommandLineTest categoriesFor: #testRepeatBlockOptionalArgumentPresent!block!public! !
+!CommandLineTest categoriesFor: #testRepeatShortBlockNoArgument!block!public! !
+!CommandLineTest categoriesFor: #testShortBlockNoArgument!block!public! !
+!CommandLineTest categoriesFor: #testShortBlockOptionalArgumentAbsent!block!public! !
+!CommandLineTest categoriesFor: #testShortBlockRequiredArgumentPresent!block!public! !
 !CommandLineTest categoriesFor: #testSlashPrefix!public! !
 !CommandLineTest categoriesFor: #testUnrecognizedOption!errors!public! !
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base.pax
@@ -30,7 +30,7 @@ Object subclass: #CommandLine
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Object subclass: #CommandLineOption
-	instanceVariableNames: 'name isArgumentAllowed isArgumentRequired'
+	instanceVariableNames: 'name isArgumentAllowed isArgumentRequired block'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
@@ -89,7 +89,7 @@ commandLineParser
 	"
 
 	^(CommandLine argv: self argvLegacyOptionsRemoved)
-		options: 'd::f:hi:qx';
+		options: 'hq';	"Options with arguments described elsewhere"
 		yourself!
 
 dolphinNewsgroupUrl
@@ -407,34 +407,31 @@ primaryStartup
 	self openSources!
 
 processCommandLine
-	"Private - 
+	"private
 	-d path - Rebase Dolphin core packages to supplied path
 	-f fileInFile - file in an ST chunk file
+	-h - headless (embedded) mode
 	-i imageFile - initialize a new image
+	-q - quiet startup (no splash)
 	-x - immediately exit
 	"
 
-	| commandLine options arguments |
-	commandLine := self commandLineParser.
-	options := commandLine options.
-	arguments := commandLine arguments.
-	arguments notEmpty 		"If no image name is provided then the default is Dolphin.img7"
-		ifTrue: [arguments := arguments allButFirst]. "leave off image name"
-	"Clone a new image to the given path"
-	options at: $i
-		ifPresent: [:newImageFile | newImageFile notNil ifTrue: [self saveImage: newImageFile]].
-	"Rebase the Dolphin boot packages to live in a (presumably shared) location relative to the installation directory"
-	options at: $d
-		ifPresent: 
-			[:rebasePath | 
+	| commandLine arguments |
+	commandLine := self commandLineParser
+		"-h and -q are already defined"
+		addOptionAllowingArgumentNamed: $d whenPresentDo: [:rebasePath | 
 			Package manager rebaseBasePackagesTo: (rebasePath ifNil: ['.']).
-			self saveImage].
-	"File in a given file"
-	options at: $f ifPresent: [:fileInFile | SourceManager default fileIn: fileInFile].
+			self saveImage];
+		addOptionRequiringArgumentNamed: $f whenPresentDo: [:fileInFile | SourceManager default fileIn: fileInFile];
+		addOptionAllowingArgumentNamed: $i whenPresentDo: [:newImageFile | self saveImage: (newImageFile ifNil: ['Dolphin'])];
+		addOptionNamed: $x whenPresentDo: [self quit];
+		valueBlocks;
+		yourself.
+	(arguments := commandLine arguments) isEmpty ifTrue: [^self].
 	"Open a source file (CLS, ST, PAX, PAC, SML) in the appropriate tool"
-	arguments do: [:openFile | openFile notNil ifTrue: [self open: openFile]].
-	"Immediately exit the image following startup activities"
-	options at: $x ifPresent: [:val | self quit]!
+	arguments allButFirst 		 "leave off image name"
+		do: [:openFile |self open: openFile].
+!
 
 productDetails
 	"Private - Answers an eight element <Array> describing this version of the development environment


### PR DESCRIPTION
One of the characteristics of the getopt() approach is that the options are processed in order and a given option can appear multiple times. With the changes included here we now have that capability in Dolphin. Instead of testing for various keys in a dictionary (where the original order is lost and each key can have only one value), we now have the ability to provide a code block with each option definition and the code block is evaluated in the order each option is encountered. This also allows us to avoid writing if statements--something that seems to me to indicate a good design. To see the impact, see the simplification in DevelopmentSessionManager>>#processCommandLine.

One can now file in chunks from multiple files and the file-in can be done both before and after creating a new image (with the -i option). This avoids the problems "fixed" earlier by changing the order of the option testing (I wanted the file-in to happen after the new image was created, but someone might want it the other way).

Also this allows creation of an image without providing a name, and 'Dolphin' is the default (since it is the default if Dolphin7.exe is launched without any arguments). To see one use try the following to create two images:

C:\Dolphin>Dolphin7 DPRO.img7 -q -i -i JadeDev -x

With this I believe I've addressed the major goals of a command line parsing tool. Refinements and fixes can certainly come, but I think it is basically feature complete (unless someone wants the getopt_long_only capability to have long options with a single - prefix). 

Comments and suggestions are welcome.