### PR TITLE
Fix local failures in PackageTest and ProcessTest

### DIFF
--- a/Core/Object Arts/Dolphin/Base/DolphinTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DolphinTest.cls
@@ -77,14 +77,6 @@ runKnownBug: aString test: aSymbol
 	#todo.	"Make this controllable by an option or class var"
 	^false!
 
-setUp
-
-	super setUp.
-	(SessionManager inputState)
-		pumpMessages;
-		processDeferredActions.
-!
-
 shouldRaiseZeroDivide: aBlock
 	| raised |
 	Float reset.
@@ -105,7 +97,6 @@ shouldRaiseZeroDivide: aBlock
 !DolphinTest categoriesFor: #isOnline!public!unit tests! !
 !DolphinTest categoriesFor: #methodContextClass!constants!private! !
 !DolphinTest categoriesFor: #runKnownBug:test:!public!unit tests! !
-!DolphinTest categoriesFor: #setUp!public!Running! !
 !DolphinTest categoriesFor: #shouldRaiseZeroDivide:!Accessing!public! !
 
 !DolphinTest class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/DolphinTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DolphinTest.cls
@@ -105,7 +105,7 @@ shouldRaiseZeroDivide: aBlock
 !DolphinTest categoriesFor: #isOnline!public!unit tests! !
 !DolphinTest categoriesFor: #methodContextClass!constants!private! !
 !DolphinTest categoriesFor: #runKnownBug:test:!public!unit tests! !
-!DolphinTest categoriesFor: #setUp!public! !
+!DolphinTest categoriesFor: #setUp!public!Running! !
 !DolphinTest categoriesFor: #shouldRaiseZeroDivide:!Accessing!public! !
 
 !DolphinTest class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/DolphinTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DolphinTest.cls
@@ -77,6 +77,14 @@ runKnownBug: aString test: aSymbol
 	#todo.	"Make this controllable by an option or class var"
 	^false!
 
+setUp
+
+	super setUp.
+	(SessionManager inputState)
+		pumpMessages;
+		processDeferredActions.
+!
+
 shouldRaiseZeroDivide: aBlock
 	| raised |
 	Float reset.
@@ -97,6 +105,7 @@ shouldRaiseZeroDivide: aBlock
 !DolphinTest categoriesFor: #isOnline!public!unit tests! !
 !DolphinTest categoriesFor: #methodContextClass!constants!private! !
 !DolphinTest categoriesFor: #runKnownBug:test:!public!unit tests! !
+!DolphinTest categoriesFor: #setUp!public! !
 !DolphinTest categoriesFor: #shouldRaiseZeroDivide:!Accessing!public! !
 
 !DolphinTest class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/PackageTest.cls
