### PR TITLE
Float>>printOn:decimalPlaces: does not handle NaN

### DIFF
--- a/Core/Object Arts/Dolphin/Base/CRTLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/CRTLibrary.cls
@@ -158,12 +158,6 @@ _i64toa: aSmallInteger string: aString radix: anInteger
 	<cdecl: lpstr _i64toa sqword lpstr sdword>
 	^self invalidCall!
 
-_isnan: aFloat
-	"Answer whether the argument is NaN (Not a Number)."
-
-	<cdecl: bool _isnan double>
-	^self invalidCall!
-
 _logb: aFloat
 	"Answer the exponent of the argument, aFloat."
 
@@ -695,7 +689,6 @@ wcscspn: aUnicodeString strCharSet: strCharSet
 !CRTLibrary categoriesFor: #_gcvt:count:buffer:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_getcwd:maxlen:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_i64toa:string:radix:!CRT functions-data conversion!public! !
-!CRTLibrary categoriesFor: #_isnan:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_logb:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_ltoa:string:radix:!CRT functions-data conversion!public! !
 !CRTLibrary categoriesFor: #_makepath:drive:dir:fname:ext:!CRT functions-file handling!public! !

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -1387,7 +1387,7 @@ ArithmeticValue subclass: #Point
 	classInstanceVariableNames: ''!
 Number variableByteSubclass: #Float
 	instanceVariableNames: ''
-	classVariableNames: 'EMin FMax FMin Infinity Ln2 MinValLogBase2 NegativeZero Precision SignificantDifference'
+	classVariableNames: 'EMin FpClassInfinite FpClassNaN FpClassNegative FpClassStrictlyPositive FpClassZero Ln2 MinValLogBase2 Precision SignificantDifference'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Number subclass: #Fraction

--- a/Core/Object Arts/Dolphin/Base/Float.cls
+++ b/Core/Object Arts/Dolphin/Base/Float.cls
@@ -2,14 +2,18 @@
 
 Number variableByteSubclass: #Float
 	instanceVariableNames: ''
-	classVariableNames: 'EMin FMax FMin Infinity Ln2 MinValLogBase2 NegativeZero Precision SignificantDifference'
+	classVariableNames: 'EMin FpClassInfinite FpClassNaN FpClassNegative FpClassStrictlyPositive FpClassZero Ln2 MinValLogBase2 Precision SignificantDifference'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Float guid: (GUID fromString: '{87B4C65A-026E-11D3-9FD7-00A0CC3E4A32}')!
 Float addClassConstant: 'EMin' value: -1022!
+Float addClassConstant: 'FpClassInfinite' value: 516!
+Float addClassConstant: 'FpClassNaN' value: 3!
+Float addClassConstant: 'FpClassNegative' value: 60!
+Float addClassConstant: 'FpClassStrictlyPositive' value: 896!
+Float addClassConstant: 'FpClassZero' value: 96!
 Float addClassConstant: 'Ln2' value: 0.6931471805599453!
 Float addClassConstant: 'MinValLogBase2' value: -1074!
-Float addClassConstant: 'NegativeZero' value: -0.0!
 Float addClassConstant: 'Precision' value: 53!
 Float addClassConstant: 'SignificantDifference' value: 1.0e-9!
 Float comment: 'Float is the class of double precision floating point Numbers (64-bit) in IEEE-754 format. Note that the original Smalltalk-80 definition of Float, was only single precision, but this is considered somewhat outdated. Rather than introduce the complexity of multiple classes to represent floating point numbers, we have chosen to standardise on double precision.
@@ -108,10 +112,6 @@ absPrintExactlyOn: aStream base: base
 	by using exact integer arithmetic, and is based on the same method in Squeak."
 
 	| significand exp baseExpEstimate r s mPlus mMinus scale roundingIncludesLimits d tc1 tc2 fixedFormat decPointCount slowbit shead |
-	self isInfinite
-		ifTrue: 
-			[aStream nextPutAll: 'Infinity'.
-			^self].
 	significand := self finiteSignificand.
 	roundingIncludesLimits := significand even.
 	exp := self exponent - 52 max: MinValLogBase2.
