### PR TITLE
Improving compiler bytecode generation for [ifNil:]ifNotNil: with no args

### DIFF
--- a/Boot.st
+++ b/Boot.st
@@ -6,7 +6,7 @@
 "Boot a workable Dolphin from the boot image"
 
 "Reload the base package constituents to reflect any changes since the boot image was created."
-SourceManager default fileIn: 'Core\Object Arts\Dolphin\Base\BootSessionManager.cls'.
+SourceManager default fileIn: 'Core\Object Arts\Dolphin\Base\BootSessionManager.cls'!
 SessionManager current reloadSystemPackage!
 
 "Install some bare bones packages to get the Installation Management system working"
@@ -69,7 +69,6 @@ ExternalStructure allSubclasses do: [:e | e byteSize]!
 "Mark all the booted packages as base"
 Package manager markAllPackagesAsBase!
 
-SourceManager default compressSources.
 SessionManager current saveImage!
 
 "Remove rogue .img and unnecessary .chg files"

--- a/Core/Contributions/IDB/ProfilerSamplesPresenter.cls
+++ b/Core/Contributions/IDB/ProfilerSamplesPresenter.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Presenter subclass: #ProfilerSamplesPresenter
 	instanceVariableNames: 'selectorFilter filterTarget index frame'
@@ -108,17 +108,20 @@ model: aProfilerSampleSet
 onFrameSelectionChanged
 	"The frame selection has changed so update the source view accordingly"
 
-	| selection text selectionRange |
+	| selection text selectionRange styler |
 	selection := (self presenterNamed: 'frames') selectionOrNil.
 	selection isNil 
 		ifTrue: 
 			[text := String new.
-			selectionRange := 0 to: 0]
+			selectionRange := 0 to: 0.
+			styler := NullScintillaStyler]
 		ifFalse: 
 			[text := selection coloredSource.
+			styler := selection compiledCode stylerClass.
 			selectionRange := selection selectionRange].
 	(self presenterNamed: 'workspace')
 		text: text;
+		stylerClass: styler;
 		selectionRange: selectionRange!
 
 onSampleIndexChanged

--- a/Core/Contributions/IDB/ProfilerSelectorListPresenter.cls
+++ b/Core/Contributions/IDB/ProfilerSelectorListPresenter.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ProfilerListsPresenter subclass: #ProfilerSelectorListPresenter
 	instanceVariableNames: ''
@@ -59,8 +59,19 @@ items
 onSelectionChanged
 	"The selector selection has changed so update the source view accordingly"
 
-	(self presenterNamed: 'workspace') 
-		text: (self hasSelection ifTrue: [self selectedMethod getSource] ifFalse: [String new]).
+	| styler text |
+	self hasSelection 
+		ifTrue: 
+			[| method |
+			method := self selectedMethod.
+			text := method getSource.
+			styler := method stylerClass]
+		ifFalse: 
+			[text := String new.
+			styler := NullScintillaStyler].
+	(self presenterNamed: 'workspace')
+		text: text;
+		stylerClass: styler.
 	self trigger: #onSelectionChanged!
 
 onViewOpened

--- a/Core/Contributions/IDB/ProfilerTreesPresenter.cls
+++ b/Core/Contributions/IDB/ProfilerTreesPresenter.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ProfilerPresenter subclass: #ProfilerTreesPresenter
 	instanceVariableNames: ''
@@ -76,21 +76,24 @@ filterSelector: aCompiledCodeOrNil
 onSelectionChanged
 	"The frame selection has changed so update the source view accordingly"
 
-	| sourceText sourceSelectionRange disassemblyText disassemblySelectionLine |
+	| sourceText sourceSelectionRange disassemblyText disassemblySelectionLine styler |
 	self selectedNode 
 		ifNil: 
 			[sourceText := String new.
 			sourceSelectionRange := 0 to: 0.
 			disassemblyText := String new.
-			disassemblySelectionLine := 0]
+			disassemblySelectionLine := 0.
+			styler := NullScintillaStyler]
 		ifNotNil: 
 			[:arg | 
 			sourceText := arg object coloredSource.
 			sourceSelectionRange := arg object selectionRange.
 			disassemblyText := arg object disassemblySource.
-			disassemblySelectionLine := arg object disassemblySelectionLine].
+			disassemblySelectionLine := arg object disassemblySelectionLine.
+			styler := arg object compiledCode stylerClass].
 	(self workspacePresenter)
 		text: sourceText;
+		stylerClass: styler;
 		selectionRange: sourceSelectionRange.
 	(self presenterNamed: 'disassembly') text: disassemblyText.
 	disassemblySelectionLine ~~ 0 

--- a/Core/Object Arts/Dolphin/Base/Array.cls
+++ b/Core/Object Arts/Dolphin/Base/Array.cls
@@ -47,6 +47,40 @@ refersToLiteral: anObject
 	self do: [:each | (each refersToLiteral: anObject) ifTrue: [^true]].
 	^false!
 
+replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger 
+	"Private - Replace the indexable instance variables of the variable pointer object,
+	anIndexableObject, between startInteger and stopInteger inclusive with elements of the
+	receiver starting from startAtInteger."
+
+	| offset |
+	<primitive: 188>
+	offset := startAtInteger - startInteger.
+	(anIndexableObject == self and: [startAtInteger < startInteger]) 
+		ifTrue: 
+			[stopInteger to: startInteger
+				by: -1
+				do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]]
+		ifFalse: 
+			[startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]]!
+
+replaceFrom: startInteger to: stopInteger with: aSequencedReadableCollection startingAt: startAtInteger 
+	"Destructively replace the elements of the receiver between the <integer> arguments
+	startInteger and stopInteger inclusive with the <Object> elements of the
+	<sequencedReadableCollection> argument, aSequencedReadableCollection, beginning with its
+	element with <integer> index startAtInteger. Answer the receiver. Overlapping moves are
+	correctly handled. Unlike #replaceFrom:to:with:, the size of aSequenceableCollection is not
+	checked directly (X3J20 does not specify that this should be an error), but an error will be
+	raised when an attempt is made to access an out-of-bounds element in replacementElements. It
+	is not an error to specify an empty replacement interval, even if startInteger, stopInteger,
+	and/or startAtInteger are out-of-bounds (this is compatible with the major
+	implementations)."
+
+	aSequencedReadableCollection 
+		replaceElementsOf: self
+		from: startInteger
+		to: stopInteger
+		startingAt: startAtInteger!
+
 storeOn: aStream 
 	"Append to the <puttableStream> argument, target, an expression which when 
 	evaluated will answer a collection similar to the receiver."
@@ -74,6 +108,8 @@ storeOn: aStream
 !Array categoriesFor: #isLiteral!public!testing! !
 !Array categoriesFor: #printPrefixOn:!printing!private! !
 !Array categoriesFor: #refersToLiteral:!private!testing! !
+!Array categoriesFor: #replaceElementsOf:from:to:startingAt:!private!replacing! !
+!Array categoriesFor: #replaceFrom:to:with:startingAt:!public!replacing! !
 !Array categoriesFor: #storeOn:!printing!public! !
 
 Array methodProtocol: #Array attributes: #(#ansi #readOnly) selectors: #(#, #after: #allSatisfy: #anySatisfy: #asArray #asBag #asByteArray #asOrderedCollection #asSet #asSortedCollection #asSortedCollection: #at: #at:ifAbsent: #at:put: #atAll:put: #atAllPut: #before: #collect: #copyFrom:to: #copyReplaceAll:with: #copyReplaceFrom:to:with: #copyReplaceFrom:to:withObject: #copyReplacing:withObject: #copyWith: #copyWithout: #detect: #detect:ifNone: #do: #do:separatedBy: #findFirst: #findLast: #first #from:to:do: #from:to:keysAndValuesDo: #includes: #indexOf: #indexOf:ifAbsent: #indexOfSubCollection:startingAt: #indexOfSubCollection:startingAt:ifAbsent: #inject:into: #isEmpty #keysAndValuesDo: #last #notEmpty #occurrencesOf: #rehash #reject: #replaceFrom:to:with: #replaceFrom:to:with:startingAt: #replaceFrom:to:withObject: #reverse #reverseDo: #select: #size #with:do:)!

--- a/Core/Object Arts/Dolphin/Base/ByteArray.cls
+++ b/Core/Object Arts/Dolphin/Base/ByteArray.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ArrayedCollection variableByteSubclass: #ByteArray
 	instanceVariableNames: ''
@@ -413,11 +413,15 @@ replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart
 	stop to: start by: -1 do: [:i | aByteObject at: i put: (self basicAt: i + fromOffset)].
 	^aByteObject!
 
-replaceFrom: start to: stop with: aByteObject startingAt: fromStart
+replaceFrom: startInteger to: stopInteger with: aByteObject startingAt: startAtInteger 
 	"Standard method for transfering bytes from one variable
 	byte object to another. See String>>replaceFrom:to:with:startingAt:."
 
-	aByteObject replaceBytesOf: self from: start to: stop startingAt: fromStart!
+	aByteObject 
+		replaceBytesOf: self
+		from: startInteger
+		to: stopInteger
+		startingAt: startAtInteger!
 
 retryDwordAtOffset: anInteger put: anObject 
 	"Private - Fallback code for storing unsigned 32-bit integer into the receiver when a

--- a/Core/Object Arts/Dolphin/Base/CompiledCode.cls
+++ b/Core/Object Arts/Dolphin/Base/CompiledCode.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object variableSubclass: #CompiledCode
 	instanceVariableNames: 'header methodClass selector sourceDescriptor byteCodes '
@@ -467,6 +467,21 @@ refersToLiteral: anObject
 		do: [:i | ((self at: i) refersToLiteral: anObject) ifTrue: [^true]].
 	^false!
 
+replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger 
+	"Private - Replace the indexable instance variables of the variable pointer object,
+	anIndexableObject, between startInteger and stopInteger inclusive with literals from the
+	receiver starting from startAtInteger."
+
+	| offset |
+	offset := startAtInteger - startInteger.
+	(anIndexableObject == self and: [startAtInteger < startInteger]) 
+		ifTrue: 
+			[stopInteger to: startInteger
+				by: -1
+				do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]]
+		ifFalse: 
+			[startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]]!
+
 selector
 	"Answer the message selector under which the receiver is entered in its class' method
 	dictionary."
