### PR TITLE
ColorRef>>asRGB converts in-place rather than answering a new object #121 

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/Debugger.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Debugger.cls
@@ -955,6 +955,10 @@ parseContext
 parseTree
 	^sourcePresenter parseTree!
 
+performMethodsRefactoring: aMonadicValuable name: aString 
+	self promptToSaveChanges ifFalse: [^self].
+	^sourcePresenter executeRefactoring: aMonadicValuable with: self selectedMethods!
+
 populateImplementMenu: aMenu 
 	"Private - Build the menu which lists the classes into which a stub can be generated for
 	messages which were either not understood, or not implemented directly by the receiver's
@@ -1938,6 +1942,7 @@ variableAtIndex: anInteger put: anObject
 !Debugger categoriesFor: #onWalkback:topFrame:resumable:!event handling!private! !
 !Debugger categoriesFor: #parseContext!accessing!public! !
 !Debugger categoriesFor: #parseTree!commands!private! !
+!Debugger categoriesFor: #performMethodsRefactoring:name:!private!refactoring! !
 !Debugger categoriesFor: #populateImplementMenu:!helpers!private! !
 !Debugger categoriesFor: #populateStackModel!private!updating! !
 !Debugger categoriesFor: #prevIPOfFrame:!accessing!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Canvas.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Canvas.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #Canvas
 	instanceVariableNames: 'handle source owned pen brush font saved saveIds'
@@ -350,6 +350,11 @@ fonts: aString do: operation
 				lParam: 0.
 	callback free.
 	^answer!
+
+forecolor
+	"Get the receiver's colour for drawing text."
+
+	^ColorRef fromInteger: (GDILibrary default getTextColor: self asParameter)!
 
 forecolor: colour
 	"Set the receiver's colour for drawing text."
@@ -1032,6 +1037,7 @@ windowScaling
 !Canvas categoriesFor: #font:!accessing!public!tools! !
 !Canvas categoriesFor: #fontNames!enquiries!public! !
 !Canvas categoriesFor: #fonts:do:!enumerating!public! !
+!Canvas categoriesFor: #forecolor!modes!public! !
 !Canvas categoriesFor: #forecolor:!modes!public! !
 !Canvas categoriesFor: #formatText:in:!drawing!public! !
 !Canvas categoriesFor: #formatText:in:flags:!drawing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/ColorRef.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ColorRef.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Color subclass: #ColorRef
 	instanceVariableNames: 'code'
@@ -51,7 +51,8 @@ asParameter
 asRGB
 	"Answer the <RGB> colour equivalent to the receiver."
 
-	^self becomeA: RGB!
+	code > 16rFFFFFF ifTrue: [self errorNotARealColor].
+	^RGB fromInteger: code!
 
 brush
 	"Answer a Brush configured for solid painting of the receiver's color."
@@ -65,7 +66,7 @@ code
 
 errorNotARealColor
 	"Private - Raise an error to the effect that the receiver does not represent a real colour
-	value, and cannot therefore be converted to type of <Color>."
+	value, and cannot therefore be converted to another type of <Color>."
 
 	^self error: 'Cannot convert to another type of Color'!
 

--- a/Core/Object Arts/Dolphin/MVP/Base/GDILibrary.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/GDILibrary.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 PermanentLibrary subclass: #GDILibrary
 	instanceVariableNames: ''
@@ -547,6 +547,16 @@ getStockObject: fnObject
 			int fnObject);"
 
 	<stdcall: handle GetStockObject sdword>
+	^self invalidCall!
+
+getTextColor: hdc 
+	"The GetTextColor function retrieves the current text color for the specified device context.
+
+	COLORREF GetTextColor(
+		HDC hdc			// handle of device context  
+	);"
+
+	<stdcall: dword GetTextColor handle>
 	^self invalidCall!
 
 getTextExtentPoint32: hdc lpString: lpString cbString: cbString lpSize: lpSize
