### PR TITLE
Remove redundant and subtly-wrong ListView>>selectionByIndex:ifAbsent:.

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -1848,25 +1848,6 @@ selectIndex: anInteger set: aBoolean
 	aBoolean ifTrue: [anLvItem dwState: mask].
 	self lvmSetItem: anInteger - 1 state: anLvItem!
 
-selectionByIndex: anInteger ifAbsent: exceptionHandler 
-	"Select the object identified by the specified <integer> index in the receiver. If the index
-	is zero then all selections are cleared. "
-
-	(lastSelIndices includes: anInteger) 
-		ifFalse: 
-			[| newSelIndices |
-			anInteger = self noSelection 
-				ifTrue: 
-					[self basicResetSelection.
-					newSelIndices := #()]
-				ifFalse: 
-					[(anInteger between: 1 and: self size) ifFalse: [^exceptionHandler value].
-					self ensureVisible: anInteger.
-					newSelIndices := Array with: anInteger.
-					self basicSelectionsByIndex: newSelIndices].
-			self onSelChanged].
-	^anInteger!
-
 selectionFromPoint: pos
 	"Private - Answer the <integer> selection that would occur if a mouse click at the
 	<Point>, pos, was passed to the control."
@@ -2352,7 +2333,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #selectAll!public!selection! !
 !ListView categoriesFor: #selectedCount!private!selection! !
 !ListView categoriesFor: #selectIndex:set:!private!selection!wine fix! !
-!ListView categoriesFor: #selectionByIndex:ifAbsent:!public!selection! !
 !ListView categoriesFor: #selectionFromPoint:!event handling!private! !
 !ListView categoriesFor: #selections:ifAbsent:!public!selection! !
 !ListView categoriesFor: #selectionsByIndex:ifAbsent:!public!selection! !


### PR DESCRIPTION
I stumbled across this while writing a test, doing something like:

```
someListView selectionsByIndex: #(1 2 4).
"Do some other stuff..."
someListView selectionByIndex: #(1).
"Make some assertions about how other views change as a result"
```

And being baffled why those assertions were failing—then looking at the view and realizing that the selection never changed. I traced the cause to a bug in the way ListView>>selectionByIndex: decides whether or not it can just bail because nothing is changing, such that trying to set the selection to exactly one of the (multiple) items that are already selected will bail without deselecting the others.

It seems like the inherited implementation already forwards to #selection*s*ByIndex: in a reasonable way (which works fine for a view in single-select mode), so the override can simply be removed.