### PR TITLE
Limit tool search to classes if multiple classes match

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSearchPresenter.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSearchPresenter.cls
@@ -154,14 +154,21 @@ rangeToCompleteAt: anInteger
 				ifFalse: [anInteger to: view caretPosition - 1]]!
 
 searchItemsStartingWith: aString maxItems: anInteger 
-	| result classes |
+	| classNamePrefix result classes |
 	aString first isLowerCase 
 		ifTrue: 
 			[| matchingSymbols |
 			matchingSymbols := self selectorsStartingWith: aString maxItems: anInteger.
 			^matchingSymbols collect: [:each | each displayString]].
+	classNamePrefix := aString upTo: $>.
+	classes := environment classes select: [:each | each name beginsWith: classNamePrefix].
+	(aString includes: $>) 
+		ifTrue: [classes := classes select: [:each | each name asString = classNamePrefix]].
 	result := OrderedCollection new.
-	classes := environment classes select: [:each | each name first = aString first].
+	classes size > 1 
+		ifTrue: 
+			[classes do: [:eachClass | result add: eachClass name].
+			^result].
 	classes do: 
 			[:eachClass | 
 			result add: eachClass name.

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSearchPresenter.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSearchPresenter.cls
@@ -154,16 +154,22 @@ rangeToCompleteAt: anInteger
 				ifFalse: [anInteger to: view caretPosition - 1]]!
 
 searchItemsStartingWith: aString maxItems: anInteger 
-	| classNamePrefix result classes |
+	| result classes filter |
 	aString first isLowerCase 
 		ifTrue: 
 			[| matchingSymbols |
 			matchingSymbols := self selectorsStartingWith: aString maxItems: anInteger.
 			^matchingSymbols collect: [:each | each displayString]].
-	classNamePrefix := aString upTo: $>.
-	classes := environment classes select: [:each | each name beginsWith: classNamePrefix].
-	(aString includes: $>) 
-		ifTrue: [classes := classes select: [:each | each name asString = classNamePrefix]].
+	filter := (aString includes: $>) 
+				ifTrue: 
+					[| classNamePrefix |
+					classNamePrefix := aString upTo: $>.
+					[:each | each name asString = classNamePrefix]]
+				ifFalse: 
+					[(aString includes: Character space) 
+						ifTrue: [[:each | each name beginsWith: aString]]
+						ifFalse: [[:each | each isMetaclass not and: [each name beginsWith: aString]]]].
+	classes := environment classes select: filter.
 	result := OrderedCollection new.
 	classes size > 1 
 		ifTrue: 


### PR DESCRIPTION
The SmalltalkSearchPresenter shows all the methods for the first class before showing any other classes. This limits the initial list of options to something more manageable. Since it does change the behavior I'm not sure if others will find it as useful as I do. What do you think? If you want to keep the existing behavior is it worth making this optional?