### PR TITLE
Image changes for DolphinVM issue #62

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Array.cls
+++ b/Core/Object Arts/Dolphin/Base/Array.cls
@@ -47,21 +47,22 @@ refersToLiteral: anObject
 	self do: [:each | (each refersToLiteral: anObject) ifTrue: [^true]].
 	^false!
 
-replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger 
+replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger
 	"Private - Replace the indexable instance variables of the variable pointer object,
 	anIndexableObject, between startInteger and stopInteger inclusive with elements of the
-	receiver starting from startAtInteger."
+	receiver starting from startAtInteger. Answers anIndexableObject."
 
 	| offset |
 	<primitive: 188>
 	offset := startAtInteger - startInteger.
-	(anIndexableObject == self and: [startAtInteger < startInteger]) 
+	(anIndexableObject == self and: [startAtInteger < startInteger])
 		ifTrue: 
 			[stopInteger to: startInteger
 				by: -1
 				do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]]
 		ifFalse: 
-			[startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]]!
+			[startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]].
+	^anIndexableObject!
 
 replaceFrom: startInteger to: stopInteger with: aSequencedReadableCollection startingAt: startAtInteger 
 	"Destructively replace the elements of the receiver between the <integer> arguments

--- a/Core/Object Arts/Dolphin/Base/CompiledCode.cls
+++ b/Core/Object Arts/Dolphin/Base/CompiledCode.cls
@@ -360,8 +360,11 @@ literals
 
 	| count |
 	count := self literalCount.
-	^(Array new: count)
-		replaceFrom: 1 to: count with: self startingAt: 1!
+	^self
+		replaceElementsOf: (Array new: count)
+		from: 1
+		to: count
+		startingAt: 1!
 
 literalsDetect: discriminator ifNone: exceptionHandler
 	"Evaluate the <monadicValuable> argument, discriminator, for each of the 
@@ -467,20 +470,22 @@ refersToLiteral: anObject
 		do: [:i | ((self at: i) refersToLiteral: anObject) ifTrue: [^true]].
 	^false!
 
-replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger 
+replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger
 	"Private - Replace the indexable instance variables of the variable pointer object,
 	anIndexableObject, between startInteger and stopInteger inclusive with literals from the
-	receiver starting from startAtInteger."
+	receiver starting from startAtInteger. Answers anIndexableObject."
 
 	| offset |
+	<primitive: 188>
 	offset := startAtInteger - startInteger.
-	(anIndexableObject == self and: [startAtInteger < startInteger]) 
+	(anIndexableObject == self and: [startAtInteger < startInteger])
 		ifTrue: 
 			[stopInteger to: startInteger
 				by: -1
 				do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]]
 		ifFalse: 
-			[startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]]!
+			[startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self basicAt: offset + i)]].
+	^anIndexableObject!
 
 selector
 	"Answer the message selector under which the receiver is entered in its class' method

--- a/Core/Object Arts/Dolphin/Base/ExternalArray.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalArray.cls
@@ -325,14 +325,15 @@ replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart
 
 	^bytes replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart-1*self elementSize+1!
 
-replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger 
+replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger
 	"Private - Replace the indexable instance variables of the variable pointer object,
 	anIndexableObject, between startInteger and stopInteger inclusive with values from the
-	receiver starting from startAtInteger."
+	receiver starting from startAtInteger. Answers anIndexableObject."
 
 	| offset |
 	offset := startAtInteger - startInteger.
-	startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self at: offset + i)]!
+	startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self at: offset + i)].
+	^anIndexableObject!
 
 replaceFrom: startInteger to: stopInteger with: aByteObject startingAt: startAtInteger 
 	"Standard method for transfering bytes from one variable

--- a/Core/Object Arts/Dolphin/Base/OrderedCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/OrderedCollection.cls
@@ -288,6 +288,18 @@ removeAtIndex: index
 			lastIndex := lastIndex - 1].
 	^element!
 
+replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger
+	"Private - Replace the indexable instance variables of the variable pointer object,
+	anIndexableObject, between startInteger and stopInteger inclusive with elements of the
+	receiver starting from startAtInteger. Answers anIndexableObject."
+
+	<primitive: 188>
+	^super
+		replaceElementsOf: anIndexableObject
+		from: startInteger
+		to: stopInteger
+		startingAt: startAtInteger!
+
 resize: anInteger
 	"Private - Override back to the basic implementation as our elements are contiguously located.
 	This changes the capacity of the receiver, but has no other effect."
@@ -376,6 +388,7 @@ uncheckedFrom: startInteger to: stopInteger keysAndValuesDo: aDyadicValuable
 !OrderedCollection categoriesFor: #removeAll!public!removing! !
 !OrderedCollection categoriesFor: #removeAllSuchThat:!accessing!public! !
 !OrderedCollection categoriesFor: #removeAtIndex:!public!removing! !
