### PR TITLE
#isNilOrEmpty

### DIFF
--- a/Core/Contributions/ITC Gorisek/Dialect Abstraction Layer.pax
+++ b/Core/Contributions/ITC Gorisek/Dialect Abstraction Layer.pax
@@ -40,7 +40,6 @@ package methodNames
 	add: #ByteArray -> #itcAsInteger;
 	add: #Character -> #itcAsInteger;
 	add: #Collection -> #conform:;
-	add: #Collection -> #isNilOrEmpty;
 	add: #Collection -> #itcGetAbsSum;
 	add: #Collection -> #itcGetMax;
 	add: #Collection -> #itcGetMin;
@@ -96,7 +95,6 @@ package methodNames
 	add: #Object -> #isBlockClosure;
 	add: #Object -> #isDictionaryOrLookupTable;
 	add: #Object -> #isFileStream;
-	add: #Object -> #isNilOrEmpty;
 	add: #Object -> #isNilOrZero;
 	add: #Object -> #itcAsInteger;
 	add: #Object -> #itcAsNumberOrZero;
@@ -176,7 +174,6 @@ package methodNames
 	add: #UndefinedObject -> #+~;
 	add: #UndefinedObject -> #add:withDelimiter:;
 	add: #UndefinedObject -> #asString;
-	add: #UndefinedObject -> #isNilOrEmpty;
 	add: 'Exception class' -> #signalWithMessage:;
 	add: 'FileStream class' -> #delete:;
 	add: 'ScaledDecimal class' -> #numerator:denominator:scale:;
@@ -399,9 +396,6 @@ conform: discriminator
 	self do: [:e | (discriminator value: e) ifFalse: [^false]].
 	^true!
 
-isNilOrEmpty
-	^self isEmpty!
-
 itcGetAbsSum
 	| sum |
 	sum := 0.
@@ -435,7 +429,6 @@ itcGetSumOrNil
 		do: [:each | each isNil ifFalse: [sum isNil ifTrue: [sum := each] ifFalse: [sum := sum + each]]].
 	^sum! !
 !Collection categoriesFor: #conform:!enumerating!public! !
-!Collection categoriesFor: #isNilOrEmpty!public! !
 !Collection categoriesFor: #itcGetAbsSum!enumerating!public! !
 !Collection categoriesFor: #itcGetMax!enumerating!public! !
 !Collection categoriesFor: #itcGetMin!enumerating!public! !
@@ -859,9 +852,6 @@ isDictionaryOrLookupTable
 isFileStream
 	^false!
 
-isNilOrEmpty
-	^false!
-
 isNilOrZero
 	^self isNil or: [self = 0]!
 
@@ -911,7 +901,6 @@ sestej: selectors
 !Object categoriesFor: #isBlockClosure!constants!public! !
 !Object categoriesFor: #isDictionaryOrLookupTable!public!testing! !
 !Object categoriesFor: #isFileStream!public!testing! !
-!Object categoriesFor: #isNilOrEmpty!public! !
 !Object categoriesFor: #isNilOrZero!public! !
 !Object categoriesFor: #itcAsInteger!comparing!public! !
 !Object categoriesFor: #itcAsNumberOrZero!comparing!public! !
@@ -1822,15 +1811,11 @@ add: aString withDelimiter: delimiter
 	^aString isNilOrEmpty ifFalse: [aString] ifTrue: ['']!
 
 asString
-	^''!
-
-isNilOrEmpty
-	^true! !
+	^''! !
 !UndefinedObject categoriesFor: #-~!public! !
 !UndefinedObject categoriesFor: #+~!public! !
 !UndefinedObject categoriesFor: #add:withDelimiter:!control flow!public! !
 !UndefinedObject categoriesFor: #asString!public! !
-!UndefinedObject categoriesFor: #isNilOrEmpty!public! !
 
 "End of package definition"!
 

--- a/Core/Object Arts/Dolphin/Base/Collection.cls
+++ b/Core/Object Arts/Dolphin/Base/Collection.cls
@@ -393,6 +393,9 @@ isEmpty
 	^self size == 0
 !
 
+isNilOrEmpty
+	^self isEmpty!
+
 maxPrint
 	"Private - Answer the maximum number of characters to be printed onto a stream as 
 	the string representation of the receiver."
@@ -618,6 +621,7 @@ union: comperand
 !Collection categoriesFor: #inject:into:!enumerating!public! !
 !Collection categoriesFor: #intersection:!public!set operations! !
 !Collection categoriesFor: #isEmpty!public!testing! !
+!Collection categoriesFor: #isNilOrEmpty!public! !
 !Collection categoriesFor: #maxPrint!constants!private! !
 !Collection categoriesFor: #newSelection!enumerating!private! !
 !Collection categoriesFor: #noDifference:!public!set operations! !