@@ -193,10 +193,6 @@ absPrintExactlyOn: aStream base: base decimalPlaces: placesDesired showTrailingF
 	June 1996.."
 
 	| significand exp baseExpEstimate r s mPlus mMinus scale roundingLowIncludesLimits roundingHighIncludesLimits d tc1 tc2 decPointCount slowbit shead delta |
-	self isInfinite
-		ifTrue: 
-			[aStream nextPutAll: 'Infinity'.
-			^self].
 	significand := self finiteSignificand.
 	exp := self exponent - 52 max: MinValLogBase2.
 	exp >= 0
@@ -487,6 +483,9 @@ floorLog10
 
 	^self log floor!
 
+fpClass
+	^CRTLibrary default _fpclass: self!
+
 fractionPart
 	"Answer a <Float> representing the fractional part of the receiver."
 
@@ -548,8 +547,7 @@ isFinite
 isInfinite
 	"Answer whether the receiver represents infinity (positive or negative)."
 
-	^(CRTLibrary default _fpclass: self)
-		anyMask: ##(CRTConstants._FPCLASS_NINF | CRTConstants._FPCLASS_PINF)!
+	^self fpClass anyMask: FpClassInfinite!
 
 isLiteral
 	"Answer whether the receiver has a literal string representation that can be compiled to
@@ -561,7 +559,7 @@ isLiteral
 isNaN
 	"Answer whether the receiver is Not a Number."
 
-	^CRTLibrary default _isnan: self!
+	^self fpClass anyMask: FpClassNaN!
 
 lessOrEquals: aNumber 
 	"Answer whether the receiver is numerically less than or equal to aNumber, within the
@@ -625,30 +623,43 @@ printOn: aStream base: anInteger
 	representation. More over, every Float can be reconstructed from its printed representation
 	with #readFrom:."
 
-	self isNaN
+	| classification |
+	classification := self fpClass.
+	(classification anyMask: FpClassNaN)
 		ifTrue: 
 			[aStream nextPutAll: 'NaN'.
-			^self].	"check for NaN before sign"
-	self > 0.0
-		ifTrue: [self absPrintExactlyOn: aStream base: anInteger]
-		ifFalse: 
-			[self sign = -1 ifTrue: [aStream nextPutAll: '-'].
-			self = 0.0
-				ifTrue: [aStream nextPutAll: '0.0']
-				ifFalse: [self negated absPrintExactlyOn: aStream base: anInteger]]!
+			^self].
+	(classification anyMask: FpClassNegative) ifTrue: [aStream nextPut: $-].
+	(classification anyMask: FpClassInfinite)
+		ifTrue: 
+			[aStream nextPutAll: 'Infinity'.
+			^self].
+	(classification anyMask: FpClassZero)
+		ifTrue: [aStream nextPutAll: '0.0']
+		ifFalse: [self absPrintExactlyOn: aStream base: anInteger]!
 
 printOn: aStream decimalPlaces: anInteger
-	"Append the printed representation of the receiver to the <puttableStream>, aStream, rounded to the <integer> number of decimal places, anInteger."
+	"Append the printed representation of the receiver to the <puttableStream>, aStream, rounded
+	to the <integer> number of decimal places, anInteger."
 