+!OrderedCollection categoriesFor: #replaceElementsOf:from:to:startingAt:!private!replacing! !
 !OrderedCollection categoriesFor: #resize:!mutating!private! !
 !OrderedCollection categoriesFor: #reverseDo:!enumerating!public! !
 !OrderedCollection categoriesFor: #select:!enumerating!public! !

--- a/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
@@ -126,6 +126,17 @@ approxSize
 
 	^self size!
 
+asArray
+	"Answer an <Array> whose elements are those of the receiver in the same sequence."
+
+	| size |
+	size := self size.
+	^self
+		replaceElementsOf: (Array new: size)
+		from: 1
+		to: size
+		startingAt: 1!
+
 asRunArray
 	"Answer a <RunArray> whose elements are the same as those of the receiver. The order of
 	elements will be the same, and there will be the same number when enumerated, but the
@@ -908,20 +919,21 @@ replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart
 	start to: stop do: [:i | aByteObject at: i put: (self at: i + fromOffset)].
 	^aByteObject!
 
-replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger 
+replaceElementsOf: anIndexableObject from: startInteger to: stopInteger startingAt: startAtInteger
 	"Private - Replace the indexable instance variables of the variable pointer object,
 	anIndexableObject, between startInteger and stopInteger inclusive with elements of the
-	receiver starting from startAtInteger."
+	receiver starting from startAtInteger. Answers anIndexableObject."
 
 	| offset |
 	offset := startAtInteger - startInteger.
-	(anIndexableObject == self and: [startAtInteger < startInteger]) 
+	(anIndexableObject == self and: [startAtInteger < startInteger])
 		ifTrue: 
 			[stopInteger to: startInteger
 				by: -1
 				do: [:i | anIndexableObject basicAt: i put: (self at: offset + i)]]
 		ifFalse: 
-			[startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self at: offset + i)]]!
+			[startInteger to: stopInteger do: [:i | anIndexableObject basicAt: i put: (self at: offset + i)]].
+	^anIndexableObject!
 
 replaceFrom: start to: stop with: replacementElements
 	"Destructively replace the elements of the receiver between the <integer> arguments
@@ -1129,6 +1141,7 @@ writeStream
 !SequenceableCollection categoriesFor: #anyOne!accessing!public! !
 !SequenceableCollection categoriesFor: #appendToStream:!double dispatch!private! !
 !SequenceableCollection categoriesFor: #approxSize!accessing!private! !
+!SequenceableCollection categoriesFor: #asArray!converting!public! !
 !SequenceableCollection categoriesFor: #asRunArray!converting!public! !
 !SequenceableCollection categoriesFor: #associations!accessing!public! !
 !SequenceableCollection categoriesFor: #at:!accessing!public!testing! !

--- a/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
@@ -89,6 +89,166 @@ earlyTermination: aBoolean
 			self assert: proc isTerminated.
 			self assert: Processor pendingTerminations isEmpty]!
 