--- a/Core/Object Arts/Dolphin/Base/DolphinCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DolphinCollectionTest.cls
@@ -25,6 +25,11 @@ testFold
 		do: 
 			[:i | 
 			result := (1 to: i) fold: [:product :each | product * each].
-			self assert: result = i factorial]! !
+			self assert: result = i factorial]!
+
+testIsNilOrEmpty
+	self assert: #() isNilOrEmpty.
+	self deny: #(nil) isNilOrEmpty.! !
 !DolphinCollectionTest categoriesFor: #testFold!public!unit tests! !
+!DolphinCollectionTest categoriesFor: #testIsNilOrEmpty!public!testing / testing! !
 

--- a/Core/Object Arts/Dolphin/Base/Object.cls
+++ b/Core/Object Arts/Dolphin/Base/Object.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 nil subclass: #Object
 	instanceVariableNames: ''
@@ -916,6 +916,9 @@ isNil
 
 	^false!
 
+isNilOrEmpty
+	^false!
+
 isNumber
 	"Coerces numbers to true and everything else to false. Number 
 	overrides with ^true"
@@ -1589,6 +1592,7 @@ yourself
 !Object categoriesFor: #isLiteral!private!testing! !
 !Object categoriesFor: #isMemberOf:!public!testing! !
 !Object categoriesFor: #isNil!public!testing! !
+!Object categoriesFor: #isNilOrEmpty!public! !
 !Object categoriesFor: #isNumber!public!testing! !
 !Object categoriesFor: #isString!public!testing! !
 !Object categoriesFor: #isSymbol!public!RefactoringBrowser! !

--- a/Core/Object Arts/Dolphin/Base/ObjectTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ObjectTest.cls
@@ -62,6 +62,9 @@ testIfNilAndIfNotNil
 	self assert: (evaluated not).
 	!
 
+testIsNilOrEmpty
+	self deny: Object new isNilOrEmpty!
+
 testObjectEventRegistry
 	self assert: _EventsRegister countElements = _EventsRegister size!
 
@@ -281,6 +284,7 @@ testZeroArgEvent
 !ObjectTest categoriesFor: #testDeepCopy!public!unit tests! !
 !ObjectTest categoriesFor: #testEventCollectionWeakness!public!unit tests! !
 !ObjectTest categoriesFor: #testIfNilAndIfNotNil!public!unit tests! !
+!ObjectTest categoriesFor: #testIsNilOrEmpty!public!testing / testing! !
 !ObjectTest categoriesFor: #testObjectEventRegistry!public!unit tests! !
 !ObjectTest categoriesFor: #testOneArgEvent!public!unit tests! !
 !ObjectTest categoriesFor: #testRemoveEventsTriggeredFor!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/UndefinedObject.cls
+++ b/Core/Object Arts/Dolphin/Base/UndefinedObject.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #UndefinedObject
 	instanceVariableNames: ''
@@ -94,6 +94,9 @@ isNil
 
 	^true
 !
+
+isNilOrEmpty
+	^true!
 
 isNull
 	"Private - Answer whether the receiver is 'Null'. A Dolphin object is Null
@@ -199,6 +202,7 @@ yourAddress
 !UndefinedObject categoriesFor: #includesBehavior:!class hierarchy-testing!public! !
 !UndefinedObject categoriesFor: #isLiteral!public!testing! !
 !UndefinedObject categoriesFor: #isNil!public!testing! !
+!UndefinedObject categoriesFor: #isNilOrEmpty!public! !
 !UndefinedObject categoriesFor: #isNull!private!testing! !
 !UndefinedObject categoriesFor: #name!accessing!public! !
 !UndefinedObject categoriesFor: #newClassBuilder:instanceVariableNames:classVariableNames:poolDictionaries:!class hierarchy-adding!private! !

--- a/Core/Object Arts/Dolphin/Base/UndefinedObjectTest.cls
+++ b/Core/Object Arts/Dolphin/Base/UndefinedObjectTest.cls
@@ -37,6 +37,9 @@ testIsLiteral
 testIsNil
 	self assert: nil isNil!
 
+testIsNilOrEmpty
+	self assert: nil isNilOrEmpty!
+
 testNew
 	self assert: UndefinedObject new == nil!
 
@@ -67,6 +70,7 @@ testStoreOn
 !UndefinedObjectTest categoriesFor: #testIfNotNilIfNil!public!testing / testing! !
 !UndefinedObjectTest categoriesFor: #testIsLiteral!public!testing / testing! !
 !UndefinedObjectTest categoriesFor: #testIsNil!public!testing / testing! !
+!UndefinedObjectTest categoriesFor: #testIsNilOrEmpty!public!testing / testing! !
 !UndefinedObjectTest categoriesFor: #testNew!public!unit tests! !
 !UndefinedObjectTest categoriesFor: #testNotNil!public!testing / testing! !
 !UndefinedObjectTest categoriesFor: #testPrintOn!public!testing / printing! !


### PR DESCRIPTION
This method is added to Collection, Object, and UndefinedObject by a contribution but its use requires inclusion of that third-party package in the image and the runtime packaging process. It would be easier if it were in the base.