### PR TITLE
Normalize line endings when filing in .st files of unknown source 

### DIFF
--- a/Core/Contributions/ITC Gorisek/Dialect Abstraction Layer.pax
+++ b/Core/Contributions/ITC Gorisek/Dialect Abstraction Layer.pax
@@ -135,7 +135,6 @@ package methodNames
 	add: #SocketWriteStream -> #itcFlush;
 	add: #SocketWriteStream -> #sendLine:;
 	add: #Stream -> #itcCrLf;
-	add: #Stream -> #nextOrNil;
 	add: #String -> #add:withDelimiter:;
 	add: #String -> #asDateFromDDMMYYYYString;
 	add: #String -> #asDecimalOrFloat;
@@ -1224,14 +1223,8 @@ sendLine: aCollection
 
 itcCrLf
 	self nextPutAll: '
-'!
-
-nextOrNil
-	"Squeak compatibility method (for #next)"
-
-	^self atEnd ifFalse: [self next]! !
+'! !
 !Stream categoriesFor: #itcCrLf!accessing!public! !
-!Stream categoriesFor: #nextOrNil!accessing!public! !
 
 !String methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/ByteArray.cls
+++ b/Core/Object Arts/Dolphin/Base/ByteArray.cls
@@ -552,7 +552,7 @@ storeOn: puttableStream
 	self printPrefixOn: puttableStream.
 	1 to: self size do: [:i | 
 		(self at: i) printDigitsOn: puttableStream base: 10.
-		puttableStream nextPut: $ ].
+		puttableStream nextPut: $\x20].
 	self printSuffixOn: puttableStream.!
 
 swordAtOffset: anInteger

--- a/Core/Object Arts/Dolphin/Base/Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Character.cls
@@ -7,7 +7,16 @@ Magnitude subclass: #Character
 	classInstanceVariableNames: ''!
 Character guid: (GUID fromString: '{87B4C651-026E-11D3-9FD7-00A0CC3E4A32}')!
 Character addClassConstant: 'EscapeChars' value: #($0 nil nil nil nil nil nil $a $b $t $n $v $f $r)!
-Character comment: 'Character is the class of objects which serve as the elemental values of Smalltalk Strings. There is a finite set of Characters (256 in the current Dolphin implementation). Characters have a literal syntax which is the $ symbol followed by the normal printed representation of the character.
+Character comment: 'Character is the class of objects which serve as the elemental values of Smalltalk Strings. There is a finite set of Characters (256 in the current Dolphin implementation). Smalltalk characters have a literal syntax which is the $ symbol followed by the normal printed representation of the character. Dolphin also supports the following escaped literal formats to provide a literal representation of any character:
+	$\0	- Null
+	$\a	- Bell
+	$\b	- Backspace
+	$\t	- Tab
+	$\n	- Newline
+	$\v	- Vertical tab
+	$\f	- Form Feed
+	$\r	- Carriage return
+	$\x<HH> - where <HH> is the hex representation of the character''s code point - can be used to represent any character in the set.
 
 Note that the ANSI standard does not require that Characters be identity objects, but they are in Dolphin.
 '!

--- a/Core/Object Arts/Dolphin/Base/ChunkSourceFiler.cls
+++ b/Core/Object Arts/Dolphin/Base/ChunkSourceFiler.cls
@@ -2,10 +2,11 @@
 
 SourceFiler subclass: #ChunkSourceFiler
 	instanceVariableNames: 'sourceFileIndex'
-	classVariableNames: ''
+	classVariableNames: 'NormalizeEolsMask'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ChunkSourceFiler guid: (GUID fromString: '{558B318A-9FF3-4346-A445-76EE18D5458B}')!
+ChunkSourceFiler addClassConstant: 'NormalizeEolsMask' value: 2!
 ChunkSourceFiler comment: ''!
 !ChunkSourceFiler categoriesForClass!Development!System-Support! !
 !ChunkSourceFiler methodsFor!
@@ -337,12 +338,24 @@ nextChunk
 	Implementation Note: String concatenation is more efficient here in the loop body because most 
 	chunks do not include embedded chunk markers."
 
-	| result |
+	| chunk |
 	stream skipSeparators.
-	result := stream upTo: $!!.
-	[stream atEnd or: [(stream peekFor: $!!) not]]
-		whileFalse: [result := result, '!!', (stream upTo: $!!)].
-	^result!
+	^self normalizeLineEndings
+		ifTrue: 
+			[| next |
+			chunk := String writeStream: 512.
+			[(next := stream nextOrNil) isNil or: [next == $!! and: [(stream peekFor: $!!) not]]] whileFalse: 
+					[((next == $\r and: 
+							[stream peekFor: $\n.
+							true]) or: [next == $\n])
+						ifTrue: [chunk nextPutAll: String.LineDelimiter]
+						ifFalse: [chunk nextPut: next]].
+			chunk contents]
+		ifFalse: 
+			["Much faster, as we don't need to read and compare each character individually"
+			chunk := stream upTo: $!!.
+			[stream atEnd or: [(stream peekFor: $!!) not]] whileFalse: [chunk := chunk , '!!' , (stream upTo: $!!)].
+			chunk]!
 
 nextChunkPut: aString 
 	"Private - Print the string, aString, to the <puttableStream> aWriteStream as a chunk. 
@@ -352,6 +365,12 @@ nextChunkPut: aString
 	self emitString: aString.
 	stream nextPut: $!!.
 	^aString!
+
+normalizeLineEndings
+	^flags anyMask: NormalizeEolsMask!
+
+normalizeLineEndings: aBoolean
+	flags := flags mask: NormalizeEolsMask set: aBoolean!
 
 sourceDescriptorForIndex: indexInteger position: positionInteger 
 	"Private - Answer an <integer> source descriptor which encodes the <integer> source file
@@ -446,6 +465,8 @@ storeSourceString: aString forMethod: aCompiledMethod
 !ChunkSourceFiler categoriesFor: #logEvaluation:!private!source filing! !
 !ChunkSourceFiler categoriesFor: #nextChunk!private!source filing! !
 !ChunkSourceFiler categoriesFor: #nextChunkPut:!private!source filing! !
+!ChunkSourceFiler categoriesFor: #normalizeLineEndings!accessing!public! !
+!ChunkSourceFiler categoriesFor: #normalizeLineEndings:!accessing!public! !
 !ChunkSourceFiler categoriesFor: #sourceDescriptorForIndex:position:!private!source filing! !
 !ChunkSourceFiler categoriesFor: #sourceFileIndex:!accessing!private! !
 !ChunkSourceFiler categoriesFor: #storeCommentString:forClass:!public!source filing! !
