### PR TITLE
Add ability to create #storeString for most views

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/OCX/AXControlSite.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/OCX/AXControlSite.cls
@@ -795,6 +795,29 @@ state
 	sequence list addAll: controlState afterIndex: 1.
 	^sequence!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	| default name |
+	name := self storeNameIn: aDictionary.
+	aStream display: name; cr.
+	anInteger + 1 timesRepeat: [aStream tab].
+	[
+		default := (self class progId: self progId) create; show.
+		aStream
+			nextPutAll: ' progId: ';
+			print: self progId;
+			nextPut: $; ;
+			cr.
+		anInteger + 1 timesRepeat: [aStream tab].
+		aStream nextPutAll: 'create;'.
+		self storeAttributesDifferingFrom: default On: aStream variables: aDictionary indent: anInteger + 1.
+		aStream cr.
+		anInteger + 1 timesRepeat: [aStream tab].
+		aStream nextPutAll: 'yourself.'; cr.
+	] ensure: [
+		default topView close.
+	].!
+
 supportedInterfaces
 	"Answer the set of interface classes supported by the receiver.
 	We need only support the standard property notification sink interface since
@@ -903,6 +926,7 @@ usesAmbientColors
 !AXControlSite categoriesFor: #showHatching!ambient properties!public!testing! !
 !AXControlSite categoriesFor: #sink!accessing!public! !
 !AXControlSite categoriesFor: #state!binary filing!private! !
+!AXControlSite categoriesFor: #storeOn:indent:variables:!printing!public! !
 !AXControlSite categoriesFor: #supportedInterfaces!constants!public! !
 !AXControlSite categoriesFor: #triggeredEvents!events!public! !
 !AXControlSite categoriesFor: #usesAmbientColors!public!testing! !

--- a/Core/Object Arts/Dolphin/Base/ArrayedCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/ArrayedCollection.cls
@@ -121,7 +121,36 @@ sortUsing: aSortAlgorithm
 	aSortAlgorithm 
 		sort: self
 		from: 1
-		to: self size! !
+		to: self size!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+	"Append to the <puttableStream> argument, target, an expression which when 
+	evaluated will answer a collection similar to the receiver."
+
+	(self allSatisfy: [:each | each isImmutable]) ifTrue: [
+		aStream print: self.
+		^self.
+	].
+	aStream
+		nextPutAll: '((';
+		nextPutAll: self class name;
+		nextPutAll: ' new: ';
+		print: self size;
+		nextPut: $).
+	1 to: self size do: [:i | 
+		aStream cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream 
+			nextPutAll: 'at: ';
+			print: i;
+			nextPutAll: ' put: '.
+		(self at: i) storeOn: aStream indent: anInteger + 1 variables: aDictionary.
+		aStream nextPut: $;.
+	].
+	aStream cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream nextPutAll: 'yourself)'
+! !
 !ArrayedCollection categoriesFor: #add:!adding!public! !
 !ArrayedCollection categoriesFor: #at:!accessing!public! !
 !ArrayedCollection categoriesFor: #at:put:!accessing!public! !
@@ -135,6 +164,7 @@ sortUsing: aSortAlgorithm
 !ArrayedCollection categoriesFor: #resize:!mutating!public! !
 !ArrayedCollection categoriesFor: #size!accessing!public! !
 !ArrayedCollection categoriesFor: #sortUsing:!public!sorting! !
+!ArrayedCollection categoriesFor: #storeOn:indent:variables:!printing!public! !
 
 !ArrayedCollection class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/BlockClosure.cls
+++ b/Core/Object Arts/Dolphin/Base/BlockClosure.cls
@@ -549,6 +549,33 @@ stackTempCount: anInteger
 	info := (info bitAnd: ##((16rFF << 15) bitInvert)) 
 				bitOr: ((anInteger bitAnd: 16rFF) bitShift: 15)!
 
+storeOn: aStream
+	"Append, to aStream, a <String> whose characters can recreate the receiver."
+
+	| m block class selector string |
+	m := self method.
+	(m notNil and: [m isExpression]) ifTrue: [	"We can print the source"
+		aStream 
+			nextPut: $(;
+			nextPutAll: m getSource;
+			nextPut: $).
+		^self].
+	m ifNil: [^super storeOn: aStream].
+	class := m methodClass.
+	selector := m selector.
+	(class isKindOf: Class) ifTrue: [
+		string := class name , ' new ' , selector.
+		block := class new perform: selector.
+	] ifFalse: [
+		string := class instanceClass name , ' ' , selector.
+		block := class instanceClass perform: selector.
+	].
+	block = self ifTrue: [
+		aStream nextPutAll: string.
+	] ifFalse: [
+		super storeOn: aStream.
+	]!
+
 tempCount
 	"Answer the total <integer> number of temps used by the receiver. 
 	This includes all arguments, stack temps, copied values, and environment 
@@ -778,6 +805,7 @@ whileTrue: iterationBlock
 !BlockClosure categoriesFor: #repeat!evaluating!public! !
 !BlockClosure categoriesFor: #stackTempCount!accessing!private! !
 !BlockClosure categoriesFor: #stackTempCount:!accessing!development!private! !
+!BlockClosure categoriesFor: #storeOn:!development!printing!public! !
 !BlockClosure categoriesFor: #tempCount!accessing!public! !
 !BlockClosure categoriesFor: #value!evaluating!public! !
 !BlockClosure categoriesFor: #value:!evaluating!public! !

--- a/Core/Object Arts/Dolphin/Base/Boolean.cls
+++ b/Core/Object Arts/Dolphin/Base/Boolean.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #Boolean
 	instanceVariableNames: ''
@@ -154,6 +154,10 @@ shallowCopy
 
 	^self!
 
+storeOn: aStream
+
+	self printOn: aStream!
+
 xor: operand
 	"Answer whether either the receiver or the <boolean> argument, operand,
 	is true, but not both.
@@ -180,6 +184,7 @@ xor: operand
 !Boolean categoriesFor: #not!logical operations!public! !
 !Boolean categoriesFor: #or:!control flow!public! !
 !Boolean categoriesFor: #shallowCopy!copying!public! !
+!Boolean categoriesFor: #storeOn:!printing!public! !
 !Boolean categoriesFor: #xor:!logical operations!public! !
 
 Boolean methodProtocol: #boolean attributes: #(#ansi #readOnly) selectors: #(#& #| #and: #eqv: #ifFalse: #ifFalse:ifTrue: #ifTrue: #ifTrue:ifFalse: #not #or: #xor:)!

--- a/Core/Object Arts/Dolphin/Base/Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Character.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Magnitude subclass: #Character
 	instanceVariableNames: 'asciiValue '
@@ -286,7 +286,11 @@ species
 	Implementation Note: The primitive superclass implementation
 	will fail for immediate classes, so we must override here."
 
-	^Character! !
+	^Character!
+
+storeOn: aStream
+
+	self printOn: aStream! !
 !Character categoriesFor: #_beginsString:!comparing!double dispatch!private! !
 !Character categoriesFor: #_separateSubStringsIn:!double dispatch!private! !
 !Character categoriesFor: #<!comparing!public! !
@@ -329,6 +333,7 @@ species
 !Character categoriesFor: #shallowCopy!copying!public! !
 !Character categoriesFor: #size!accessing!private! !
 !Character categoriesFor: #species!accessing!public! !
+!Character categoriesFor: #storeOn:!printing!public! !
 
 Character methodProtocol: #Character attributes: #(#ansi #readOnly) selectors: #(#asLowercase #asString #asUppercase #codePoint #isAlphaNumeric #isDigit #isLetter #isLowercase #isUppercase)!
 

--- a/Core/Object Arts/Dolphin/Base/Class.cls
+++ b/Core/Object Arts/Dolphin/Base/Class.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ClassDescription subclass: #Class
 	instanceVariableNames: 'name classPool sharedPools comment classCategories _guid '
@@ -603,6 +603,13 @@ storeGUID
 	self sourceManager storeGUIDForClass: self
 !
 
+storeOn: aStream
+
+	aStream
+		nextPutAll: '##(';
+		nextPutAll: self name;
+		nextPut: $)!
+
 subclass: aClassSymbol instanceVariableNames: instVarString classVariableNames: classVarString poolDictionaries: poolDictString
 	^(self 
 		newClassBuilder: aClassSymbol
@@ -815,6 +822,7 @@ variableSubclass: aClassSymbol
 !Class categoriesFor: #stbSaveOn:!binary filing!public! !
 !Class categoriesFor: #stbVersion!binary filing!public! !
 !Class categoriesFor: #storeGUID!development!private!source filing-methods! !
+!Class categoriesFor: #storeOn:!printing!public! !
 !Class categoriesFor: #subclass:instanceVariableNames:classVariableNames:poolDictionaries:!class hierarchy-adding!public! !
 !Class categoriesFor: #subclass:instanceVariableNames:classVariableNames:poolDictionaries:category:!class hierarchy-adding!public! !
 !Class categoriesFor: #subclass:instanceVariableNames:classVariableNames:poolDictionaries:classInstanceVariableNames:!class hierarchy-adding!public! !

--- a/Core/Object Arts/Dolphin/Base/Date.cls
+++ b/Core/Object Arts/Dolphin/Base/Date.cls
@@ -277,12 +277,14 @@ storeOn: aStream
 
 	"Use a format which is locale invariant."
 
-	aStream
-		display: self class;
-		space;
-		display: #fromDays:;
-		space;
-		display: self asDays!
+	aStream 
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' fromDays: ';
+		print: days;
+		nextPutAll: ' "';
+		print: self;
+		nextPutAll: '")'!
 
 subtractDate: aDate
 	"Answer the difference in days between the receiver and aData, as an Integer"

--- a/Core/Object Arts/Dolphin/Base/Message.cls
+++ b/Core/Object Arts/Dolphin/Base/Message.cls
@@ -107,6 +107,32 @@ setSelector: aSymbol arguments: argArray
 	selector := aSymbol.
 	args := argArray!
 
+storeOn: aStream
+
+	self argumentCount == 0 ifTrue: [
+		aStream
+			nextPutAll: '(Message selector: ';
+			print: selector;
+			nextPut: $).
+		^self
+	].
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' selector: ';
+		print: selector.
+	0 < self argumentCount ifTrue: [
+		1 == self argumentCount ifTrue: [
+			aStream nextPutAll: ' argument: '.
+			(args at: 1) storeOn: aStream.
+		] ifFalse: [
+			aStream nextPutAll: ' arguments: '.
+			args storeOn: aStream.
+		].
+	].
+	aStream nextPut: $).
+!
+
 value: anObject
 	"Answer the result of sending the receiver to the object, anObject.
 	Implementation Note: By implementing this selector from the monadic
@@ -148,6 +174,7 @@ valueWithArguments: argArray
 !Message categoriesFor: #selector!accessing!public! !
 !Message categoriesFor: #selector:!accessing!public! !
 !Message categoriesFor: #setSelector:arguments:!accessing!private! !
+!Message categoriesFor: #storeOn:!printing!public! !
 !Message categoriesFor: #value:!evaluating!public! !
 !Message categoriesFor: #value:value:!evaluating!public! !
 !Message categoriesFor: #valueWithArguments:!evaluating!public! !

--- a/Core/Object Arts/Dolphin/Base/MessageSendAbstract.cls
+++ b/Core/Object Arts/Dolphin/Base/MessageSendAbstract.cls
@@ -99,6 +99,28 @@ receiver: anObject
 
 	^self subclassResponsibility!
 
+storeOn: aStream
+
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' receiver: '.
+	self receiver storeOn: aStream.
+	aStream 
+		nextPutAll: ' selector: ';
+		print: selector.
+	0 < self argumentCount ifTrue: [
+		1 == self argumentCount ifTrue: [
+			aStream nextPutAll: ' argument: '.
+			(args at: 1) storeOn: aStream.
+		] ifFalse: [
+			aStream nextPutAll: ' arguments: '.
+			args storeOn: aStream.
+		].
+	].
+	aStream nextPut: $).
+!
+
 value
 	"Evaluates the receiver send the message identified by the 
 	receiver's selector to the receiver's receiver, with the 
