### PR TITLE
debugPrintString gives walkback for Collection and Dictionary

### DIFF
--- a/Core/Object Arts/Dolphin/Base/ArrayTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ArrayTest.cls
@@ -13,6 +13,13 @@ ArrayTest comment: ''!
 collectionClass
 	^Array!
 
+testCyclicRefPrinting
+
+	| array |
+	array := Array new: 1.
+	array at: 1 put: array.
+	self assert: array debugPrintString = '#(... a cyclic ref to an Array...)'!
+
 testIsLiteral
 	| example1 |
 	example1 := #(1 2 3 4 5) copy.
@@ -44,6 +51,7 @@ testNonLiteralStoreOn
 	self deny: rehydrated isLiteral.
 	self assert: rehydrated = array! !
 !ArrayTest categoriesFor: #collectionClass!helpers!private! !
+!ArrayTest categoriesFor: #testCyclicRefPrinting!public! !
 !ArrayTest categoriesFor: #testIsLiteral!public!unit tests! !
 !ArrayTest categoriesFor: #testLiteralStoreOn!public!unit tests! !
 !ArrayTest categoriesFor: #testNonLiteralStoreOn!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/DictionaryTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DictionaryTest.cls
@@ -74,8 +74,9 @@ testAtIfAbsentPutModifyingCollection
 testCyclicRefPrinting
 	| dictionary |
 	dictionary := self newEmpty.
+	(dictionary class == PoolConstantsDictionary) ifTrue: [^self].
 	dictionary at: dictionary put: dictionary.
-	self assert: dictionary debugPrintString = 'a Dictionary(... a cyclic ref to a Dictionary... -> ... a cyclic ref to a Dictionary...)'!
+	self assert: 0 < (dictionary debugPrintString indexOfSubCollection: '... a cyclic ref to ' startingAt: 1)!
 
 testDeepCopy
 	"#2066"

--- a/Core/Object Arts/Dolphin/Base/DictionaryTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DictionaryTest.cls
@@ -71,6 +71,12 @@ testAtIfAbsentPutModifyingCollection
 	test keysDo: [:each | keys addLast: each].
 	self assert: keys asSortedCollection asArray = #('a' 'b' 'c')!
 
+testCyclicRefPrinting
+	| dictionary |
+	dictionary := self newEmpty.
+	dictionary at: dictionary put: dictionary.
+	self assert: dictionary debugPrintString = 'a Dictionary(... a cyclic ref to a Dictionary... -> ... a cyclic ref to a Dictionary...)'!
+
 testDeepCopy
 	"#2066"
 
@@ -105,6 +111,7 @@ testRemoveKey
 !DictionaryTest categoriesFor: #testAtIfAbsent!public!unit tests! !
 !DictionaryTest categoriesFor: #testAtIfAbsentPut!public!unit tests! !
 !DictionaryTest categoriesFor: #testAtIfAbsentPutModifyingCollection!public!unit tests! !
+!DictionaryTest categoriesFor: #testCyclicRefPrinting!public! !
 !DictionaryTest categoriesFor: #testDeepCopy!public!unit tests! !
 !DictionaryTest categoriesFor: #testIncludesKey!public!unit tests! !
 !DictionaryTest categoriesFor: #testRemoveKey!public!unit tests! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -1686,7 +1686,7 @@ debugPrintString
 	| stream printed |
 	stream := String writeStream: 32.
 	printed := Processor activeProcess _alreadyPrinted.
-	(printed includes: self) ifTrue: [^self printCyclicRefOn: stream].
+	(printed includes: self) ifTrue: [self printCyclicRefOn: stream. ^stream contents].
 	printed add: self.
 	
 	[| tooMany |
@@ -2112,7 +2112,7 @@ debugPrintString
 	| stream printed |
 	stream := String writeStream: 32.
 	printed := Processor activeProcess _alreadyPrinted.
-	(printed includes: self) ifTrue: [^self printCyclicRefOn: stream].
+	(printed includes: self) ifTrue: [self printCyclicRefOn: stream. ^stream contents].
 	printed add: self.
 	
 	[| tooMany |


### PR DESCRIPTION
If there is a cycle the #'debugPrintString' method returns self instead of a String. This commit fixes that (and adds tests).