@@ -1182,6 +1192,7 @@ textOut: hdc nXStart: nXStart nYStart: nYStart lpString: lpString cbString: cbSt
 !GDILibrary categoriesFor: #getPixel:xPos:yPos:!public!win32 functions-device context! !
 !GDILibrary categoriesFor: #getROP2:!**auto generated**!public!win32 functions-device context! !
 !GDILibrary categoriesFor: #getStockObject:!**auto generated**!public!win32 functions-device context! !
+!GDILibrary categoriesFor: #getTextColor:!public!win32 functions-font and text! !
 !GDILibrary categoriesFor: #getTextExtentPoint32:lpString:cbString:lpSize:!**auto generated**!public!win32 functions-font and text! !
 !GDILibrary categoriesFor: #getTextMetrics:lptm:!public!win32 functions-font and text! !
 !GDILibrary categoriesFor: #getViewportExtEx:lpSize:!public!win32 functions-transformations! !

--- a/Core/Object Arts/Dolphin/MVP/ColorTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ColorTest.cls
@@ -1,0 +1,56 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #ColorTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ColorTest guid: (GUID fromString: '{7B5098B5-74D7-46C5-99DE-AE2E0558FE5C}')!
+ColorTest comment: ''!
+!ColorTest categoriesForClass!Unclassified! !
+!ColorTest methodsFor!
+
+testConversions
+	"The virtual colours 'none' and 'default' do not relate to any particular colour in general, only in context."
+
+	(Array with: Color none with: Color default) do: [:each | self should: [each asRGB] raise: Error].
+	"Try a few standard colours"
+	((OrderedCollection new)
+		add: Color white -> (RGB 
+							red: 255
+							green: 255
+							blue: 255);
+		add: Color black -> (RGB 
+							red: 0
+							green: 0
+							blue: 0);
+		add: Color red -> (RGB 
+							red: 255
+							green: 0
+							blue: 0);
+		add: Color green -> (RGB 
+							red: 0
+							green: 255
+							blue: 0);
+		add: Color blue -> (RGB 
+							red: 0
+							green: 0
+							blue: 255);
+		add: Color brown -> (RGB 
+							red: 128
+							green: 128
+							blue: 0);
+		yourself) do: 
+				[:each | 
+				| rgb |
+				rgb := each key asRGB.
+				self assert: (rgb isKindOf: RGB).
+				self assert: rgb red = each value red.
+				self assert: rgb green = each value green.
+				self assert: rgb blue = each value blue.
+				self assert: rgb asIndexedColor == each key.
+				self assert: (Color fromInteger: each key asParameter) == each key].
+	"For system colours we don't know what the RGB values are, so not much we can check."
+	self assert: (Color menu asRGB isKindOf: RGB)! !
+!ColorTest categoriesFor: #testConversions!public! !
+

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/ColorDialog.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/ColorDialog.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 CommonDialog subclass: #ColorDialog
 	instanceVariableNames: 'validationBlock'
@@ -40,9 +40,12 @@ extractResult: aBoolean
 	color = self defaultColor 
 		ifTrue: [self value: Color default]
 		ifFalse: 
-			[| std |
-			std := color asIndexedColor.
-			self value: (std asRGB = color ifTrue: [std] ifFalse: [color])].
+			[color isNone 
+				ifFalse: 
+					[| std |
+					std := color asIndexedColor.
+					std asRGB = color ifTrue: [color := std] ifFalse: [color]].
+			self value: color].
 	self apply!
 
 initialize
@@ -61,7 +64,7 @@ prepareStruct
 	color := self value isNil ifTrue: [self defaultColor] ifFalse: [self value].
 	(self winStruct)
 		hInstance: VMLibrary default applicationHandle;
-		rgbResult: color asRGB asParameter;
+		rgbResult: color asColorRef asParameter;
 		maskIn: CC_RGBINIT;
 		lpCustColors: customColors!
 

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -10,6 +10,7 @@ package classNames
 	add: #BrushTest;
 	add: #CanvasTest;
 	add: #ChoicePresenterTest;
+	add: #ColorTest;
 	add: #ContainerViewTest;
 	add: #FlowLayoutTest;
 	add: #FramingLayoutTest;