@@ -154,6 +176,7 @@ valueWithArguments: triggerArguments
 !MessageSendAbstract categoriesFor: #printOn:!printing!public! !
 !MessageSendAbstract categoriesFor: #receiver!accessing!public! !
 !MessageSendAbstract categoriesFor: #receiver:!accessing!public! !
+!MessageSendAbstract categoriesFor: #storeOn:!printing!public! !
 !MessageSendAbstract categoriesFor: #value!evaluating!public! !
 !MessageSendAbstract categoriesFor: #value:!evaluating!public! !
 !MessageSendAbstract categoriesFor: #value:value:!evaluating!public! !

--- a/Core/Object Arts/Dolphin/Base/Metaclass.cls
+++ b/Core/Object Arts/Dolphin/Base/Metaclass.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ClassDescription subclass: #Metaclass
 	instanceVariableNames: 'instanceClass '
@@ -164,7 +164,15 @@ sharedStaticPools
 stbSaveOn: anSTBOutFiler
 	"Save out a binary representation of the receiver to anSTBOutFiler."
 
-	anSTBOutFiler saveObject: self as: (STBMetaclassProxy forClass: self)! !
+	anSTBOutFiler saveObject: self as: (STBMetaclassProxy forClass: self)!
+
+storeOn: aStream
+
+	aStream
+		nextPutAll: '##(';
+		nextPutAll: self name;
+		nextPutAll: ' class'
+		nextPut: $)! !
 !Metaclass categoriesFor: #addToSuper!class hierarchy-adding!private! !
 !Metaclass categoriesFor: #bindingFor:!compiling!public! !
 !Metaclass categoriesFor: #classPool!class variables!public! !
@@ -185,6 +193,7 @@ stbSaveOn: anSTBOutFiler
 !Metaclass categoriesFor: #setSharedPoolNames:!pool variables!private! !
 !Metaclass categoriesFor: #sharedStaticPools!pool variables!public! !
 !Metaclass categoriesFor: #stbSaveOn:!binary filing!public! !
+!Metaclass categoriesFor: #storeOn:!printing!public! !
 
 !Metaclass class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/Number.cls
+++ b/Core/Object Arts/Dolphin/Base/Number.cls
@@ -242,6 +242,10 @@ sqrt
 	
 	^self asFloat sqrt!
 
+storeOn: aStream
+
+	self printOn: aStream!
+
 tan
 	"Answer a <Float> which is the tangent of the receiver, 
 	which is treated as an angle in radians."
@@ -314,6 +318,7 @@ to: stop do: operation
 !Number categoriesFor: #raisedTo:!mathematical!public! !
 !Number categoriesFor: #sin!mathematical!public! !
 !Number categoriesFor: #sqrt!mathematical!public! !
+!Number categoriesFor: #storeOn:!printing!public! !
 !Number categoriesFor: #tan!mathematical!public! !
 !Number categoriesFor: #to:!enumerating!public! !
 !Number categoriesFor: #to:by:!enumerating!public! !

--- a/Core/Object Arts/Dolphin/Base/Object.cls
+++ b/Core/Object Arts/Dolphin/Base/Object.cls
@@ -1319,11 +1319,61 @@ stbSaveOn: anSTBOutFiler
 
 	anSTBOutFiler saveObject: self!
 
+storeAttributesDifferingFrom: default On: aStream variables: aDictionary indent: anInteger
+
+	| aspects rejects specialAspects |
+	rejects := #(#'controlDispatch' #'yourself').
+	specialAspects := IdentityDictionary new
+		at: #'commandDescription' 	put: [:anObject | aStream nextPutAll: 'command: '; print: anObject command];
+		at: #'buddy'			 	put: [:anObject | 
+			self isAutoBuddy ifTrue: [
+				aStream nextPutAll: 'isAutoBuddy: true'
+			] ifFalse: [
+				aStream nextPutAll: 'buddy: '; nextPutAll: (aDictionary at: anObject)
+			]
+		];
+		yourself.
+	aspects := self class publishedAspectsOfInstances asSortedCollection.
+	aspects := aspects reject: [:each | rejects includes: each name].
+	aspects do: [:each | | x |
+		(x := self perform: each name) = (default perform: each name) ifFalse: [
+			aStream cr.
+			anInteger timesRepeat: [aStream tab].
+			each isWriteable ifTrue: [
+				aStream display: each name; nextPutAll: ': '.
+				x storeOn: aStream indent: anInteger + 1 variables: aDictionary.
+			] ifFalse: [
+				(specialAspects at: each name ifAbsent: [self halt]) value: x.
+			].
+			aStream nextPut: $;.
+		].
+	]!
+
+storeAttributesOn: aStream indent: anInteger variables: aDictionary
+
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new'.
+	self storeAttributesDifferingFrom: self class new On: aStream variables: aDictionary indent: anInteger.
+	aStream cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream nextPutAll: 'yourself)'
+!
+
 storeOn: aStream
 	"Append to the <puttableStream> argument, target, an expression which when 
 	evaluated will answer a collection similar to the receiver."
 
-	self printOn: aStream!
+	aStream nextPutAll: '(Object fromLiteralStoreArray: '.
+	self literalStoreArray storeOn: aStream.
+	aStream nextPut: $)!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+	"Append to the <puttableStream> argument, target, an expression which when 
+	evaluated will answer a collection similar to the receiver."
+
+	self storeOn: aStream!
 
 storeString
 	"Answer a <readableString> which, when compiled and evaluated, results in
@@ -1633,7 +1683,10 @@ yourself
 !Object categoriesFor: #species!accessing!public! !
 !Object categoriesFor: #stbFixup:at:!binary filing!public! !
 !Object categoriesFor: #stbSaveOn:!binary filing!public! !
+!Object categoriesFor: #storeAttributesDifferingFrom:On:variables:indent:!printing!public! !
+!Object categoriesFor: #storeAttributesOn:indent:variables:!printing!public! !
 !Object categoriesFor: #storeOn:!printing!public! !
+!Object categoriesFor: #storeOn:indent:variables:!printing!public! !
 !Object categoriesFor: #storeString!printing!public! !
 !Object categoriesFor: #subclassResponsibility!exceptions!public! !
 !Object categoriesFor: #swappingBecome:!mutating!public! !

--- a/Core/Object Arts/Dolphin/Base/OrderedCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/OrderedCollection.cls
@@ -344,6 +344,32 @@ stbSaveOn: anSTBOutFiler
 
 	anSTBOutFiler saveObject: self as: (STBCollectionProxy forCollection: self)!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+	"Append to the <puttableStream> argument, target, an expression which when 
+	evaluated will answer a collection similar to the receiver."
+
+	aStream
+		nextPutAll: '(';
+		nextPutAll: self class name;
+		nextPutAll: ' new'.
+	self storeValuesOn: aStream indent: anInteger variables: aDictionary!
+
+storeValuesOn: aStream indent: anInteger variables: aDictionary
+	"Append to the <puttableStream> argument, target, an expression which when 
+	evaluated will answer a collection similar to the receiver."
+
+	self do: [:each | 
+		aStream cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream  nextPutAll: 'add: '.
+		each storeOn: aStream indent: anInteger + 1 variables: aDictionary.
+		aStream nextPut: $;.
+	].
+	aStream cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream nextPutAll: 'yourself)'
+!
+
 uncheckedFrom: startInteger to: stopInteger keysAndValuesDo: aDyadicValuable 
 	"Private - Evaluate the <dyadicValuable> argument for each element of the receiver
 	between the specified <integer> indices, inclusive, with the element and its index as
@@ -383,6 +409,8 @@ uncheckedFrom: startInteger to: stopInteger keysAndValuesDo: aDyadicValuable
 !OrderedCollection categoriesFor: #size!accessing!public! !
 !OrderedCollection categoriesFor: #sortUsing:!public!sorting! !
 !OrderedCollection categoriesFor: #stbSaveOn:!binary filing!public! !
+!OrderedCollection categoriesFor: #storeOn:indent:variables:!printing!public! !
+!OrderedCollection categoriesFor: #storeValuesOn:indent:variables:!printing!public! !
 !OrderedCollection categoriesFor: #uncheckedFrom:to:keysAndValuesDo:!enumerating!private! !
 
 !OrderedCollection class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/Point.cls
+++ b/Core/Object Arts/Dolphin/Base/Point.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ArithmeticValue subclass: #Point
 	instanceVariableNames: 'x y '
@@ -241,6 +241,10 @@ roundTo: aNumber
 
 	^(x roundTo: aNumber) @ (y roundTo: aNumber)!
 
+storeOn: aStream
+
+	self printOn: aStream!
+
 subtractFromPoint: aPoint
 	"Private - Answer the result of subtracting the receiver from the known Point,
 	aPoint, by coercing the less general of it and the receiver. Overridden by 
@@ -319,6 +323,7 @@ y: aNumber
 !Point categoriesFor: #raisedTo:!mathematical!public! !
 !Point categoriesFor: #rounded!public!truncation and round off! !
 !Point categoriesFor: #roundTo:!public!truncation and round off! !
+!Point categoriesFor: #storeOn:!printing!public! !
 !Point categoriesFor: #subtractFromPoint:!double dispatch!private! !
 !Point categoriesFor: #transpose!operations!public! !
 !Point categoriesFor: #truncated!public!truncation and round off! !

--- a/Core/Object Arts/Dolphin/Base/Rectangle.cls
+++ b/Core/Object Arts/Dolphin/Base/Rectangle.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #Rectangle
 	instanceVariableNames: 'origin corner'
@@ -419,6 +419,15 @@ scaleBy: delta
 
 	^self species vertex: origin * delta vertex: corner * delta!
 
+storeOn: aStream
+
+	aStream 
+		nextPut: $(;
+		print: origin; 
+		nextPutAll: ' corner: '; 
+		print: corner;
+		nextPut: $)!
+
 top
 	"Answer the position of the receiver's top edge."
 
@@ -570,6 +579,7 @@ width: aNumber
 !Rectangle categoriesFor: #rightCenter:!accessing!public! !
 !Rectangle categoriesFor: #rounded!public!truncation and round off! !
 !Rectangle categoriesFor: #scaleBy:!public!transforming! !
+!Rectangle categoriesFor: #storeOn:!printing!public! !
 !Rectangle categoriesFor: #top!accessing!public! !
 !Rectangle categoriesFor: #top:!accessing!public! !
 !Rectangle categoriesFor: #topAlign!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/SortedCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SortedCollection.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 OrderedCollection variableSubclass: #SortedCollection
 	instanceVariableNames: 'algorithm '
@@ -271,7 +271,22 @@ stbSaveOn: anSTBOutFiler
 
 	super stbSaveOn: anSTBOutFiler
 
-	! !
+	!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+	"Append to the <puttableStream> argument, target, an expression which when 
+	evaluated will answer a collection similar to the receiver."
+
+	(algorithm isKindOf: DefaultSortAlgorithm) ifTrue: [
+		^super storeOn: aStream indent: anInteger variables: aDictionary.
+	].
+	aStream
+		nextPutAll: '((';
+		nextPutAll: self class name;
+		nextPutAll: ' sortBlock: '.
+	algorithm sortBlock storeOn: aStream.
+	aStream nextPut: $).
+	self storeValuesOn: aStream indent: anInteger variables: aDictionary! !
 !SortedCollection categoriesFor: #,!copying!public! !
 !SortedCollection categoriesFor: #add:!adding!public! !
 !SortedCollection categoriesFor: #add:afterIndex:!adding!public! !