@@ -454,6 +475,9 @@ storeSourceString: aString forMethod: aCompiledMethod
 !ChunkSourceFiler categoriesFor: #storeSourceString:forMethod:!private!source filing! !
 
 !ChunkSourceFiler class methodsFor!
+
+initialize
+	self addClassConstant: 'NormalizeEolsMask' value: 2.!
 
 on: aWriteStream sourceFileIndex: anInteger
 	"Answer a new instance of the receiver for filing out source code onto the 
@@ -464,5 +488,6 @@ on: aWriteStream sourceFileIndex: anInteger
 	^(self on: aWriteStream)
 		sourceFileIndex: anInteger;
 		yourself! !
+!ChunkSourceFiler class categoriesFor: #initialize!public! !
 !ChunkSourceFiler class categoriesFor: #on:sourceFileIndex:!instance creation!public! !
 

--- a/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
@@ -34,7 +34,6 @@ package methodNames
 	add: #Object -> #asDword;
 	add: #Package -> #script:;
 	add: #Package -> #script:put:;
-	add: #SourceManager -> #nextChunkFrom:;
 	add: #String -> #asDword;
 	add: 'ExternalCallback class' -> #receiver:prototype:;
 	add: 'ExternalCallback class' -> #receiver:prototype:closure:;
@@ -264,13 +263,6 @@ name: nameString comment: commentString
 		basicComment: commentString;
 		yourself! !
 !Package class categoriesFor: #name:comment:!instance creation!public! !
-
-!SourceManager methodsFor!
-
-nextChunkFrom: aStream 
-	#deprecated.	"Use a ChunkSourceFiler"
-	^(ChunkSourceFiler on: aStream) nextChunk! !
-!SourceManager categoriesFor: #nextChunkFrom:!private!source filing! !
 
 !String methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -301,8 +301,8 @@ Object subclass: #Sound
 	poolDictionaries: 'MessageBoxConstants Win32Constants'
 	classInstanceVariableNames: ''!
 Object subclass: #SourceFiler
-	instanceVariableNames: 'stream evaluationContext isSourceOnly'
-	classVariableNames: ''
+	instanceVariableNames: 'stream evaluationContext flags'
+	classVariableNames: 'SourceOnlyMask'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Object subclass: #SourceManager
@@ -1547,7 +1547,7 @@ PluggableSortAlgorithm subclass: #IntrosortAlgorithm
 	classInstanceVariableNames: ''!
 SourceFiler subclass: #ChunkSourceFiler
 	instanceVariableNames: 'sourceFileIndex'
-	classVariableNames: ''
+	classVariableNames: 'NormalizeEolsMask'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 SourceManager subclass: #VeryBasicSourceManager

--- a/Core/Object Arts/Dolphin/Base/FileStream.cls
+++ b/Core/Object Arts/Dolphin/Base/FileStream.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ReadWriteStream subclass: #FileStream
 	instanceVariableNames: 'file flags pageBase logicalFileSize'
@@ -268,6 +268,16 @@ next: sizeInteger putAll: aSequenceableCollection startingAt: startInteger
 					self beDirty]].
 	^aSequenceableCollection!
 
+nextOrNil
+	"Answer a <Character>, or <integer> in the range 0..255, being the next of the 
+	receiver's future sequence values. Answer nil if at EOF."
+
+	<primitive: 65>
+	^self atEnd
+		ifFalse: 
+			[self position: self position.
+			collection at: (position := position + 1)]!
+
 nextPut: anIntegerOrCharacter 
 	"Write anIntegerOrCharacter to the receiver and answer the argument."
 
@@ -397,6 +407,7 @@ writePage
 !FileStream categoriesFor: #next!accessing!public! !
 !FileStream categoriesFor: #next:into:startingAt:!accessing!public! !
 !FileStream categoriesFor: #next:putAll:startingAt:!accessing!public! !
+!FileStream categoriesFor: #nextOrNil!accessing!public! !
 !FileStream categoriesFor: #nextPut:!accessing!public! !
 !FileStream categoriesFor: #nextPutAll:!accessing!public! !
 !FileStream categoriesFor: #position!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/PositionableStream.cls
+++ b/Core/Object Arts/Dolphin/Base/PositionableStream.cls
@@ -1,7 +1,7 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 SequencedStream subclass: #PositionableStream
-	instanceVariableNames: 'collection position readLimit '
+	instanceVariableNames: 'collection position readLimit'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -187,6 +187,30 @@ size
 	readLimit < position ifTrue: [readLimit := position].
 	^self lastPosition!
 
+upTo: anObject
+	"Answer a collection of elements starting with the next element accessed by the receiver,
+	and up to, not inclusive of, the next element that is equal to anObject. Positions the
+	stream after anObject if found. If anObject is not in the collection, answer the entire rest
+	of the collection. If the receiver is at its end, answer an empty Collection."
+
+	| startIndex endIndex |
+	self isReadable ifFalse: [^self shouldNotImplement].
+	startIndex := position + 1.
+	"Override as we can perform a fast scan for anObject in the collection. Most streamed over
+	SequenceableCollections have a primitive implementation of #nextIdentityIndexOf:from:to:"
+	position := collection
+				nextIdentityIndexOf: anObject
+				from: startIndex
+				to: readLimit.
+	position == 0
+		ifTrue: 
+			["Not found. Result is equivalent of #upToEnd"
+			endIndex := position := readLimit]
+		ifFalse: 
+			["Found. Answer the elements before anObject, and leave the stream positioned immediately after it."
+			endIndex := position - 1].
+	^collection copyFrom: startIndex to: endIndex!
+
 upToEnd
 	"Answer a collection consisting of the future sequence values of the receiver (i.e. from 
 	the current position to the end)."
@@ -217,6 +241,7 @@ upToEnd
 !PositionableStream categoriesFor: #reverseContents!accessing!public! !
 !PositionableStream categoriesFor: #setToEnd!positioning!public! !
 !PositionableStream categoriesFor: #size!accessing!public! !
+!PositionableStream categoriesFor: #upTo:!accessing!public! !
 !PositionableStream categoriesFor: #upToEnd!accessing!public! !
 
 PositionableStream methodProtocol: #collectionStream attributes: #(#ansi #readOnly) selectors: #(#close #contents #isEmpty #position #position: #reset #setToEnd)!

