### PR TITLE
Changing the superclass and instanceVariables of a class in a single operation can produce apparent duplicate or missing instance variables

### DIFF
--- a/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
@@ -488,10 +488,15 @@ mutateInSitu
 	"Private - Mutate the class being modified without mutating its instances.
 	In fact, we only need to change the superclass."
 
-	self superclassIsBeingChanged ifFalse: [^self].
-	currentClass class setSuperclass: (self class classOf: superclass).
-	currentClass setSuperclass: superclass.
-	self recompilationRequired: true!
+	self superclassIsBeingChanged
+		ifTrue:
+			[currentClass class setSuperclass: (self class classOf: superclass).
+			currentClass setSuperclass: superclass.
+			self recompilationRequired: true].
+	self instanceVariablesAreBeingChanged
+		ifTrue:
+			[self setInstanceVariablesOf: currentClass.
+			self recompilationRequired: true].!
 
 mutateToNewClass
 	"Private - Set currentClass to a mutation of itself based on the information

--- a/Core/Object Arts/Dolphin/Base/ClassBuilderTests.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassBuilderTests.cls
@@ -174,6 +174,35 @@ testPoolVariablePrecedence
 	self assert: 'ClassBuilderTestPool3.PoolVar6'
 		equals: (self classBuilderTestSubclass2 bindingFor: 'PoolVar6') value!
 
+testReparentSubClassWithSameAllInstVars
+	| testClass testInstance |
+	testClass := self classBuilderTestSubclass1.
+	testInstance := testClass new.
+	testInstance var1: 42.
+	testInstance var2: 'hello'.
+	testInstance var3: 'foo'.
+	testInstance var4: #bar.
+	"Change the superclass and instVars of the class at the same time, such that the answer to #allInstVarNames does not change."
+	Object
+		subclass: #ClassBuilderTestSubClass
+		instanceVariableNames: 'var1 var2 var3 var4'
+		classVariableNames: ''
+		poolDictionaries: ''
+		category: 'Tests-Kernel-Classes'.
+
+	"test state of new class"
+	self assert: testClass instSize = 4.
+	self assert: testClass instVarNames = #('var1' 'var2' 'var3' 'var4').
+	self assert: testClass allInstVarNames = #('var1' 'var2' 'var3' 'var4').
+
+	"test transparency of mapping. Accessors for var1 and var2 were inherited, so are no longer available."
+	self assert: testInstance var3 = 'foo'.
+	self assert: testInstance var4 = #bar.
+	self assert: (testInstance instVarAt: 1) = 42.
+	self assert: (testInstance instVarAt: 2) = 'hello'.
+	self assert: (testInstance instVarAt: 3) = 'foo'.
+	self assert: (testInstance instVarAt: 4) = #bar!
+
 testReshapeClass
 	"see if reshaping classes works"
 
@@ -313,6 +342,7 @@ testUnderscoreWarning
 !ClassBuilderTests categoriesFor: #testAddRemovePools!public!Running! !
 !ClassBuilderTests categoriesFor: #testMoveVariable!public!Running! !
 !ClassBuilderTests categoriesFor: #testPoolVariablePrecedence!public!Running! !
+!ClassBuilderTests categoriesFor: #testReparentSubClassWithSameAllInstVars!public!Running! !
 !ClassBuilderTests categoriesFor: #testReshapeClass!public!Running! !
 !ClassBuilderTests categoriesFor: #testReshapeClassWithJugglingInstVars!public!Running! !
 !ClassBuilderTests categoriesFor: #testReshapeSubClass!public!Running! !


### PR DESCRIPTION
For example:

```smalltalk
"Given this state:"
Object subclass: #ClassA
    instanceVariableNames: 'var1'
    classVariableNames: ''
    poolDictionaries: ''.
Object subclass: #ClassB
    instanceVariableNames: 'var1 var2'
    classVariableNames: ''
    poolDictionaries: ''.
"Then, presumably later:"
ClassA subclass: #ClassB
    instanceVariableNames: 'var2'
    classVariableNames: ''
    poolDictionaries: ''.
```

The mutation can be performed in-situ, and #mutateInSitu only checks if the superclass has changed—presumably assuming that an instance variable change would require a full mutation, which it usually would, but not in this one unique case.

So, the current implementation does not set the instance variables of `ClassB`, and both classes end up declaring `var1`. `ClassB`'s `#instSize` is correct (2), but any new methods referencing `var2` will probably get a BoundsError when run, because the Compiler thinks `var2` is at index 3, instead of the correct 2.

This also happens in reverse—given `ClassB` is already a subclass of `ClassA`, evaluating `Object subclass: #ClassB instanceVariableNames: 'var1 var2'` ...etc. leaves ClassB with an `#instSize` of 2, but thinking it only has `var2`, so methods which reference `var1` will presumably not compile. (In both cases, no recompilation is triggered, so existing methods will continue to work correctly until recompiled.)

One note: I added `self recompilationRequired: true` to match the superclassIsBeingChanged case, but I'm not sure why recompilation would ever be required when mutating in-situ—doesn't the requirement that #allInstVarNames remains unchanged automatically mean that all existing methods are valid?