### PR TITLE
Prevent re-running ReferencesCategory>>initialize from *removing* all installed <ReferencesCategory>s.

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/ReferencesCategory.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/ReferencesCategory.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 VirtualMethodCategory subclass: #ReferencesCategory
 	instanceVariableNames: 'literal'
@@ -43,17 +43,16 @@ initialize
 	"
 
 	self referenceSymbols do: 
-			[:each | 
+			[:each |
 			| cat suffix |
 			suffix := each asPhrase asLowercase.
 			cat := (self newNamed: self pseudPrefix , suffix)
 						literal: each asSymbol;
 						yourself.
 			self
-				addPseud: cat;
-				removeCategory: suffix.
-			Table at: suffix put: cat]
-!
+				removeCategory: suffix;
+				addPseud: cat.
+			Table at: suffix put: cat]!
 
 newNamed: aString literal: anObject 
 	^((VMLibrary default indexOfSpecialSelector: anObject ifAbsent: []) 


### PR DESCRIPTION
Essentially, saying `self removeCategory: 'something'` will remove the existing ReferencesCategory `'*-something'` if it was also aliased to the unprefixed form. This means that re-running #initialize is not safe, because without the strong reference from Pseuds, the newly-added category will get garbage-collected from Table (which is of course weak). It seems reasonable in any case to remove the old thing before installing the new one, rather than the reverse...