### PR TITLE
KernelLibrary class>>#’isWine’ doesn’t work properly in runtime

### DIFF
--- a/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
@@ -1242,6 +1242,7 @@ requiredClasses
 	^(IdentitySet new: 32)
 		add: Process;
 		add: ProcessorScheduler;
+		add: NTLibrary;		"see KernalLibrary class>>#'isWine' "
 		add: self runtimeSessionManagerClass asSessionManagerClass;
 		addAll: self vmReferencedClasses;
 		yourself!

--- a/Core/Object Arts/Dolphin/Lagoon/Lagoon Image Stripper.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/Lagoon Image Stripper.pax
@@ -33,6 +33,7 @@ package globalAliases: (Set new
 
 package setPrerequisites: (IdentitySet new
 	add: '..\Base\Dolphin';
+	add: '..\Base\Dolphin Base';
 	yourself).
 
 package!


### PR DESCRIPTION
It checks to see if NTLibrary is present, but by default it is stripped. This causes it to be included. An alternate edit would be to change the KernelLibrary method. Comments and suggestions welcome!