@@ -301,6 +316,7 @@ stbSaveOn: anSTBOutFiler
 !SortedCollection categoriesFor: #sortBlock:!accessing!public! !
 !SortedCollection categoriesFor: #sortFrom:to:!algorithms!private! !
 !SortedCollection categoriesFor: #stbSaveOn:!binary filing!public! !
+!SortedCollection categoriesFor: #storeOn:indent:variables:!printing!public! !
 
 SortedCollection methodProtocol: #SortedCollection attributes: #(#ansi #readOnly) selectors: #(#, #add: #addAll: #after: #allSatisfy: #anySatisfy: #asArray #asBag #asByteArray #asOrderedCollection #asSet #asSortedCollection #asSortedCollection: #at: #at:ifAbsent: #before: #collect: #copyFrom:to: #copyReplaceAll:with: #copyReplaceFrom:to:with: #copyReplaceFrom:to:withObject: #copyReplacing:withObject: #copyWith: #copyWithout: #detect: #detect:ifNone: #do: #do:separatedBy: #findFirst: #findLast: #first #from:to:do: #from:to:keysAndValuesDo: #includes: #indexOf: #indexOf:ifAbsent: #indexOfSubCollection:startingAt: #indexOfSubCollection:startingAt:ifAbsent: #inject:into: #isEmpty #keysAndValuesDo: #last #notEmpty #occurrencesOf: #rehash #reject: #remove: #remove:ifAbsent: #removeAll: #removeAtIndex: #removeFirst #removeLast #reverse #reverseDo: #select: #size #sortBlock #sortBlock: #with:do:)!
 

--- a/Core/Object Arts/Dolphin/Base/Time.cls
+++ b/Core/Object Arts/Dolphin/Base/Time.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Magnitude subclass: #Time
 	instanceVariableNames: 'milliseconds '
@@ -118,10 +118,16 @@ setMilliseconds: anInteger
 	milliseconds := anInteger!
 
 storeOn: aStream 
+
 	aStream
-		display: self class;
-		nextPutAll: ' fromString: '.
-	self displayString printOn: aStream!
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' fromMilliseconds: '.
+	milliseconds storeOn: aStream .
+	aStream 
+		nextPutAll: ' "';
+		print: self;
+		nextPutAll: '")'!
 
 subtractTime: aTimeOrDate
 	"Answer a new Time, aTimeOrDate seconds before the receiver."

--- a/Core/Object Arts/Dolphin/Base/UndefinedObject.cls
+++ b/Core/Object Arts/Dolphin/Base/UndefinedObject.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #UndefinedObject
 	instanceVariableNames: ''
@@ -145,6 +145,10 @@ shallowCopy
 
 	^self!
 
+storeOn: aStream
+
+	self printOn: aStream!
+
 subclass: aClassSymbol instanceVariableNames: instVarString classVariableNames: classVarString poolDictionaries: poolDictString
 	^(self 
 		newClassBuilder: aClassSymbol
@@ -207,6 +211,7 @@ yourAddress
 !UndefinedObject categoriesFor: #printOn:!printing!public! !
 !UndefinedObject categoriesFor: #printString!printing!public! !
 !UndefinedObject categoriesFor: #shallowCopy!copying!public! !
+!UndefinedObject categoriesFor: #storeOn:!printing!public! !
 !UndefinedObject categoriesFor: #subclass:instanceVariableNames:classVariableNames:poolDictionaries:!class hierarchy-adding!public! !
 !UndefinedObject categoriesFor: #subclass:instanceVariableNames:classVariableNames:poolDictionaries:category:!class hierarchy-adding!public! !
 !UndefinedObject categoriesFor: #subclass:instanceVariableNames:classVariableNames:poolDictionaries:classInstanceVariableNames:!class hierarchy-adding!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/InternalBitmap.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/InternalBitmap.cls
@@ -129,7 +129,15 @@ printOn: aStream
 	self asByteArray printOn: aStream upTo: 100000!
 
 setBitmap: aGdiplusBitmap 
-	gdiplusBitmap := aGdiplusBitmap! !
+	gdiplusBitmap := aGdiplusBitmap!
+
+storeOn: aStream 
+	"Append the ASCII representation of the receiver to aStream."
+
+	aStream
+		nextPut: $(;
+		print: self;
+		nextPut: $)! !
 !InternalBitmap categoriesFor: #=!comparing!comparison!public! !
 !InternalBitmap categoriesFor: #addToImageList:mask:!double dispatch!private! !
 !InternalBitmap categoriesFor: #asBitmap!public! !
@@ -151,6 +159,7 @@ setBitmap: aGdiplusBitmap
 !InternalBitmap categoriesFor: #internalize!public! !
 !InternalBitmap categoriesFor: #printOn:!printing!public! !
 !InternalBitmap categoriesFor: #setBitmap:!initializing!private! !
+!InternalBitmap categoriesFor: #storeOn:!printing!public! !
 
 !InternalBitmap class methodsFor!
 

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkStyler.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkStyler.cls
@@ -324,6 +324,12 @@ resetStylingIn: aScintillaView from: startInteger to: stopInteger
 scannerClass
 	^SmalltalkStylingScanner!
 
+storeOn: aStream
+
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' new'!
+
 styleForBar
 	| lastStyle |
 	lastStyle := self lastStyle.
@@ -419,6 +425,7 @@ tokenBefore: anInteger
 !SmalltalkStyler categoriesFor: #prepareToStyleView:!initializing!public! !
 !SmalltalkStyler categoriesFor: #resetStylingIn:from:to:!helpers!private! !
 !SmalltalkStyler categoriesFor: #scannerClass!constants!private! !
+!SmalltalkStyler categoriesFor: #storeOn:!printing!public! !
 !SmalltalkStyler categoriesFor: #styleForBar!helpers!private! !
 !SmalltalkStyler categoriesFor: #styleForToken:!helpers!private! !
 !SmalltalkStyler categoriesFor: #stylingStartBefore:in:!helpers!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/BorderLayout.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/BorderLayout.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 LayoutManager subclass: #BorderLayout
 	instanceVariableNames: 'horizontalGap verticalGap north south east west center'
@@ -254,6 +254,50 @@ south: aView
 
 	south := aView!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	| hasOverrides |
+	hasOverrides := false.
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new'.
+	#(
+		#(#'horizontalGap' 0)
+		#(#'verticalGap' 0)
+		#(#'north' nil)
+		#(#'south' nil)
+		#(#'east' nil)
+		#(#'west' nil)
+		#(#'center' nil)
+	) do: [:each | | selector default actual |
+		selector := each at: 1.
+		default := each at: 2.
+		actual := self perform: selector.
+		actual ~= default ifTrue: [
+			aStream cr.
+			anInteger timesRepeat: [aStream tab].
+			aStream
+				nextPutAll: selector;
+				nextPutAll: ': '.
+			(aDictionary at: actual ifAbsent: [nil]) ifNotNil: [:variableName | 
+				aStream nextPutAll: variableName.
+			] ifNil: [
+				actual storeOn: aStream.
+			].
+			aStream nextPut: $;.
+			hasOverrides := true.
+		].
+	].
+	hasOverrides ifFalse: [
+		aStream nextPut: $)
+	] ifTrue: [
+		aStream cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream nextPutAll: 'yourself)'
+	]
+!
+
 verticalGap
 	"Answer the vertical gap between items laid out by the receiver."
 
@@ -302,6 +346,7 @@ widthForEdge: aView ofHeight: anInteger inContext: aLayoutContext
 !BorderLayout categoriesFor: #resolutionScaledBy:!geometry!private! !
 !BorderLayout categoriesFor: #south!accessing!public! !
 !BorderLayout categoriesFor: #south:!accessing!public! !
+!BorderLayout categoriesFor: #storeOn:indent:variables:!printing!public! !
 !BorderLayout categoriesFor: #verticalGap!accessing!public! !
 !BorderLayout categoriesFor: #verticalGap:!accessing!public! !
 !BorderLayout categoriesFor: #west!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Color.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Color.cls
@@ -155,7 +155,11 @@ red
 saturation
 	"Answer the saturation of the receiver."
 
-	^self asRGB hls at: 3! !
+	^self asRGB hls at: 3!
+
+storeOn: aStream
+
+	self printOn: aStream! !
 !Color categoriesFor: #alpha!accessing!public! !
 !Color categoriesFor: #asColorRef!converting!public! !
 !Color categoriesFor: #asDword!converting!public! !
@@ -181,6 +185,7 @@ saturation
 !Color categoriesFor: #penClass!constants!private! !
 !Color categoriesFor: #red!accessing!public! !
 !Color categoriesFor: #saturation!accessing!public! !
+!Color categoriesFor: #storeOn:!printing!public! !
 
 Color methodProtocol: #color attributes: #(#readOnly) selectors: #(#asParameter #asRGB #brush #pen)!
 

--- a/Core/Object Arts/Dolphin/MVP/Base/CommandDescription.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/CommandDescription.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #CommandDescription
 	instanceVariableNames: 'command description acceleratorKey flags image'
@@ -110,6 +110,22 @@ displayOn: aStream
 
 	self description displayOn: aStream!
 
+fromStrings
+	"If the receiver can be reproduced by a String sent to #'fromString:' on the class side, then return it; else, return nil.
+		'<title>/[keyString]/<command>'
+	Menu Item with title as the text. This may include an & preceeding an Alt
+	mnemonic. KeyString, if included, represents an accelerator key attached to this
+	menu item, this is of the form [Ctrl+][Shift+]<key>, where key is a single character
+	or a special key such as: Ins, Home, Del, etc. Command is processed if
+	the menu item is chosen."
+
+	flags == 0 ifFalse: [^nil].
+	image ifNotNil: [^nil].
+	(command isKindOf: Symbol) ifFalse: [^nil].
+	(description includes: $/) ifTrue: [^nil].
+	^description , '/' , (AcceleratorTable keyStringFromCode: self acceleratorKey) , '/' , command
+!
+
 hasAcceleratorKey
 	"Answer whether the receiver defines an accelerator key."
 
@@ -198,6 +214,52 @@ registerAcceleratorKeyIn: accelerators
 
 	acceleratorKey == 0 ifFalse: [accelerators addCommand: self]!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	| closeFlag |
+	(closeFlag := self hasAcceleratorKey or: [self isModalCommand]) ifTrue: [aStream nextPut: $(].
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream nextPutAll: 'command: '.
+	command storeOn: aStream.
+	aStream cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream 
+		nextPutAll: 'description: ';
+		print: description.
+	image ifNotNil: [
+		aStream cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream nextPutAll: 'image: ('.
+		image storeOn: aStream.
+		aStream nextPut: $)
+	].
+	aStream nextPut: $).
+	self isModalCommand ifTrue: [
+		aStream cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream nextPutAll: 'isModalCommand: true;'
+	].
+	self hasAcceleratorKey ifTrue: [
+		aStream cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream 
+			nextPutAll: 'acceleratorKey: ';
+			print: acceleratorKey;
+			nextPutAll:  ' "';
+			nextPutAll: (AcceleratorTable keyStringFromCode: acceleratorKey);
+			nextPutAll: '";'.
+	].
+	closeFlag ifTrue: [
+		aStream cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream nextPutAll: 'yourself)'
+	].
+!
+
 toolTipText
 	"Answer a <readableString> suitable for displaying in a Tool-tip control."
 
@@ -215,6 +277,7 @@ toolTipText
 !CommandDescription categoriesFor: #description!accessing!public! !
 !CommandDescription categoriesFor: #description:!accessing!public! !
 !CommandDescription categoriesFor: #displayOn:!printing!public! !
+!CommandDescription categoriesFor: #fromStrings!development!printing!public! !
 !CommandDescription categoriesFor: #hasAcceleratorKey!public!testing! !
 !CommandDescription categoriesFor: #id!accessing!public! !
 !CommandDescription categoriesFor: #image!accessing!public! !
