### PR TITLE
Delegate choosing the icon for a CompiledMethod to the development system

### DIFF
--- a/Core/Contributions/ITC Gorisek/StsMethodEdition.cls
+++ b/Core/Contributions/ITC Gorisek/StsMethodEdition.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 StsEdition subclass: #StsMethodEdition
 	instanceVariableNames: 'classSymbol selector isPrivate categoriesString source'
@@ -274,7 +274,9 @@ displayOn: aStream
 				nextPutAll: developer]!
 
 icon
-	^isPrivate == true ifTrue: [CompiledMethod privateIcon] ifFalse: [CompiledMethod publicIcon]!
+	^isPrivate == true
+		ifTrue: [Smalltalk developmentSystem privateMethodIcon]
+		ifFalse: [Smalltalk developmentSystem publicMethodIcon]!
 
 isExpression
 	^false!

--- a/Core/Object Arts/Dolphin/Base/CompiledMethod.cls
+++ b/Core/Object Arts/Dolphin/Base/CompiledMethod.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 CompiledCode variableSubclass: #CompiledMethod
 	instanceVariableNames: ''
@@ -77,12 +77,9 @@ hasChanged
 icon
 	"Answers an Icon that can be used to represent this object."
 
-	self isDeprecated ifTrue: [^self class deprecatedIcon].
-
-	^self isPrivate
-		ifTrue: [self class privateIcon]
-		ifFalse: [self class publicIcon]
-!
+	^(Smalltalk at: #SmalltalkSystem ifPresent: [:a | a current])
+		ifNil: [super icon]
+		ifNotNil: [:a | a iconForMethod: self]!
 
 infoTip
 	"Private - Answer a suitable 'info tip' for the receiver."
@@ -108,13 +105,6 @@ isClassMethod
 	"Answer true if the receiver is a class method."
 
 	^self methodClass isMeta!
-
-isDeprecated
-	"Answer whether the receiver is marked as being deprecated.
-	This is based on whether a reference to the symbol, #deprecated, is found
-	in the method, for which we use a ReferencesCategory."
-
-	^MethodCategory deprecatedMethods includesMethod: self!
 
 isExpression
 	"Private - Answer whether the receiver is a standalone (unbound) expression as opposed to 
@@ -236,7 +226,6 @@ storeSourceString: aString
 !CompiledMethod categoriesFor: #infoTip!accessing!development!private! !
 !CompiledMethod categoriesFor: #isChanged!development!private!testing! !
 !CompiledMethod categoriesFor: #isClassMethod!public!testing! !
-!CompiledMethod categoriesFor: #isDeprecated!development!public!testing! !
 !CompiledMethod categoriesFor: #isExpression!private!testing! !
 !CompiledMethod categoriesFor: #isExternalCall!private!testing! !
 !CompiledMethod categoriesFor: #isGetter!public!testing! !

--- a/Core/Object Arts/Dolphin/Base/CompiledMethod.cls
+++ b/Core/Object Arts/Dolphin/Base/CompiledMethod.cls
@@ -74,13 +74,6 @@ hasChanged
 
 	^self changeManager hasMethodChanged: self!
 
-icon
-	"Answers an Icon that can be used to represent this object."
-
-	^(Smalltalk at: #SmalltalkSystem ifPresent: [:a | a current])
-		ifNil: [super icon]
-		ifNotNil: [:a | a iconForMethod: self]!
-
 infoTip
 	"Private - Answer a suitable 'info tip' for the receiver."
 
@@ -222,7 +215,6 @@ storeSourceString: aString
 !CompiledMethod categoriesFor: #getDebugInfo!development!private! !
 !CompiledMethod categoriesFor: #getSource!accessing!development!public! !
 !CompiledMethod categoriesFor: #hasChanged!development!private!testing! !
-!CompiledMethod categoriesFor: #icon!constants!development!public! !
 !CompiledMethod categoriesFor: #infoTip!accessing!development!private! !
 !CompiledMethod categoriesFor: #isChanged!development!private!testing! !
 !CompiledMethod categoriesFor: #isClassMethod!public!testing! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -189,7 +189,7 @@ package methodNames
 	add: #CompiledExpression -> #stylerClass;
 	add: #CompiledMethod -> #asDebugMethod;
 	add: #CompiledMethod -> #browse;
-	add: #CompiledMethod -> #isDeprecated;
+	add: #CompiledMethod -> #icon;
 	add: #CompiledMethod -> #searchForInTool:;
 	add: #CompiledMethod -> #stylerClass;
 	add: #CompileFailedMethod -> #asDebugMethod;
@@ -1983,12 +1983,10 @@ browse
     
     	^Smalltalk developmentSystem browseMethod: self!
 
-isDeprecated
-	"Answer whether the receiver is marked as being deprecated.
-	This is based on whether a reference to the symbol, #deprecated, is found
-	in the method, for which we use a ReferencesCategory."
+icon
+	"Answers an Icon that can be used to represent this object."
 
-	^MethodCategory deprecatedMethods includesMethod: self!
+	^Smalltalk developmentSystem iconForMethod: self!
 
 searchForInTool: aSmalltalkToolShell 
 	aSmalltalkToolShell searchForMethod: self!
@@ -1997,7 +1995,7 @@ stylerClass
 	^Smalltalk developmentSystem methodStylerClass! !
 !CompiledMethod categoriesFor: #asDebugMethod!development!private! !
 !CompiledMethod categoriesFor: #browse!development!public! !
-!CompiledMethod categoriesFor: #isDeprecated!development!public!testing! !
+!CompiledMethod categoriesFor: #icon!constants!development!public! !
 !CompiledMethod categoriesFor: #searchForInTool:!public! !
 !CompiledMethod categoriesFor: #stylerClass!constants!public! !
 

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -189,6 +189,7 @@ package methodNames
 	add: #CompiledExpression -> #stylerClass;
 	add: #CompiledMethod -> #asDebugMethod;
 	add: #CompiledMethod -> #browse;
+	add: #CompiledMethod -> #isDeprecated;
 	add: #CompiledMethod -> #searchForInTool:;
 	add: #CompiledMethod -> #stylerClass;
 	add: #CompileFailedMethod -> #asDebugMethod;
@@ -1982,6 +1983,13 @@ browse
     
     	^Smalltalk developmentSystem browseMethod: self!
 
+isDeprecated
+	"Answer whether the receiver is marked as being deprecated.
+	This is based on whether a reference to the symbol, #deprecated, is found
+	in the method, for which we use a ReferencesCategory."
+
+	^MethodCategory deprecatedMethods includesMethod: self!
+
 searchForInTool: aSmalltalkToolShell 
 	aSmalltalkToolShell searchForMethod: self!
 
@@ -1989,6 +1997,7 @@ stylerClass
 	^Smalltalk developmentSystem methodStylerClass! !
 !CompiledMethod categoriesFor: #asDebugMethod!development!private! !
 !CompiledMethod categoriesFor: #browse!development!public! !
+!CompiledMethod categoriesFor: #isDeprecated!development!public!testing! !
 !CompiledMethod categoriesFor: #searchForInTool:!public! !
 !CompiledMethod categoriesFor: #stylerClass!constants!public! !
 

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
@@ -1685,6 +1685,11 @@ deleteResource: aResourceIdentifier
 				, aResourceIdentifier storeString.
 	self resourceManager removeResource: aResourceIdentifier!
 
+deprecatedMethodIcon
+	"Private - Answers an Icon that can be used to represent a deprecated method"
+
+	^Icon fromId: 'COMPILEDMETHOD_DEPRECATED.ICO'!
+
 disassembleMethod: aCompiledCode 
 	^'Disassembly is only available in Dolphin Professional'!
 
@@ -1891,8 +1896,8 @@ hierarchyBrowserClass: toolClass
 iconForMethod: aCompiledMethod
 	"Answer an icon that can be used to represent the <CompiledMethod> argument in a development environment."
 
-	aCompiledMethod isDeprecated ifTrue: [^CompiledMethod deprecatedIcon].
-	^aCompiledMethod isPrivate ifTrue: [CompiledMethod privateIcon] ifFalse: [CompiledMethod publicIcon]!
+	(self isDeprecatedMethod: aCompiledMethod) ifTrue: [^self deprecatedMethodIcon].
+	^aCompiledMethod isPrivate ifTrue: [self privateMethodIcon] ifFalse: [self publicMethodIcon]!
 
 ideaSpaceFilesType
 	"Private - Answer a two element array suitable for adding to the FileDialog
@@ -2043,6 +2048,13 @@ interruptHotKey: anInteger
 	go badly."
 
 	VMLibrary default registryAt: #interruptHotKey put: anInteger!
+
+isDeprecatedMethod: aCompiledMethod
+	"Answer whether the <CompiledMethod> argument is marked as being deprecated.
+	This is based on whether a reference to the symbol, #deprecated, is found
+	in the method, for which we use a ReferencesCategory."
+
+	^MethodCategory deprecatedMethods includesMethod: aCompiledMethod!
 
 isOAD
 	"Private - Is this an Object Arts Development version"
@@ -2849,6 +2861,11 @@ printSignatureForKeywordsAndArgs: keywordsAndArgs on: aWriteStream
 						space]].
 	aWriteStream pop!
 