@@ -630,6 +645,7 @@ writesInstVar: aString at: anInteger
 !CompiledCode categoriesFor: #readsInstVar:!development!public!testing! !
 !CompiledCode categoriesFor: #readsInstVar:at:!development!public!testing! !
 !CompiledCode categoriesFor: #refersToLiteral:!private!testing! !
+!CompiledCode categoriesFor: #replaceElementsOf:from:to:startingAt:!private!replacing! !
 !CompiledCode categoriesFor: #selector!accessing!public! !
 !CompiledCode categoriesFor: #selector:!accessing!private! !
 !CompiledCode categoriesFor: #sendsSelector:!development!public!testing! !

--- a/Core/Object Arts/Dolphin/Base/ExternalArray.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalArray.cls
@@ -325,18 +325,27 @@ replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart
 
 	^bytes replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart-1*self elementSize+1!
 
-replaceFrom: start to: stop  with: aByteObject startingAt: fromStart
+replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger 
+	"Private - Replace the indexable instance variables of the variable pointer object,
+	anIndexableObject, between startInteger and stopInteger inclusive with values from the
+	receiver starting from startAtInteger."
+
+	| offset |
+	offset := startAtInteger - startInteger.
+	startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self at: offset + i)]!
+
+replaceFrom: startInteger to: stopInteger with: aByteObject startingAt: startAtInteger 
 	"Standard method for transfering bytes from one variable
 	byte object to another. See String>>replaceFrom:to:with:startingAt:"
 
 	| elemSize offset |
 	elemSize := self elementSize.
-	offset := start-1 * elemSize.
+	offset := (startInteger - 1) * elemSize.
 	aByteObject 
-		replaceBytesOf: self bytes 
-		from: 1+offset
-		to: stop * elemSize
-		startingAt: fromStart!
+		replaceBytesOf: self bytes
+		from: 1 + offset
+		to: stopInteger * elemSize
+		startingAt: startAtInteger!
 
 select: discriminator
 	"Evaluate the <monadicValuable> argument, discriminator, for each of the receiver's elements.
@@ -416,6 +425,7 @@ uncheckedFrom: startInteger to: stopInteger keysAndValuesDo: operation
 !ExternalArray categoriesFor: #notEmpty!public!testing! !
 !ExternalArray categoriesFor: #printOn:!development!printing!public! !
 !ExternalArray categoriesFor: #replaceBytesOf:from:to:startingAt:!double dispatch!private! !
+!ExternalArray categoriesFor: #replaceElementsOf:from:to:startingAt:!private!replacing! !
 !ExternalArray categoriesFor: #replaceFrom:to:with:startingAt:!public!replacing! !
 !ExternalArray categoriesFor: #select:!enumerating!public! !
 !ExternalArray categoriesFor: #size!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/Object.cls
+++ b/Core/Object Arts/Dolphin/Base/Object.cls
@@ -733,19 +733,12 @@ identityHash
 	<primitive: 75>
 	^self primitiveFailed!
 
-ifNil: aBlock
-	"If the receiver is the nil object, then answer the result of evaluating
-	the <niladicValuable>, aBlock, otherwise answer the receiver."
+ifNil: nilBlock 
+	"If the receiver is the nil object, then answer the result of evaluating the
+	<niladicValuable>, nilBlock, otherwise answer the receiver."
 
-	"Implementation Note: This message is normally inlined by the compiler and so
-	is never sent unless #perform'd. The inline form of the bytecodes is:
-
-			dup
-			jmp ifNotNil @notNil
-			pop
-			[...]
-		@notNil
-	"
+	"Implementation Note: This message is normally inlined by the compiler and so is never sent
+	unless #perform'd."
 
 	^self!
 
@@ -753,52 +746,33 @@ ifNil: nilBlock ifNotNil: notNilBlock
 	"If the receiver is the nil object, then answer the result of evaluating the
 	<niladicValuable>, nilBlock, otherwise answer the result of evaluating the <valuable>,
 	notNilBlock. notNilBlock can be a <niladicValuable> or a <monadicValuable>, in which case it
-	is evaluated with the receiver as its argument, "
+	is evaluated with the receiver as its argument."
 
 	"Implementation Note: This message is normally inlined by the compiler and so is never sent
-	unless #perform'd. The inline form of the bytecodes in the normal case where the notNilBlock
-	is monadic is:
+	unless #perform'd."
 
-			dup
-			jmp ifNotNil @notNil
-			pop
-			[...]
-			jmp @exit
-		@notNil
-			pop'n'store 'value'
-			[:value | ...]
-		@exit	
-	"
+	^notNilBlock cull: self!
 
-	^notNilBlock argumentCount = 1 ifTrue: [notNilBlock value: self] ifFalse: [notNilBlock value]!
-
-ifNotNil: aBlock 
+ifNotNil: notNilBlock 
 	"If the receiver is not the nil object, then answer the result of evaluating the valuable