@@ -228,6 +291,7 @@ toolTipText
 !CommandDescription categoriesFor: #printOn:!development!printing!public! !
 !CommandDescription categoriesFor: #queryCommand:!commands!private! !
 !CommandDescription categoriesFor: #registerAcceleratorKeyIn:!operations!private! !
+!CommandDescription categoriesFor: #storeOn:indent:variables:!development!printing!public! !
 !CommandDescription categoriesFor: #toolTipText!accessing!public! !
 
 CommandDescription methodProtocol: #commandTarget attributes: #(#readOnly) selectors: #(#queryCommand:)!

--- a/Core/Object Arts/Dolphin/MVP/Base/CommandMenuItem.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/CommandMenuItem.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 MenuItem subclass: #CommandMenuItem
 	instanceVariableNames: 'commandDescription image _reserved'
@@ -81,6 +81,20 @@ displayOn: aStream
 	user would want to see"
 
 	aStream display: self description!
+
+fromStrings
+	"If the receiver can be reproduced by a String sent to #'fromString:' on the class side, then return it; else, return nil.
+		'<title>/[keyString]/<command>'
+	Menu Item with title as the text. This may include an & preceeding an Alt
+	mnemonic. KeyString, if included, represents an accelerator key attached to this
+	menu item, this is of the form [Ctrl+][Shift+]<key>, where key is a single character
+	or a special key such as: Ins, Home, Del, etc. Command is processed if
+	the menu item is chosen."
+
+	flags == 0 ifFalse: [^nil].
+	image ifNotNil: [^nil].
+	^commandDescription fromStrings
+!
 
 id
 	"Answers the menu item identifier for the receiver. This is the command
@@ -170,6 +184,22 @@ stbSaveOn: anSTBOutFiler
 	anSTBOutFiler override: image with: nil.
 	super stbSaveOn: anSTBOutFiler!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	flags == 0 ifFalse: [aStream nextPut: $(].
+	aStream 
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' commandDescription: '.
+	commandDescription storeOn: aStream indent: anInteger variables: aDictionary.
+	flags == 0 ifFalse: [
+		aStream 
+			nextPutAll: ') flags: ';
+			print: flags;
+			nextPutAll: '; yourself'
+	].
+	aStream nextPut: $)!
+
 text
 	"Answer the menu text (i.e. the text that appears in the menu) for the receiver."
 
@@ -186,6 +216,7 @@ text
 !CommandMenuItem categoriesFor: #description!accessing!public! !
 !CommandMenuItem categoriesFor: #description:!accessing!public! !
 !CommandMenuItem categoriesFor: #displayOn:!displaying!public! !
+!CommandMenuItem categoriesFor: #fromStrings!printing!public! !
 !CommandMenuItem categoriesFor: #id!accessing!public! !
 !CommandMenuItem categoriesFor: #image!accessing!public! !
 !CommandMenuItem categoriesFor: #image:!accessing!public! !
@@ -201,6 +232,7 @@ text
 !CommandMenuItem categoriesFor: #queryAlong:!operations!public! !
 !CommandMenuItem categoriesFor: #registerAcceleratorKeyIn:!menus!public! !
 !CommandMenuItem categoriesFor: #stbSaveOn:!binary filing!public! !
+!CommandMenuItem categoriesFor: #storeOn:indent:variables:!printing!public! !
 !CommandMenuItem categoriesFor: #text!accessing!public! !
 
 CommandMenuItem methodProtocol: #commandSource attributes: #(#readOnly) selectors: #(#commandDescription)!

--- a/Core/Object Arts/Dolphin/MVP/Base/DividerMenuItem.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DividerMenuItem.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 MenuItem subclass: #DividerMenuItem
 	instanceVariableNames: ''
@@ -46,6 +46,16 @@ displayOn: aStream
 
 	aStream display: '|'!
 
+fromStrings
+	"If the receiver can be reproduced by a String sent to #'fromString:' on the class side, then return it; else, return nil."
+
+	| styleName |
+	styleName := self styleName.
+	styleName == #'separator' 	ifTrue: [^'-'].
+	styleName == #'break' 	ifTrue: [^'|'].
+	styleName == #'barBreak'	ifTrue: [^'||'].
+	self error: 'Unrecognized DividerMenuItem'!
+
 id
 	"Answers the menu item identifier for the receiver"
 
@@ -65,6 +75,15 @@ queryAlong: aCommandPolicy
 	"Answer an enabled <CommandQuery> as dividers must always be enabled."
 
 	^CommandQuery new beEnabled!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	| styleName |
+	styleName := self styleName.
+	styleName == #'separator' 	ifTrue: [aStream nextPutAll: 'DividerMenuItem separator'.	^self].
+	styleName == #'break' 	ifTrue: [aStream nextPutAll: 'DividerMenuItem break'.		^self].
+	styleName == #'barBreak' 	ifTrue: [aStream nextPutAll: 'DividerMenuItem barBreak'.	^self].
+	self error: 'Unrecognized DividerMenuItem'!
 
 styleName
 	"Answer a Symbol description of the style of the reciver"
@@ -86,10 +105,12 @@ text
 !DividerMenuItem categoriesFor: #command!accessing!private! !
 !DividerMenuItem categoriesFor: #commandDescription!accessing!private! !
 !DividerMenuItem categoriesFor: #displayOn:!displaying!public! !
+!DividerMenuItem categoriesFor: #fromStrings!printing!public! !
 !DividerMenuItem categoriesFor: #id!accessing!public! !
 !DividerMenuItem categoriesFor: #isDivider!public!testing! !
 !DividerMenuItem categoriesFor: #populateItemInfo:!private!realizing/unrealizing! !
 !DividerMenuItem categoriesFor: #queryAlong:!operations!public! !
+!DividerMenuItem categoriesFor: #storeOn:indent:variables:!printing!public! !
 !DividerMenuItem categoriesFor: #styleName!accessing!public! !
 !DividerMenuItem categoriesFor: #styleName:!accessing!private! !
 !DividerMenuItem categoriesFor: #text!accessing!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/FlowLayout.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/FlowLayout.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 LayoutManager subclass: #FlowLayout
 	instanceVariableNames: 'horizontalGap verticalGap flags'
@@ -157,6 +157,24 @@ resolutionScaledBy: scale
 	horizontalGap := (horizontalGap * scale x) truncated.
 	verticalGap := (verticalGap * scale y) truncated!
 
+storeOn: aStream
+
+	| default |
+	default := self class new.
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new'.
+	#(#'horizontalGap' #'verticalGap' #'alignment') do: [:each | 
+		| x |
+		(x := self perform: each) = (default perform: each) ifFalse: [
+			aStream space; nextPutAll: each; nextPutAll: ': '.
+			x storeOn: aStream.
+			aStream nextPut: $;
+		].
+	].
+	aStream space; nextPutAll: 'yourself)'!
+
 verticalAlignment
 	^flags bitAnd: ##(AlignTop | AlignVCenter | AlignBottom)!
 
@@ -180,6 +198,7 @@ verticalGap: anInteger
 !FlowLayout categoriesFor: #preferredLayoutExtentOf:context:!enquiries!public! !
 !FlowLayout categoriesFor: #resize:to:!geometry!public! !
 !FlowLayout categoriesFor: #resolutionScaledBy:!geometry!private! !
+!FlowLayout categoriesFor: #storeOn:!printing!public! !
 !FlowLayout categoriesFor: #verticalAlignment!accessing!private! !
 !FlowLayout categoriesFor: #verticalGap!accessing!public! !
 !FlowLayout categoriesFor: #verticalGap:!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Font.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Font.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 GraphicsTool subclass: #Font
 	instanceVariableNames: 'logfont resolution'
@@ -228,6 +228,33 @@ resolution: aPoint
 	self pointSize: ptSize] 
 			ifCurtailed: [resolution := oldres]!
 
+storeOn: aStream
+
+	| default isDefault name |
+	name := self name.
+	default := self class name: name.
+	aStream
+		nextPutAll: '((';
+		nextPutAll: self class name;
+		nextPutAll: ' name: ';
+		print: name;
+		nextPut: $);
+		yourself.
+	isDefault := true.
+	#(#'characterSet' #'isBold' #'isItalic' #'isStruckThrough' #'isUnderlined' #'pointSize' #'resolution' #'weight') do: [:each | | x |
+		(x := self perform: each) = (default perform: each) ifFalse: [
+			aStream cr; tab; nextPutAll: each; nextPutAll: ': '.
+			x storeOn: aStream.
+			aStream nextPut: $;.
+			isDefault := false.
+		].
+	].
+	isDefault ifTrue: [
+		aStream nextPut: $)
+	] ifFalse: [
+		aStream cr; tab; nextPutAll: 'yourself)'
+	]!
+
 weight
 	"Answer the receiver's <integer> 'weight' (thickness)."
 
@@ -275,6 +302,7 @@ weight: anInteger
 !Font categoriesFor: #printOn:!development!printing!public! !
 !Font categoriesFor: #resolution!accessing!public! !
 !Font categoriesFor: #resolution:!accessing!public! !
+!Font categoriesFor: #storeOn:!development!printing!public! !
 !Font categoriesFor: #weight!accessing!public! !
 !Font categoriesFor: #weight:!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/FramingConstraints.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/FramingConstraints.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #FramingConstraints
 	instanceVariableNames: 'leftFraming leftOffset rightFraming rightOffset topFraming topOffset bottomFraming bottomOffset'
@@ -219,6 +219,10 @@ rightOffset
 rightOffset: aNumber 
 	rightOffset := aNumber!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	self storeAttributesOn: aStream indent: anInteger variables: aDictionary!
+
 topFraming
 	"Answer the <Symbol> name of the framing calculation used to calculate the receiver's top edge."
 
@@ -302,6 +306,7 @@ updateFor: aView rectangle: aRectangle layoutContext: aLayoutContext
 !FramingConstraints categoriesFor: #rightFraming:!accessing!public! !
 !FramingConstraints categoriesFor: #rightOffset!accessing!public! !
 !FramingConstraints categoriesFor: #rightOffset:!accessing!public! !
+!FramingConstraints categoriesFor: #storeOn:indent:variables:!printing!public! !
 !FramingConstraints categoriesFor: #topFraming!accessing!public! !
 !FramingConstraints categoriesFor: #topFraming:!accessing!public! !
 !FramingConstraints categoriesFor: #topOffset!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/FramingLayout.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/FramingLayout.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 LayoutManager subclass: #FramingLayout
 	instanceVariableNames: 'framings'
@@ -108,7 +108,28 @@ resolutionScaledBy: aPoint
 	has changed since the point at which the view was saved. Scale any internal pixels by <Point>
 	scale."
 
-	framings do: [:each | each resolutionScaledBy: aPoint]! !
+	framings do: [:each | each resolutionScaledBy: aPoint]!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' new'
+"
+	framings keysAndValuesDo: [:eachKey :eachValue | 
+		aStream cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream
+			nextPutAll: 'arrangementOf: ';
+			nextPutAll: (aDictionary at: eachKey);
+			nextPutAll: ' put: '.
+		eachValue storeOn: aStream indent: anInteger + 1 variables: aDictionary.
+		aStream nextPut: $;
+	].
+	aStream cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream nextPutAll: 'yourself)'
+"! !
 !FramingLayout categoriesFor: #arrangementOf:!accessing!public! !
 !FramingLayout categoriesFor: #arrangementOf:put:!accessing!public! !
 !FramingLayout categoriesFor: #initialize!initializing!private! !
@@ -118,4 +139,5 @@ resolutionScaledBy: aPoint
 !FramingLayout categoriesFor: #reposition:to:!geometry!private! !
 !FramingLayout categoriesFor: #resize:to:!geometry!public! !
 !FramingLayout categoriesFor: #resolutionScaledBy:!geometry!private! !
+!FramingLayout categoriesFor: #storeOn:indent:variables:!printing!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/GridLayout.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/GridLayout.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 LayoutManager subclass: #GridLayout
 	instanceVariableNames: 'rows columns horizontalGap verticalGap'
