### PR TITLE
Re-enable and improve SelectableItemsTreeTest>>testSelection

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/MoenTreeViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MoenTreeViewTest.cls
@@ -1227,9 +1227,8 @@ testRemoveSelection
 	self assert: treeView selection = 'C'.
 	"Remove selected last child"
 	treeModel remove: 'C'.
-	"Selection moves up to parent"
-	self assert: treeView selection = 'ROOT2'.
-	treeView selection: 'A'.
+	"Selection moves to prev sibling"
+	self assert: treeView selection = 'A'.
 	"Remove first child"
 	treeModel remove: 'A'.
 	"Selection moves to parent"

--- a/Core/Object Arts/Dolphin/MVP/SelectableTreeItemsTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/SelectableTreeItemsTest.cls
@@ -33,6 +33,7 @@ objectsToTest
 		add: ArithmeticValue;
 		add: Point;
 		add: Number;
+		add: Point3D;
 		yourself!
 
 testAddRemove
@@ -110,6 +111,74 @@ testHierarchyMove
 	"Tidy up"
 	self treeModel removeAll!
 
+testSelection
+	"Test selection"
+
+	| objects |
+	objects := self objectsToTest.
+	self addAllObjects: objects.
+	objects do: 
+			[:each | 
+			self 
+				should: [presenter selection: each]
+				trigger: #selectionChanged
+				butNot: #selectionChanging:
+				against: presenter.
+			self assert: presenter selection == each].
+	self 
+		should: [presenter resetSelection]
+		trigger: #selectionChanged
+		butNot: #selectionChanging:
+		against: presenter.
+
+	"remove should not upset selection"
+	presenter selection: objects first.
+	self 
+		shouldnt: [self treeModel remove: objects last]
+		triggerAnyOf: #(#selectionChanged #selectionChanging:)
+		against: presenter.
+	self assert: presenter selection == objects first.
+
+	"add should not upset selection"
+	self 
+		shouldnt: [self treeModel add: objects last asChildOf: objects last superclass]
+		triggerAnyOf: #(#selectionChanged #selectionChanging:)
+		against: presenter.
+	self assert: presenter selection == objects first.
+	"remove of selected object should trigger #selectionChanged and leave the parent of the selection selected"
+	(Array 
+		with: Number
+		with: Point3D
+		with: Point
+		with: ArithmeticValue) do: 
+				[:each | 
+				presenter selection: each.
+				self 
+					should: [self treeModel remove: each]
+					trigger: #selectionChanged
+					butNot: #selectionChanging:
+					against: presenter.
+				"If the selected object has siblings, the next of those should be selected, if not the parent"
+				presenter selection = each superclass 
+					ifTrue: 
+						["Parent selected, should be no remaining siblings"
+						self assert: (self treeModel childrenOf: presenter selection) isEmpty]
+					ifFalse: [self assert: presenter selection superclass = each superclass]].
+
+	"No selection tests"
+	objects do: [:each | self treeModel add: each asChildOf: each superclass].
+	objects do: 
+			[:each | 
+			presenter selection: each.
+			self 
+				should: [presenter resetSelection]
+				trigger: #selectionChanged
+				butNot: #selectionChanging:
+				against: presenter.
+			self assert: presenter selectionOrNil isNil.
+			self should: [presenter selection] raise: Error].
+	self treeModel removeAll!
+
 testSelectionChangeTriggeredOnRemove
 	self addRoot: #a.
 	self addRoot: #b.
@@ -164,6 +233,7 @@ treeModel
 !SelectableTreeItemsTest categoriesFor: #objectsToTest!helpers!private! !
 !SelectableTreeItemsTest categoriesFor: #testAddRemove!public!unit tests! !
 !SelectableTreeItemsTest categoriesFor: #testHierarchyMove!public!unit tests! !
+!SelectableTreeItemsTest categoriesFor: #testSelection!public!unit tests! !
 !SelectableTreeItemsTest categoriesFor: #testSelectionChangeTriggeredOnRemove!public!unit tests! !
 !SelectableTreeItemsTest categoriesFor: #testSetImageBlockDoesNotAffectSelection!public!unit tests! !
 !SelectableTreeItemsTest categoriesFor: #testSetTextBlockDoesNotAffectSelection!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/Views/MoenTree/MoenTreeView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/MoenTree/MoenTreeView.cls