+privateMethodIcon
+	"Private - Answers an Icon that can be used to represent a private method."
+
+	^Icon fromId: 'COMPILEDMETHOD_PRIVATE.ICO'!
+
 privatePrefix
 	"Private - Answer the prefix to be used in the comments of private methods."
 
@@ -3036,6 +3053,11 @@ publicizeMethod: aCompiledMethod
 		ifTrue: 
 			[catClass public addMethod: aCompiledMethod.
 			aCompiledMethod storeCategories]!
+
+publicMethodIcon
+	"Private - Answers an Icon that can be used to represent a public method"
+
+	^Icon fromId: 'COMPILEDMETHOD_PUBLIC.ICO'!
 
 queryCommand: aCommandQuery 
 	"Private - Enter details about a potential command for the receiver into the <CommandQuery>."
@@ -4060,6 +4082,7 @@ wrapText: aString toWidth: max indent: colInteger tabWidth: tabInteger
 !SmalltalkSystem categoriesFor: #definitionsOf:!browsing!private! !
 !SmalltalkSystem categoriesFor: #deleteClassHierarchy:!operations!public! !
 !SmalltalkSystem categoriesFor: #deleteResource:!browsing!commands!public! !
+!SmalltalkSystem categoriesFor: #deprecatedMethodIcon!constants!development!private! !
 !SmalltalkSystem categoriesFor: #disassembleMethod:!public! !
 !SmalltalkSystem categoriesFor: #disassemblyStylerClass!constants!public! !
 !SmalltalkSystem categoriesFor: #displayOn:!displaying!public! !