--- a/Core/Object Arts/Dolphin/Base/PositionableStreamTest.cls
+++ b/Core/Object Arts/Dolphin/Base/PositionableStreamTest.cls
@@ -33,106 +33,91 @@ testNew
 	self should: [self streamClass new] raise: Error!
 
 testNextLine
+	"No line delimiters"
+
 	#('' 'a' 'ab' 'abc') do: 
-			[:each | 
-			| stream line |
+			[:each |
+			| stream |
 			stream := self streamOn: each.
-			line := stream nextLine.
-			self assert: line = each.
+			self assert: each equals: stream nextLine.
 			self assert: stream atEnd.
 			self closeTempStream: stream].
 
 	"Empty but for a single line delimiter"
 	(Array with: (String with: Character lf) with: String lineDelimiter) do: 
-			[:each | 
+			[:each |
 			| stream |
 			stream := self streamOn: each.
-			self assert: stream nextLine = ''.
+			self assert: '' equals: stream nextLine.
 			self assert: stream atEnd.
 			self closeTempStream: stream].
+	"Finishes with line delimiter"
 	(Array with: (String with: Character lf) with: String lineDelimiter) do: 
-			[:eachDelim | 
+			[:eachDelim |
 			#('a' 'ab' 'abc') do: 
-					[:each | 
-					| stream |
-					stream := self streamOn: eachDelim , each.
-					self assert: stream nextLine = ''.
-					self assert: stream atEnd not.
-					self assert: stream nextLine = each.
-					self assert: stream atEnd.
-					self closeTempStream: stream]].
-	(Array with: (String with: Character lf) with: String lineDelimiter) do: 
-			[:eachDelim | 
-			#('a' 'ab' 'abc') do: 
-					[:each | 
-					| stream |
-					stream := self streamOn: each , eachDelim , each.
-					self assert: stream nextLine = each.
-					self assert: stream atEnd not.
-					self assert: stream nextLine = each.
-					self assert: stream atEnd.
-					self closeTempStream: stream]].
-	(Array with: (String with: Character lf) with: String lineDelimiter) do: 
-			[:eachDelim | 
-			#('a' 'ab' 'abc') do: 
-					[:each | 
-					| stream line |
-					stream := self streamOn: each , eachDelim , eachDelim , each.
-					stream reset.
-					line := stream nextLine.
-					self assert: line = each.
-					self assert: stream atEnd not.
-					line := stream nextLine.
-					self assert: line = ''.
-					self assert: stream atEnd not.
-					line := stream nextLine.
-					self assert: line = each.
-					self assert: stream atEnd.
-					self closeTempStream: stream]].
-	(Array with: (String with: Character lf) with: String lineDelimiter) do: 
-			[:eachDelim | 
-			#('a' 'ab' 'abc') do: 
-					[:each | 
-					| stream |
-					stream := self streamOn: each , eachDelim , eachDelim , each , eachDelim.
-					self assert: stream nextLine = each.
-					self assert: stream atEnd not.
-					self assert: stream nextLine = ''.
-					self assert: stream atEnd not.
-					self assert: stream nextLine = each.
-					self assert: stream atEnd.
-					self closeTempStream: stream]].
-	(Array with: (String with: Character lf) with: String lineDelimiter) do: 
-			[:eachDelim | 
-			#('' 'a' 'ab' 'abc') do: 
-					[:each | 
+					[:each |
 					| stream |
 					stream := self streamOn: each , eachDelim.
 					self assert: stream nextLine = each.
 					self assert: stream atEnd.
 					self closeTempStream: stream]].
+	"Finishes with pair of line delimiters"
+	(Array with: (String with: Character lf) with: String lineDelimiter) do: 
+			[:eachDelim |
+			#('' 'a' 'ab' 'abc') do: 
+					[:each |
+					| stream |
+					stream := self streamOn: each , eachDelim , eachDelim.
+					self assert: each equals: stream nextLine.
+					self assert: stream atEnd not.
+					"Empty line"
+					self assert: '' equals: stream nextLine.
+					self assert: stream atEnd.
+					self closeTempStream: stream]].
+	"Starts with line delimiter, delimiter between lines, two delimiters between lines"
+	(Array with: (String with: Character lf) with: String lineDelimiter) do: 
+			[:eachDelim |
+			#('a' 'ab' 'abc') do: 
+					[:each |
+					| stream |
+					stream := self streamOn: eachDelim , each , eachDelim , each , eachDelim , eachDelim , each.
+					self assert: '' equals: stream nextLine.
+					self deny: stream atEnd.
+					self assert: each equals: stream nextLine.
+					self deny: stream atEnd.
+					self assert: each equals: stream nextLine.
+					self deny: stream atEnd.
+					self assert: '' equals: stream nextLine.
+					self deny: stream atEnd.
+					self assert: each equals: stream nextLine.
+					self assert: stream atEnd.
+					self closeTempStream: stream]].
 
-	"Single CR - not treated as a line delimiter unless last in file"
+
+	"Single CR at end of file"
 	#('' 'a' 'ab' 'abc') do: 
-			[:each | 
+			[:each |
 			| line chars stream |
 			chars := each , (String with: Character cr).
 			stream := self streamOn: chars.
 			stream reset.
 			line := stream nextLine.
-			self assert: line = each.
+			self assert: each equals: line.
 			self assert: stream atEnd.
-			self closeTempStream: stream].
+			self closeTempStream: stream]!
 
-	"Single CR - not treated as a line delimiter unless last in file"
+testNextLineCrOnly
+	"Test PositionableStream>>nextLine for text streams with <CR> between lines"
+
 	#('a' 'ab' 'abc') do: 
-			[:each | 
-			| line2 chars stream |
+			[:each |
+			| chars stream |
 			chars := each , (String with: Character cr) , each.
 			stream := self streamOn: chars.
 			stream reset.
-			line2 := stream nextLine.
-			self assert: line2 = chars.
+			self assert: each equals: stream nextLine.
+			self deny: stream atEnd.
+			self assert: each equals: stream nextLine.
 			self assert: stream atEnd.
 			self closeTempStream: stream]!
 
@@ -175,6 +160,35 @@ testNextWord
 				self assert: stream nextWord isNil.
 				self assert: stream atEnd.
 				self closeTempStream: stream]!
+
+testPeekFor
+	"Test PositionableStream>>peekFor:"
+
+	"Empty stream (initlially at end)"
+	| stream |
+	stream := self streamOn: ''.
+	self deny: (stream peekFor: $a).
+	self assert: stream atEnd.
+	self closeTempStream: stream.
+	"Non-empty stream"
+	stream := self streamOn: 'ab'.
+	"Not at end but mismatch"
+	self deny: (stream peekFor: $b).
+	self assert: 0 equals: stream position.
+	"Successful match"
+	self assert: (stream peekFor: $a).
+	self assert: 1 equals: stream position.
+	"Another mismatch"
+	self deny: (stream peekFor: $c).
+	self assert: 1 equals: stream position.
+	"Another Successful match"
+	self deny: stream atEnd.
+	self assert: (stream peekFor: $b).
+	self assert: stream atEnd.
+	"Now at end"
+	self deny: (stream peekFor: $a).
+	self assert: stream atEnd.
+	self closeTempStream: stream!
 
 testSkipToAllColon
 	| chars stream |
@@ -383,7 +397,9 @@ testUpToEnd
 !PositionableStreamTest categoriesFor: #testContents!public!unit tests! !
 !PositionableStreamTest categoriesFor: #testNew!public!testing! !
 !PositionableStreamTest categoriesFor: #testNextLine!public!unit tests! !
+!PositionableStreamTest categoriesFor: #testNextLineCrOnly!public!unit tests! !
 !PositionableStreamTest categoriesFor: #testNextWord!public!unit tests! !
+!PositionableStreamTest categoriesFor: #testPeekFor!public!unit tests! !
 !PositionableStreamTest categoriesFor: #testSkipToAllColon!public!unit tests! !
 !PositionableStreamTest categoriesFor: #testUpToAllColon!public!unit tests! !
 !PositionableStreamTest categoriesFor: #testUpToEnd!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/ReadStream.cls
+++ b/Core/Object Arts/Dolphin/Base/ReadStream.cls
@@ -55,11 +55,20 @@ nextAvailable
 	being streamed over is known not to contain nils."
 
 	<primitive: 65>
-	^position >= readLimit ifFalse: [collection at: (position := position + 1)]! !
+	^position >= readLimit ifFalse: [collection at: (position := position + 1)]!
+
+nextOrNil
+	"Answer a <Character>, or <integer> in the range 0..255, being the next of the 
+	receiver's future sequence values. Answer nil if at EOF."
+
+	<primitive: 65>
+	^position >= readLimit
+		ifFalse: [collection at: (position := position + 1)]! !
 !ReadStream categoriesFor: #isReadable!public!testing! !
 !ReadStream categoriesFor: #next!accessing!public! !
 !ReadStream categoriesFor: #next:into:startingAt:!accessing!public! !
 !ReadStream categoriesFor: #nextAvailable!accessing!public! !
+!ReadStream categoriesFor: #nextOrNil!accessing!public! !
 
 ReadStream methodProtocol: #ReadStream attributes: #(#ansi #readOnly) selectors: #(#atEnd #close #contents #do: #isEmpty #next #next: #nextLine #nextMatchFor: #peek #peekFor: #position #position: #reset #setToEnd #skip: #skipTo: #upTo:)!
 

--- a/Core/Object Arts/Dolphin/Base/ReadWriteStream.cls
+++ b/Core/Object Arts/Dolphin/Base/ReadWriteStream.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 WriteStream subclass: #ReadWriteStream
 	instanceVariableNames: ''
@@ -55,11 +55,20 @@ next: count into: aSequenceableCollection startingAt: startAt
 		with: collection
 		startingAt: position+1.
 	self position: stop.
-	^aSequenceableCollection! !
+	^aSequenceableCollection!
+
+nextOrNil
+	"Answer a <Character>, or <integer> in the range 0..255, being the next of the 
+	receiver's future sequence values. Answer nil if at EOF."
+
+	<primitive: 65>
+	^position >= readLimit
+		ifFalse: [collection at: (position := position + 1)]! !
 !ReadWriteStream categoriesFor: #contents!accessing!public! !
 !ReadWriteStream categoriesFor: #isReadable!public!testing! !
 !ReadWriteStream categoriesFor: #next!accessing!public! !
 !ReadWriteStream categoriesFor: #next:into:startingAt:!accessing!public! !
+!ReadWriteStream categoriesFor: #nextOrNil!accessing!public! !
 
 ReadWriteStream methodProtocol: #ReadWriteStream attributes: #(#ansi #readOnly) selectors: #(#atEnd #close #contents #cr #do: #flush #isEmpty #next #next: #nextLine #nextMatchFor: #nextPut: #nextPutAll: #peek #peekFor: #position #position: #reset #setToEnd #skip: #skipTo: #space #tab #upTo:)!
 

--- a/Core/Object Arts/Dolphin/Base/SequencedStream.cls
+++ b/Core/Object Arts/Dolphin/Base/SequencedStream.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Stream subclass: #SequencedStream
 	instanceVariableNames: ''
@@ -45,13 +45,17 @@ nextLine
 	the receiver's contents are answered. If the receiver is at its end, then an empty
 	collection is answered. "
 
-	"N.B. This method works for Unix and Windows line delimiters (that is CR/LF and LF sequences
-	respectively), but not if the line delimiter consists solely of a CR."
+	"N.B. This method works for CR, LF and CR/LF line delimiters."
 
-	| result eol |
-	eol := String lineDelimiter.
-	result := self upTo: eol last.
-	^(result notEmpty and: [result last = eol first]) ifTrue: [result allButLast] ifFalse: [result]!
+	| newStream nextObject |
+	newStream := self contentsSpecies writeStream: 128.
+	
+	[(nextObject := self nextOrNil) isNil
+		or: [nextObject == $\n or: [nextObject == $\r and: 
+							[self peekFor: $\n.
+							true]]]]
+			whileFalse: [newStream nextPut: nextObject].
+	^newStream contents!
 
 nextWord
 	"Answer the next 'word' in the receiver's element stream, where a word is defined as a
@@ -85,15 +89,14 @@ peek
 			self position: self position - 1.
 			anObject]!
 
-peekFor: anObject 
+peekFor: anObject
 	"Determine the response to the message peek. If it is the same as the argument, anObject,
 	then advance the current position and answer true. Otherwise answer false and do not change
 	the current position."
 
-	^self atEnd not and: 
-			[self next = anObject 
-				ifTrue: [true]
-				ifFalse: 
+	| next |
+	^(next := self nextOrNil) notNil and: 
+			[next = anObject or: 
 					["We don't use #skip:, since we know going back 1 is in bounds"
 					self position: self position - 1.
 					false]]!
@@ -139,8 +142,9 @@ skipSeparators
 	"Implementation Note: Implementable in terms of #skipWhile:, but this is called so
 	frequently that we open code to avoid instantiating a block."
 
-	[self atEnd] whileFalse: 
-			[self next isSeparator 
+	| next |
+	[(next := self nextOrNil) isNil] whileFalse: 
+			[next isSeparator
 				ifFalse: 
 					[self position: self position - 1.
 					^true]].

--- a/Core/Object Arts/Dolphin/Base/SourceFiler.cls
+++ b/Core/Object Arts/Dolphin/Base/SourceFiler.cls
@@ -1,11 +1,12 @@
 "Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #SourceFiler
-	instanceVariableNames: 'stream evaluationContext isSourceOnly '
-	classVariableNames: ''
+	instanceVariableNames: 'stream evaluationContext flags'
+	classVariableNames: 'SourceOnlyMask'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 SourceFiler guid: (GUID fromString: '{847F25F1-CD60-490C-817F-3F0F2CEFD567}')!
+SourceFiler addClassConstant: 'SourceOnlyMask' value: 1!
 SourceFiler comment: ''!
 !SourceFiler categoriesForClass!Development!System-Support! !
 !SourceFiler methodsFor!
@@ -240,14 +241,14 @@ getSourceFromDescriptor: sourceDescriptor
 	^self subclassResponsibility!
 
 isSourceOnly
-	^isSourceOnly!
+	^flags anyMask: SourceOnlyMask!
 
-isSourceOnly: aBoolean 
-	isSourceOnly := aBoolean!
+isSourceOnly: aBoolean
+	flags := flags mask: SourceOnlyMask set: aBoolean!
 
-setStream: aPuttableStream 
+setStream: aPuttableStream
 	stream := aPuttableStream.
-	self isSourceOnly: false!
+	flags := 0!
 
 setToEnd
 	"Seek to the end of the source stream."
@@ -342,6 +343,9 @@ SourceFiler methodProtocol: #sourceFiler attributes: #(#readOnly) selectors: #(#
 
 !SourceFiler class methodsFor!
 
+initialize
+	self addClassConstant: 'SourceOnlyMask' value: 1.!
+
 on: aWriteStream 
 	"Answer a new instance of the receiver for filing out source code onto the 
 	<puttableStream> argument."
@@ -349,5 +353,6 @@ on: aWriteStream
 	^(self new)
 		setStream: aWriteStream;
 		yourself! !
+!SourceFiler class categoriesFor: #initialize!public! !
 !SourceFiler class categoriesFor: #on:!instance creation!public! !
 

--- a/Core/Object Arts/Dolphin/Base/SourceManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SourceManager.cls
@@ -1,7 +1,7 @@
 "Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #SourceManager
-	instanceVariableNames: 'mutex '
+	instanceVariableNames: 'mutex'
 	classVariableNames: 'ChangesIndex DefaultInstance SourcesIndex'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -113,8 +113,8 @@ changesStream
 
 	^self basicChangesFiler ifNotNil: [:changes | changes stream]!
 
-chunkFilerOn: aStream 
-	"Answer a <ChunkSourceFiler> on the specified stream."
+chunkFilerOn: aStream
+	"Answer a <ChunkSourceFiler> on the specified stream. The filer leaves existing line endings alone."
 
 	^ChunkSourceFiler on: aStream!
 
@@ -276,16 +276,29 @@ errorNotPackaged: anObject
 fileIn: aFileName
 	"File in the chunk format file named, aFileName, into the system."
 
+	self fileIn: aFileName normalizeLineEndings: false!
+
+fileIn: aString normalizeLineEndings: aBoolean
+	"File in the chunk format file named, aString, into the system. If the <Boolean> argument is
+	true then any non-standard CR or LF line endings are converted to CR-LF pairs."
+
 	| stream |
-	stream := FileStream read: aFileName.
-	[self fileInFrom: stream] ensure: [stream close].!
+	stream := FileStream read: aString.
+	[self fileInFrom: stream normalizeLineEndings: aBoolean] ensure: [stream close]!
 
-fileInFrom: aStream 
-	"Private - File in the expressions/definitions from the chunk stream, aStream.
-	in the receiver's chunk format. Any methods that do not	compile are stubbed 
-	with instances of CompileFailedMethod and errors logged to the Transcript."
+fileInFrom: aStream
+	"Private - File in the expressions/definitions from the chunk stream, aStream. in the
+	receiver's chunk format. Any methods that do not compile are stubbed with instances of
+	CompileFailedMethod and errors logged to the Transcript. Existing line endings are
+	preserved, which is probably only appropriate if the source stream is known to have CR-LF
+	line endings already."
 
-	(self chunkFilerOn: aStream) fileIn!
+	self fileInFrom: aStream normalizeLineEndings: false!
+
+fileInFrom: aStream normalizeLineEndings: aBoolean
+	(self chunkFilerOn: aStream)
+		normalizeLineEndings: aBoolean;
+		fileIn!
 
 fileInHere: aFileName 
 	"File in the chunk format file named, aFileName, into the system but with
@@ -687,7 +700,9 @@ truncateChanges
 !SourceManager categoriesFor: #emitFileOutHeaderOn:!private!source filing! !
 !SourceManager categoriesFor: #errorNotPackaged:!exceptions!private! !
 !SourceManager categoriesFor: #fileIn:!public!source filing! !
+!SourceManager categoriesFor: #fileIn:normalizeLineEndings:!public!source filing! !
 !SourceManager categoriesFor: #fileInFrom:!private!source filing! !
+!SourceManager categoriesFor: #fileInFrom:normalizeLineEndings:!private!source filing! !
 !SourceManager categoriesFor: #fileInHere:!public!source filing! !
 !SourceManager categoriesFor: #fileInPackagedClass:!public!source filing! !
 !SourceManager categoriesFor: #fileInPackagedClass:from:!public!source filing! !

--- a/Core/Object Arts/Dolphin/Base/StdioFileStream.cls
+++ b/Core/Object Arts/Dolphin/Base/StdioFileStream.cls
@@ -6,7 +6,7 @@ SequencedStream subclass: #StdioFileStream
 	poolDictionaries: 'CRTConstants'
 	classInstanceVariableNames: ''!
 StdioFileStream guid: (GUID fromString: '{7B8405B3-0819-421F-8110-CA2763BCB59A}')!
-StdioFileStream comment: 'StdioFileStream is a <FileStream> implemented over C runtime library stdio streams. Its main purpose is to wrap the stdin, stdout, and stderr streams in console applications, and it is not intended for general use. FileStream itself should be used by preference in most cases.
+StdioFileStream comment: 'StdioFileStream is a <FileStream> implemented over C runtime library stdio streams. Its main purpose is to wrap the stdin, stdout, and stderr streams in console applications, and it is not intended for general use. In order to avoid blocking the main Dolphin thread when attempting to read from stdin, the CRT stream I/O calls are overlapped (i.e. run on a threadpool thread), which makes them rather slow. FileStream itself should be used by preference in most cases.
 
 Instance Variables:
 	stream	<ExternalHandle>. FILE* stream handle.
@@ -26,7 +26,14 @@ asParameter
 atEnd
 	"Answer whether the receiver cannot access any more objects"
 
-	^(CRTLibrary default feof: stream) ~~ 0 or: [self peek isNil]!
+	| crt |
+	crt := CRTLibrary default.
+	^(crt feof: stream) ~~ 0 or: 
+			["feof returns non-zero only when an attempt has been made to read past the end of stream, so we have to peek."
+			| ch |
+			(ch := crt fgetc: stream) == -1 or: 
+					[crt ungetc: ch stream: stream.
+					false]]!
 
 attach: anExternalHandle toFd: fdInteger mode: aSymbol text: aBoolean 
 	"Private - Attach the stdio descriptor identified by fdInteger (usually one of 0=stdin,
@@ -112,9 +119,6 @@ display: anObject
 
 	anObject displayOn: self!
 
-elementFor: anInteger 
-	^isText ifTrue: [Character value: anInteger] ifFalse: [anInteger]!
-
 externalType
 	"Answer a <symbol> which names the external stream type of the receiver."
 
@@ -163,7 +167,9 @@ next
 
 	| ch |
 	ch := CRTLibrary default fgetc: stream.
-	^ch == -1 ifTrue: [self errorEndOfStream] ifFalse: [self elementFor: ch]!
+	^ch == -1
+		ifTrue: [self errorEndOfStream]
+		ifFalse: [isText ifTrue: [Character value: ch] ifFalse: [ch]]!
 
 next: countInteger into: aSequenceableCollection startingAt: startInteger 
 	"Destructively replace the elements of the argument, aSequenceableCollection,
@@ -251,6 +257,15 @@ nextLine
 				ifFalse: [answer copyFrom: 1 to: len - 1]]
 		ifFalse: [last == $\r ifTrue: [answer copyFrom: 1 to: len - 1] ifFalse: [answer]]!
 
+nextOrNil
+	"Answer a <Character>, or <integer> in the range 0..255, being the next of the 
+	receiver's future sequence values. Answer nil if at EOF."
+
+	| ch |
+	ch := CRTLibrary default fgetc: stream.
+	^ch == -1
+		ifFalse: [isText ifTrue: [Character value: ch] ifFalse: [ch]]!
+
 nextPut: anObject 
 	"Store the <Character> or <integer> (in the range 0..255) as the next element of the receiver."
 
@@ -269,21 +284,22 @@ peek
 
 	| ch |
 	ch := CRTLibrary default fgetc: stream.
-	^ch == -1 
+	^ch == -1
 		ifFalse: 
 			[CRTLibrary default ungetc: ch stream: stream.
-			self elementFor: ch]!
+			isText ifTrue: [Character value: ch] ifFalse: [ch]]!
 
-peekFor: anObject 
+peekFor: anObject
 	"Determine the response to the message peek. If it is the same as the
 	argument, anObject, then increment the position reference and answer true.
 	Otherwise answer false and do not change the position reference"
 
 	| ch |
 	ch := CRTLibrary default fgetc: stream.
-	^ch ~~ -1 and: 
-			[CRTLibrary default ungetc: ch stream: stream.
-			(self elementFor: ch) = anObject]!
+	^ch ~~ -1
+		and: [anObject asInteger == ch or: 
+					[CRTLibrary default ungetc: ch stream: stream.
+					false]]!
 
 position
 	"Answer the absolute (zero-based) position of the file pointer."
@@ -367,7 +383,6 @@ tab: anInteger
 !StdioFileStream categoriesFor: #crtab!accessing!public! !
 !StdioFileStream categoriesFor: #crtab:!accessing!public! !
 !StdioFileStream categoriesFor: #display:!printing!public! !
-!StdioFileStream categoriesFor: #elementFor:!accessing!private! !
 !StdioFileStream categoriesFor: #externalType!accessing!public! !
 !StdioFileStream categoriesFor: #fileno!accessing!private! !
 !StdioFileStream categoriesFor: #finalize!finalizing!private! !
@@ -383,6 +398,7 @@ tab: anInteger
 !StdioFileStream categoriesFor: #next:putAll:startingAt:!accessing!public! !
 !StdioFileStream categoriesFor: #nextAvailable:!accessing!public! !
 !StdioFileStream categoriesFor: #nextLine!accessing!public! !
+!StdioFileStream categoriesFor: #nextOrNil!accessing!public! !
 !StdioFileStream categoriesFor: #nextPut:!accessing!public! !
 !StdioFileStream categoriesFor: #nextPutAll:!accessing!public! !
 !StdioFileStream categoriesFor: #peek!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/StdioFileStreamTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StdioFileStreamTest.cls
@@ -11,6 +11,21 @@ StdioFileStreamTest comment: ''!
 !StdioFileStreamTest methodsFor!
 
 streamClass
-	^StdioFileStream! !
+	^StdioFileStream!
+
+testNextLineCrOnly
+	"Test PositionableStream>>nextLine for text streams with <CR> between lines"
+
+	#('a' 'ab' 'abc') do: 
+			[:each |
+			| chars stream |
+			chars := each , (String with: Character cr) , each.
+			stream := self streamOn: chars.
+			stream reset.
+			"CRT I/O stream in translated text mode does not recognise single CR as a line ending"
+			self assert: chars equals: stream nextLine.
+			self assert: stream atEnd.
+			self closeTempStream: stream]! !
 !StdioFileStreamTest categoriesFor: #streamClass!helpers!private! !
+!StdioFileStreamTest categoriesFor: #testNextLineCrOnly!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/Stream.cls
+++ b/Core/Object Arts/Dolphin/Base/Stream.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #Stream
 	instanceVariableNames: ''
@@ -110,6 +110,12 @@ nextMatchFor: anObject
 
 	^anObject = self next!
 
+nextOrNil
+	"Answer a <Character>, or <integer> in the range 0..255, being the next of the 
+	receiver's future sequence values. Answer nil if at EOF."
+
+	^self atEnd ifFalse: [self next]!
+
 skipThrough: anObject 
 	"Set the receivers position reference to be past the next occurrence of the argument,
 	anObject, in the collection. Answer the receiver, or nil if no such occurrence existed."
@@ -135,9 +141,7 @@ upTo: anObject
 
 	| newStream nextObject |
 	newStream := self contentsSpecies writeStream: 128.
-	[self atEnd or: 
-			[nextObject := self next.
-			nextObject = anObject]] 
+	[(nextObject := self nextOrNil) isNil or: [nextObject = anObject]] 
 		whileFalse: [newStream nextPut: nextObject].
 	^newStream contents!
 
@@ -161,6 +165,7 @@ upToEnd
 !Stream categoriesFor: #next:into:startingAt:!accessing!public! !
 !Stream categoriesFor: #nextAvailable:!accessing!public! !
 !Stream categoriesFor: #nextMatchFor:!accessing!public! !
+!Stream categoriesFor: #nextOrNil!accessing!public! !
 !Stream categoriesFor: #skipThrough:!positioning!public! !
 !Stream categoriesFor: #skipTo:!positioning!public! !
 !Stream categoriesFor: #upTo:!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/StreamTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StreamTest.cls
@@ -19,10 +19,30 @@ streamClass
 streamOn: aString 
 	"Private - Answer a <gettableStream> of the type the receiver is testing, on the <String> argument."
 
-	^self streamClass on: aString! !
+	^self streamClass on: aString!
+
+testUpTo
+	| chars stream |
+	chars := 'abcdefghij'.
+	stream := self streamOn: chars.
+	self assert: '' equals: (stream upTo: $a).
+	self assert: '' equals: (stream upTo: $b).
+	self assert: 'c' equals: (stream upTo: $d).
+	self assert: 'ef' equals: (stream upTo: $g).
+	self assert: 'hij' equals: (stream upTo: $z).
+	self assert: stream atEnd.
+	self assert: '' equals: (stream upTo: $z).
+	stream reset.
+	self assert: 'abcdefghi' equals: (stream upTo: $j).
+	self assert: stream atEnd.
+	stream reset.
+	self assert: chars equals: (stream upTo: $z).
+	self assert: stream atEnd.
+	self closeTempStream: stream! !
 !StreamTest categoriesFor: #closeTempStream:!helpers!private! !
 !StreamTest categoriesFor: #streamClass!helpers!private! !
 !StreamTest categoriesFor: #streamOn:!helpers!private! !
+!StreamTest categoriesFor: #testUpTo!public! !
 
 !StreamTest class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -980,7 +980,7 @@ unescapePercents
 					startingAt: oldPos.
 				char := self at: pos.
 				char == $+ 
-					ifTrue: [answer nextPut: $ ]
+					ifTrue: [answer nextPut: $\x20]
 					ifFalse: 
 						[(char == $% and: [pos + 2 <= self size]) 
 							ifTrue: 

--- a/Core/Object Arts/Dolphin/Base/WriteStreamTest.cls
+++ b/Core/Object Arts/Dolphin/Base/WriteStreamTest.cls
@@ -56,12 +56,24 @@ testNextLine
 	stream reset.
 	self readOperationNotImplemented: [stream nextLine]!
 
+testNextLineCrOnly
+	| stream |
+	stream := self streamWith: (String with: $\r) , 'abc'.
+	stream reset.
+	self readOperationNotImplemented: [stream nextLine]!
+
 testNextWord
 	| stream |
 	stream := self streamWith: 'abc'.
 	stream reset.
 	"It is an error to attempt to read from a WriteStream"
 	self should: [stream nextWord] raise: Error!
+
+testPeekFor
+	| stream |
+	stream := self streamWith: 'abc'.
+	stream reset.
+	self readOperationNotImplemented: [stream peekFor: $a]!
 
 testSetToEnd
 	| string stream |
@@ -79,6 +91,9 @@ testSkipToAllColon
 	stream := self streamOn: chars.
 
 	self readOperationNotImplemented: [stream skipToAll: 'a']!
+
+testUpTo
+	self readOperationNotImplemented: [super testUpTo]!
 
 testUpToAllColon
 	| chars stream |
@@ -98,9 +113,12 @@ testUpToEnd
 !WriteStreamTest categoriesFor: #testContents!public!unit tests! !
 !WriteStreamTest categoriesFor: #testNewContents!public!unit tests! !
 !WriteStreamTest categoriesFor: #testNextLine!public!unit tests! !
+!WriteStreamTest categoriesFor: #testNextLineCrOnly!public!unit tests! !
 !WriteStreamTest categoriesFor: #testNextWord!public!unit tests! !
+!WriteStreamTest categoriesFor: #testPeekFor!public!unit tests! !
 !WriteStreamTest categoriesFor: #testSetToEnd!public!testing! !
 !WriteStreamTest categoriesFor: #testSkipToAllColon!public!unit tests! !
+!WriteStreamTest categoriesFor: #testUpTo!public!unit tests! !
 !WriteStreamTest categoriesFor: #testUpToAllColon!public!unit tests! !
 !WriteStreamTest categoriesFor: #testUpToEnd!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
@@ -1703,13 +1703,13 @@ dolphinNewsgroup
 dolphinWikiWeb
 	self openUrl: self sessionManager dolphinWikiUrl!
 
-dropClassFile: aString 
-	(MessageBox 
+dropClassFile: aString
+	(MessageBox
 		confirm: ('File in <1p>?<n><n>If the class is new it will be <2s>.' expandMacrosWith: aString
-				with: (self packageManager defaultPackage 
+				with: (self packageManager defaultPackage
 						ifNil: ['unpackaged']
-						ifNotNil: [:pkg | 'added to the default package (<1d>)' expandMacrosWith: pkg]))) 
-			ifTrue: [self sourceManager fileIn: aString]!
+						ifNotNil: [:pkg | 'added to the default package (<1d>)' expandMacrosWith: pkg])))
+			ifTrue: [self sourceManager fileIn: aString normalizeLineEndings: true]!
 
 dropFile: aString 
 	[ShellLibrary default shellOpen: aString] on: Win32Error
@@ -1748,14 +1748,14 @@ fileFileIn
 	| filename |
 	filename := (FileOpenDialog new)
 				caption: 'File in...';
-				fileTypes: (Array 
+				fileTypes: (Array
 							with: self smalltalkFilesType
 							with: self classFilesType
 							with: FileDialog allFilesType);
 				defaultExtension: '';
 				showModal.
-	filename notNil 
-		ifTrue: [Cursor wait showWhile: [self sourceManager fileIn: filename]]!
+	filename notNil
+		ifTrue: [Cursor wait showWhile: [self sourceManager fileIn: filename normalizeLineEndings: true]]!
 
 fileNew
 	"Basic implementation of context-sensitive file-new command. Tools typically implement

--- a/Core/Object Arts/Dolphin/IDE/Base/TranscriptShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/TranscriptShell.cls
@@ -115,13 +115,13 @@ fileFileIn
 	(containing chunks) and file it in."
 
 	| filename |
-	filename := FileOpenDialog new
-		caption: 'File in...';
-		fileTypes: (Array with: self smalltalkFilesType with: FileDialog allFilesType);
-		defaultExtension: '';
-		showModal.
-	filename notNil ifTrue: [
-		Cursor wait showWhile: [self class sourceManager fileIn: filename]]!
+	filename := (FileOpenDialog new)
+				caption: 'File in...';
+				fileTypes: (Array with: self smalltalkFilesType with: FileDialog allFilesType);
+				defaultExtension: '';
+				showModal.
+	filename notNil
+		ifTrue: [Cursor wait showWhile: [self class sourceManager fileIn: filename normalizeLineEndings: true]]!
 
 flush
 	"Flush the buffered output to the display."

--- a/Core/Object Arts/Dolphin/MVP/Base/Font.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Font.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 GraphicsTool subclass: #Font
 	instanceVariableNames: 'logfont resolution'
@@ -57,10 +57,9 @@ displayOn: aStream
 	would want to see it."
 
 	self name displayOn: aStream.
-	aStream nextPut: $ .
+	aStream nextPut: $\x20.
 	self pointSize displayOn: aStream.
-	aStream nextPutAll: 'pt'.
-!
+	aStream nextPutAll: 'pt'!
 
 handle: hFont
 	"Sets the non-owned handle for the receiver and queries its logical info."

--- a/Core/Object Arts/Dolphin/Sockets/SocketReadStream.cls
+++ b/Core/Object Arts/Dolphin/Sockets/SocketReadStream.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ReadStream subclass: #SocketReadStream
 	instanceVariableNames: 'socket'
@@ -76,6 +76,12 @@ next: countInteger into: aSequenceableCollection startingAt: startInteger
 nextAvailable
 	^self atEnd ifFalse: [self next]!
 
+nextOrNil
+	"Answer a <Character>, or <integer> in the range 0..255, being the next of the 
+	receiver's future sequence values. Answer nil if at EOF."
+
+	^self atEnd ifFalse: [self next]!
+
 readPage
 	"Private - Read ahead, a whole page or as much input as is available, into the buffer."
 
@@ -109,6 +115,18 @@ socket: aSocket
 
 	socket := aSocket!
 
+upTo: anObject 
+	"Answer a collection of elements starting with the next element accessed by the receiver,
+	and up to, not inclusive of, the next element that is equal to anObject. Positions the
+	stream after anObject if found. If anObject is not in the collection, answer the entire rest
+	of the collection. If the receiver is at its end, answer an empty Collection."
+
+	| newStream nextObject |
+	newStream := self contentsSpecies writeStream: 128.
+	[(nextObject := self nextOrNil) isNil or: [nextObject = anObject]] 
+		whileFalse: [newStream nextPut: nextObject].
+	^newStream contents!
+
 upToEnd
 	"Answer a collection consisting of the remaining elements in the receiver (i.e. from the current
 	position to the end)."
@@ -127,11 +145,13 @@ upToEnd
 !SocketReadStream categoriesFor: #next!accessing!public! !
 !SocketReadStream categoriesFor: #next:into:startingAt:!accessing!public! !
 !SocketReadStream categoriesFor: #nextAvailable!public! !
+!SocketReadStream categoriesFor: #nextOrNil!accessing!public! !
 !SocketReadStream categoriesFor: #readPage!operations!private! !
 !SocketReadStream categoriesFor: #setToEnd!positioning!public! !
 !SocketReadStream categoriesFor: #size!accessing!public! !
 !SocketReadStream categoriesFor: #socket!accessing!private! !
 !SocketReadStream categoriesFor: #socket:!accessing!private! !
+!SocketReadStream categoriesFor: #upTo:!accessing!public! !
 !SocketReadStream categoriesFor: #upToEnd!accessing!public! !
 
 !SocketReadStream class methodsFor!

--- a/Core/Object Arts/Dolphin/System/Compiler/StToken.cls
+++ b/Core/Object Arts/Dolphin/System/Compiler/StToken.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #StToken
 	instanceVariableNames: 'sourcePointer comments'
@@ -65,7 +65,7 @@ length
 
 printOn: aStream 
 	aStream
-		nextPut: $ ;
+		nextPut: $\x20;
 		nextPutAll: self class name!
 
 removePositions

--- a/PreBoot.st
+++ b/PreBoot.st
@@ -44,3 +44,37 @@ hasBytecodeRepresentation: anObject
 	SmallIntegers, Characters."
 
 	^anObject isImmediate or: [anObject isNil or: [anObject == true or: [anObject == false]]]! !
+
+SourceFiler removeSelectors: #(#isSourceOnly #isSourceOnly:)!
+
+Object subclass: #SourceFiler
+	instanceVariableNames: 'stream evaluationContext flags'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+
+SourceFiler addClassConstant: 'SourceOnlyMask' value: 1!
+
+!SourceFiler methodsFor!
+
+isSourceOnly
+	^flags anyMask: SourceOnlyMask!
+
+isSourceOnly: aBoolean
+	flags := flags mask: SourceOnlyMask set: aBoolean!
+
+setStream: aPuttableStream
+	stream := aPuttableStream.
+	flags := 0! !
+
+ChunkSourceFiler allInstances do: [:each | each setStream: each stream]!
+
+ChunkSourceFiler addClassConstant: 'NormalizeEolsMask' value: 2!
+
+!ChunkSourceFiler methodsFor!
+
+normalizeLineEndings
+	^flags anyMask: NormalizeEolsMask!
+
+normalizeLineEndings: aBoolean
+	flags := flags mask: NormalizeEolsMask set: aBoolean! !


### PR DESCRIPTION
- Add an option to chunk source filer to normalize line endings when reading
chunks, and use this from commands that file in individual files (though
not when filing in packages, since it is slower).
- Fix the fact that SequencedStream>>nextLine does not work for single-CR
line endings (like those from Squeak/Pharo).
- Optimize a number of methods across the Stream hierarchy.