### PR TITLE
ClassBuilder does not work for addition of variables to Class itself #172

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Behavior.cls
+++ b/Core/Object Arts/Dolphin/Base/Behavior.cls
@@ -78,12 +78,9 @@ addSubclass: aClass
 		subclasses := (subs asSortedCollection add: aClass; yourself) asArray]!
 
 addToSuper
-	"Private - Add the receiver to its superclasses' subclass collection.
-	Root classes will have a superclass of nil - we do not put such
-	classes into a subclass collection."
+	"Private - Add the receiver to its superclasses' subclass collection."
 
-	superclass notNil
-		ifTrue: [superclass addSubclass: self]!
+	superclass addSubclass: self!
 
 allClassVarNames
 	"Answer a <Set> of the <readableString> names of the receiver's and the 

--- a/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
@@ -15,6 +15,9 @@ basicTertiaryStartup
 
 	"Nothing to do - this SessionManager should never be installed on startup anyway?"!
 
+fileInClass: aClass 
+	aClass sourceManager fileIn: aClass fileOutName!
+
 keepAlive
 	"We stay alive until explicitly terminated."
 
@@ -117,16 +120,20 @@ reloadSystemPackage
 	Notification signal: 'Reloading BCL constants pools...'.
 	basePackage sourceGlobalVariables 
 		collect: [:each | srcMgr fileIn: (File relativePathOf: each value fileOutName to: imageDir)].
+	Notification signal: 'Updating ClassBuilder...'.
+	self fileInClass: ClassBuilder.
 	Notification signal: 'Reloading BCL class definitions...'.
 	"First tag all the existing classes so we can spot the dead ones later."
 	srcMgr fileIn: (File relativePathOf: basePackage classDefinitionsFileName to: imageDir).