+++ b/Core/Object Arts/Dolphin/Base/PackageTest.cls
@@ -268,6 +268,7 @@ testPacTimestampUpdate
 	2 timesRepeat: 
 			[stamp := a timestamp.
 			warned := false.
+			self waitForFileSystemClockTick.
 			self assert: ([a save] on: Warning
 						do: 
 							[:ex | 
@@ -276,13 +277,12 @@ testPacTimestampUpdate
 			self deny: warned.
 			self deny: a isUsingPAX.
 			self deny: a isRenegade.
-			self assert: a timestamp asInteger > stamp asInteger.
-			Processor sleep: 1].
+			self assert: a timestamp asInteger > stamp asInteger].
 	stream := FileStream read: a packageFileName text: true.
 	text := stream contents.
 	stream close.
 	self deny: a isRenegade.
-	Processor sleep: 10.
+	self waitForFileSystemClockTick.
 	stream := FileStream write: a packageFileName text: true.
 	stream nextPutAll: text.
 	stream close.
@@ -320,6 +320,7 @@ testPaxTimestampUpdate
 	2 timesRepeat: 
 			[stamp := b timestamp.
 			warned := false.
+			self waitForFileSystemClockTick.
 			self assert: ([b save] on: Warning
 						do: 
 							[:ex | 
@@ -328,13 +329,12 @@ testPaxTimestampUpdate
 			self deny: warned.
 			self assert: b isUsingPAX.
 			self deny: b isRenegade.
-			self assert: b timestamp asInteger > stamp asInteger.
-			Processor sleep: 10].
+			self assert: b timestamp asInteger > stamp asInteger].
 	stream := FileStream read: b fileOutName text: true.
 	text := stream contents.
 	stream close.
 	self deny: b isRenegade.
-	Processor sleep: 10.
+	self waitForFileSystemClockTick.
 	stream := FileStream write: b fileOutName text: true.
 	stream nextPutAll: text.
 	stream close.
@@ -363,7 +363,25 @@ testPaxTimestampUpdate
 	self deny: b isRenegade!
 
 testTimestampInitialized
-	self assert: Package new timestamp asInteger = 0! !
+	self assert: Package new timestamp asInteger = 0!
+
+waitForFileSystemClockTick
+	"Some files systems have larger granularity than 100 nanoseconds.
+	We use the image to guess the actual delay required."
+
+	| x y z |
+	x := (File lastWriteTime: SessionManager current imagePath , '.img7') asInteger.
+	y := x \\ 10000.		"remainder will eventually be non-zero"
+	x := x // 10000.	"adjusted time"
+	z := 0.			"needed delay"
+	[0 < x and: [y == 0 and: [z < 10000]]] whileTrue: [
+		z := z * 10 max: 1.
+		y := x \\ 10.
+		x := x // 10.
+	].
+	z := (z max: 10) min: 2000.	"wait at least 10 ms, but not more than 2 seconds"
+	(Delay forMilliseconds: z) wait.
+! !
 !PackageTest categoriesFor: #checkNoTestPackageContents!private!unit tests! !
 !PackageTest categoriesFor: #checkTestPackageContents!private!unit tests! !
 !PackageTest categoriesFor: #d5ForwardRefTestPacContents!private!unit tests! !
@@ -383,6 +401,7 @@ testTimestampInitialized
 !PackageTest categoriesFor: #testPacTimestampUpdate!public!unit tests! !
 !PackageTest categoriesFor: #testPaxTimestampUpdate!public!unit tests! !
 !PackageTest categoriesFor: #testTimestampInitialized!public!unit tests! !
+!PackageTest categoriesFor: #waitForFileSystemClockTick!public!unit tests! !
 
 !PackageTest class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/PackageTest.cls
+++ b/Core/Object Arts/Dolphin/Base/PackageTest.cls
@@ -260,128 +260,8 @@ testPackages
 		with: DolphinTestPackages current b
 		with: DolphinTestPackages current c!
 
-testPacTimestampUpdate
-	| a stamp stream text warned |
-	a := DolphinTestPackages current a.
-	self deny: a isUsingPAX.
-	self deny: a isRenegade.
-	2 timesRepeat: 
-			[stamp := a timestamp.
-			warned := false.
-			self waitForFileSystemClockTick.
-			self assert: ([a save] on: Warning
-						do: 
-							[:ex | 
-							warned := true.
-							false]).
-			self deny: warned.
-			self deny: a isUsingPAX.
-			self deny: a isRenegade.
-			self assert: a timestamp asInteger > stamp asInteger].
-	stream := FileStream read: a packageFileName text: true.
-	text := stream contents.
-	stream close.
-	self deny: a isRenegade.
-	self waitForFileSystemClockTick.
-	stream := FileStream write: a packageFileName text: true.
-	stream nextPutAll: text.
-	stream close.
-	self assert: a isRenegade.
-	self deny: ([a save] on: Warning do: [:ex | false]).
-	self assert: a isRenegade.
-	warned := false.
-	self assert: ([a save] on: Warning
-				do: 
-					[:ex | 
-					warned := true.
-					ex resume]).
-	self assert: warned.
-	self deny: a isRenegade.
-	warned := false.
-	self assert: ([a save] on: Warning
-				do: 
-					[:ex | 
-					warned := true.
-					false]).
-	self deny: warned.
-	"Finally remove and reinstall it"
-	a uninstall.
-	a := (Package manager install: a packageFileName) first.
-	self assert: a name = 'A'.
-	self deny: a isRenegade!
-
-testPaxTimestampUpdate
-	| b stamp stream text warned |
-	b := DolphinTestPackages current b.
-	self deny: b isRenegade.
-	b fileOutAll.
-	self assert: b isUsingPAX.
-	self deny: b isRenegade.
-	2 timesRepeat: 
-			[stamp := b timestamp.
-			warned := false.
-			self waitForFileSystemClockTick.
-			self assert: ([b save] on: Warning
-						do: 
-							[:ex | 
-							warned := true.
-							false]).
-			self deny: warned.
-			self assert: b isUsingPAX.
-			self deny: b isRenegade.
-			self assert: b timestamp asInteger > stamp asInteger].
-	stream := FileStream read: b fileOutName text: true.
-	text := stream contents.
-	stream close.
-	self deny: b isRenegade.
-	self waitForFileSystemClockTick.
-	stream := FileStream write: b fileOutName text: true.
-	stream nextPutAll: text.
-	stream close.
-	self assert: b isRenegade.
-	self deny: ([b save] on: Warning do: [:ex | false]).
-	self assert: b isRenegade.
-	warned := false.
-	self assert: ([b save] on: Warning
-				do: 
-					[:ex | 
-					warned := true.
-					ex resume]).
-	self assert: warned.
-	self deny: b isRenegade.
-	warned := false.
-	self assert: ([b save] on: Warning
-				do: 
-					[:ex | 
-					warned := true.
-					false]).
-	self deny: warned.
-	"Finally remove and reinstall it"
-	b uninstall.
-	b := (Package manager install: b fileOutName) first.
-	self assert: b name = 'B'.
-	self deny: b isRenegade!
-
 testTimestampInitialized
-	self assert: Package new timestamp asInteger = 0!
-
-waitForFileSystemClockTick
-	"Some files systems have larger granularity than 100 nanoseconds.
-	We use the image to guess the actual delay required."
-
-	| x y z |
-	x := (File lastWriteTime: SessionManager current imagePath , '.img7') asInteger.
-	y := x \\ 10000.		"remainder will eventually be non-zero"
-	x := x // 10000.	"adjusted time"
-	z := 0.			"needed delay"
-	[0 < x and: [y == 0 and: [z < 10000]]] whileTrue: [
-		z := z * 10 max: 1.
-		y := x \\ 10.
-		x := x // 10.
-	].
-	z := (z max: 10) min: 2000.	"wait at least 10 ms, but not more than 2 seconds"
-	(Delay forMilliseconds: z) wait.
-! !
+	self assert: Package new timestamp asInteger = 0! !
 !PackageTest categoriesFor: #checkNoTestPackageContents!private!unit tests! !
 !PackageTest categoriesFor: #checkTestPackageContents!private!unit tests! !
 !PackageTest categoriesFor: #d5ForwardRefTestPacContents!private!unit tests! !
@@ -398,10 +278,7 @@ waitForFileSystemClockTick
 !PackageTest categoriesFor: #testLoad60Pac!public!unit tests! !
 !PackageTest categoriesFor: #testLoad60Pax!public!unit tests! !
 !PackageTest categoriesFor: #testPackages!public!unit tests! !
-!PackageTest categoriesFor: #testPacTimestampUpdate!public!unit tests! !
-!PackageTest categoriesFor: #testPaxTimestampUpdate!public!unit tests! !
 !PackageTest categoriesFor: #testTimestampInitialized!public!unit tests! !
-!PackageTest categoriesFor: #waitForFileSystemClockTick!public!unit tests! !
 
 !PackageTest class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/ProcessTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ProcessTest.cls
@@ -327,7 +327,7 @@ testCopyExceptionHandlers
 	Trace
 		display: Processor activeProcess id printString , ': 5 ' , String lineDelimiter;
 		flush.
-	self waitForProcess: (shared at: #copyProcess) toTerminate: 50.
+	self waitForProcess: (shared at: #copyProcess) toTerminate: 500.
 	Trace
 		display: Processor activeProcess id printString , ': 6 ' , String lineDelimiter;
 		flush.


### PR DESCRIPTION
Something about my environment means that I consistently get three test failures. This fixes them by allowing more time for a process to terminate and delaying longer between file operations if the file system has one-second granularity on timestamps. It also improves the UI updating during the SUnit tests and should not slow down the tests on unaffected platforms.