### PR TITLE
Avoid loading MVP code in the boot script if the product to boot was passed as a parameter

### DIFF
--- a/Boot.st
+++ b/Boot.st
@@ -18,27 +18,20 @@ Package manager install: 'Core\Object Arts\Dolphin\Registry\Dolphin Registry Acc
 "We need this to install any packages containing binaries"
 Package manager install: 'Core\Object Arts\Dolphin\System\Base64\Dolphin Base64.pax'!
 
-"We'll need MVP bits in order to be able to display the choice prompter for the image version to boot"
-Package manager 	install: 'Core\Object Arts\Dolphin\Base\Dolphin Base.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\Installation Manager\Dolphin Products.pax'!
-Package manager  	install: 'Core\Object Arts\Dolphin\MVP\Dialogs\Common\Dolphin Common Dialogs.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Presenters\Choice\Dolphin Choice Presenter.pax'!
-Package manager  	install: 'Core\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter.pax'!
-Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Choice Prompter.pax'!
-
 "Set Dolphin package version and about operation"
 Object owningPackage 
 	packageVersion: VMLibrary default versionString!
+
+"Load standard Dolphin products"
+Package manager install: 'Core\Object Arts\Dolphin\Installation Manager\Dolphin Products.pax'!
 
 "If required, prompt to boot the desired end product"
 | productName product isPrompted |
 
 productName := SessionManager current argv at: 3 ifAbsent: [ | p |
-	p := ChoicePrompter
+	"We'll need MVP bits in order to be able to display the choice prompter for the image version to boot"
+	Package manager install: 'Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Choice Prompter.pax'.
+	p := (Smalltalk at: #ChoicePrompter)
 		choices: (DolphinProduct allSubclasses reject: [:each | each isAbstract]) 
 		caption: 'Product to boot...'.
 	p isNil ifTrue: [SessionManager current quit: -1].

--- a/Boot.st
+++ b/Boot.st
@@ -30,12 +30,6 @@ Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Presenters\Choice\Dolphi
 Package manager  	install: 'Core\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter.pax'!
 Package manager 	install: 'Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Choice Prompter.pax'!
 
-"It was a crap idea to have classes whose names only differed by case wasn't it - hence we need this bodge even now"
-SourceManager default fileIn: 'Core\Object Arts\Dolphin\MVP\Base\BITMAP_Struct.cls'!
-BITMAP initializeAfterLoad!
-SourceManager default fileIn: 'Core\Object Arts\Dolphin\MVP\Base\DIBSECTION_Struct.cls'!
-DIBSECTION initializeAfterLoad!
-
 "Set Dolphin package version and about operation"
 Object owningPackage 
 	packageVersion: VMLibrary default versionString!

--- a/Core/Object Arts/Dolphin/Installation Manager/Dolphin Products.pax
+++ b/Core/Object Arts/Dolphin/Installation Manager/Dolphin Products.pax
@@ -22,7 +22,6 @@ package globalAliases: (Set new
 
 package setPrerequisites: (IdentitySet new
 	add: '..\Base\Dolphin';
-	add: '..\MVP\Base\Dolphin MVP Base';
 	yourself).
 
 package!

--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinCoreProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinCoreProduct.cls
@@ -100,7 +100,13 @@ contents
 	^contents!
 
 defaultSystemFolderColor
-	^RGB red: 41 green: 124 blue: 182!
+	"Reference RGB indirectly to eliminate hard dependency on Dolphin MVP Base.
+	This method will only be called if SmalltalkSystemShell is loaded, in which case RGB will be as well."
+
+	^(Smalltalk at: #RGB)
+		red: 41
+		green: 124
+		blue: 182.!
 
 fullName
 	"Answer the full product name associated with the receiver"

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -12,7 +12,12 @@ GDILibrary openDefault!!
 "Opening the CommCtrlLibrary causes the common controls to be registered"
 CommCtrlLibrary default!!
 "Due to a limitation of the Dolphin protocols system, any protocols on a class that are incomplete without loose methods in an add-on package are lost when the add-on package is uninstalled (essentially this is because the package system is largely unaware of protocols, and so only protocols defined in the basic class are maintained). In this case we add #queryCommand: to MessageSend so that it can be used as a closed command. The command routing framework tests for the <commandTarget> protocol to see whether it should include the command itself in the route."
-MessageSend addProtocol: #commandTarget!!'.
+MessageSend addProtocol: #commandTarget!!
+"It was a crap idea to have classes whose names only differed by case wasn''t it - hence we need this bodge even now"
+SourceManager default fileIn: self path , ''BITMAP_Struct.cls''!!
+BITMAP initializeAfterLoad!!
+SourceManager default fileIn: self path , ''DIBSECTION_Struct.cls''!!
+DIBSECTION initializeAfterLoad!!'.
 package basicScriptAt: #postuninstall put: '| resIds |
 resIds := ResourceIdentifier allResourceIdentifiers.
 resIds isEmpty 


### PR DESCRIPTION
I remember some discussion on the newsgroup some months ago about the advantages of deploying applications by "building them up" from the boot image rather than "tearing them down" from a development image with Lagoon. I noticed shortly after using Dolphin 7 for the first time that the boot script loads MVP code early on even if it does not need to display a ChoicePrompter because the product to boot was provided as a command-line argument. It seems like eliminating this requirement would make it easier to boot a command-line app, or even just a simple MVP app that doesn't use ChoicePresenter/Prompter.

Dolphin Products itself also depended on Dolphin MVP Base due to using class `RGB` for `#defaultSystemFolderColor`. Since the call to that is guarded behind a `Smalltalk at: #SmalltalkSystemShell ifPresent:`, it seemed reasonable to convert this to a `Smalltalk at:` also in order to break that dependency.

Perhaps ideally, `DolphinProduct`, with all its infrastructure for the boot process, would live in its own package, with `DolphinCoreProduct` and subclasses in another package. It could then override `#boot` to add `#installSystemFolderOptions` and `#installSplash`, allowing them to be left out of the base class entirely and keeping the dependency graph reasonable without indirection. If this seems like a good idea to you, I'm happy to go ahead and do it, either on this branch or as a separate pull request.