### PR TITLE
Replace deprecated SQLError function with SQLGetDiagRec

### DIFF
--- a/Core/Object Arts/Dolphin/Database/DBConnection.cls
+++ b/Core/Object Arts/Dolphin/Database/DBConnection.cls
@@ -1447,8 +1447,7 @@ transact: aDBConnection action: anInteger
 				sqlEndTran: SQL_HANDLE_DBC
 				handle: aDBConnection asParameter
 				completionType: anInteger.
-	ret ~= SQL_SUCCESS 
-		ifTrue: [DBError signalWith: (self exceptionDetails: ret)]! !
+	ret ~= SQL_SUCCESS ifTrue: [DBError signalWith: (aDBConnection exceptionDetails: ret)].! !
 !DBConnection class categoriesFor: #allocHandle!helpers!private! !
 !DBConnection class categoriesFor: #connections!accessing!public! !
 !DBConnection class categoriesFor: #connectString:do:!operations!private! !

--- a/Core/Object Arts/Dolphin/Database/DBExceptionDetails.cls
+++ b/Core/Object Arts/Dolphin/Database/DBExceptionDetails.cls
@@ -33,32 +33,40 @@ buildErrorInfo
 	 a 'reduced' error is created using the return code from function
 	 which caused the error"
 
-	(code ~~ SQL_SUCCESS and: [code ~~ SQL_INVALID_HANDLE]) 
-		ifTrue: 
-			[| szSqlState fNativeError szErrorMsg cbErrorMsg |
-			szSqlState := String new: SQL_STATE_SIZE + 1.
-			szErrorMsg := String new: 512.
-			cbErrorMsg := SWORD new.
-			fNativeError := SDWORD new.
-			
-			[(ODBCLibrary default 
-				sqlError: hEnv
-				hdbc: hDBC
-				hstmt: hStmt
-				szSqlState: szSqlState
-				pfNativeError: fNativeError
-				szErrorMsg: szErrorMsg
-				cbErrorMsgMax: szErrorMsg size
-				pcbErrorMsg: cbErrorMsg) = SQL_SUCCESS] 
-					whileTrue: 
-						[| newErr |
-						newErr := DBErrorDetails 
-									fromSQLError: (szErrorMsg copyFrom: 1 to: cbErrorMsg asInteger).
-						newErr
-							nativeErr: fNativeError asInteger;
-							sqlState: (szSqlState copyFrom: 1 to: 5).
-						self addErrorDetails: newErr]].
-	errors isNil ifTrue: [self retCodeError: code]!
+	(code ~~ SQL_SUCCESS and: [code ~~ SQL_INVALID_HANDLE]) ifTrue:
+			[hEnv isNull ifFalse: [self buildErrorInfoFrom: hEnv type: SQL_HANDLE_ENV].
+			hDBC isNull ifFalse: [self buildErrorInfoFrom: hDBC type: SQL_HANDLE_DBC].
+			hStmt isNull ifFalse: [self buildErrorInfoFrom: hStmt type: SQL_HANDLE_STMT]].
+	errors isNil ifTrue: [self retCodeError: code].!
+
+buildErrorInfoFrom: anExternalHandle type: anIntegerHandleType
+	"Private - Retrieve all error information available from the ODBC Driver
+	 for <anExternalHandle>, which is of type <anIntegerHandleType>"
+
+	| szSqlState fNativeError szErrorMsg cbErrorMsg recNumber |
+	szSqlState := String new: SQL_STATE_SIZE + 1.
+	szErrorMsg := String new: 512.
+	cbErrorMsg := SWORD new.
+	fNativeError := SDWORD new.
+	recNumber := 1.
+	
+	[(ODBCLibrary default
+		sqlGetDiagRec: anIntegerHandleType
+		handle: anExternalHandle
+		recNumber: recNumber
+		szSqlState: szSqlState
+		pfNativeError: fNativeError
+		szErrorMsg: szErrorMsg
+		cbErrorMsgMax: szErrorMsg size
+		pcbErrorMsg: cbErrorMsg) = SQL_SUCCESS] 
+			whileTrue:
+				[| newErr |
+				newErr := DBErrorDetails fromSQLError: (szErrorMsg copyFrom: 1 to: cbErrorMsg asInteger).
+				newErr
+					nativeErr: fNativeError asInteger;
+					sqlState: (szSqlState copyFrom: 1 to: 5).
+				self addErrorDetails: newErr.
+				recNumber := recNumber + 1].!
 
 code
 	"Answer the code instance variable."
