### PR TITLE
#64 - Remove redundant DCE boot configuration

### DIFF
--- a/BootAll.cmd
+++ b/BootAll.cmd
@@ -1,3 +1,2 @@
 CALL BootCore
-CALL BootDCE
 CALL BootDPRO

--- a/BootDCE.cmd
+++ b/BootDCE.cmd
@@ -1,6 +1,0 @@
-@ECHO OFF
-Dolphin7 DBOOT.img7 DolphinCommunityEdition
-IF %ERRORLEVEL% NEQ 0 (
-  ECHO Boot failed, Code=%ERRORLEVEL%
-  PAUSE
-)


### PR DESCRIPTION
Removing DCE from BootAll saves a good 3 minutes on the AppVeyor build.
Note that the DolphinProduct and the IDE package have been left behind, as there isn't much 
immediate value in removing these.