+	Class subclasses: nil.
+	Smalltalk clearCachedClasses.
 	"Then reload all base package classes in breadth-first order"
 	Notification signal: 'Reloading BCL classes...'.
 	baseClasses := basePackage classesInHierarchyOrder.
 	missingClasses := OrderedCollection new.
 	baseClasses do: 
 			[:each | 
-			each == BootSessionManager 
+			(#(#BootSessionManager #ClassBuilder) identityIncludes: each name) 
 				ifFalse: 
 					[| relativePath |
 					relativePath := File relativePathOf: each fileOutName to: imageDir.
@@ -257,6 +264,7 @@ updateBootImage
 
 	self reloadSystemPackage! !
 !BootSessionManager categoriesFor: #basicTertiaryStartup!operations-startup!public! !
+!BootSessionManager categoriesFor: #fileInClass:!private! !
 !BootSessionManager categoriesFor: #keepAlive!idling!public! !
 !BootSessionManager categoriesFor: #logError:!operations-logging!public! !
 !BootSessionManager categoriesFor: #main!operations-startup!public! !

--- a/Core/Object Arts/Dolphin/Base/Class.cls
+++ b/Core/Object Arts/Dolphin/Base/Class.cls
@@ -59,8 +59,9 @@ addToSuper
 	"Private - Add the receiver as a subclass of its superclass
 	and do the same for the receiver's metaclass buddy."
 
-	super addToSuper.
-	self class addToSuper!
+	superclass notNil ifTrue: [
+		super addToSuper.
+		self class addToSuper]!
 
 basicClassPool
 	"Private - Answer the receiver's class pool (dictionary of class variables)."

--- a/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
@@ -488,7 +488,12 @@ mutateClass: oldClass toBeASubclassOf: newSuperclass
 			newClass := self newClassLike: oldClass superclass: newSuperclass.
 			self install: newClass.
 			self mutateAllInstancesOf: oldClass toBeInstancesOf: newClass.
-			oldClass subclasses do: [:cls | self mutateClass: cls toBeASubclassOf: newClass].
+			oldClass == Class 
+				ifTrue: 
+					["In Dolphin Object class et al are not in the subclasses
+					collection of Class, so need special case handling"
+					Smalltalk allRoots do: [:each | self mutateClass: each class toBeASubclassOf: newClass]]
+				ifFalse: [oldClass subclasses do: [:cls | self mutateClass: cls toBeASubclassOf: newClass]].
 			oldClass class removeFromSuper.
 			oldClass removeFromSuper.
 			oldClass become: newClass.
@@ -700,14 +705,13 @@ translateInstance: oldInstance intoANewInstanceOf: newClass via: mappingArray
 				ifTrue: [newInstance instVarAt: i put: (oldInstance instVarAt: index)]].
 	^newInstance!
 
-updateVMRegistryWith: aClass
+updateVMRegistryWith: aClass 
 	"Private - Ensure that if aClass is a VM registered class then the VM's
 	entry is updated to the new class."
 
 	| name |
 	name := aClass name asSymbol.
-	(VMLibrary default registryKeys includesKey: name)
-		ifTrue: [VMLibrary default registryAt: name put: aClass]!
+	(VMLibrary registryKeys includesKey: name) ifTrue: [VMLibrary default registryAt: name put: aClass]!
 
 validateClass
 	"Private - Ensure that currentClass is a valid Behavior."

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -1032,7 +1032,7 @@ PermanentLibrary subclass: #UserLibrary
 	classInstanceVariableNames: ''!
 PermanentLibrary subclass: #VMLibrary
 	instanceVariableNames: 'wndProc dlgProc genericCallback vtable specialSelectorStart '
-	classVariableNames: 'Registry'
+	classVariableNames: 'Registry RegistryKeys'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ExternalStructure subclass: #_FPIEEE_RECORD

--- a/Core/Object Arts/Dolphin/Base/Metaclass.cls
+++ b/Core/Object Arts/Dolphin/Base/Metaclass.cls
@@ -27,13 +27,14 @@ Metaclass has the following instance variables:
 !Metaclass methodsFor!
 
 addToSuper
-	"Private - Add the receiver into its superclasses' subclass collection.
-	Root Metaclasses will have a superclass of Class - we do not put such
-	classes into Class's subclass collection."	
+	"Private - Add the receiver as a subclass of its superclass, but not
+	if a root class."
 
-	superclass ~~ Class
-		ifTrue: [super addToSuper]
-!
+	"Implementation Note: Identify Class as the superclass by name, as if the ClassBuilder is
+	currently mutating Class, the Class variable may temporarily be pointing at the old Class
+	object."
+
+	superclass name ~~ #Class ifTrue: [super addToSuper]!
 
 bindingFor: aString 
 	"Answer a variable binding for the named variable in the scope of this class. 

--- a/Core/Object Arts/Dolphin/Base/VMLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/VMLibrary.cls
@@ -2,7 +2,7 @@
 
 PermanentLibrary subclass: #VMLibrary
 	instanceVariableNames: 'wndProc dlgProc genericCallback vtable specialSelectorStart '
-	classVariableNames: 'Registry'
+	classVariableNames: 'Registry RegistryKeys'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 VMLibrary guid: (GUID fromString: '{87B4C58F-026E-11D3-9FD7-00A0CC3E4A32}')!
@@ -384,7 +384,7 @@ onStartup
 	THIS MUST BE DONE FIRST."
 
 	handle := Registry at: 122.
-	specialSelectorStart := self registryKeys at: #arithmeticSelectors.
+	specialSelectorStart := RegistryKeys at: #arithmeticSelectors.
 	wndProc := dlgProc := vtable := genericCallback := nil!
 
 primRegistryAt:  anInteger put: anObject
@@ -421,89 +421,14 @@ registry
 registryAt: aSymbol 
 	"Private - Answer the VM registered object with the name, aSymbol."
 
-	^Registry at: (self registryKeys at: aSymbol)!
+	^Registry at: (RegistryKeys at: aSymbol)!
 
 registryAt: aSymbol put: anObject 
 	"Private - Register the argument, anObject, as the VM registered object with the name,
 	aSymbol."
 
-	self primRegistryAt: (self registryKeys at: aSymbol) put: anObject.
+	self primRegistryAt: (RegistryKeys at: aSymbol) put: anObject.
 	^anObject!
-
-registryKeys
-	"Private - Answer the map between symbolic names and VM registry indices."
-
-	^##((IdentityDictionary new)
-		at: #Smalltalk put: 9;
-		at: #Processor put: 10;
-		at: #arithmeticSelectors put: 16;
-		at: #commonSelectors put: 31;
-		at: #Metaclass put: 81;
-		at: #Character put: 82;
-		at: #Array put: 83;
-		at: #String put: 84;
-		at: #Symbol put: 85;
-		at: #SmallInteger put: 86;
-		at: #Process put: 87;
-		at: #CompiledMethod put: 88;
-		at: #Context put: 89;
-		at: #BlockClosure put: 90;
-		at: #Message put: 91;
-		at: #ByteArray put: 92;
-		at: #UnicodeString put: 93;
-		at: #CompiledExpression put: 94;
-		at: #ExternalMethod put: 95;
-		at: #Float put: 96;
-		at: #UndefinedObject put: 97;
-		at: #VariableBinding put: 98;
-		at: #Semaphore put: 99;
-		at: #ExternalAddress put: 100;
-		at: #ExternalHandle put: 101;
-		at: #Dispatcher put: 102;
-		at: #LPVOID put: 103;
-		at: #PoolConstantsDictionary put: 105;
-		at: #LargeInteger put: 107;
-		at: #VARIANT put: 108;
-		at: #BSTR put: 109;
-		at: #DATE put: 110;
-		at: #Corpse put: 111;
-		at: #InputSemaphore put: 112;
-		at: #FinalizeSemaphore put: 113;
-		at: #BereavementSemaphore put: 114;
-		at: #FinalizeQueue put: 118;
-		at: #BereavementQueue put: 119;
-		at: #GUID put: 120;
-		at: #KernelHandle put: 121;
-		at: #VMHandle put: 122;
-		at: #DolphinHandle put: 123;
-		at: #IUnknown put: 124;
-		at: #WakeupEvent put: 125;
-		at: #MsgWndHandle put: 127;
-		at: #IDispatch put: 128;
-		at: #ImageVersionMajor put: 129;
-		at: #ImageVersionMinor put: 130;
-		at: #interruptHotKey put: 131;
-		at: #CRTHandle put: 132;
-		at: #MemoryManager put: 133;
-		at: #BYTE put: 134;
-		at: #SBYTE put: 135;
-		at: #WORD put: 136;
-		at: #SWORD put: 137;
-		at: #DWORD put: 138;
-		at: #SDWORD put: 139;
-		at: #FLOAT put: 140;
-		at: #DOUBLE put: 141;
-		at: #VARIANT_BOOL put: 142;
-		at: #CURRENCY put: 143;
-		at: #DECIMAL put: 144;
-		at: #LPBSTR put: 145;
-		at: #ULARGE_INTEGER put: 146;
-		at: #LARGE_INTEGER put: 147;
-		at: #UINT_PTR put: 148;
-		at: #INT_PTR put: 149;
-		isImmutable: true;
-		shrink;
-		yourself)!
 
 removeDesktopMessage: anExternalHandle
 	<stdcall: void RemoveDesktopMessage handle>
@@ -648,7 +573,6 @@ versionFormatString
 !VMLibrary categoriesFor: #registry!accessing!private! !
 !VMLibrary categoriesFor: #registryAt:!accessing-registry!private! !
 !VMLibrary categoriesFor: #registryAt:put:!accessing-registry!private! !
-!VMLibrary categoriesFor: #registryKeys!constants!private! !
 !VMLibrary categoriesFor: #removeDesktopMessage:!operations!private! !
 !VMLibrary categoriesFor: #shortName!accessing!public! !
 !VMLibrary categoriesFor: #signedFromUnsigned:!helpers!private! !
@@ -669,6 +593,86 @@ fileName
 
 	^self shouldNotImplement!
 
+initialize
+	"Private - Initialize the receiver's class variables - see class comment for further details.
+
+		VMLibrary initialize
+	"
+
+	"Registry := DO NOT ASSIGN ME."
+
+	##(RegistryKeys := (IdentityDictionary new)
+				at: #Smalltalk put: 9;
+				at: #Processor put: 10;
+				at: #arithmeticSelectors put: 16;
+				at: #commonSelectors put: 31;
+				at: #Metaclass put: 81;
+				at: #Character put: 82;
+				at: #Array put: 83;
+				at: #String put: 84;
+				at: #Symbol put: 85;
+				at: #SmallInteger put: 86;
+				at: #Process put: 87;
+				at: #CompiledMethod put: 88;
+				at: #Context put: 89;
+				at: #BlockClosure put: 90;
+				at: #Message put: 91;
+				at: #ByteArray put: 92;
+				at: #UnicodeString put: 93;
+				at: #CompiledExpression put: 94;
+				at: #ExternalMethod put: 95;
+				at: #Float put: 96;
+				at: #UndefinedObject put: 97;
+				at: #VariableBinding put: 98;
+				at: #Semaphore put: 99;
+				at: #ExternalAddress put: 100;
+				at: #ExternalHandle put: 101;
+				at: #Dispatcher put: 102;
+				at: #LPVOID put: 103;
+				at: #PoolConstantsDictionary put: 105;
+				at: #LargeInteger put: 107;
+				at: #VARIANT put: 108;
+				at: #BSTR put: 109;
+				at: #DATE put: 110;
+				at: #Corpse put: 111;
+				at: #InputSemaphore put: 112;
+				at: #FinalizeSemaphore put: 113;
+				at: #BereavementSemaphore put: 114;
+				at: #FinalizeQueue put: 118;
+				at: #BereavementQueue put: 119;
+				at: #GUID put: 120;
+				at: #KernelHandle put: 121;
+				at: #VMHandle put: 122;
+				at: #DolphinHandle put: 123;
+				at: #IUnknown put: 124;
+				at: #WakeupEvent put: 125;
+				at: #MsgWndHandle put: 127;
+				at: #IDispatch put: 128;
+				at: #ImageVersionMajor put: 129;
+				at: #ImageVersionMinor put: 130;
+				at: #interruptHotKey put: 131;
+				at: #CRTHandle put: 132;
+				at: #MemoryManager put: 133;
+				at: #BYTE put: 134;
+				at: #SBYTE put: 135;
+				at: #WORD put: 136;
+				at: #SWORD put: 137;
+				at: #DWORD put: 138;
+				at: #SDWORD put: 139;
+				at: #FLOAT put: 140;
+				at: #DOUBLE put: 141;
+				at: #VARIANT_BOOL put: 142;
+				at: #CURRENCY put: 143;
+				at: #DECIMAL put: 144;
+				at: #LPBSTR put: 145;
+				at: #ULARGE_INTEGER put: 146;
+				at: #LARGE_INTEGER put: 147;
+				at: #UINT_PTR put: 148;
+				at: #INT_PTR put: 149;
+				isImmutable: true;
+				shrink;
+				yourself)!
+
 maxBlockNesting
 	^VMConstants.MaxBlockNesting!
 