@@ -140,6 +140,23 @@ rows: anInteger
 
 	rows := anInteger!
 
+storeOn: aStream
+
+	| default |
+	default := GridLayout new.
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new'.
+	#(#'rows' #'columns' #'horizontalGap' #'verticalGap') do: [:each | | x |
+		(x := self perform: each) = (default perform: each) ifFalse: [
+			aStream space; nextPutAll: each; nextPutAll: ': '.
+			x storeOn: aStream.
+			aStream nextPut: $;.
+		].
+	].
+	aStream space; nextPutAll: 'yourself)'!
+
 verticalGap
 	"Answer the vertical gap between items laid out by the receiver."
 
@@ -159,6 +176,7 @@ verticalGap: anInteger
 !GridLayout categoriesFor: #resolutionScaledBy:!geometry!private! !
 !GridLayout categoriesFor: #rows!accessing!public! !
 !GridLayout categoriesFor: #rows:!accessing!public! !
+!GridLayout categoriesFor: #storeOn:!printing!public! !
 !GridLayout categoriesFor: #verticalGap!accessing!public! !
 !GridLayout categoriesFor: #verticalGap:!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/Image.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Image.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 GraphicsTool subclass: #Image
 	instanceVariableNames: 'fileLocator identifier instanceHandle'
@@ -245,7 +245,14 @@ printOn: aStream
 						space;
 						nextPutAll: #fromId:;
 						space;
-						print: id]]! !
+						print: id]]!
+
+storeOn: aStream
+
+	aStream
+		nextPut: $(;
+		print: self;
+		nextPut: $)! !
 !Image categoriesFor: #=!comparing!public! !
 !Image categoriesFor: #addToImageList:mask:!private!testing! !
 !Image categoriesFor: #asSharedCopy!converting!public! !
@@ -274,6 +281,7 @@ printOn: aStream
 !Image categoriesFor: #loadFromInstance:!private!realizing/unrealizing! !
 !Image categoriesFor: #pixelData!public! !
 !Image categoriesFor: #printOn:!printing!public! !
+!Image categoriesFor: #storeOn:!printing!public! !
 
 Image methodProtocol: #image attributes: #(#readOnly) selectors: #(#drawOn: #drawOn:at: #drawOn:at:extent: #extent)!
 

--- a/Core/Object Arts/Dolphin/MVP/Base/Menu.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Menu.cls
@@ -240,6 +240,21 @@ find: aString ifAbsent: exceptionHandler
 flags: anInteger 
 	flags := anInteger!
 
+fromStrings
+	"If the receiver can be reproduced an Array sent to #'fromStrings:' on the class side, then return it; else, return nil."
+
+	| itemList |
+	name ifNotNil: [^nil].
+	flags == 0 ifFalse: [^nil].
+	image ifNotNil: [^nil].
+	itemList := OrderedCollection with: text.
+	items do: [:each | 
+		each fromStrings 
+			ifNil: [^nil] 
+			ifNotNil: [:anObject | itemList add: anObject].
+	].
+	^itemList asArray!
+
 fromStrings: menuArray 
 	"Private - Convert menuArray into a series of MenuItems.
 	menuArray is an array of strings. 
@@ -635,6 +650,64 @@ size
 
 	^items size!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	| newLine |
+	self fromStrings ifNotNil: [:anArray |
+		aStream
+			nextPut: $(;
+			nextPutAll: self class name;
+			nextPutAll: ' fromStrings: '.
+		anArray storeOn: aStream indent: anInteger variables: aDictionary.
+		aStream nextPut: $).
+		^self
+	].
+
+	newLine := WriteStream on: String new.
+	newLine cr.
+	anInteger timesRepeat: [newLine tab].
+	newLine := newLine contents.
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new'.
+	#(#'text' #'name' #'image' #'hasSharedImageColumn' #'isAutoDismiss' #'isModeless') do: [:each |
+		(self perform: each) ifNotNil: [:value | 
+			value ~~ false ifTrue: [
+				aStream
+					nextPutAll: newLine;
+					nextPutAll: each;
+					nextPutAll: ': '.
+				value storeOn: aStream.
+				aStream nextPut: $;
+			].
+		]
+	].
+	aStream nextPutAll: newLine.
+	items isEmpty ifTrue: [
+		aStream nextPutAll: 'items: #();'.
+	] ifFalse: [
+		aStream
+			nextPutAll: 'items: ((Array new: ';
+			print: items size;
+			nextPut: $).
+		1 to: items size do: [:i | 
+			aStream
+				nextPutAll: newLine; tab;
+				nextPutAll: 'at: ';
+				print: i;
+				nextPutAll: ' put: '.
+			(items at: i) storeOn: aStream indent: anInteger + 2 variables: aDictionary.
+			aStream nextPut: $;
+		].
+		aStream
+			nextPutAll: newLine; tab;
+			nextPutAll: 'yourself);'
+	].
+	aStream
+		nextPutAll: newLine;
+		nextPutAll: 'yourself)'.!
+
 styleFlags
 	"Private - Answer the MENUITEMINFO style flags of the receiver (see
 	Win32 SDK docs for fType field)."
@@ -694,6 +767,7 @@ updateItem: indexInteger id: idInteger text: newText
 !Menu categoriesFor: #find:!accessing!public! !
 !Menu categoriesFor: #find:ifAbsent:!accessing!public! !
 !Menu categoriesFor: #flags:!accessing!private! !
+!Menu categoriesFor: #fromStrings!printing!public! !
 !Menu categoriesFor: #fromStrings:!converting!private! !
 !Menu categoriesFor: #hasSharedImageColumn!public!testing! !
 !Menu categoriesFor: #hasSharedImageColumn:!accessing!public! !
@@ -745,6 +819,7 @@ updateItem: indexInteger id: idInteger text: newText
 !Menu categoriesFor: #setItem:info:!accessing!private! !
 !Menu categoriesFor: #showIn:position:!drawing!public! !
 !Menu categoriesFor: #size!accessing!public! !
+!Menu categoriesFor: #storeOn:indent:variables:!printing!public! !
 !Menu categoriesFor: #styleFlags!private!realizing/unrealizing! !
 !Menu categoriesFor: #text!accessing!public! !
 !Menu categoriesFor: #text:!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Pen.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Pen.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 GraphicsTool subclass: #Pen
 	instanceVariableNames: 'logPen'
@@ -42,6 +42,19 @@ logPen: aLOGPEN
 	logPen := aLOGPEN.
 	self free!
 
+storeOn: aStream
+
+	aStream
+		nextPutAll: '((';
+		nextPutAll: self class name;
+		nextPutAll: ' withStyleName: ';
+		print: self styleName;
+		nextPutAll: ') width: ';
+		print: self width;
+		nextPutAll: '; color: '.
+	self color storeOn: aStream.
+	aStream nextPutAll: '; yourself)'!
+
 style
 	^logPen style!
 
@@ -77,6 +90,7 @@ width: anInteger
 !Pen categoriesFor: #createHandle!private!realizing/unrealizing! !
 !Pen categoriesFor: #handle:!accessing!private! !
 !Pen categoriesFor: #logPen:!accessing!private! !
+!Pen categoriesFor: #storeOn:!printing!public! !
 !Pen categoriesFor: #style!accessing!private! !
 !Pen categoriesFor: #style:!accessing!private! !
 !Pen categoriesFor: #styleName!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/PluggableColor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/PluggableColor.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Color subclass: #PluggableColor
 	instanceVariableNames: 'valuable'
@@ -26,11 +26,22 @@ asRGB
 	^valuable value asRGB!
 
 setValuable: aNiladicValuable 
-	valuable := aNiladicValuable! !
+	valuable := aNiladicValuable!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+	"Put an ASCII representation of receiver onto aStream."
+
+	aStream
+		nextPut: $(;
+		display: self class;
+		nextPutAll: ' with: '.
+	valuable storeOn: aStream indent: anInteger variables: aDictionary.
+	aStream nextPut: $)! !
 !PluggableColor categoriesFor: #asIndexedColor!converting!public! !
 !PluggableColor categoriesFor: #asParameter!converting!public! !
 !PluggableColor categoriesFor: #asRGB!converting!public! !
 !PluggableColor categoriesFor: #setValuable:!initializing!private! !
+!PluggableColor categoriesFor: #storeOn:indent:variables:!development!printing!public! !
 
 !PluggableColor class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Base/ProportionalLayout.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ProportionalLayout.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 LinearLayout subclass: #ProportionalLayout
 	instanceVariableNames: 'proportions isVertical'
@@ -197,6 +197,25 @@ reposition: aView to: aPoint
 	prevView basicInvalidateLayout.
 	nextView basicInvalidateLayout!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	aStream 
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new';
+		cr; tab; tab; nextPutAll: 'isVertical: '.
+	self isVertical storeOn: aStream.
+	aStream nextPut: $;.
+	proportions keysAndValuesDo: [:eachKey :eachValue | 
+		aStream cr; tab; tab; 
+			nextPutAll: 'arrangementOf: ';
+			nextPutAll: (aDictionary at: eachKey);
+			nextPutAll: ' put: '.
+		eachValue storeOn: aStream.
+		aStream nextPut: $;.
+	].
+	aStream cr; tab; tab; nextPutAll: 'yourself)'!
+
 totalProportionsOf: viewCollection
 	"Private - Answer the sum of all the views proportions."
 
@@ -215,5 +234,6 @@ totalProportionsOf: viewCollection
 !ProportionalLayout categoriesFor: #proportions!accessing!private! !
 !ProportionalLayout categoriesFor: #removeSubView:!public!removing! !
 !ProportionalLayout categoriesFor: #reposition:to:!operations!private! !
+!ProportionalLayout categoriesFor: #storeOn:indent:variables:!printing!public! !
 !ProportionalLayout categoriesFor: #totalProportionsOf:!helpers!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/SystemColor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/SystemColor.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Color subclass: #SystemColor
 	instanceVariableNames: 'id'
@@ -59,13 +59,19 @@ printOn: aStream
 		nextPut: $(;
 		display: self class;
 		display: ' fromId: ';
+		display: id;
+		nextPutAll: ' "';
 		display: self idName;
-		nextPut: $)!
+		nextPutAll: '")'!
 
 setId: anInteger
 	"Private - Set the system id of the receiver"
 
-	id := anInteger! !
+	id := anInteger!
+
+storeOn: aStream
+
+	self printOn: aStream! !
 !SystemColor categoriesFor: #=!comparing!public! !
 !SystemColor categoriesFor: #asIndexedColor!converting!public! !
 !SystemColor categoriesFor: #asParameter!converting!public! !
@@ -76,6 +82,7 @@ setId: anInteger
 !SystemColor categoriesFor: #idName!accessing!development!private! !
 !SystemColor categoriesFor: #printOn:!development!printing!public! !
 !SystemColor categoriesFor: #setId:!accessing!private! !
+!SystemColor categoriesFor: #storeOn:!development!printing!public! !
 
 !SystemColor class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -3282,6 +3282,108 @@ stbSaveOn: anSTBOutFiler
 
 	anSTBOutFiler saveObject: self as: self filerProxy!
 
