### PR TITLE
Support definition of new base system classes in boot process

### DIFF
--- a/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
@@ -112,7 +112,7 @@ productVersion
 !
 
 reloadSystemPackage
-	| srcMgr basePackage baseClasses imageDir obsoleteMethodFilter missingClasses |
+	| srcMgr basePackage baseClasses imageDir obsoleteMethodFilter missingClasses classesBefore |
 	basePackage := PackageManager systemPackage.
 	imageDir := self imageBase.
 	srcMgr := SourceManager default.
@@ -122,11 +122,14 @@ reloadSystemPackage
 		collect: [:each | srcMgr fileIn: (File relativePathOf: each value fileOutName to: imageDir)].
 	Notification signal: 'Updating ClassBuilder...'.
 	self fileInClass: ClassBuilder.
+	classesBefore := Object withAllSubclasses.
 	Notification signal: 'Reloading BCL class definitions...'.
 	srcMgr fileIn: (File relativePathOf: basePackage classDefinitionsFileName to: imageDir).
 	Class subclasses: nil.
 	"Ensure all base classes (including any defined after the boot image was created) are packaged"
-	Object withAllSubclassesDo: [:each | each owningPackage: basePackage].
+	(Object withAllSubclasses difference: classesBefore) do: [:each | 
+		Notification signal: 'Adding new class ', each name, ' to BCL package'.
+		each owningPackage: basePackage].
 	Smalltalk clearCachedClasses.
 	"Then reload all base package classes in breadth-first order"
 	Notification signal: 'Reloading BCL classes...'.

--- a/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
@@ -123,9 +123,10 @@ reloadSystemPackage
 	Notification signal: 'Updating ClassBuilder...'.
 	self fileInClass: ClassBuilder.
 	Notification signal: 'Reloading BCL class definitions...'.
-	"First tag all the existing classes so we can spot the dead ones later."
 	srcMgr fileIn: (File relativePathOf: basePackage classDefinitionsFileName to: imageDir).
 	Class subclasses: nil.
+	"Ensure all base classes (including any defined after the boot image was created) are packaged"
+	Object withAllSubclassesDo: [:each | each owningPackage: basePackage].
 	Smalltalk clearCachedClasses.
 	"Then reload all base package classes in breadth-first order"
 	Notification signal: 'Reloading BCL classes...'.

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base.pax
@@ -8,7 +8,6 @@ package classNames
 	add: #CommandLine;
 	add: #CommandLineError;
 	add: #CommandLineOption;
-	add: #NTLibrary;
 	yourself.
 
 package binaryGlobalNames: (Set new
@@ -36,11 +35,6 @@ Object subclass: #CommandLineOption
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Notification subclass: #CommandLineError
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
-ExternalLibrary subclass: #NTLibrary
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -990,6 +990,11 @@ ExternalLibrary subclass: #ExternalResourceLibrary
 	classVariableNames: 'Libraries'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
+ExternalLibrary subclass: #NTLibrary
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
 ExternalLibrary subclass: #PermanentLibrary
 	instanceVariableNames: ''
 	classVariableNames: ''

--- a/Core/Object Arts/Dolphin/Base/KernelLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/KernelLibrary.cls
@@ -1746,8 +1746,7 @@ fileName
 	^'KERNEL32'!
 
 isWine
-	Smalltalk at: #NTLibrary ifPresent: [:ntl | ^ntl isWine].
-	^false !
+	^NTLibrary isWine!
 
 open
 	"Answer a new instance of the receiver to represent the Kernel32 DLL. Special handling 

--- a/Core/Object Arts/Dolphin/Base/MessageBox.cls
+++ b/Core/Object Arts/Dolphin/Base/MessageBox.cls
@@ -267,13 +267,13 @@ result
 	"Answer a portable symbolic constant describing the button that was pressed by the user
 	to close the receiver."
 
-	KernelLibrary isWine 
+	NTLibrary isWine
 		ifTrue: 
 			[#wineFix.
 			"Suppressible message boxes under Wine have a bug where they ignore the
 			buttonStyles #yesNo and #yesNoCancel and will always answer #ok or #cancel
 			instead. Here we map the return button ids to the correct values"
-			(self buttonStyle == #yesNo or: [self buttonStyle == #yesNoCancel]) 
+			(self buttonStyle == #yesNo or: [self buttonStyle == #yesNoCancel])
 				ifTrue: 
 					[button = IDOK ifTrue: [button := IDYES].
 					button = IDCANCEL ifTrue: [button := IDNO]]].

--- a/Core/Object Arts/Dolphin/Base/NTLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/NTLibrary.cls
@@ -6,6 +6,7 @@ ExternalLibrary subclass: #NTLibrary
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 NTLibrary guid: (GUID fromString: '{8293E458-7D81-4ABA-97A5-C1001C4B2153}')!
+NTLibrary comment: ''!
 !NTLibrary categoriesForClass!External-Libraries! !
 !NTLibrary methodsFor!
 


### PR DESCRIPTION
Classes add too the base system package were not loaded at boot time when the base system package is "reloaded" because they were not being added to the base package (hence unpackaged). Fix that, and move NTLibrary to the base to test it.