-	argument, aBlock, otherwise answer nil. aBlock can be a <niladicValuable> or a
-	<monadicValuable>, in which case it is evaluated with the receiver as its argument, "
+	argument, notNilBlock, otherwise answer nil. notNilBlock can be a <niladicValuable> or a
+	<monadicValuable>, in which case it is evaluated with the receiver as its argument."
 
 	"Implementation Note: This message is normally inlined by the compiler and so is never sent
-	unless #perform'd. The inline form of the bytecodes is:
+	unless #perform'd."
 
-			dup
-			jmp ifNil @nil
-			pop'n'store 'value'
-			[:value | ...]
-		@nil
-	"
-
-	^aBlock argumentCount = 1 ifTrue: [aBlock value: self] ifFalse: [aBlock value]!
+	^notNilBlock cull: self!
 
 ifNotNil: notNilBlock ifNil: nilBlock 
 	"If the receiver is the nil object, then answer the result of evaluating the
 	<niladicValuable>, nilBlock, otherwise answer the result of evaluating the <valuable>,
 	notNilBlock. notNilBlock can be a <niladicValuable> or a <monadicValuable>, in which case it
-	is evaluated with the receiver as its argument, "
+	is evaluated with the receiver as its argument."
 
 	"Implementation Note: This message is normally inlined by the compiler and so is never sent
 	unless #perform'd."
 
-	^notNilBlock argumentCount = 1 ifTrue: [notNilBlock value: self] ifFalse: [notNilBlock value]!
+	^notNilBlock cull: self!
 
 initialize
 	"Initialise the receiver following instantiation. The default is to do nothing.

--- a/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
@@ -908,6 +908,21 @@ replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart
 	start to: stop do: [:i | aByteObject at: i put: (self at: i + fromOffset)].
 	^aByteObject!
 
+replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger 
+	"Private - Replace the indexable instance variables of the variable pointer object,
+	anIndexableObject, between startInteger and stopInteger inclusive with elements of the
+	receiver starting from startAtInteger."
+
+	| offset |
+	offset := startAtInteger - startInteger.
+	(anIndexableObject == self and: [startAtInteger < startInteger]) 
+		ifTrue: 
+			[stopInteger to: startInteger
+				by: -1
+				do: [:i | anIndexableObject basicAt: i put: (self at: offset + i)]]
+		ifFalse: 
+			[startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self at: offset + i)]]!
+
 replaceFrom: start to: stop with: replacementElements
 	"Destructively replace the elements of the receiver between the <integer> arguments
 	start and stop with the <Object> elements of the <sequencedReadableCollection> argument, 
@@ -918,32 +933,32 @@ replaceFrom: start to: stop with: replacementElements
 		ifFalse: [^self error: 'size of replacement incorrect'].
 	^self replaceFrom: start to: stop with: replacementElements startingAt: 1!
 
-replaceFrom: start to: stop with: replacementElements startingAt: repStart
+replaceFrom: startInteger to: stopInteger with: aSequencedReadableCollection startingAt: startAtInteger 
 	"Destructively replace the elements of the receiver between the <integer> arguments
-	start and stop with the <Object> elements of the <sequencedReadableCollection> 
-	argument, replacementElements beginning with its element with <integer> index 
-	repStart. Answer the receiver. Overlapping moves are correctly handled.
-	Unlike #replaceFrom:to:with:, the size of replacementElements is not checked
-	directly (X3J20 does not specify that this should be an error), but an error will
-	be raised when an attempt is made to access an out-of-bounds element in
-	replacementElements.
-	N.B. It is not an error to specify an empty replacement interval, even if
-	start, stop, and/or repStart are out-of-bounds (this is compatible with the major
-	implementations).
-	Implementation Note: The performance of this method is very important to overall 
+	startInteger and stopInteger inclusive with the <Object> elements of the
+	<sequencedReadableCollection> argument, aSequencedReadableCollection, beginning with its
+	element with <integer> index startAtInteger. Answer the receiver. Overlapping moves are
+	correctly handled. Unlike #replaceFrom:to:with:, the size of aSequenceableCollection is not
+	checked directly (X3J20 does not specify that this should be an error), but an error will be
+	raised when an attempt is made to access an out-of-bounds element in replacementElements. It
+	is not an error to specify an empty replacement interval, even if startInteger, stopInteger,
+	and/or startAtInteger are out-of-bounds (this is compatible with the major
+	implementations)."
+
+	"Implementation Note: The performance of this method is very important to overall 
 	system performance. This implementation is mostly inlined by the compiler."
 
 	| offset |
-	offset := repStart - start.
-	(self == replacementElements and: [repStart < start])
-		ifTrue: [
-			"Move within same object overlaps, so do backwards"
-			stop to: start by: -1 do: [:i |
-				self at: i put: (replacementElements at: offset + i)]]
-		ifFalse: [
-			"Non-overlapping moves are done forwards"
-			start to: stop do: [:i |
-				self at: i put: (replacementElements at: offset + i)]]!
+	offset := startAtInteger - startInteger.
+	"Perform overlapping moves backwards, otherwise forwards"
+	(self == aSequencedReadableCollection and: [startAtInteger < startInteger]) 
+		ifTrue: 
+			[stopInteger to: startInteger
+				by: -1
+				do: [:i | self at: i put: (aSequencedReadableCollection at: offset + i)]]
+		ifFalse: 
+			[startInteger to: stopInteger
+				do: [:i | self at: i put: (aSequencedReadableCollection at: offset + i)]]!
 
 replaceFrom: start to: stop withObject: replacementElement
 	"Destructively replace the elements of the receiver between the