@@ -958,7 +958,7 @@ moveSelectionUp
 	(self previousSibling: self selectedNode) 
 		ifNotNil: [:node | self basicSelection: node cause: #keyboard]!
 
-nearestNodeTo: aMoenTreeNode
+nearestNodeTo: aMoenTreeNode 
 	"Private - Answer the 'nearest' node to the <MoenTreeNode> argument in the receiver in the 
 	following order of priority.
 	1) The node's next sibling
@@ -968,12 +968,9 @@ nearestNodeTo: aMoenTreeNode
 	^aMoenTreeNode sibling notNil 
 		ifTrue: [aMoenTreeNode sibling]
 		ifFalse: 
-			["Root nodes are handled differently in that the selection moves to the previous sibling (if any)
-			 rather than the parent, I suppose because there is no parent"
-
-			aMoenTreeNode parent == anchorNode 
-				ifTrue: [self previousSibling: aMoenTreeNode]
-				ifFalse: [aMoenTreeNode parent]]!
+			["If there is no subsequent sibling, move to the previous one, and failing that up to the parent"
+			(self previousSibling: aMoenTreeNode) 
+				ifNil: [aMoenTreeNode parent == anchorNode ifFalse: [aMoenTreeNode parent]]]!
 
 nodeAtPosition: position ifNone: exceptionHandler 
 	"Private - Answer the <MoenTreeNode> whose item rectangle contains the 

--- a/Core/Object Arts/Dolphin/Tests/Known Failing Tests.pax
+++ b/Core/Object Arts/Dolphin/Tests/Known Failing Tests.pax
@@ -15,7 +15,6 @@ package methodNames
 	add: #PackageSelectorTest -> #testPackageCreationDoesntAlterSelection;
 	add: #PackageSelectorTest -> #testPackageRemovalDoesntAlterSelection;
 	add: #PackageTest -> #testImageStripperPrereqs;
-	add: #SelectableTreeItemsTest -> #testSelection;
 	add: #StyledContainerTest -> #test1PixDottedBorderPaint;
 	add: #StyledContainerTest -> #test1PixDottedBorderPrint;
 	add: #ViewComposerTest -> #testResizeDoesNotMove;
@@ -192,69 +191,6 @@ testImageStripperPrereqs
 	self assert: ((Package manager packageNamed: 'Autoplay') prerequisiteNames asArray 
 				includes: 'Lagoon Image Stripper')! !
 !PackageTest categoriesFor: #testImageStripperPrereqs!public!unit tests! !
-
-!SelectableTreeItemsTest methodsFor!
-
-testSelection
-	"Test selection"
-
-	| objects |
-	objects := self objectsToTest.
-	self addAllObjects: objects.
-	objects do: 
-			[:each | 
-			self 
-				should: [presenter selection: each]
-				trigger: #selectionChanged
-				butNot: #selectionChanging:
-				against: presenter.
-			self assert: presenter selection == each].
-	self 
-		should: [presenter resetSelection]
-		trigger: #selectionChanged
-		butNot: #selectionChanging:
-		against: presenter.
-
-	"remove should not upset selection"
-	presenter selection: objects first.
-	self 
-		shouldnt: [self treeModel remove: objects last]
-		triggerAnyOf: #(#selectionChanged #selectionChanging:)
-		against: presenter.
-	self assert: presenter selection == objects first.
-
-	"add should not upset selection"
-	self 
-		shouldnt: [self treeModel add: objects last asChildOf: objects last superclass]
-		triggerAnyOf: #(#selectionChanged #selectionChanging:)
-		against: presenter.
-	self assert: presenter selection == objects first.
-
-	"remove of selected object should trigger #selectionChanged and leave the parent of the selection selected"
-	(Array with: objects last) do: 
-			[:each | 
-			presenter selection: each.
-			self 
-				should: [self treeModel remove: each]
-				trigger: #selectionChanged
-				butNot: #selectionChanging:
-				against: presenter.
-			self assert: presenter selection = each superclass].
-
-	"No selection tests"
-	objects do: [:each | self treeModel add: each asChildOf: each superclass].
-	objects do: 
-			[:each | 
-			presenter selection: each.
-			self 
-				should: [presenter resetSelection]
-				trigger: #selectionChanged
-				butNot: #selectionChanging:
-				against: presenter.
-			self assert: presenter selectionOrNil isNil.
-			self should: [presenter selection] raise: Error].
-	self treeModel removeAll! !
-!SelectableTreeItemsTest categoriesFor: #testSelection!public!unit tests! !
 
 !StyledContainerTest methodsFor!
 


### PR DESCRIPTION
Current TreeView implementation attempts to move selection to next sibling,
failing that previous sibling, and failing that to the parent.
Modified the MoenTreeView to behave in the same way as the TreeView.