@@ -4107,6 +4130,7 @@ wrapText: aString toWidth: max indent: colInteger tabWidth: tabInteger
 !SmalltalkSystem categoriesFor: #instVarWriterFilter:in:!helpers!private! !
 !SmalltalkSystem categoriesFor: #interruptHotKey!options!public! !
 !SmalltalkSystem categoriesFor: #interruptHotKey:!options!public! !
+!SmalltalkSystem categoriesFor: #isDeprecatedMethod:!public!testing! !
 !SmalltalkSystem categoriesFor: #isOAD!accessing!private!product! !
 !SmalltalkSystem categoriesFor: #isRegisteredTool:!public!testing! !
 !SmalltalkSystem categoriesFor: #isValidClassVarName:for:!enquiries!helpers!private!refactoring! !
@@ -4193,6 +4217,7 @@ wrapText: aString toWidth: max indent: colInteger tabWidth: tabInteger
 !SmalltalkSystem categoriesFor: #preferAlternateInspectors!accessing!public! !
 !SmalltalkSystem categoriesFor: #preferAlternateInspectors:!accessing!public! !
 !SmalltalkSystem categoriesFor: #printSignatureForKeywordsAndArgs:on:!autocompletion!helpers!private! !
+!SmalltalkSystem categoriesFor: #privateMethodIcon!constants!development!private! !
 !SmalltalkSystem categoriesFor: #privatePrefix!constants!private! !
 !SmalltalkSystem categoriesFor: #privatizeMethod:!operations!private! !
 !SmalltalkSystem categoriesFor: #promptForClass!enquiries!public! !
@@ -4206,6 +4231,7 @@ wrapText: aString toWidth: max indent: colInteger tabWidth: tabInteger
 !SmalltalkSystem categoriesFor: #protocolBrowserClass!options!public! !
 !SmalltalkSystem categoriesFor: #protocolBrowserClass:!options!public! !
 !SmalltalkSystem categoriesFor: #publicizeMethod:!operations!private! !
+!SmalltalkSystem categoriesFor: #publicMethodIcon!constants!development!private! !
 !SmalltalkSystem categoriesFor: #queryCommand:!commands!private! !
 !SmalltalkSystem categoriesFor: #redoChange!commands!public! !
 !SmalltalkSystem categoriesFor: #referencesMatching:in:!browsing!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
@@ -1888,6 +1888,12 @@ hierarchyBrowserClass: toolClass
 
 	hierarchyBrowserClass := toolClass!
 