@@ -1185,6 +1200,7 @@ writeStream
 !SequenceableCollection categoriesFor: #readStream!public!streaming! !
 !SequenceableCollection categoriesFor: #remove:ifAbsent:!public!removing! !
 !SequenceableCollection categoriesFor: #replaceBytesOf:from:to:startingAt:!double dispatch!primitives!private! !
+!SequenceableCollection categoriesFor: #replaceElementsOf:from:to:startingAt:!private!replacing! !
 !SequenceableCollection categoriesFor: #replaceFrom:to:with:!public!replacing! !
 !SequenceableCollection categoriesFor: #replaceFrom:to:with:startingAt:!public!replacing! !
 !SequenceableCollection categoriesFor: #replaceFrom:to:withObject:!public!replacing! !

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -755,13 +755,16 @@ replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart
 	stop to: start by: -1 do: [:i | aByteObject at: i put: (self at: i + fromOffset)].
 	^aByteObject!
 
-replaceFrom: start to: stop with: replacementElements startingAt: startAt
-	"Replace the characters of the receiver at the <integer> index positions 
-	start through stop with consecutive characters of the <readableString>
-	replacementElements beginning at <integer> index position startAt. 
-	Answer the receiver."
+replaceFrom: startInteger to: stopInteger with: aReadableString startingAt: startAtInteger 
+	"Replace the characters of the receiver at the <integer> index positions startInteger
+	through stopInteger inclusive with consecutive characters of the <readableString>
+	aReadableString beginning at <integer> index position startAtInteger. Answer the receiver."
 
-	replacementElements replaceBytesOf: self from: start to: stop startingAt: startAt!
+	aReadableString 
+		replaceBytesOf: self
+		from: startInteger
+		to: stopInteger
+		startingAt: startAtInteger!
 
 reverse
 	"Answer a copy of the receiver but with its elements in reverse order.

--- a/Core/Object Arts/Dolphin/Base/UndefinedObject.cls
+++ b/Core/Object Arts/Dolphin/Base/UndefinedObject.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #UndefinedObject
 	instanceVariableNames: ''
@@ -38,29 +38,26 @@ displayOn: aStream
 	"Append a representation of the receiver to aStream as a user would want to see it.
 	The default is to do nothing, since, from the end-user perspective, the receiver is a null."!
 
-ifNil: aBlock 
-	"If the receiver is the nil object, then answer the result of evaluating the
-	<niladicValuable>, aBlock, otherwise answer the receiver."
-
-	"Implementation Note: This message is normally inlined by the compiler and so is never sent
-	unless #perform'd."
-
-	^aBlock value!
-
-ifNil: nilBlock ifNotNil: notNilBlock 
-	"If the receiver is the nil object, then answer the result of evaluating the
-	<niladicValuable>, nilBlock, otherwise answer the result of evaluating the
-	<monadicValuable>, notNilBlock, with the receiver as its argument."
+ifNil: nilBlock 
+	"As the receiver is the nil object, answer the result of evaluating the <niladicValuable>,
+	nilBlock."
 
 	"Implementation Note: This message is normally inlined by the compiler and so is never sent
 	unless #perform'd."
 
 	^nilBlock value!
 
-ifNotNil: aBlock 
-	"If the receiver is not the nil object, then answer the result of evaluating the valuable
-	argument, aBlock, otherwise answer nil. aBlock can be a <niladicValuable> or a
-	<monadicValuable>, in which case it is evaluated with the receiver as its argument, "
+ifNil: nilBlock ifNotNil: notNilBlock 
+	"As the receiver is the nil object, answer the result of evaluating the <niladicValuable>,
+	nilBlock."
+
+	"Implementation Note: This message is normally inlined by the compiler and so is never sent
+	unless #perform'd."
+
+	^nilBlock value!
+
+ifNotNil: notNilBlock 
+	"As the receiver is the nil object, ignore the <valuable> argument and answer nil."
 
 	"Implementation Note: This message is normally inlined by the compiler and so is never sent
 	unless #perform'd."
@@ -68,9 +65,8 @@ ifNotNil: aBlock
 	^self!
 
 ifNotNil: notNilBlock ifNil: nilBlock 
-	"If the receiver is the nil object, then answer the result of evaluating the
-	<niladicValuable>, nilBlock, otherwise answer the result of evaluating the
-	<monadicValuable>, notNilBlock, with the receiver as its argument."
+	"As the receiver is the nil object, answer the result of evaluating the <niladicValuable>,
+	nilBlock."
 
 	"Implementation Note: This message is normally inlined by the compiler and so is never sent
 	unless #perform'd."

--- a/Core/Object Arts/Dolphin/Base/UnicodeString.cls
+++ b/Core/Object Arts/Dolphin/Base/UnicodeString.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 String variableByteSubclass: #UnicodeString
 	instanceVariableNames: ''