+storeNameIn: aDictionary
+
+	| name |
+	(name := self parentView nameOf: self) ifNil: [
+		name := self class name , ((aDictionary keys select: [:each | each class == self class]) size + 1) printString.
+		name at: 1 put: (name at: 1) asLowercase.
+	] ifNotNil: [ 
+		| i x |
+		i := 0.
+		name at: 1 put: (name at: 1) asLowercase.
+		[0 < (i := name indexOf: Character space)] whileTrue: [
+			name := (name copyFrom: 1 to: i - 1) , (name copyFrom: i + 1 to: i + 1) asUppercase , (name copyFrom: i + 2 to: name size).
+		].
+		x := name.
+		[aDictionary includes: x] whileTrue: [
+			i := i + 1.
+			x := name , i printString.
+		].
+		name := x.
+	].
+	^aDictionary at: self put: name!
+
+storeOn: aStream
+
+	| codeStream variables names |
+	variables := IdentityDictionary new.
+	codeStream := WriteStream on: String new.
+	self storeOn: codeStream indent: 0 variables: variables. 
+	aStream 
+		nextPut: $";
+		nextPutAll: self class name;
+		nextPut: $";
+		cr; nextPutAll: '| '.
+	names := variables asSortedCollection.
+	names do: [:each | aStream nextPutAll: each; space].
+	aStream nextPut: $|; cr.
+	names do: [:each | 
+		aStream 
+			display: each;
+			nextPutAll: ' := ';
+			nextPutAll: (variables keyAtValue: each) class name; 
+			nextPutAll: ' new.';
+			cr.
+	].
+	aStream 
+		nextPutAll: (variables at: self);
+		nextPutAll: ' show.';
+		cr; nextPutAll: codeStream contents;
+		nextPutAll: (variables at: self)
+!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	| arrangement default name subViews stream |
+	stream := WriteStream on: String new.
+	subViews := OrderedCollection new.
+	self subViewsDo: [:each | 
+		each storeOn: stream indent: anInteger variables: aDictionary.
+		subViews add: each.
+	].
+	name := self storeNameIn: aDictionary.
+	aStream display: name.
+	[
+		(default := self class show) ifNil: [self error: 'Why no default?'].
+		self storeAttributesDifferingFrom: default On: aStream variables: aDictionary indent: 1.
+	] ensure: [
+		default ifNotNil: [default topShell close].
+	].
+	((self parentView isKindOf: ContainerView) and: [(arrangement := self arrangement) isKindOf: FramingConstraints]) ifTrue: [
+		aStream cr.
+		anInteger + 1 timesRepeat: [aStream tab].
+		aStream nextPutAll: ' arrangement: '.
+		arrangement storeOn: aStream indent: anInteger + 1 variables: aDictionary.
+		aStream nextPut: $;
+	].
+	self storeSubviewsA: subViews on: aStream variables: aDictionary.
+	aStream 
+		cr; tab; 
+		nextPutAll: 'yourself.';
+		cr.
+	self storeSubviewsB: subViews on: aStream variables: aDictionary.
+	aStream nextPutAll: stream contents!
+
+storeSubviewsA: aList on: aStream variables: aDictionary
+
+	aList do: [:each | 
+		aStream 
+			cr; tab; 
+			nextPutAll: 'addSubView: ';
+			nextPutAll: (aDictionary at: each).
+		(self nameOf: each) ifNotNil: [:aString | 
+			aStream
+				nextPutAll: ' name: ';
+				print: aString
+		].
+		aStream nextPut: $;
+	].
+!
+
+storeSubviewsB: aList on: aStream variables: aDictionary
+	"See SlideyInneyOuteyThing for override"!
+
 styles
 	"Answer a two element Array containing the creation style bits for the receiver.
 	See the comment under #style:"
@@ -4791,6 +4893,11 @@ zOrderTop
 !View categoriesFor: #state!accessing!private! !
 !View categoriesFor: #state:!accessing!private! !
 !View categoriesFor: #stbSaveOn:!binary filing!public! !
+!View categoriesFor: #storeNameIn:!printing!public! !
+!View categoriesFor: #storeOn:!printing!public! !
+!View categoriesFor: #storeOn:indent:variables:!printing!public! !
+!View categoriesFor: #storeSubviewsA:on:variables:!printing!public! !
+!View categoriesFor: #storeSubviewsB:on:variables:!printing!public! !
 !View categoriesFor: #styles!accessing-styles!public! !
 !View categoriesFor: #styles:!accessing-styles!private! !
 !View categoriesFor: #subclassWindow!operations!private! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Boolean/BooleanToText.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Boolean/BooleanToText.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 AbstractToTextConverter subclass: #BooleanToText
 	instanceVariableNames: 'format'
@@ -61,7 +61,20 @@ rightToLeft: aString
 	^self errorInvalidFormat
 
 
-	! !
+	!
+
+storeOn: aStream
+
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new'.
+	self actualFormat ifNotNil: [
+		aStream nextPutAll: ' format: '.
+		format storeOn: aStream.
+		aStream nextPutAll: '; yourself'.
+	].
+	aStream nextPut: $)! !
 !BooleanToText categoriesFor: #actualFormat!accessing!private! !
 !BooleanToText categoriesFor: #defaultFormat!constants!private! !
 !BooleanToText categoriesFor: #errorInvalidFormat!exceptions!private! !
@@ -69,4 +82,5 @@ rightToLeft: aString
 !BooleanToText categoriesFor: #format:!accessing!public! !
 !BooleanToText categoriesFor: #leftToRight:!operations!private! !
 !BooleanToText categoriesFor: #rightToLeft:!operations!private! !
+!BooleanToText categoriesFor: #storeOn:!printing!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Difference/DiffsScintillaStyler.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Difference/DiffsScintillaStyler.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ScintillaStyler subclass: #DiffsScintillaStyler
 	instanceVariableNames: 'diffs'
@@ -55,6 +55,13 @@ onStyleNeeded: aScintillaView from: startInteger to: stopInteger
 		from: current
 		to: stopInteger!
 
+storeOn: aStream
+
+	diffs = #() 
+		ifTrue: [aStream nextPutAll: self class name; nextPutAll: ' new']
+		ifFalse: [super storeOn: aStream]
+!
+
 whitespaceStyleName
 	^#whitespace! !
 !DiffsScintillaStyler categoriesFor: #colorNormal:from:to:!public! !
@@ -62,5 +69,6 @@ whitespaceStyleName
 !DiffsScintillaStyler categoriesFor: #initialize!initializing!private! !
 !DiffsScintillaStyler categoriesFor: #lookupStyle:in:!helpers!private! !
 !DiffsScintillaStyler categoriesFor: #onStyleNeeded:from:to:!event handling!public! !
+!DiffsScintillaStyler categoriesFor: #storeOn:!printing!public! !
 !DiffsScintillaStyler categoriesFor: #whitespaceStyleName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/RichText.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/RichText.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #RichText
 	instanceVariableNames: 'rtf'
@@ -101,7 +101,16 @@ setTextInto: aView
 	the receiver. The receiver is assumed to be rich text, so sends the #richText
 	message back to aView."
 	
-	aView richText: self! !
+	aView richText: self!
+
+storeOn: aStream
+
+	aStream 
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' fromRtf: '.
+	rtf storeOn: aStream.
+	aStream nextPut: $)! !
 !RichText categoriesFor: #=!comparing!public! !
 !RichText categoriesFor: #asParameter!converting!public! !
 !RichText categoriesFor: #asRichText!converting!public! !
@@ -117,6 +126,7 @@ setTextInto: aView
 !RichText categoriesFor: #rtf!accessing!private! !
 !RichText categoriesFor: #rtf:!accessing!private! !
 !RichText categoriesFor: #setTextInto:!double dispatch!private! !
+!RichText categoriesFor: #storeOn:!printing!public! !
 
 RichText methodProtocol: #richString attributes: #(#readOnly) selectors: #(#setTextInto:)!
 

--- a/Core/Object Arts/Dolphin/MVP/Type Converters/NullConverter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Type Converters/NullConverter.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 TypeConverter subclass: #NullConverter
 	instanceVariableNames: ''
@@ -10,6 +10,16 @@ NullConverter comment: 'NullConverter is a <typeConverter> which applies no tran
 !NullConverter categoriesForClass!MVP-Type Converters-General! !
 !NullConverter methodsFor!
 
+= comparand
+
+	^self class == comparand class and: [
+		self leftNullValue = comparand leftNullValue and: [
+		self rightNullValue = comparand rightNullValue]]!
+
+hash
+
+	^leftNullValue hash!
+
 leftToRight: anObject
 	"Private - For a NullConverter this does nothing"
 	
@@ -18,7 +28,18 @@ leftToRight: anObject
 rightToLeft: anObject
 	"Private - For a NullConverter this does nothing"
 	
-	^anObject! !
+	^anObject!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	(leftNullValue isNil and: [rightNullValue isNil]) ifTrue: [
+		aStream nextPutAll: 'NullConverter new'.
+	] ifFalse: [
+		super storeOn: aStream indent: anInteger variables: aDictionary.
+	].! !
+!NullConverter categoriesFor: #=!comparing!public! !
+!NullConverter categoriesFor: #hash!comparing!public! !
 !NullConverter categoriesFor: #leftToRight:!operations!private! !
 !NullConverter categoriesFor: #rightToLeft:!operations!private! !
+!NullConverter categoriesFor: #storeOn:indent:variables:!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Type Converters/TypeConverter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Type Converters/TypeConverter.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #TypeConverter
 	instanceVariableNames: 'leftNullValue rightNullValue'
@@ -91,7 +91,11 @@ rightToLeft: anObject
 	type to an <Object> of the receivers left type. Answers the result of the conversion. 
 	Must be overridden by subclasses to perform specific conversions"
 
-	^self subclassResponsibility! !
+	^self subclassResponsibility!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	self storeAttributesOn: aStream indent: anInteger variables: aDictionary! !
 !TypeConverter categoriesFor: #convertFromLeftToRight:!converting!public! !
 !TypeConverter categoriesFor: #convertFromRightToLeft:!converting!public! !
 !TypeConverter categoriesFor: #inverted!operations!public! !
@@ -103,6 +107,7 @@ rightToLeft: anObject
 !TypeConverter categoriesFor: #rightNullValue!accessing!public! !
 !TypeConverter categoriesFor: #rightNullValue:!accessing!public! !
 !TypeConverter categoriesFor: #rightToLeft:!operations!private! !
+!TypeConverter categoriesFor: #storeOn:indent:variables:!printing!public! !
 
 TypeConverter methodProtocol: #typeConverter attributes: #(#readOnly) selectors: #(#convertFromLeftToRight: #convertFromRightToLeft: #inverted #leftNullValue #leftNullValue: #rightNullValue #rightNullValue:)!
 

--- a/Core/Object Arts/Dolphin/MVP/ViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ViewTest.cls
@@ -10,17 +10,50 @@ ViewTest comment: ''!
 !ViewTest categoriesForClass!Unclassified! !
 !ViewTest methodsFor!
 
+_testStoreStringForIdentifier: anIdentifier
+"
+	ViewTest new setTestSelector: #'testStoreString'; _testStoreStringForIdentifier: (ResourceIdentifier class: StyledContainer name: 'Default view').
+"
+	| string view1 view2 x |
+	[
+		Transcript cr; show: anIdentifier printString.
+		view1 := Smalltalk developmentSystem
+			loadViewResource: anIdentifier resource
+			inContext: View desktop.
+		[
+			string := view1 storeString.
+			view2 := Compiler evaluate: string.
+		] on: CompilerNotification , Error do: [:ex | 
+			Transcript show: ' - FAIL'. self halt.
+		].
+	] ensure: [
+		SessionManager inputState
+			pumpMessages;
+			processDeferredActions.
+		(x := view1 topShell) == View desktop ifTrue: [view1 close] ifFalse: [x close].
+		view2 ifNotNil: [(x := view2 topShell) == View desktop ifTrue: [view2 close] ifFalse: [x close]].
+	].
+!
+
 allResourceIdentifiers
 
 	| badList list |
 	badList := self badResourceIdentifiers.
 	list := ResourceIdentifier allResourceIdentifiers.
 	list := list reject: [:each | badList includes: each printString].
+	list := list reject: [:each | each owningClass name < ''].
 	^list!
 
 badResourceIdentifiers
 
 	^#(
+		'AXControlBrowser.Default view'
+		'AXControlSite.Default view'
+		'AXValueConvertingControlSite.Default view'
+		'EditableListViewDemo.Default view'
+		'ListPresenter.Editable list view'
+		'WordPad.Default view'
+		'XmlPad.Default view'
 	)!
 
 testAllResourceIdentifiers
