### PR TITLE
Add a (failing) test for Compiler issue DolphinVM#57

### DIFF
--- a/Core/Object Arts/Dolphin/Base/CompiledExpression.cls
+++ b/Core/Object Arts/Dolphin/Base/CompiledExpression.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 CompiledCode variableSubclass: #CompiledExpression
 	instanceVariableNames: ''
@@ -71,6 +71,11 @@ storeSourceString: aString evaluationPools: anArray logged: aBoolean
 	self 
 		sourceDescriptor: (pools isNil ifTrue: [aString] ifFalse: [Array with: aString with: pools])!
 
+value
+	"Evaluate the expression with nil as 'self'."
+
+	^self value: nil!
+
 value: anObject
 	"Evaluate the receiver with the argument, anObject, 
 	as its receiver, answering the result."
@@ -83,5 +88,6 @@ value: anObject
 !CompiledExpression categoriesFor: #isExpression!private!testing! !
 !CompiledExpression categoriesFor: #owningPackage!accessing!public! !
 !CompiledExpression categoriesFor: #storeSourceString:evaluationPools:logged:!accessing!private! !
+!CompiledExpression categoriesFor: #value!evaluating!public! !
 !CompiledExpression categoriesFor: #value:!evaluating!public! !
 

--- a/Core/Object Arts/Dolphin/Tests/Known Failing Tests.pax
+++ b/Core/Object Arts/Dolphin/Tests/Known Failing Tests.pax
@@ -8,6 +8,7 @@ Tests should not be added to this package without creating a Github issue, as ot
 
 package methodNames
 	add: #BlockClosureTest -> #testFullBlockEquality;
+	add: #CompilerTest -> #testOptimizedLoopReadBeforeWritten;
 	add: #DebuggerTest -> #testRemapIPSmokeTest;
 	add: #GdiplusBitmapTest -> #testAsByteArray;
 	add: #ListViewTest -> #testColumnWidth;
@@ -60,6 +61,25 @@ testFullBlockEquality
 	self assert: block1 = block2.
 	self assert: block1 ~= block3! !
 !BlockClosureTest categoriesFor: #testFullBlockEquality!public!unit tests-known failures! !
+
+!CompilerTest methodsFor!
+
+testOptimizedLoopReadBeforeWritten
+	| expected expr actual |
+	expected := OrderedCollection new.
+	(1 to: 5) do: 
+			[:i | 
+			| a |
+			expected add: a displayString , i displayString.
+			a := i].
+	expr := (self 
+				compileExpression: '| r | r := OrderedCollection new. 1 to: 5 do: [:i | | a | r add: a displayString, i displayString. a := i]. r') 
+					method.
+	actual := expr value.
+	"Results of actual block evaluation in a loop and optimized loop should be the same - any
+	read-before-written locals must be reinitialized to zero on each iteration"
+	self assert: actual = expected! !
+!CompilerTest categoriesFor: #testOptimizedLoopReadBeforeWritten!public!unit tests! !
 
 !DebuggerTest methodsFor!
 


### PR DESCRIPTION
Compiler generates incorrect code for optimized loop with
read-before-written temps DolphinVM#57