@@ -128,24 +128,20 @@ nextIndexOf: anElement from: start to: stop
 	self from: start to: stop keysAndValuesDo: [:i :elem | elem = anElement ifTrue: [^i]].
 	^0!
 
-replaceFrom: start to: stop with: replacementElements startingAt: repStart
-	"Replace the characters of the receiver at index positions start through stop with 
-	consecutive characters of aString beginning at index position startAt. Answer the 
-	receiver."
+replaceFrom: startInteger to: stopInteger with: aReadableString startingAt: startAtInteger 
+	"Replace the characters of the receiver at index positions startInteger through stopInteger
+	inclusive with consecutive characters of the <readableString>, aReadableString, beginning at
+	index position startAtInteger. Answer the receiver."
 
 	| offset |
-	offset := repStart - start.
-	(self == replacementElements and: [repStart < start]) 
+	offset := startAtInteger - startInteger.
+	"Perform overlapping moves backwards, otherwise forwards"
+	(self == aReadableString and: [startAtInteger < startInteger]) 
 		ifTrue: 
-			["Move within same object overlaps, so do backwards"
-
-			stop to: start
+			[stopInteger to: startInteger
 				by: -1
-				do: [:i | self at: i put: (replacementElements at: offset + i)]]
-		ifFalse: 
-			["Non-overlapping moves are done forwards"
-
-			start to: stop do: [:i | self at: i put: (replacementElements at: offset + i)]]!
+				do: [:i | self at: i put: (aReadableString at: offset + i)]]
+		ifFalse: [startInteger to: stopInteger do: [:i | self at: i put: (aReadableString at: offset + i)]]!
 
 resize: anInteger
 	^super resize: anInteger * 2!

--- a/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
@@ -10,6 +10,13 @@ CompilerTest comment: ''!
 !CompilerTest categoriesForClass!Unclassified! !
 !CompilerTest methodsFor!
 
+assertBlocksOptimized: compiled 
+	| literals |
+	self deny: compiled method needsContext.
+	literals := compiled method literals.
+	self deny: (literals anySatisfy: [:each | each isKindOf: BlockClosure]).
+	self deny: (literals anySatisfy: [:each | StProgramNode optimizedSelectors includes: each])!
+
 checkCompileError: ex range: anInterval code: anInteger message: msgFormat line: lineInteger source: aString 
 	^ex errorCode = anInteger and: [ex range = anInterval]!
 
@@ -481,132 +488,106 @@ testFloatScanning
 		do: [:each | self assert: (self evaluateExpression: ('1.0e<d>' expandMacrosWith: each)) - (10.0 ** each)]"!
 
 testIfNil
-	| compiled expected |
-	compiled := self compileExpression: '1 ifNil: [2]'.
+	| compiled |
+	compiled := self compileExpression: 'key ifNil: [value]' in: Association.
+	self assert: (compiled method value: nil -> 2) = 2.
+	self assert: (compiled method value: 1 -> 2) = 1.
 	self deny: (compiled method literals includes: 'ifNil:' asSymbol).
-	expected := 'Normal, 0 args, 0 literals
-
-	1	Push 1
-	2	Dup
-	3	Jump If Not Nil +2 to 7
-	5	Pop
-	6	Push 2
-	7	Return '.
-	self assert: compiled method disassembly = expected!
+	self assertBlocksOptimized: compiled!
 
 testIfNilifNotNil
