### PR TITLE
Eliminate rogue ".img" file in early boot process

### DIFF
--- a/Boot.st
+++ b/Boot.st
@@ -83,8 +83,7 @@ devsesh onPreSaveImage.
 	maxObjects: 24576*1024
 ] ensure: [devsesh onPostSaveImage]!
 
-"Remove rogue .img and unnecessary .chg files"
-File delete: (File default: SessionManager current imagePath extension: 'img').
+"Remove unnecessary .chg files"
 File delete: 'DBOOT.chg'!
 
 SessionManager current quit!

--- a/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
@@ -292,6 +292,6 @@ updateBootImage
 imageExtension
 	"Answer the suffix for an executable image file"
 
-	^'img'! !
+	^'img7'.! !
 !BootSessionManager class categoriesFor: #imageExtension!constants!public! !
 


### PR DESCRIPTION
Seems like this was mentioned many months ago as a silly minor annoyance... Poking around SessionManager, it seems like getting rid of it is really simple, so unless I'm missing something, here you go.