### PR TITLE
Relax compiler error range check for blocks too deep test

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/AbstractParserErrorTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/AbstractParserErrorTest.cls
@@ -107,7 +107,8 @@ buildNestedBlocks2: nesting
 
 checkCompileError: ex range: anInterval code: anInteger message: msgFormat line: lineInteger source: aString 
 	^ex errorCode = anInteger and: 
-			[ex range = anInterval and: 
+			[((anInterval stop isNil and: [ex range start = anInterval start]) or: [ex range = anInterval]) 
+				and: 
 					[(lineInteger < 0 or: [ex line < 0 or: [ex line = lineInteger]]) and: 
 							[| msgString |
 							msgString := msgFormat 
@@ -547,10 +548,7 @@ testErrorsBlockNestingTooDeep
 	mark := (source indexOfSubCollection: nesting displayString) - 3.
 	self 
 		parseExprError: source
-		range: (mark to: (source 
-						nextIndexOf: $]
-						from: mark
-						to: source size) + 1)
+		range: (mark to: nil)
 		line: 1
 		code: CErrBlockNestingTooDeep!
 


### PR DESCRIPTION
The compilation error for block nesting too deep will no longer report
the full source range of the 256th block as the compiler will now report
this error immediately it detects the opening block token.