-	| compiled expected |
-	compiled := self compileExpression: '1 ifNil: [ | x | x := 2. 1+x] ifNotNil: [:x | 1+x]'.
-	self assert: (compiled method value: nil withArguments: #()) = 2.
-	expected := 'Normal, 0 args, 2 stack temps, 0 literals
-
-	1	Push 1
-	2	Dup
-	3	Jump If Not Nil +7 to 12
-	5	Pop
-	6	Push 2
-	7	Pop Temp[0]
-	8	Push 1
-	9	Push Temp[0]
-	10	Special Send #+
-	11	Return 
-	12	Pop Temp[1]
-	13	Push 1
-	14	Push Temp[1]
-	15	Special Send #+
-	16	Return '.
-	self assert: compiled method disassembly = expected
-
-	"
-DiffBrowser compare: compiled method disassembly with: expecteda DiffBrowser
-"!
+	| compiled |
+	compiled := self compileExpression: 'key ifNil: [value+1] ifNotNil: [:x | 1+x]' in: Association.
+	self assert: (compiled method value: nil -> 1 withArguments: #()) = 2.
+	self assert: (compiled method value: 5 -> nil withArguments: #()) = 6.
+	self assertBlocksOptimized: compiled!
 
 testIfNilifNotNilNoArg
-	| compiled expected |
-	compiled := self compileExpression: '1 ifNil: [3] ifNotNil: [2]'.
-	self assert: (compiled method value: nil withArguments: #()) = 2.
-	expected := 'Normal, 0 args, 0 literals
+	| compiled |
+	compiled := self compileExpression: 'key ifNil: [value] ifNotNil: [key+2]' in: Association.
+	self assert: (compiled method value: nil -> 4 withArguments: #()) = 4.
+	self assert: (compiled method value: 1 -> 4 withArguments: #()) = 3.
+	self assertBlocksOptimized: compiled!
 
-	1	Push 1
-	2	Jump If Not Nil +3 to 7
-	4	Push 3
-	6	Return 
-	7	Push 2
-	8	Return '.
-	self assert: compiled method disassembly = expected
+testIfNilifNotNilNoArgUnused
+	| compiled expected actual |
+	compiled := self compileExpression: 'key ifNil: [value+3] ifNotNil: [value+2]. value'
+				in: Association.
+	self assert: (compiled method value: nil -> 4 withArguments: #()) = 4.
+	self assert: (compiled method value: 1 -> 4 withArguments: #()) = 4.
+	self assertBlocksOptimized: compiled!
 
-	"
-DiffBrowser compare: compiled method disassembly with: expected
-"!
+testIfNilifNotNilUnused
+	| compiled |
+	compiled := self compileExpression: 'key ifNil: [value+1] ifNotNil: [:x | 1+x]. value'
+				in: Association.
+	self assert: (compiled method value: nil -> 1 withArguments: #()) = 1.
+	self assert: (compiled method value: 5 -> 1 withArguments: #()) = 1.
+	self assertBlocksOptimized: compiled!
+
+testIfNilUnused
+	| compiled |
+	compiled := self compileExpression: 'key ifNil: [2]. value' in: Association.
+	self assert: (compiled method value: nil -> 1) = 1.
+	self assert: (compiled method value: 1 -> 2) = 2.
+	self deny: (compiled method literals includes: 'ifNil:' asSymbol).
+	self assertBlocksOptimized: compiled!
 
 testIfNotNil
-	| compiled expected result |
-	compiled := self compileExpression: '1 ifNotNil: [:x | x + 2]'.
-	expected := 'Normal, 0 args, 1 stack temps, 0 literals
-
-	1	Push 1
-	2	Dup
-	3	Jump If Nil +3 to 8
-	5	Store Temp[0]
-	6	Push 2
-	7	Special Send #+
-	8	Return '.
-	result := compiled method disassembly.
-	self assert: result = expected.
-	"
-DiffBrowser compare: result with: expected
-"
-
-	compiled := self compileExpression: '1 ifNotNil: [1+2]'.
-	expected := 'Normal, 0 args, 0 literals
-
-	1	Push 1
-	2	Dup
-	3	Jump If Nil +4 to 9
-	5	Pop
-	6	Push 1
-	7	Push 2
-	8	Special Send #+
-	9	Return '.
-	result := compiled method disassembly.
-	self assert: result = expected
-	"
-DiffBrowser compare: result with: expected
-"!
+	| compiled |
+	compiled := self compileExpression: 'key ifNotNil: [:x | x + 2]' in: Association.
+	self assert: (compiled method value: 1 -> nil) = 3.
+	self assert: (compiled method value: nil -> 1) isNil.
+	self assertBlocksOptimized: compiled!
 
 testIfNotNilifNil
-	| compiled expected |
-	compiled := self compileExpression: '1 ifNotNil: [:x | 2] ifNil: [3]'.
-	expected := 'Normal, 0 args, 1 stack temps, 0 literals
-
-	1	Push 1
-	2	Dup
-	3	Jump If Nil +3 to 8
-	5	Pop Temp[0]
-	6	Push 2
-	7	Return 
-	8	Pop
-	9	Push 3
-	11	Return '.
-	self assert: compiled method disassembly = expected!
+	| compiled |
+	compiled := self compileExpression: 'key ifNotNil: [:x | x + 2] ifNil: [3]' in: Association.
+	self assert: (compiled method value: 5 -> nil) = 7.
+	self assert: (compiled method value: nil -> 5) = 3.
+	self assertBlocksOptimized: compiled!
 
 testIfNotNilifNilNoArg
-	| compiled expected |
-	compiled := self compileExpression: '1 ifNotNil: [2] ifNil: [3]'.
-	expected := 'Normal, 0 args, 0 literals
+	| compiled |
+	compiled := self compileExpression: 'key ifNotNil: [key] ifNil: [value]' in: Association.
+	self assert: (compiled method value: 1 -> 2) = 1.
+	self assert: (compiled method value: nil -> 2) = 2.
+	self assertBlocksOptimized: compiled!
 
-	1	Push 1
-	2	Jump If Nil +2 to 6
-	4	Push 2
-	5	Return 
-	6	Push 3
-	8	Return '.
-	self assert: compiled method disassembly = expected
+testIfNotNilifNilNoArgUnused
+	| compiled |
+	compiled := self compileExpression: 'key ifNotNil: [key+1] ifNil: [value+1]. self' in: Association.
+	self assert: (compiled method value: 1 -> 2) = (1 -> 2).
+	self assert: (compiled method value: nil -> 2) = (nil -> 2).
+	self assertBlocksOptimized: compiled!
 
+testIfNotNilifNilUnused
+	| compiled |
+	compiled := self compileExpression: 'key ifNotNil: [:x | x + 2] ifNil: [3]. value' in: Association.
+	self assert: (compiled method value: 5 -> 8) = 8.
+	self assert: (compiled method value: nil -> 5) = 5.
+	self assertBlocksOptimized: compiled!
 
-	"
-DiffBrowser compare: compiled method disassembly with: expected
-"!
+testIfNotNilNoArg
+	| compiled |
+	compiled := self compileExpression: 'key ifNotNil: [1+2]' in: Association.
+	self assert: (compiled method value: 4 -> nil) = 3.
+	self assert: (compiled method value: nil -> 1) isNil.
+	self assertBlocksOptimized: compiled!
+
+testIfNotNilNoArgUnused
+	| compiled |
+	compiled := self compileExpression: 'key ifNotNil: [key+1]. value' in: Association.
+	self assert: (compiled method value: 1 -> 5) = 5.
+	self assert: (compiled method value: nil -> 10) = 10.
+	self assertBlocksOptimized: compiled!
+
+testIfNotNilUnused
+	| compiled |
+	compiled := self compileExpression: 'key ifNotNil: [:x | x + 2]. value' in: Association.
+	self assert: (compiled method value: 1 -> 10) = 10.
+	self assert: (compiled method value: nil -> 11) = 11.
+	self assertBlocksOptimized: compiled!
 
 testImmutableLiterals
 	| method |
@@ -1345,6 +1326,7 @@ testWriteAccessor
 			self assert: accessor extraIndex = 7.
 			inst perform: selector with: each.
 			self assert: (inst perform: each asSymbol) = each]! !
+!CompilerTest categoriesFor: #assertBlocksOptimized:!helpers!private! !
 !CompilerTest categoriesFor: #checkCompileError:range:code:message:line:source:!helpers!private! !
 !CompilerTest categoriesFor: #compilationErrorClass!constants!private! !
 !CompilerTest categoriesFor: #compilationWarningClass!constants!public! !
@@ -1385,9 +1367,17 @@ testWriteAccessor
 !CompilerTest categoriesFor: #testIfNil!public!unit tests! !
 !CompilerTest categoriesFor: #testIfNilifNotNil!public!unit tests! !
 !CompilerTest categoriesFor: #testIfNilifNotNilNoArg!public!unit tests! !
+!CompilerTest categoriesFor: #testIfNilifNotNilNoArgUnused!public!unit tests! !
+!CompilerTest categoriesFor: #testIfNilifNotNilUnused!public!unit tests! !
+!CompilerTest categoriesFor: #testIfNilUnused!public!unit tests! !
 !CompilerTest categoriesFor: #testIfNotNil!public!unit tests! !
 !CompilerTest categoriesFor: #testIfNotNilifNil!public!unit tests! !
 !CompilerTest categoriesFor: #testIfNotNilifNilNoArg!public!unit tests! !
+!CompilerTest categoriesFor: #testIfNotNilifNilNoArgUnused!public!unit tests! !
+!CompilerTest categoriesFor: #testIfNotNilifNilUnused!public!unit tests! !
+!CompilerTest categoriesFor: #testIfNotNilNoArg!public!unit tests! !
+!CompilerTest categoriesFor: #testIfNotNilNoArgUnused!public!unit tests! !
+!CompilerTest categoriesFor: #testIfNotNilUnused!public! !
 !CompilerTest categoriesFor: #testImmutableLiterals!public!unit tests! !
 !CompilerTest categoriesFor: #testIncrementDecrementOptimisation!public!unit tests! !
 !CompilerTest categoriesFor: #testIncrementPushTempOptimisation!public!unit tests! !

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
@@ -75,6 +75,7 @@ package methodNames
 	add: #ClassDescription -> #definesVariable:;
 	add: #ClassDescription -> #directlyDefinesClassVariable:;
 	add: #ClassDescription -> #directlyDefinesInstanceVariable:;
+	add: #ClassDescription -> #directlyDefinesVariable:;
 	add: #ClassDescription -> #hierarchyDefinesVariable:;
 	add: #ClassSelector -> #abstractClassVariables;
 	add: #ClassSelector -> #abstractInstanceVariables;
@@ -673,6 +674,10 @@ directlyDefinesClassVariable: aString
 directlyDefinesInstanceVariable: aString 
 	^self instVarNames includes: aString!
 
+directlyDefinesVariable: aVariableName 
+	^(self directlyDefinesClassVariable: aVariableName) 
+		or: [self directlyDefinesInstanceVariable: aVariableName]!
+
 hierarchyDefinesVariable: aString 
 	(self definesVariable: aString) ifTrue: [^true].
 	^self allSubclasses anySatisfy: [:each | each directlyDefinesVariable: aString]! !
@@ -681,6 +686,7 @@ hierarchyDefinesVariable: aString
 !ClassDescription categoriesFor: #definesVariable:!public!testing! !
 !ClassDescription categoriesFor: #directlyDefinesClassVariable:!public!testing! !
 !ClassDescription categoriesFor: #directlyDefinesInstanceVariable:!public!testing! !
+!ClassDescription categoriesFor: #directlyDefinesVariable:!public!testing! !
 !ClassDescription categoriesFor: #hierarchyDefinesVariable:!public!testing! !
 
 !ClassSelector methodsFor!


### PR DESCRIPTION
Image size changes for DolphinVM issue #60: Compiler generates inefficient code for #ifNotNil: with zero arg block.
Also added image side support for a VM primitive to speed up block copy of Arrays, etc.