@@ -129,6 +137,7 @@ retCodeError: anInteger
 			yourself)! !
 !DBExceptionDetails categoriesFor: #addErrorDetails:!operations!private! !
 !DBExceptionDetails categoriesFor: #buildErrorInfo!operations!private! !
+!DBExceptionDetails categoriesFor: #buildErrorInfoFrom:type:!operations!private! !
 !DBExceptionDetails categoriesFor: #code!accessing!public! !
 !DBExceptionDetails categoriesFor: #code:!accessing!private! !
 !DBExceptionDetails categoriesFor: #errors!accessing!public! !

--- a/Core/Object Arts/Dolphin/Database/ODBCLibrary.cls
+++ b/Core/Object Arts/Dolphin/Database/ODBCLibrary.cls
@@ -219,23 +219,6 @@ sqlEndTran: anExternalHandleEnv handle: anExternalHandleDBC completionType: anIn
 	<stdcall: sword SQLEndTran sword handle sword>
 	^self invalidCall!
 
-sqlError: anExternalHandleENV hdbc: anExternalHandleDBC hstmt: anExternalHandleSTMT szSqlState: anSQLStateParm pfNativeError: anIntegerParmNErr szErrorMsg: anExternalBufferErrMsg cbErrorMsgMax: anInteger pcbErrorMsg: anIntegerParmLen 
-	"RETCODE SQL_API SQLError(
-		HENV        henv,
-		HDBC        hdbc,
-		HSTMT       hstmt,
-		UCHAR  FAR *szSqlState,
-		SDWORD FAR *pfNativeError,
-		UCHAR  FAR *szErrorMsg,
-		SWORD       cbErrorMsgMax,
-		SWORD  FAR *pcbErrorMsg);
-
-	Get error or status information"
-
-	<stdcall: sword SQLError handle handle handle lpvoid lpvoid lpvoid sword lpvoid>
-	#todo.	"This API has been deprecated - replace with SQLGetDiagRec"
-	^self invalidCall!
-
 sqlExecDirect: anExternalHandle statementText: aString textLength: anInteger 
 	"SQLRETURN SQLExecDirect(
 		SQLHSTMT StatementHandle,
@@ -285,8 +268,8 @@ sqlFreeStmt: anExternalHandle option: anInteger
 	^self invalidCall!
 
 sqlGetConnectAttr: anExternalHandle attribute: idInteger valuePtr: anIntegerOrStringOrBytes bufferLength: lengthInteger stringLengthPtr: anSDWORD 
-	<stdcall: sword SQLGetConnectOption handle sdword lpvoid sdword sdword*>
-	^self invalidCall!
+	<stdcall: sword SQLGetConnectAttr handle sdword lpvoid sdword sdword*>
+	^self invalidCall.!
 
 sqlGetData: anExternalHandleSTMT columnNumber: anIntegerPar targetType: anIntegerCType targetValuePtr: anExternalBuffer bufferLength: anIntegerMax strLenOrIndPtr: anSDWORD 
 	"SQLRETURN SQLGetData(
@@ -299,6 +282,20 @@ sqlGetData: anExternalHandleSTMT columnNumber: anIntegerPar targetType: anIntege
 
 	<stdcall: sword SQLGetData handle word sword lpvoid sdword SDWORD*>
 	^self invalidCall!