@@ -49,9 +82,21 @@ testRecreateMaintainsModelConnection
 	t model value: 'bbb'.
 	"If this fails, then the view did not receive a #valueChanged event from the model"
 	self assert: t view value = 'bbb'.
-	t topShell exit! !
+	t topShell exit!
+
+testStoreString
+"
+	ViewTest debug: #'testStoreString'
+"
+	true ifTrue: [^self].		"https://github.com/dolphinsmalltalk/Dolphin/pull/108"
+	self allResourceIdentifiers do: [:each | 
+		self _testStoreStringForIdentifier: each.
+	].
+! !
+!ViewTest categoriesFor: #_testStoreStringForIdentifier:!public!unit tests! !
 !ViewTest categoriesFor: #allResourceIdentifiers!public!unit tests! !
 !ViewTest categoriesFor: #badResourceIdentifiers!public!unit tests! !
 !ViewTest categoriesFor: #testAllResourceIdentifiers!public!unit tests! !
 !ViewTest categoriesFor: #testRecreateMaintainsModelConnection!public!unit tests! !
+!ViewTest categoriesFor: #testStoreString!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListViewColumn.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListViewColumn.cls
@@ -362,6 +362,10 @@ sortBlock: aDyadicValuableOrNil
 	getSortValueBlock := aDyadicValuableOrNil.
 	self update!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	self storeAttributesOn: aStream indent: anInteger variables: aDictionary!
+
 text
 	"Answer the title for this column in the list view header."
 
@@ -456,6 +460,7 @@ width: anInteger
 !ListViewColumn categoriesFor: #rowSortBlock!adapters!private! !
 !ListViewColumn categoriesFor: #sortBlock!adapters!public!sorting! !
 !ListViewColumn categoriesFor: #sortBlock:!adapters!public!sorting! !
+!ListViewColumn categoriesFor: #storeOn:indent:variables:!printing!public! !
 !ListViewColumn categoriesFor: #text!accessing!public! !
 !ListViewColumn categoriesFor: #text:!accessing!public! !
 !ListViewColumn categoriesFor: #textFromRow:!adapters!private! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBar.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBar.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ControlBarAbstract subclass: #StatusBar
 	instanceVariableNames: 'parts leftOverSeparator layoutManager'
@@ -326,7 +326,7 @@ setText: aStatusBarItem
 	aStatusOwnerDraw."
 
 	| index text |
-	index := self indexOfItem: aStatusBarItem.
+	(index := self indexOfItem: aStatusBarItem) == 0 ifTrue: [^self].
 	text := aStatusBarItem getText.
 	(self 
 		sendMessage: SB_SETTEXT

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBarItem.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBarItem.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 StatusBarItemAbstract subclass: #StatusBarItem
 	instanceVariableNames: 'getTextBlock getImageBlock reserved1'
@@ -133,7 +133,29 @@ printOn: aStream
 		basicPrint: self;
 		nextPut: $(;
 		print: (self parentView notNil ifTrue: [self name]);
-		nextPut: $)! !
+		nextPut: $)!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	| default |
+	default := self class new
+		parentView: View desktop;
+		yourself.
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new';
+		cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream 
+		nextPutAll: 'parentView: ';
+		nextPutAll: (aDictionary at: parentView);
+		nextPut: $;.
+	self storeAttributesDifferingFrom: default On: aStream variables: aDictionary indent: anInteger.
+	aStream cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream nextPutAll: 'yourself)'
+! !
 !StatusBarItem categoriesFor: #defaultGetImageBlock!adapters!constants!private! !
 !StatusBarItem categoriesFor: #defaultGetTextBlock!adapters!constants!private! !
 !StatusBarItem categoriesFor: #drawImageOn:in:!drawing!private! !
@@ -147,6 +169,7 @@ printOn: aStream
 !StatusBarItem categoriesFor: #imageManager!accessing!public! !
 !StatusBarItem categoriesFor: #initialize!initializing!private! !
 !StatusBarItem categoriesFor: #printOn:!development!printing!public! !
+!StatusBarItem categoriesFor: #storeOn:indent:variables:!development!printing!public! !
 
 !StatusBarItem class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBarNullItem.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBarNullItem.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 StatusBarItemAbstract subclass: #StatusBarNullItem
 	instanceVariableNames: ''
@@ -14,6 +14,14 @@ StatusBarNullItem comment: 'StatusBarNullItem is a class of status bar items tha
 drawItem: aCanvas bounding: boundingRectangle 
 	"Private - A request to draw the receiver. As we are just a placeholder, we do nothing."
 
-	! !
+	!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' separator: 0)'! !
 !StatusBarNullItem categoriesFor: #drawItem:bounding:!drawing!private! !
+!StatusBarNullItem categoriesFor: #storeOn:indent:variables:!printing!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/ToolbarButton.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/ToolbarButton.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ToolbarItem subclass: #ToolbarButton
 	instanceVariableNames: 'bitmap bitmapIndex'
@@ -210,6 +210,62 @@ stateMask: stateMask
 
 	self toolbar tbSetState: self commandId state: stateMask!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	| bitmapName indexName prefix |
+	bitmap == IDB_STD_SMALL_COLOR 	ifTrue: [bitmapName := 'Standard'	. prefix := 'STD_'	] ifFalse: [
+	bitmap == IDB_VIEW_SMALL_COLOR	ifTrue: [bitmapName := 'View'		. prefix := 'VIEW_'	] ifFalse: [
+	bitmap == IDB_HIST_SMALL_COLOR	ifTrue: [bitmapName := 'History'	. prefix := 'HIST_'	]]].
+	prefix ifNotNil: [
+		ToolbarConstants keysAndValuesDo: [:eachKey :eachValue | 
+			(eachValue == bitmapIndex and: [eachKey beginsWith: prefix]) ifTrue: [indexName := eachKey].
+		].
+		aStream
+			nextPut: $(;
+			nextPutAll: self class name;
+			cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream
+			nextPutAll: 'bitmap: ';
+			print: bitmap;
+			nextPutAll: ' "';
+			nextPutAll: bitmapName;
+			nextPut: $";
+			cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream
+			nextPutAll: 'index: ';
+			print: bitmapIndex;
+			nextPutAll: ' "';
+			nextPutAll: indexName;
+			nextPut: $";
+			cr.
+		anInteger timesRepeat: [aStream tab].
+		aStream
+			nextPutAll: 'commandDescription: '.
+		commandDescription storeOn: aStream indent: anInteger + 1 variables: aDictionary.
+		aStream nextPut: $).
+		^self
+	].
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream nextPutAll: 'bitmap: '.
+	bitmap storeOn: aStream indent: anInteger + 1 variables: aDictionary.
+	aStream cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream 
+		nextPutAll: 'index: ';
+		print: bitmapIndex;
+		cr.
+	anInteger timesRepeat: [aStream tab].
+	aStream nextPutAll: 'commandDescription: '.
+	commandDescription storeOn: aStream indent: anInteger + 1 variables: aDictionary.
+	aStream nextPut: $).
+!
+
 text
 	"Answers a short String description of the receiver's command. Uses the String
 	representation of the command itself if no explicit description has been
@@ -279,6 +335,7 @@ validateUserInterface: route
 !ToolbarButton categoriesFor: #rectangle!accessing!public! !
 !ToolbarButton categoriesFor: #screenRectangle!accessing!public! !
 !ToolbarButton categoriesFor: #stateMask:!public!state! !
+!ToolbarButton categoriesFor: #storeOn:indent:variables:!printing!public! !
 !ToolbarButton categoriesFor: #text!accessing!public! !
 !ToolbarButton categoriesFor: #text:!accessing!public! !
 !ToolbarButton categoriesFor: #textIndexIn:!operations!private! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/ToolbarIconButton.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/ToolbarIconButton.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ToolbarButton subclass: #ToolbarIconButton
 	instanceVariableNames: ''
@@ -65,6 +65,15 @@ stbFixup: anSTBInFiler at: newObjectIndex
 
 	!
 
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' commandDescription: '.
+	commandDescription storeOn: aStream indent: anInteger variables: aDictionary.
+	aStream nextPut: $)!
+
 toolbar: aToolbar 
 	"Private - Set the toolbar in which the receiver exists to aToolbar."
 
@@ -84,6 +93,7 @@ update
 !ToolbarIconButton categoriesFor: #onStartup!private! !
 !ToolbarIconButton categoriesFor: #renderBitmap!private! !
 !ToolbarIconButton categoriesFor: #stbFixup:at:!binary filing!public! !
+!ToolbarIconButton categoriesFor: #storeOn:indent:variables:!printing!public! !
 !ToolbarIconButton categoriesFor: #toolbar:!accessing!private! !
 !ToolbarIconButton categoriesFor: #update!accessing!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/ToolbarSeparator.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/ToolbarSeparator.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ToolbarItem subclass: #ToolbarSeparator
 	instanceVariableNames: 'width'
@@ -45,6 +45,21 @@ isDivider
 
 	^true!
 
+storeOn: aStream
+
+	width == 0 ifTrue: [
+		aStream 
+			nextPutAll: self class name;
+			nextPutAll: ' new'.
+	] ifFalse: [
+		aStream
+			nextPut: $(;
+			nextPutAll: self class name;
+			nextPutAll: ' width: ';
+			print: width;
+			nextPut: $)
+	].!
+
 textIndexIn: aToolbar
 	"Private - Answer the index of the String label for the receiver in aToolbar.
 	Answer -1 as separators do not have a text label."
@@ -65,6 +80,7 @@ width: pixelWidth
 !ToolbarSeparator categoriesFor: #imageIndexIn:!operations!private! !
 !ToolbarSeparator categoriesFor: #initialize!initializing!private! !
 !ToolbarSeparator categoriesFor: #isDivider!public!testing! !
+!ToolbarSeparator categoriesFor: #storeOn:!printing!public! !
 !ToolbarSeparator categoriesFor: #textIndexIn:!operations!private! !
 !ToolbarSeparator categoriesFor: #width!accessing!public! !
 !ToolbarSeparator categoriesFor: #width:!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/ToolbarSystemButton.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/ToolbarSystemButton.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ToolbarButton subclass: #ToolbarSystemButton
 	instanceVariableNames: ''
@@ -18,9 +18,23 @@ imageIndexIn: aToolbar
 	"Private - Adds the receiver's bitmap to aToolbar.
 	Answer the index of the bitmap from aToolbar's registered bitmaps."
 
-	^aToolbar addSystemBitmap: self bitmap index: self bitmapIndex! !
+	^aToolbar addSystemBitmap: self bitmap index: self bitmapIndex!
+
+storeOn: aStream indent: anInteger variables: aDictionary
+
+	| selector |
+	selector := commandDescription command.
+	(self class class canUnderstand: selector) ifTrue: [
+		aStream
+			nextPutAll: self class name;
+			space;
+			nextPutAll: selector.
+	] ifFalse: [
+		super storeOn: aStream indent: anInteger variables: aDictionary.
+	].! !
 !ToolbarSystemButton categoriesFor: #bitmap:!accessing!public! !
 !ToolbarSystemButton categoriesFor: #imageIndexIn:!operations!private! !
+!ToolbarSystemButton categoriesFor: #storeOn:indent:variables:!public! !
 
 !ToolbarSystemButton class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/NullScintillaStyler.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/NullScintillaStyler.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ScintillaStyler subclass: #NullScintillaStyler
 	instanceVariableNames: 'normalStyleName'
@@ -28,11 +28,25 @@ onStyleNeeded: aScintillaView from: startInteger to: stopInteger
 	"Callback from Scintilla requesting that the specified range of text be coloured.
 	In this case we just set to the default style, regardless."
 