+exerciseReplaceElementsOf: targetCollection from: startInteger to: stopInteger with: sourceCollection startingAt: startAtInteger
+	| fieldsBefore fieldsAfter captureFields expected target |
+	captureFields := [:obj | (1 to: obj class instSize) collect: [:i | obj instVarAt: i]].
+	fieldsBefore := captureFields value: targetCollection.
+	target := targetCollection copy.
+	sourceCollection
+		replaceElementsOf: target
+		from: startInteger
+		to: stopInteger
+		startingAt: startAtInteger.
+	"The fixed fields should not have been touched"
+	fieldsAfter := captureFields value: target.
+	self assert: fieldsAfter = fieldsBefore.
+	"Build the expected result using low-level operations to avoid inadvertently using the primitive under test"
+	expected := targetCollection class ofSize: targetCollection size.
+	1 to: startInteger - 1 do: [:i | expected at: i put: (targetCollection at: i)].
+	startInteger to: stopInteger
+		do: [:i | expected at: i put: (sourceCollection at: i - startInteger + startAtInteger)].
+	stopInteger + 1 to: targetCollection size do: [:i | expected at: i put: (targetCollection at: i)].
+	"Did it work?"
+	self assert: target = expected!
+
+exerciseReplaceElementsOf: targetCollection with: sourceCollection
+	| target |
+	targetCollection isImmutable: true.
+
+	"Immutable target"
+	self should: 
+			[sourceCollection
+				replaceElementsOf: targetCollection
+				from: 1
+				to: targetCollection size
+				startingAt: 1]
+		raise: Processor constWriteSignal.
+
+	"Move first of source to first of target"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: 1
+		to: 1
+		with: sourceCollection
+		startingAt: 1.
+
+	"Move last of source to first of target"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: 1
+		to: 1
+		with: sourceCollection
+		startingAt: sourceCollection size.
+
+	"First over last"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: targetCollection size
+		to: targetCollection size
+		with: sourceCollection
+		startingAt: 1.
+
+	"Move two from middle of source to middle of target"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: 2
+		to: 3
+		with: sourceCollection
+		startingAt: 3.
+
+	"From 2 to end of source over whole target"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: 1
+		to: targetCollection size
+		with: sourceCollection
+		startingAt: 2.
+
+	"Complete overwrite"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: 1
+		to: targetCollection size
+		with: sourceCollection
+		startingAt: 1.
+
+	"Move last of target to middle of source"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: 2
+		to: 2
+		with: sourceCollection
+		startingAt: sourceCollection size.
+
+	"Last two from source over last two from target"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: targetCollection size - 1
+		to: targetCollection size
+		with: sourceCollection
+		startingAt: sourceCollection size - 1.
+
+	"Shuffle down - needs to be done forwards, or will get all 5's"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: 1
+		to: targetCollection size - 1
+		with: targetCollection
+		startingAt: 2.
+
+	"Shuffle up - needs to be done in reverse, or will get all 1's"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: 2
+		to: targetCollection size
+		with: targetCollection
+		startingAt: 1.
+
+	"No-op move over self"
+	self
+		exerciseReplaceElementsOf: targetCollection
+		from: 1
+		to: targetCollection size
+		with: targetCollection
+		startingAt: 1.
+
+	"StartAt = end, count = 2 (source bounds error)"
+	target := targetCollection copy.
+	self should: 
+			[sourceCollection
+				replaceElementsOf: target
+				from: 1
+				to: 2
+				startingAt: sourceCollection size]
+		raise: BoundsError.
+
+	"Off end of target"
+	target := targetCollection copy.
+	self should: 
+			[sourceCollection
+				replaceElementsOf: target
+				from: 2
+				to: target size + 1
+				startingAt: 1]
+		raise: BoundsError.
+
+	"Overlapping out of bounds"
+	target := targetCollection copy.
+	self should: 
+			[target
+				replaceElementsOf: target
+				from: 1
+				to: 5
+				startingAt: 2]
+		raise: BoundsError.
+	self should: 
+			[target
+				replaceElementsOf: target
+				from: 2
+				to: 6
+				startingAt: 1]
+		raise: BoundsError!
+
 getCPUTime
 	"Answer the total CPU time consumed since Dolphin was started, in milliseconds."
 
@@ -625,6 +785,13 @@ testPrimitiveIsNullBytes
 			bytes := DWORDBytes newFixed: each.
 			self assert: bytes isNull]!
 
+testPrimitiveReplaceElements
+	self exerciseReplaceElementsOf: #($a $b $c $d $e) with: #(1 2 3 4 5 6).
+	self exerciseReplaceElementsOf: #($a $b $c $d $e) with: #(1 2 3 4 5 6) asOrderedCollection.
+	self exerciseReplaceElementsOf: #($a $b $c $d $e) asOrderedCollection with: #(1 2 3 4 5 6).
+	self exerciseReplaceElementsOf: #($a $b $c $d $e) asOrderedCollection
+		with: #(1 2 3 4 5 6) asOrderedCollection!
+
 testPrimitiveStringAt
 	| array |
 	
@@ -696,6 +863,8 @@ testSignedFromUnsigned
 !VMTest categoriesFor: #assertImmutableInstVarAtPut:!private!unit tests! !
 !VMTest categoriesFor: #assertImmutableResize:!private!unit tests! !
 !VMTest categoriesFor: #earlyTermination:!helpers!public! !
+!VMTest categoriesFor: #exerciseReplaceElementsOf:from:to:with:startingAt:!private!unit tests! !
+!VMTest categoriesFor: #exerciseReplaceElementsOf:with:!private!unit tests! !
 !VMTest categoriesFor: #getCPUTime!helpers!private! !
 !VMTest categoriesFor: #isGPF:reading:address:!helpers!private! !
 !VMTest categoriesFor: #suspendAndTerminate!helpers!public! !
@@ -721,6 +890,7 @@ testSignedFromUnsigned
 !VMTest categoriesFor: #testPrimitiveAt!public!unit tests! !
 !VMTest categoriesFor: #testPrimitiveAtPut!public!unit tests! !
 !VMTest categoriesFor: #testPrimitiveIsNullBytes!public!unit tests! !
+!VMTest categoriesFor: #testPrimitiveReplaceElements!public!unit tests! !
 !VMTest categoriesFor: #testPrimitiveStringAt!public!unit tests! !
 !VMTest categoriesFor: #testSignedFromUnsigned!public!unit tests! !
 


### PR DESCRIPTION
VM lacks primitive for block copying of pointer objects #62. This will be
primitive 188. Add tests and methods that will call the primitive if
running on a VM with the change.