+
+sqlGetDiagRec: anIntegerHandleType handle: anExternalHandle recNumber: anIntegerRecordNumber szSqlState: anSQLStateParm pfNativeError: anIntegerParmNErr szErrorMsg: anExternalBufferErrMsg cbErrorMsgMax: anInteger pcbErrorMsg: anIntegerParmLen
+	"SQLRETURN SQLGetDiagRec(
+		SQLSMALLINT     HandleType,
+		SQLHANDLE       Handle,
+		SQLSMALLINT     RecNumber,
+		SQLCHAR *       SQLState,
+		SQLINTEGER *    NativeErrorPtr,
+		SQLCHAR *       MessageText,
+		SQLSMALLINT     BufferLength,
+		SQLSMALLINT *   TextLengthPtr);"
+
+	<stdcall: sword SQLGetDiagRec word handle word lpvoid lpvoid lpvoid sword lpvoid>
+	^self invalidCall.!
 
 sqlGetFunctions: anExternalHandle functionId: anInteger supportedPtr: aWORD 
 	"Request confirmation that a particular function is implemented
@@ -327,8 +324,8 @@ sqlGetInfo: anExternalHandle infoType: anIntegerType infoValuePtr: bytes bufferL
 	^self invalidCall!
 
 sqlGetStmtAttr: anExternalHandle attribute: optionCode valuePtr: anIntegerOrStringOrBytes bufferLength: lengthInteger stringLengthPtr: anSDWORD 
-	<stdcall: sword SQLGetStmtOption handle sdword lpvoid sdword sdword*>
-	^self invalidCall!
+	<stdcall: sword SQLGetStmtAttr handle sdword lpvoid sdword sdword*>
+	^self invalidCall.!
 
 sqlNumResultCols: anExternalHandle pccol: anSWORD 
 	"Return the number of columns in the result set for the statement.
@@ -478,7 +475,6 @@ sqlTables: anExternalHandleSTMT
 !ODBCLibrary categoriesFor: #sqlDisconnect:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlDriverConnect:windowHandle:inConnectionString:stringLength1:outConnectionString:bufferLength:stringLength2Ptr:driverCompletion:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlEndTran:handle:completionType:!public!win32 functions-odbc library! !
-!ODBCLibrary categoriesFor: #sqlError:hdbc:hstmt:szSqlState:pfNativeError:szErrorMsg:cbErrorMsgMax:pcbErrorMsg:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlExecDirect:statementText:textLength:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlExecute:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlFetchScroll:fetchOrientation:fetchOffset:!public!win32 functions-odbc library! !
@@ -487,6 +483,7 @@ sqlTables: anExternalHandleSTMT
 !ODBCLibrary categoriesFor: #sqlFreeStmt:option:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlGetConnectAttr:attribute:valuePtr:bufferLength:stringLengthPtr:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlGetData:columnNumber:targetType:targetValuePtr:bufferLength:strLenOrIndPtr:!public!win32 functions-odbc library! !
+!ODBCLibrary categoriesFor: #sqlGetDiagRec:handle:recNumber:szSqlState:pfNativeError:szErrorMsg:cbErrorMsgMax:pcbErrorMsg:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlGetFunctions:functionId:supportedPtr:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlGetInfo:infoType:infoValuePtr:bufferLength:stringLengthPtr:!public!win32 functions-odbc library! !
 !ODBCLibrary categoriesFor: #sqlGetStmtAttr:attribute:valuePtr:bufferLength:stringLengthPtr:!public!win32 functions-odbc library! !


### PR DESCRIPTION
I was investigating an error thrown by a database operation that Dolphin couldn't figure out what it actually meant, and fell back to simply "SQL_ERROR" as the description. Looking at the docs, the SQLError() function used to retrieve the error description is deprecated. Lo and behold, replacing it with the successor SQLGetDiagRec() revealed the problem.

I also noticed and fixed a couple places where the Smalltalk selector reflected the current name of an ODBC function, but the actual declared name in the body was a slightly-different, older, deprecated name. (Two places where a function name used to end with "Options" and now ends with "Attr", with the same signature and behavior.)