### PR TITLE
Avoid 'Unrecognized option: $f' during shutdown

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
@@ -88,8 +88,17 @@ commandLineParser
 	-x - immediately exit
 	"
 
-	^(CommandLine argv: self argvLegacyOptionsRemoved)
-		options: 'hq';	"Options with arguments described elsewhere"
+	^(super commandLineParser)
+		addOptionAllowingArgument: $d
+			whenPresentDo: 
+				[:rebasePath | 
+				Package manager rebaseBasePackagesTo: (rebasePath ifNil: ['.']).
+				self saveImage];
+		addOptionRequiringArgument: $f
+			whenPresentDo: [:fileInFile | SourceManager default fileIn: fileInFile];
+		addOptionAllowingArgument: $i
+			whenPresentDo: [:newImageFile | self saveImage: (newImageFile ifNil: ['Dolphin'])];
+		addOption: $x whenPresentDo: [self quit];
 		yourself!
 
 dolphinNewsgroupUrl
@@ -418,16 +427,6 @@ processCommandLine
 
 	| commandLine arguments |
 	commandLine := (self commandLineParser)
-				addOptionAllowingArgument: $d
-					whenPresentDo: 
-						[:rebasePath | 
-						Package manager rebaseBasePackagesTo: (rebasePath ifNil: ['.']).
-						self saveImage];
-				addOptionRequiringArgument: $f
-					whenPresentDo: [:fileInFile | SourceManager default fileIn: fileInFile];
-				addOptionAllowingArgument: $i
-					whenPresentDo: [:newImageFile | self saveImage: (newImageFile ifNil: ['Dolphin'])];
-				addOption: $x whenPresentDo: [self quit];
 				processOptions;
 				yourself.
 	"-h and -q are already defined"


### PR DESCRIPTION
GUISessionManager>>#isEmbedded sends #commandLineParser and this doesn't return the full set of options, so reports an error if an allowed but unrecognized option is present.