-	self isFinite ifFalse: [^self printOn: aStream].
-	self sign = -1 ifTrue: [aStream nextPutAll: '-'].
-	self = 0.0
+	| classification |
+	classification := self fpClass.
+	(classification anyMask: FpClassNaN)
+		ifTrue: 
+			[aStream nextPutAll: 'NaN'.
+			^self].
+	(classification anyMask: FpClassNegative) ifTrue: [aStream nextPut: $-].
+	(classification anyMask: FpClassInfinite)
+		ifTrue: 
+			[aStream nextPutAll: 'Infinity'.
+			^self].
+	(classification anyMask: FpClassZero)
 		ifTrue: 
 			[aStream nextPut: $0.
 			anInteger > 0
 				ifTrue: 
 					[aStream nextPut: $..
-					anInteger timesRepeat: [aStream nextPut: $0]]]
+					aStream next: anInteger put: $0]]
 		ifFalse: 
 			[self
 				absPrintExactlyOn: aStream
@@ -725,15 +736,10 @@ sign
 		0 if equal to 0."
 
 	| classification |
-	classification := CRTLibrary default _fpclass: self.
-	(classification
-		anyMask: ##(CRTConstants._FPCLASS_PD | CRTConstants._FPCLASS_PN | CRTConstants._FPCLASS_PINF))
-			ifTrue: [^1].
+	classification := self fpClass.
+	(classification anyMask: FpClassStrictlyPositive) ifTrue: [^1].
 	"Handle IEEE-754 negative-zero by reporting a sign of -1"
-	(classification
-		anyMask: ##(CRTConstants._FPCLASS_ND | CRTConstants._FPCLASS_NN | CRTConstants._FPCLASS_NINF
-				| CRTConstants._FPCLASS_NZ))
-			ifTrue: [^-1].
+	(classification anyMask: FpClassNegative) ifTrue: [^-1].
 	^0!
 
 significandAsInteger
@@ -843,6 +849,7 @@ truncated
 !Float categoriesFor: #finiteSignificand!helpers!private! !
 !Float categoriesFor: #floor!public!truncation and round off! !
 !Float categoriesFor: #floorLog10!mathematical!public! !
+!Float categoriesFor: #fpClass!helpers!private! !
 !Float categoriesFor: #fractionPart!accessing!public! !
 !Float categoriesFor: #generality!coercing!private! !
 !Float categoriesFor: #greaterOrEquals:!comparing!public! !
@@ -926,7 +933,7 @@ fmax
 	"Answer a <Float> representing the largest value
 	allowed by the characterized floating point representation."
 
-	^FMax!
+	^1.7976931348623157e308!
 
 fmin
 	"Answer a <Float> representing the smallest value
@@ -946,7 +953,7 @@ fminNormalized
 	"Answer a <Float> representing the smallest normalized value
 	allowed by the characterized floating point representation."
 
-	^FMin!
+	^2.2250738585072014e-308!
 
 icon
 	"Answers an Icon that can be used to represent this class"
@@ -958,13 +965,27 @@ initialize
 		Float initialize
 	"
 
+	self addClassConstant: 'EMin' value: -1022.
+	self addClassConstant: 'Ln2' value: 0.6931471805599453.
+	self addClassConstant: 'MinValLogBase2' value: -1074.
+	self addClassConstant: 'Precision' value: 53.
+	self addClassConstant: 'SignificantDifference' value: 1.0e-9.
 	self assert: [SignificantDifference >= self epsilon].
+	self addClassConstant: 'FpClassInfinite'
+		value: CRTConstants._FPCLASS_NINF | CRTConstants._FPCLASS_PINF.
+	self addClassConstant: 'FpClassStrictlyPositive'
+		value: CRTConstants._FPCLASS_PD | CRTConstants._FPCLASS_PN | CRTConstants._FPCLASS_PINF.
+	self addClassConstant: 'FpClassNegative'
+		value: CRTConstants._FPCLASS_ND | CRTConstants._FPCLASS_NN | CRTConstants._FPCLASS_NINF
+				| CRTConstants._FPCLASS_NZ.
+	self addClassConstant: 'FpClassZero' value: CRTConstants._FPCLASS_NZ | CRTConstants._FPCLASS_PZ.
+	self addClassConstant: 'FpClassNaN' value: CRTConstants._FPCLASS_QNAN | CRTConstants._FPCLASS_SNAN.
 	#(#FloatD #FloatE #FloatQ) do: [:each | Smalltalk at: each ifAbsentPut: [self]]!
 
 negativeZero
 	"Answer the IEEE 754 representation for negative zero"
 
-	^NegativeZero!
+	^-0.0!
 
 new
 	"Answer a new instance of the receiver."

--- a/Core/Object Arts/Dolphin/Base/FloatTest.cls
+++ b/Core/Object Arts/Dolphin/Base/FloatTest.cls
@@ -44,6 +44,12 @@ predecessor: aFloat
 	ulp := self ulp: aFloat.
 	^aFloat - (0.5 * ulp) = aFloat ifTrue: [aFloat - ulp] ifFalse: [aFloat - (0.5 * ulp)]!
 
+printString: aFloat decimalPlaces: anInteger
+	| stream |
+	stream := String writeStream.
+	aFloat printOn: stream decimalPlaces: anInteger.
+	^stream contents!
+
 setUp
 	Float reset.
 	super setUp!
@@ -344,58 +350,68 @@ testOverflow
 !
 
 testPrintOnDecimalPlaces
-	| stream |
-	stream := String writeStream.
-	3.999 printOn: stream decimalPlaces: 4.
-	self assert: stream contents equals: '3.9990'.
-	stream := String writeStream.
-	3.999 printOn: stream decimalPlaces: 3.
-	self assert: stream contents equals: '3.999'.
-	stream := String writeStream.
-	3.999 printOn: stream decimalPlaces: 2.
-	self assert: stream contents equals: '4.00'.
-	stream := String writeStream.
-	3.999 printOn: stream decimalPlaces: 1.
-	self assert: stream contents equals: '4.0'.
-
-	"Defect #373 - produced 3"
-	stream := String writeStream.
-	3.999 printOn: stream decimalPlaces: 0.
-	self assert: stream contents equals: '4'.
-
-	"Previous implementation was failing when sending to zero."
-	stream := String writeStream.
-	0.0 printOn: stream decimalPlaces: 0.
-	self assert: stream contents equals: '0'.
-	stream := String writeStream.
-	0.0 printOn: stream decimalPlaces: 1.
-	self assert: stream contents equals: '0.0'.
-	stream := String writeStream.
-	0.0 printOn: stream decimalPlaces: 2.
-	self assert: stream contents equals: '0.00'.
-
-	"Regression test for negative zero."
-	stream := String writeStream.
-	-0.0 printOn: stream decimalPlaces: 0.
-	self assert: stream contents equals: '-0'.
-	stream := String writeStream.
-	-0.0 printOn: stream decimalPlaces: 1.
-	self assert: stream contents equals: '-0.0'.
-	stream := String writeStream.
-	-0.0 printOn: stream decimalPlaces: 2.
-	self assert: stream contents equals: '-0.00'.!
+	| fmax fminDenorm fmin |
+	self assert: '3.9990' equals: (self printString: 3.999 decimalPlaces: 4).
+	self assert: '3.999' equals: (self printString: 3.999 decimalPlaces: 3).
+	self assert: '4.00' equals: (self printString: 3.999 decimalPlaces: 2).
+	self assert: '4.0' equals: (self printString: 3.999 decimalPlaces: 1).
+	self assert: '4' equals: (self printString: 3.999 decimalPlaces: 0).
+	self assert: '0' equals: (self printString: Float zero decimalPlaces: 0).
+	self assert: '0.0' equals: (self printString: Float zero decimalPlaces: 1).
+	self assert: '0.00' equals: (self printString: Float zero decimalPlaces: 2).
+	self assert: '-0' equals: (self printString: Float negativeZero decimalPlaces: 0).
+	self assert: '-0.0' equals: (self printString: Float negativeZero decimalPlaces: 1).
+	self assert: '-0.000' equals: (self printString: Float negativeZero decimalPlaces: 3).
+	self assert: '3.141592653589793' equals: (self printString: Float pi decimalPlaces: 15).
+	self assert: '3.142' equals: (self printString: Float pi decimalPlaces: 3).
+	fmin := (String writeStream)
+				nextPutAll: '0.';
+				next: 308 - 1 put: $0;
+				nextPutAll: '22250738585072014';
+				contents.
+	self assert: fmin equals: (self printString: Float fminNormalized decimalPlaces: 308 + 16).
+	self assert: '-' , fmin
+		equals: (self printString: Float fminNormalized negated decimalPlaces: 308 + 16).
+	self assert: '0.00' equals: (self printString: Float fminNormalized decimalPlaces: 2).
+	fminDenorm := (String writeStream)
+				nextPutAll: '0.';
+				next: 324 - 1 put: $0;
+				nextPutAll: '5';
+				contents.
+	self assert: fminDenorm equals: (self printString: Float fminDenormalized decimalPlaces: 324).
+	self assert: '-' , fminDenorm
+		equals: (self printString: Float fminDenormalized negated decimalPlaces: 324).
+	fmax := (String writeStream)
+				nextPutAll: '17976931348623157';
+				next: 308 - 16 put: $0;
+				nextPutAll: '.00000';
+				contents.
+	self assert: fmax equals: (self printString: Float fmax decimalPlaces: 5).
+	self assert: '-' , fmax equals: (self printString: Float fmax negated decimalPlaces: 5).
+	self assert: 'Infinity' equals: (self printString: self infinity decimalPlaces: 2).
+	self assert: 'Infinity' equals: (self printString: self infinity decimalPlaces: 0).
+	self assert: '-Infinity' equals: (self printString: self negativeInfinity decimalPlaces: 2).
+	self assert: '-Infinity' equals: (self printString: self negativeInfinity decimalPlaces: 0).
+	self assert: 'NaN' equals: (self printString: self nan decimalPlaces: 1).
+	self assert: 'NaN' equals: (self printString: self nan decimalPlaces: 0).
+	self assert: 'NaN' equals: (self printString: self nan negated decimalPlaces: 2)!
 
 testPrintString
-	self assert: 1.3 printString equals: '1.3'.
-	self assert: (4.0 / 3.0) printString equals: '1.3333333333333333'.
-	self assert: Float negativeZero printString equals: '-0.0'.
-	self assert: Float pi printString equals: '3.141592653589793'.
-	self assert: Float fminNormalized printString equals: '2.2250738585072014e-308'.
-	self assert: Float fminDenormalized printString equals: '5.0e-324'.
-	self assert: Float fmax printString equals: '1.7976931348623157e308'.
-	self assert: self infinity printString equals: 'Infinity'.
-	self assert: self negativeInfinity printString equals: '-Infinity'.
-	self assert: self nan printString equals: 'NaN'!
+	self assert: '1.3' equals: 1.3 printString.
+	self assert: '1.3333333333333333' equals: (4.0 / 3.0) printString.
+	self assert: '0.0' equals: Float zero printString.
+	self assert: '-0.0' equals: Float negativeZero printString.
+	self assert: '3.141592653589793' equals: Float pi printString.
+	self assert: '2.2250738585072014e-308' equals: Float fminNormalized printString.
+	self assert: '-2.2250738585072014e-308' equals: Float fminNormalized negated printString.
+	self assert: '5.0e-324' equals: Float fminDenormalized printString.
+	self assert: '-5.0e-324' equals: Float fminDenormalized negated printString.
+	self assert: '1.7976931348623157e308' equals: Float fmax printString.
+	self assert: '-1.7976931348623157e308' equals: Float fmax negated printString.
+	self assert: 'Infinity' equals: self infinity printString.
+	self assert: '-Infinity' equals: self negativeInfinity printString.
+	self assert: 'NaN' equals: self nan printString.
+	self assert: 'NaN' equals: self nan negated printString!
 
 testPrintStringAndReadBack
 	"Debug reading/printing a Floating point number without accumulating round off errors"
@@ -502,6 +518,7 @@ ulp: aFloat
 !FloatTest categoriesFor: #negativeInfinity!constants!private! !
 !FloatTest categoriesFor: #normals!constants!private! !
 !FloatTest categoriesFor: #predecessor:!helpers!private! !
+!FloatTest categoriesFor: #printString:decimalPlaces:!helpers!private! !
 !FloatTest categoriesFor: #setUp!private!Running! !
 !FloatTest categoriesFor: #shouldRaiseOverflow:!helpers!private! !
 !FloatTest categoriesFor: #shouldRaiseUnderflow:!helpers!private! !


### PR DESCRIPTION
Use FP classification flags for consistent printing of floats.
Improve the unit tests and add coverage for this bug.