-	aScintillaView applyStyle: self normalStyleName toNext: stopInteger - startInteger + 1! !
+	aScintillaView applyStyle: self normalStyleName toNext: stopInteger - startInteger + 1!
+
+storeOn: aStream
+
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new'.
+	normalStyleName == #'normal' ifFalse: [
+		aStream nextPutAll: ' normalStyleName: '.
+		normalStyleName storeOn: aStream.
+		aStream nextPutAll: '; yourself'.
+	].
+	aStream nextPut: $)! !
 !NullScintillaStyler categoriesFor: #initialize!initializing!public! !
 !NullScintillaStyler categoriesFor: #normalStyleName!accessing!public! !
 !NullScintillaStyler categoriesFor: #normalStyleName:!accessing!public! !
 !NullScintillaStyler categoriesFor: #onStyleNeeded:from:to:!event handling!public! !
+!NullScintillaStyler categoriesFor: #storeOn:!printing!public! !
 
 !NullScintillaStyler class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaKeyBinding.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaKeyBinding.cls
@@ -85,6 +85,22 @@ scintillaKeyCode
 	codes := AcceleratorTable splitKeyCode: self acceleratorKey.
 	^(self translateVirtualKey: codes first) + ((codes last bitAnd: 16r1C) << 14)!
 
+storeOn: aStream
+
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' newAcceleratorKey: ';
+		print: acceleratorKey;
+		nextPutAll: ' "';
+		nextPutAll: self acceleratorKeyString;
+		nextPutAll: '" message: ';
+		print: message;
+		nextPutAll: ' "';
+		nextPutAll: self commandSymbol;
+		nextPutAll: '")'
+!
+
 translateVirtualKey: vkInteger 
 	"Private - Translate from a Windows Virtual Key code (VK_xxx) to the corresponding Scintilla
 	key code (SCK_xxx)"
@@ -103,6 +119,7 @@ translateVirtualKey: vkInteger
 !ScintillaKeyBinding categoriesFor: #message:!accessing!private! !
 !ScintillaKeyBinding categoriesFor: #printOn:!printing!public! !
 !ScintillaKeyBinding categoriesFor: #scintillaKeyCode!accessing!private! !
+!ScintillaKeyBinding categoriesFor: #storeOn:!printing!public! !
 !ScintillaKeyBinding categoriesFor: #translateVirtualKey:!helpers!private! !
 
 !ScintillaKeyBinding class methodsFor!

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
@@ -3529,7 +3529,7 @@ keyBindings
 	"Answer the collection of key bindings currently assigned in the receiver."
 
 	^(keyBindings ifNil: [self defaultKeyBindings]) 
-		asSortedCollection: [:a :b | a commandSymbol <= b commandSymbol]
+		asSortedCollection: self keyBindingsSortBlock
 	" asArray"!
 
 keyBindings: aCollectionOfScintillaKeyBindings 
@@ -3543,6 +3543,12 @@ keyBindings: aCollectionOfScintillaKeyBindings
 					[keyBindings := LookupTable new.
 					set do: [:each | keyBindings at: each acceleratorKey put: each]]].
 	self updateKeyBindings!
+
+keyBindingsSortBlock
+	"By placing sort block in its own method we can more easily reconstruct it (see BlockClosure>>#storeOn:"
+
+	^[:a :b | a commandSymbol <= b commandSymbol]
+!
 
 keyboardCommands
 	^self keyBindings collect: 
@@ -10731,6 +10737,7 @@ zoomOut
 !ScintillaView categoriesFor: #joinTarget!**auto generated**!commands!line wrapping!public!scintilla interface! !
 !ScintillaView categoriesFor: #keyBindings!accessing!key bindings!public! !
 !ScintillaView categoriesFor: #keyBindings:!accessing!key bindings!public! !
+!ScintillaView categoriesFor: #keyBindingsSortBlock!accessing!key bindings!public! !
 !ScintillaView categoriesFor: #keyboardCommands!commands!public! !
 !ScintillaView categoriesFor: #lastLineWithState!enquiries!public!styling! !
 !ScintillaView categoriesFor: #layoutCachingMode!accessing!line wrapping!public! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/SlideyInneyOuteyThing.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/SlideyInneyOuteyThing.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ContainerView subclass: #SlideyInneyOuteyThing
 	instanceVariableNames: 'tabs tray trayExtent animationDuration tickCounter siotFlags _siotReserved1 _siotReserved2'
@@ -462,6 +462,33 @@ startAutoHideTimer
 	tickCounter := 0.
 	self setTimer: AW_HIDE interval: self autoHideTimerInterval!
 
+storeSubviewsA: aList on: aStream variables: aDictionary
+	"Override to do nothing since subviews are created automatically"!
+
+storeSubviewsB: aList on: aStream variables: aDictionary
+
+	| myName variableName childName |
+	myName := aDictionary at: self.
+	aList do: [:each | 
+		childName := self nameOf: each.
+		variableName := aDictionary at: each.
+		aStream
+			nextPutAll: variableName;
+			nextPutAll: ' := ';
+			nextPutAll: (childName ifNil: [''] ifNotNil: ['(']);
+			nextPutAll: myName;
+			nextPutAll: ' subViews detect: [:each | each isKindOf: ';
+			nextPutAll: each class name;
+			nextPutAll: ']'.
+		(self nameOf: each) ifNotNil: [:aString | 
+			aStream
+				nextPutAll: ') name: ';
+				print: aString;
+				nextPutAll: '; yourself'
+		].
+		aStream nextPut: $.; cr
+	]!
+
 tabs
 	^tabs!
 
@@ -571,6 +598,8 @@ wmPrint: message wParam: wParam lParam: lParam
 !SlideyInneyOuteyThing categoriesFor: #showShell!operations!private! !
 !SlideyInneyOuteyThing categoriesFor: #showTray!commands!public! !
 !SlideyInneyOuteyThing categoriesFor: #startAutoHideTimer!private! !
+!SlideyInneyOuteyThing categoriesFor: #storeSubviewsA:on:variables:!printing!public! !
+!SlideyInneyOuteyThing categoriesFor: #storeSubviewsB:on:variables:!printing!public! !
 !SlideyInneyOuteyThing categoriesFor: #tabs!public! !
 !SlideyInneyOuteyThing categoriesFor: #tray!public! !
 !SlideyInneyOuteyThing categoriesFor: #trayAnimationType!constants!private! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/SlidingCardTray.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/SlidingCardTray.cls
@@ -75,7 +75,7 @@ implicitInsets: aLayoutContext
 		ifFalse: [0 @ self headerHeight corner: 0 @ 0]!
 
 isPinHot
-	^pinInteractor isHot!
+	^pinInteractor ifNil: [false] ifNotNil: [:value | value isHot]!
 
 isPinned
 	^slider notNil and: [slider isPinned]!
@@ -417,6 +417,17 @@ wmPrint: message wParam: wParam lParam: lParam
 !SlidingCardTray class methodsFor!
 
 initialize
-	PinImageList := nil! !
+	PinImageList := nil!
+
+resource_Default_view
+	"Answer the literal data from which the 'Default view' resource can be reconstituted.
+	DO NOT EDIT OR RECATEGORIZE THIS METHOD.
+
+	If you wish to modify this resource evaluate:
+	ViewComposer openOn: (ResourceIdentifier class: self selector: #resource_Default_view)
+	"
+
+	^#(#'!!STL' 3 788558 10 ##(Smalltalk.STBViewProxy) 8 ##(Smalltalk.SlidingCardTray) 98 22 0 0 98 2 8 1140850688 131073 416 0 524550 ##(Smalltalk.ColorRef) 8 4278190080 0 5 0 0 0 416 655878 ##(Smalltalk.CardLayout) 202 208 98 0 0 234 256 592 0 410 8 ##(Smalltalk.TabViewXP) 98 28 0 416 98 2 8 1140916736 1 624 590662 2 ##(Smalltalk.ListModel) 202 208 592 0 1310726 ##(Smalltalk.IdentitySearchPolicy) 0 0 1 0 0 0 624 0 8 4294904999 787814 3 ##(Smalltalk.BlockClosure) 0 0 918822 ##(Smalltalk.CompiledMethod) 2 3 8 ##(Smalltalk.ListControlView) 8 #defaultGetTextBlock 479764963 8 #[30 105 226 0 106] 8 #displayString 816 7 257 0 802 0 0 834 2 3 8 ##(Smalltalk.IconicListAbstract) 8 #defaultGetImageBlock 486253571 8 #[30 105 226 0 106] 8 #iconImageIndex 928 7 257 0 1049926 1 ##(Smalltalk.IconImageManager) 0 0 0 0 0 8 #noIcons 0 0 0 0 0 983302 ##(Smalltalk.MessageSequence) 202 208 98 2 721670 ##(Smalltalk.MessageSend) 8 #createAt:extent: 98 2 328198 ##(Smalltalk.Point) 1 1 1202 701 61 624 1138 8 #tcmSetExtendedStyle:dwExStyle: 98 2 -1 1 624 983302 ##(Smalltalk.WINDOWPLACEMENT) 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 94 1 0 0 30 0 0 0] 98 0 1202 193 193 0 27 0 0 1202 33 33 0 0 0 1074 202 208 98 1 1138 1168 98 2 1202 1 1 1202 701 501 416 1298 8 #[44 0 0 0 0 0 0 0 0 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 0 0 0 0 0 0 0 0 94 1 0 0 250 0 0 0] 98 1 624 1360 0 27 )! !
 !SlidingCardTray class categoriesFor: #initialize!public! !
+!SlidingCardTray class categoriesFor: #resource_Default_view!public!resources-views! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Styled Views/StyledGradientBrush.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Styled Views/StyledGradientBrush.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #StyledGradientBrush
 	instanceVariableNames: 'startColor endColor startPoint endPoint'
@@ -77,7 +77,11 @@ startPoint
 	^startPoint!
 
 startPoint: aPoint 
-	startPoint := aPoint! !
+	startPoint := aPoint!
+
+storeOn: aStream 
+	
+	self printOn: aStream! !
 !StyledGradientBrush categoriesFor: #asBackgroundGdiplusBrushFor:!converting!public! !
 !StyledGradientBrush categoriesFor: #endColor!accessing!public! !
 !StyledGradientBrush categoriesFor: #endColor:!accessing!public! !
@@ -91,6 +95,7 @@ startPoint: aPoint
 !StyledGradientBrush categoriesFor: #startColorARGB!converting!public! !
 !StyledGradientBrush categoriesFor: #startPoint!accessing!public! !
 !StyledGradientBrush categoriesFor: #startPoint:!accessing!public! !
+!StyledGradientBrush categoriesFor: #storeOn:!printing!public! !
 
 !StyledGradientBrush class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Styled Views/StyledPen.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Styled Views/StyledPen.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #StyledPen
 	instanceVariableNames: 'color width dashPattern'
@@ -41,6 +41,10 @@ printOn: aStream
 	self dashPattern printOn: aStream.
 	aStream nextPut: $)!
 
+storeOn: aStream 
+	
+	self printOn: aStream!
+
 width
 	^width!
 
@@ -52,6 +56,7 @@ width: anInteger
 !StyledPen categoriesFor: #dashPattern!public! !
 !StyledPen categoriesFor: #dashPattern:!public! !
 !StyledPen categoriesFor: #printOn:!public! !
+!StyledPen categoriesFor: #storeOn:!printing!public! !
 !StyledPen categoriesFor: #width!accessing!public! !
 !StyledPen categoriesFor: #width:!accessing!public! !
 


### PR DESCRIPTION
One of the (very few) frustrations of Dolphin is editing a view and having the only difference be changes in a massive literal array. One of the very nice features of VSE's WindowBuilder was that views were created by code so you could actually see what was changed (and even make edits directly in the code if you wanted).

With this commit, View>>#'storeString' will now return a string that when compiled will generate a similar view (with a few exceptions). I anticipate that there will be some comments and suggestions, and I look forward to the discussion!