@@ -113,6 +114,11 @@ DolphinTest subclass: #BrushTest
 	poolDictionaries: 'Win32Constants'
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #CanvasTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+DolphinTest subclass: #ColorTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/MVP/Gdiplus/Gdiplus.pax
+++ b/Core/Object Arts/Dolphin/MVP/Gdiplus/Gdiplus.pax
@@ -217,6 +217,7 @@ package methodNames
 	add: #Bitmap -> #asColorKeyedBitmap:;
 	add: #Color -> #alpha:;
 	add: #Color -> #asARGB;
+	add: #ColorRef -> #asARGB;
 	add: #Point -> #scaledOver:;
 	add: #Point -> #scaledTo:;
 	add: #Rectangle -> #asGdiplusRectangle;
@@ -731,6 +732,12 @@ asARGB
 		b: rgb blue! !
 !Color categoriesFor: #alpha:!accessing!public! !
 !Color categoriesFor: #asARGB!converting!public! !
+
+!ColorRef methodsFor!
+
+asARGB
+	^self isNone ifTrue: [ARGB fromInteger: CLR_NONE] ifFalse: [super asARGB]! !
+!ColorRef categoriesFor: #asARGB!converting!public! !
 
 !Point methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMLVCUSTOMDRAW.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMLVCUSTOMDRAW.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 NMCUSTOMDRAW subclass: #NMLVCUSTOMDRAW
 	instanceVariableNames: 'column'
@@ -15,7 +15,9 @@ NMLVCUSTOMDRAW is sent by <ListView> controls to request custom draw information
 backcolor
 	"Answer the background <Color>."
 
-	^ColorRef fromInteger: self clrTextBk!
+	| clrTextBk |
+	clrTextBk := self clrTextBk.
+	^clrTextBk = CLR_DEFAULT ifTrue: [Color window] ifFalse: [ColorRef fromInteger: clrTextBk]!
 
 backcolor: aColor
 	"Sets the background <Color>.
@@ -56,7 +58,9 @@ column: aListViewColumn
 forecolor
 	"Answer the foreground text colour."
 
-	^ColorRef fromInteger: self clrText!
+	| clrText |
+	clrText := self clrText.
+	^clrText = CLR_DEFAULT ifTrue: [Color windowText] ifFalse: [ColorRef fromInteger: clrText]!
 
 forecolor: aColor
 	"Sets the text foreground <Color>."

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMTVCUSTOMDRAW.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMTVCUSTOMDRAW.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 NMCUSTOMDRAW subclass: #NMTVCUSTOMDRAW
 	instanceVariableNames: ''
@@ -15,7 +15,9 @@ NMTVCUSTOMDRAW is sent by <TreeView> controls to request custom draw information
 backcolor
 	"Answer the background <Color>."
 
-	^ColorRef fromInteger: self clrTextBk!
+	| clrTextBk |
+	clrTextBk := self clrTextBk.
+	^clrTextBk = CLR_DEFAULT ifTrue: [Color window] ifFalse: [ColorRef fromInteger: clrTextBk]!
 
 backcolor: aColor
 	"Sets the background <Color>."
@@ -45,7 +47,9 @@ clrTextBk: anObject
 forecolor
 	"Answer the foreground text colour."
 
-	^ColorRef fromInteger: self clrText!
+	| clrText |
+	clrText := self clrText.
+	^clrText = CLR_DEFAULT ifTrue: [Color windowText] ifFalse: [ColorRef fromInteger: clrText]!
 
 forecolor: aColor
 	"Sets the text foreground <Color>."

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Toolbar.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Toolbar.cls
@@ -493,10 +493,10 @@ onEraseRequired: aColorEvent
 	| back fore rect canvas |
 	back := self basicActualBackcolor.
 	back isNone ifTrue: [^true].
-	fore := self basicActualForeolor .
+	fore := self basicActualForeolor.
 	rect := self clientRectangle.
 	canvas := aColorEvent canvas.
-	fore isNil 
+	fore isNone 
 		ifTrue: 
 			[^canvas fillRectangle: rect color: (back isDefault ifTrue: [self defaultBackcolor] ifFalse: [back])].
 	canvas 


### PR DESCRIPTION
Also Color none and default should not translate directly to RGB colours without context - these only have meaning in relation to the environment in which the color ref is being used.