@@ -684,11 +688,18 @@ maxTemps
 open
 	"Answer the singleton instance of the receiver (it cannot be re-opened)"
 
-	^default! !
+	^default!
+
+registryKeys
+	"Private - Answer the map between symbolic names and VM registry indices."
+
+	^RegistryKeys! !
 !VMLibrary class categoriesFor: #fileName!constants!public! !
+!VMLibrary class categoriesFor: #initialize!development!initializing!private! !
 !VMLibrary class categoriesFor: #maxBlockNesting!limits!public! !
 !VMLibrary class categoriesFor: #maxLiterals!limits!public! !
 !VMLibrary class categoriesFor: #maxMessageArguments!limits!public! !
 !VMLibrary class categoriesFor: #maxTemps!limits!public! !
 !VMLibrary class categoriesFor: #open!instance creation!public! !
+!VMLibrary class categoriesFor: #registryKeys!constants!private! !
 


### PR DESCRIPTION
Need to mutate all classes if Class itself has its inst vars changed. The base set cannot be changed without corresponding VM changes (and potentially painful rewriting of the boot image), but new common class instance variables can now be added easily without taking special steps.

Restore VMLibrary RegistryKeys class var as otherwise this can cause boot issues if modifications to Class inst vars necessitate a recompile before VMLibrary has been reloaded. Later this map be redefined as a class constant and set by an initializer, but for now it is a class variable again.