### PR TITLE
Replace #pumpMessages with #prod in UnitTestPlugin to avoid callback-lock

### DIFF
--- a/Core/Object Arts/Dolphin/Base/InputState.cls
+++ b/Core/Object Arts/Dolphin/Base/InputState.cls
@@ -461,9 +461,12 @@ pumpMessages
 	is received, then exit Smalltalk. This can be used from user code to empty the message queue
 	if necessary."
 
-	| msg |
-	msg := MSG new.
-	self loopWhile: [self isInputReady: msg]!
+	Processor isActiveMain
+		ifTrue: 
+			[| msg |
+			msg := MSG new.
+			self loopWhile: [self isInputReady: msg]]
+		ifFalse: [self prod].!
 
 purgeDeadWindows
 	"Remove any windows in the windows collection which have a NULL handle. In normal use there

--- a/Core/Object Arts/Dolphin/IDE/Professional/UnitTestPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/UnitTestPlugin.cls
@@ -110,11 +110,11 @@ displayDefects: aCollection
 	defectsPresenter list: aCollection.
 	defectsPresenter view isEnabled: aCollection notEmpty!
 
-displayDetails: aString
+displayDetails: aString 
 	"Display aString to indicate additional details about the current mode of operation"
 
 	detailsPresenter value: aString.
-	SessionManager inputState prod.!
+	SessionManager inputState pumpMessages!
 
 displayFail
 	"Indicate that some tests have failed and we have defects"
@@ -287,7 +287,7 @@ queryCommand: aCommandQuery
 
 refreshIcon
 	self view arrangement: self.
-	SessionManager inputState prod.!
+	SessionManager inputState pumpMessages!
 
 runIndividualTests
 	| suite |

--- a/Core/Object Arts/Dolphin/IDE/Professional/UnitTestPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/UnitTestPlugin.cls
@@ -110,11 +110,11 @@ displayDefects: aCollection
 	defectsPresenter list: aCollection.
 	defectsPresenter view isEnabled: aCollection notEmpty!
 
-displayDetails: aString 
+displayDetails: aString
 	"Display aString to indicate additional details about the current mode of operation"
 
 	detailsPresenter value: aString.
-	SessionManager inputState pumpMessages!
+	SessionManager inputState prod.!
 
 displayFail
 	"Indicate that some tests have failed and we have defects"
@@ -287,7 +287,7 @@ queryCommand: aCommandQuery
 
 refreshIcon
 	self view arrangement: self.
-	SessionManager inputState pumpMessages!
+	SessionManager inputState prod.!
 
 runIndividualTests
 	| suite |
@@ -311,8 +311,8 @@ startAutoSwitchProcess
 	autoSwitchProcess := 
 			[Processor sleep: self class autoSwitchDelayMs.
 			self ensureVisible.
-			SessionManager inputState pumpMessages] 
-					forkAt: Processor highIOPriority!
+			SessionManager inputState prod]
+					forkAt: Processor highIOPriority.!
 
 stopAutoSwitchProcess
 	autoSwitchProcess ifNotNil: [:process | process terminate].


### PR DESCRIPTION
Steps to reproduce:

1. Open two class browsers on two classes which have at least one selector in common.
2. Select a number of methods in one, including at least one method which the other class also implements. (Not sure how many methods have to be involved, or whether it has something to do with in/out of view, presence of a scroll bar, etc.)
3. Drag the methods to the other class. Answer "Yes" to "do you want to replace the existing implementation?".

The image will become callback-locked, with two Main processes waiting for each others' callbacks to return. One of them is stuck within ListView>>wmPaint:wParam:lParam:, which means the source ListView cannot repaint. Something about this also seems to make WM_TIMER stop working--autocomplete lists don't appear, the cursor doesn't blink (!), etc.

I traced the cause to the calls to #pumpMessages in three methods of the UnitTestPlugin. They are happening in a priority-6, no-longer-actually-Main process after the MessageBox returns, and end up interrupting the actual Main process (at priority 5) at a bad time.

The problem goes away if I change the #pumpMessages to a #prod. Perhaps it would also be okay to say `Processor isActiveMain ifTrue: [SessionManager inputState pumpMessages] ifFalse: [SessionManager inputState prod]`--if that's clearly better, let me know and I'll update my branch, otherwise I'm inclined to play things safe.

I think there's also a problem with the VM's handling of the callback stack, because if I terminate both Mains (this takes a couple tries and a Ctrl+F12 to clear the callbacks), the one at priority 6 remains stuck on the pendingReturns semaphore, claiming it is still within 3 callbacks. In one image I was unable to ever terminate it. Trying it now, a couple more #terminate calls did eventually make it go away, but it was clearly stuck on a "phantom" callback, since no other processes in the image had any.