+iconForMethod: aCompiledMethod
+	"Answer an icon that can be used to represent the <CompiledMethod> argument in a development environment."
+
+	aCompiledMethod isDeprecated ifTrue: [^CompiledMethod deprecatedIcon].
+	^aCompiledMethod isPrivate ifTrue: [CompiledMethod privateIcon] ifFalse: [CompiledMethod publicIcon]!
+
 ideaSpaceFilesType
 	"Private - Answer a two element array suitable for adding to the FileDialog
 	with the fileTypes: message for loading/saving idea space templates."
@@ -4086,6 +4092,7 @@ wrapText: aString toWidth: max indent: colInteger tabWidth: tabInteger
 !SmalltalkSystem categoriesFor: #helpWhatsThis!commands!public! !
 !SmalltalkSystem categoriesFor: #hierarchyBrowserClass!options!public! !
 !SmalltalkSystem categoriesFor: #hierarchyBrowserClass:!options!public! !
+!SmalltalkSystem categoriesFor: #iconForMethod:!development!helpers!public! !
 !SmalltalkSystem categoriesFor: #ideaSpaceFilesType!constants!private! !
 !SmalltalkSystem categoriesFor: #imageFilesType!constants!private! !
 !SmalltalkSystem categoriesFor: #initialize!initializing!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -341,9 +341,6 @@ package methodNames
 	add: #UserLibrary -> #validate:lpRect:;
 	add: #UserLibrary -> #windowFromPoint:;
 	add: #UserLibrary -> #winHelp:lpszHelp:uCommand:dwData:;
-	add: 'CompiledMethod class' -> #deprecatedIcon;
-	add: 'CompiledMethod class' -> #privateIcon;
-	add: 'CompiledMethod class' -> #publicIcon;
 	add: 'ConsoleSessionManager class' -> #icon;
 	add: 'Error class' -> #icon;
 	add: 'ExternalLibrary class' -> #icon;
@@ -1255,27 +1252,6 @@ SIZEL := SIZE!
 
 
 "Loose Methods"!
-
-!CompiledMethod class methodsFor!
-
-deprecatedIcon
-	"Private - Answers an Icon that can be used to represent a deprecated instance of this class"
-
-	^Icon fromId: 'COMPILEDMETHOD_DEPRECATED.ICO'
-!
-
-privateIcon
-	"Private - Answers an Icon that can be used to represent a private instance of this class"
-
-	^Icon fromId: 'COMPILEDMETHOD_PRIVATE.ICO'!
-
-publicIcon
-	"Private - Answers an Icon that can be used to represent a public instance of this class"
-
-	^Icon fromId: 'COMPILEDMETHOD_PUBLIC.ICO'! !
-!CompiledMethod class categoriesFor: #deprecatedIcon!constants!development!private! !
-!CompiledMethod class categoriesFor: #privateIcon!constants!development!private! !
-!CompiledMethod class categoriesFor: #publicIcon!constants!development!private! !
 
 !ConsoleSessionManager class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Deprecated/MultipleSelectionListBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Deprecated/MultipleSelectionListBox.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ListBox subclass: #MultipleSelectionListBox
 	instanceVariableNames: ''
@@ -64,7 +64,7 @@ selectionOrNil
 icon
 	"Answers an Icon that can be used to represent this class"
 
-	^CompiledMethod deprecatedIcon!
+	^Smalltalk developmentSystem deprecatedMethodIcon!
 
 publishedEventsOfInstances
     	"Answer a Set of Symbols that describe the published events triggered

--- a/Core/Object Arts/Dolphin/MVP/Deprecated/MultipleSelectionListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Deprecated/MultipleSelectionListView.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.2"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ListView subclass: #MultipleSelectionListView
 	instanceVariableNames: ''
@@ -64,7 +64,7 @@ selectionOrNil
 icon
 	"Answers an Icon that can be used to represent this class"
 
-	^CompiledMethod deprecatedIcon!
+	^Smalltalk developmentSystem deprecatedMethodIcon!
 
 publishedAspectsOfInstances
 	"Answer a <LookupTable> of the <Aspect>s published by instances of the receiver."


### PR DESCRIPTION
Allows for customization of method icons without further editing of base packages (by subclassing SmalltalkSystem). Examples: Different icons for auto-generated methods, basic accessors, methods marked subclassResponsibility/shouldNotImplement/notYetImplemented/etc.

Fall back to simply the class-side default (the Public icon, effectively) if no development system is present. This seems reasonable, in that I would not expect method icons to be displayed as part of a deployed executable, or if they are it seems reasonable for the developer to need to take this into account in the image-stripping process.