### PR TITLE
Fix #116: Regression tests are getting slow, but difficult to tell which

### DIFF
--- a/Core/Object Arts/Dolphin/Base/CommandLineTestRunner.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTestRunner.cls
@@ -1,0 +1,134 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+Object subclass: #CommandLineTestRunner
+	instanceVariableNames: 'results lastCase caseStart stream verbose runStart runStop'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+CommandLineTestRunner guid: (GUID fromString: '{69CAE7CC-DE76-4748-BC30-E39048DDBB3C}')!
+CommandLineTestRunner comment: ''!
+!CommandLineTestRunner categoriesForClass!Kernel-Objects! !
+!CommandLineTestRunner methodsFor!
+
+initialize
+	verbose := false!
+
+printRuntime: anInteger
+	| mS |
+	mS := anInteger / 1000.0.
+	mS < 1000.0
+		ifTrue: 
+			[mS printOn: stream decimalPlaces: (mS < 1.0 ifTrue: [3] ifFalse: [0]).
+			stream nextPutAll: ' mS']
+		ifFalse: 
+			[| secs |
+			secs := mS / 1000.0.
+			secs printOn: stream decimalPlaces: (secs < 10.0 ifTrue: [1] ifFalse: [0]).
+			stream nextPutAll: ' s']!
+
+result
+	^results!
+
+resultFor: aTestCase
+	(results isPassed: aTestCase) ifTrue: [^#passed].
+	(results isFailure: aTestCase) ifTrue: [^#failed].
+	(results isError: aTestCase) ifTrue: [^#error].
+	^#indeterminate!
+
+runSuite: aTestSuite
+	verbose ifTrue: [aTestSuite addDependentToHierachy: self].
+	results := TestResult new.
+	aTestSuite resources do: [:res | res isAvailable ifFalse: [^res signalInitializationError]].
+	stream isNil ifTrue: [stream := SessionManager current stdout].
+	runStart := Time microsecondClockValue.
+	
+	[lastCase := nil.
+	aTestSuite run: results.
+	self
+		update: nil
+		with: nil
+		from: aTestSuite]
+			ensure: 
+				[verbose ifTrue: [aTestSuite removeDependentFromHierachy: self].
+				aTestSuite resources do: [:each | each reset]].
+	self summarizeResults.
+	^results!
+
+stream: aPuttableStream
+	stream := aPuttableStream!
+
+summarizeResults
+	stream
+		nextPutAll: (results hasPassed ifTrue: ['PASSED'] ifFalse: ['FAILED']);
+		cr;
+		nextPutAll: results printString;
+		nextPutAll: ' in '.
+	self printRuntime: caseStart - runStart.
+	stream cr.
+	results failures notEmpty
+		ifTrue: 
+			[stream
+				cr;
+				nextPutAll: 'FAILURES:';
+				cr.
+			results failures do: 
+					[:each |
+					stream
+						nextPutAll: each printString;
+						cr]].
+	results errors notEmpty
+		ifTrue: 
+			[stream
+				cr;
+				nextPutAll: 'ERRORS:';
+				cr.
+			results errors do: 
+					[:each |
+					stream
+						nextPutAll: each printString;
+						cr]].
+	stream flush!
+
+update: anObject with: argument from: originator
+	| stop |
+	stop := Time microsecondClockValue.
+	originator class == TestSuite
+		ifFalse: 
+			[^super
+				update: anObject
+				with: argument
+				from: originator].
+	lastCase isNil
+		ifFalse: 
+			[stream
+				nextPutAll: (self resultFor: lastCase) asUppercase;
+				nextPutAll: ' in '.
+			self printRuntime: stop - caseStart.
+			stream cr].
+	anObject isNil
+		ifFalse: 
+			[stream
+				print: anObject;
+				nextPutAll: ' ... '].
+	stream flush.
+	lastCase := anObject.
+	caseStart := Time microsecondClockValue!
+
+verbose: anObject
+	verbose := anObject! !
+!CommandLineTestRunner categoriesFor: #initialize!initializing!private! !
+!CommandLineTestRunner categoriesFor: #printRuntime:!helpers!private! !
+!CommandLineTestRunner categoriesFor: #result!Accessing!public! !
+!CommandLineTestRunner categoriesFor: #resultFor:!helpers!private! !
+!CommandLineTestRunner categoriesFor: #runSuite:!operations!public! !
+!CommandLineTestRunner categoriesFor: #stream:!accessing!public! !
+!CommandLineTestRunner categoriesFor: #summarizeResults!helpers!private! !
+!CommandLineTestRunner categoriesFor: #update:with:from:!private!updating! !
+!CommandLineTestRunner categoriesFor: #verbose:!accessing!public! !
+
+!CommandLineTestRunner class methodsFor!
+
+new
+	^super new initialize! !
+!CommandLineTestRunner class categoriesFor: #new!instance creation!public! !
+

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -694,7 +694,7 @@ runRegressionTests
 
 runRegressionTests: aTestSuite logTo: aFilenameStringOrNil
 	| results timeMs |
-	timeMs := Time millisecondsToRun: (SessionManager current isUnattended & false
+	timeMs := Time millisecondsToRun: (SessionManager current isUnattended
 						ifTrue: 
 							[
 							[aTestSuite addDependentToHierachy: self.

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -19,6 +19,7 @@ package classNames
 	add: #ClassBuilderTests;
 	add: #CollectionCombinator;
 	add: #CommandLineTest;
+	add: #CommandLineTestRunner;
 	add: #DateTest;
 	add: #DefaultSortAlgorithmTest;
 	add: #DictionaryTest;
@@ -115,8 +116,7 @@ package methodNames
 	add: #SmalltalkSystem -> #regressionTestsLogFilename;
 	add: #SmalltalkSystem -> #regressionTestSuite;
 	add: #SmalltalkSystem -> #runRegressionTests;
-	add: #SmalltalkSystem -> #runRegressionTests:logTo:;
-	add: #SmalltalkSystem -> #update:;
+	add: #SmalltalkSystem -> #runRegressionTests:logTo:verbose:;
 	yourself.
 
 package binaryGlobalNames: (Set new
@@ -144,7 +144,6 @@ package setPrerequisites: (IdentitySet new
 	add: '..\..\..\Contributions\Refactory\Refactoring Browser\Tests\RBTests';
 	add: '..\System\Compiler\Smalltalk Parser';
 	add: '..\..\..\Contributions\Camp Smalltalk\SUnit\SUnit';
-	add: '..\..\..\Contributions\Camp Smalltalk\SUnit\SUnitUI';
 	add: '..\ActiveX\Shell\Windows Shell';
 	yourself).
 
@@ -154,6 +153,11 @@ package!
 
 Object subclass: #CollectionCombinator
 	instanceVariableNames: 'resultProcessingBlock collectionOfArrays buffer'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+Object subclass: #CommandLineTestRunner
+	instanceVariableNames: 'results lastCase caseStart stream verbose runStart runStop'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -681,7 +685,10 @@ DolphinTestClassResource subclass: #MustBeBooleanTestClasses
 !SmalltalkSystem methodsFor!
 
 regressionTestsLogFilename
-	^File default: SessionManager current imagePath extension: 'testlog'!
+	"Answer the name of the file in which to log test results, or nil to have the output sent to stdout"
+
+	^nil
+	"^File default: SessionManager current imagePath extension: 'testlog'"!
 
 regressionTestSuite
 	| suite |
@@ -690,71 +697,34 @@ regressionTestSuite
 	^suite!
 
 runRegressionTests
-	^self runRegressionTests: self regressionTestSuite logTo: self regressionTestsLogFilename!
-
-runRegressionTests: aTestSuite logTo: aFilenameStringOrNil
-	| results timeMs |
-	timeMs := Time millisecondsToRun: (SessionManager current isUnattended
-						ifTrue: 
-							[
-							[aTestSuite addDependentToHierachy: self.
-							results := [aTestSuite run] ensure: [aTestSuite removeDependentFromHierachy: self]]]
-						ifFalse: 
-							[
-							[| runner |
-							runner := TestRunner show.
-							runner runSuite: aTestSuite.
-							results := runner result]]).
-	aFilenameStringOrNil notNil
+	| suite filename |
+	filename := self regressionTestsLogFilename.
+	suite := self regressionTestSuite.
+	^filename isNil
 		ifTrue: 
+			[self
+				runRegressionTests: suite
+				logTo: SessionManager current stdout
+				verbose: true]
+		ifFalse: 
 			[| logStream |
-			logStream := FileStream write: aFilenameStringOrNil.
-			logStream
-				nextPutAll: (results hasPassed ifTrue: ['PASSED'] ifFalse: ['FAILED']);
-				cr;
-				nextPutAll: results printString;
-				nextPutAll: ' in ';
-				display: timeMs // 1000;
-				nextPutAll: 'secs';
-				cr.
-			results failures notEmpty
-				ifTrue: 
-					[logStream
-						cr;
-						nextPutAll: 'FAILURES:';
-						cr.
-					results failures do: 
-							[:each |
-							logStream
-								nextPutAll: each printString;
-								cr]].
-			results errors notEmpty
-				ifTrue: 
-					[logStream
-						cr;
-						nextPutAll: 'ERRORS:';
-						cr.
-					results errors do: 
-							[:each |
-							logStream
-								nextPutAll: each printString;
-								cr]].
-			logStream close].
-	^results!
+			logStream := FileStream write: filename.
+			
+			[self
+				runRegressionTests: suite
+				logTo: logStream
+				verbose: true]
+					ensure: [logStream close]]!
 
-update: anObject
-	(anObject isKindOf: TestCase)
-		ifTrue: 
-			[(SessionManager current stdout)
-				print: anObject;
-				cr;
-				flush]
-		ifFalse: [super update: anObject]! !
+runRegressionTests: aTestSuite logTo: logStream verbose: aBoolean
+	^(CommandLineTestRunner new)
+		stream: logStream;
+		verbose: aBoolean;
+		runSuite: aTestSuite! !
 !SmalltalkSystem categoriesFor: #regressionTestsLogFilename!public!tests! !
 !SmalltalkSystem categoriesFor: #regressionTestSuite!private!tests! !
 !SmalltalkSystem categoriesFor: #runRegressionTests!public!tests! !
-!SmalltalkSystem categoriesFor: #runRegressionTests:logTo:!public!tests! !
-!SmalltalkSystem categoriesFor: #update:!helpers!public! !
+!SmalltalkSystem categoriesFor: #runRegressionTests:logTo:verbose:!public!tests! !
 
 "End of package definition"!
 

--- a/Core/Object Arts/Dolphin/Base/Win32Constants.st
+++ b/Core/Object Arts/Dolphin/Base/Win32Constants.st
@@ -453,6 +453,7 @@ Win32Constants at: 'MEM_RELEASE' put: 16r8000!
 Win32Constants at: 'MEM_RESERVE' put: 16r2000!
 Win32Constants at: 'MEM_TOP_DOWN' put: 16r100000!
 Win32Constants at: 'MERGECOPY' put: 16rC000CA!
+Win32Constants at: 'MF_BYCOMMAND' put: 16r0!
 Win32Constants at: 'MF_BYPOSITION' put: 16r400!
 Win32Constants at: 'MF_POPUP' put: 16r10!
 Win32Constants at: 'MFS_CHECKED' put: 16r8!
@@ -616,6 +617,7 @@ Win32Constants at: 'SB_THUMBPOSITION' put: 16r4!
 Win32Constants at: 'SB_THUMBTRACK' put: 16r5!
 Win32Constants at: 'SB_TOP' put: 16r6!
 Win32Constants at: 'SB_VERT' put: 16r1!
+Win32Constants at: 'SC_CLOSE' put: 16rF060!
 Win32Constants at: 'SIF_ALL' put: 16r17!
 Win32Constants at: 'SIF_DISABLENOSCROLL' put: 16r8!
 Win32Constants at: 'SIF_PAGE' put: 16r2!

--- a/Core/Object Arts/Dolphin/IDE/Base/Debugger.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Debugger.cls
@@ -1451,7 +1451,7 @@ returnFromMessage
 							on: compilerClass errorClass
 							do: 
 								[:cn | 
-								MessageBox errorMsg: cn text , String lineDelimiter , String lineDelimiter , 'Please try again.'
+								MessageBox errorMsg: cn errorMessage , String lineDelimiter , String lineDelimiter , 'Please try again.'
 									caption: 'Error in expression...'.
 								loopCookie]].
 	returnValue == loopCookie] 

--- a/Core/Object Arts/Dolphin/Lagoon/CRTLibraryImportTest.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/CRTLibraryImportTest.cls
@@ -30,7 +30,7 @@ testStubCrtExports
 			[procs := (CRTLibrary selectMethods: [:each | each isExternalCall])
 						collect: [:each | each functionName].
 			missing := procs select: [:each | (l getProcAddress: each ifAbsent: []) isNil].
-			self assert: (missing noDifference: expected)]
+			self assert: (missing difference: expected) isEmpty]
 					ensure: [l close]]! !
 !CRTLibraryImportTest categoriesFor: #devOnlyCrtFunctions!constants!private! !
 !CRTLibraryImportTest categoriesFor: #stubNames!constants!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -212,6 +212,7 @@ package classNames
 	yourself.
 
 package methodNames
+	add: #KernelLibrary -> #getConsoleWindow;
 	add: #MessageSend -> #queryCommand:;
 	add: #Object -> #addToImageList:mask:;
 	add: #Point -> #@;
@@ -276,6 +277,7 @@ package methodNames
 	add: #UserLibrary -> #getNextDlgTabItem:hCtl:bPrevious:;
 	add: #UserLibrary -> #getProp:lpString:;
 	add: #UserLibrary -> #getScrollInfo:fnBar:lpsi:;
+	add: #UserLibrary -> #getSystemMenu:bRevert:;
 	add: #UserLibrary -> #getTopWindow:;
 	add: #UserLibrary -> #getUpdateRect:lpRect:bErase:;
 	add: #UserLibrary -> #getWindow:uCmd:;
@@ -1285,6 +1287,13 @@ icon
 	^Icon fromId: 2 in: (ExternalResourceLibrary open: 'Shell32')! !
 !File class categoriesFor: #icon!constants!development!public! !
 
+!KernelLibrary methodsFor!
+
+getConsoleWindow
+	<stdcall: handle GetConsoleWindow>
+	^self invalidCall! !
+!KernelLibrary categoriesFor: #getConsoleWindow!public!win32 functions-console! !
+
 !MessageSend methodsFor!
 
 queryCommand: query
@@ -1970,6 +1979,10 @@ getScrollInfo: aWindowHandle fnBar: flag lpsi: struct
 		);"
 
 	<stdcall: bool GetScrollInfo handle sdword SCROLLINFO* >
+	^self invalidCall!
+
+getSystemMenu: anExternalHandle bRevert: aBoolean
+	<stdcall: handle GetSystemMenu handle bool>
 	^self invalidCall!
 
 getTopWindow: aHandle
@@ -2820,6 +2833,7 @@ winHelp: hwndMain lpszHelp: lpszHelp uCommand: uCommand dwData: dwData
 !UserLibrary categoriesFor: #getNextDlgTabItem:hCtl:bPrevious:!public!win32 functions-window! !
 !UserLibrary categoriesFor: #getProp:lpString:!public!win32 functions-window property! !
 !UserLibrary categoriesFor: #getScrollInfo:fnBar:lpsi:!public!win32 functions-scroll bar! !
+!UserLibrary categoriesFor: #getSystemMenu:bRevert:!public!win32 functions-menu!win32 functions-system information! !
 !UserLibrary categoriesFor: #getTopWindow:!public!win32 functions-window! !
 !UserLibrary categoriesFor: #getUpdateRect:lpRect:bErase:!public!win32 functions-painting and drawing! !
 !UserLibrary categoriesFor: #getWindow:uCmd:!public!win32 functions-window! !

--- a/Core/Object Arts/Dolphin/MVP/Base/GUISessionManager.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/GUISessionManager.cls
@@ -22,9 +22,21 @@ Instance Variables:
 allocConsole
 	"Private - Open a console window for this session."
 
-	| lib |
-	lib := KernelLibrary default.
-	(self isUnattended and: [lib attachConsole: ATTACH_PARENT_PROCESS]) ifFalse: [lib allocConsole]!
+	| kernel |
+	kernel := KernelLibrary default.
+	(self isUnattended and: [kernel attachConsole: ATTACH_PARENT_PROCESS])
+		ifFalse: 
+			[| hConsole hMenu user |
+			kernel allocConsole.
+			"Remove the close button from the console window as otherwise if the user
+			closes it Windows will kill this process with no way to intercept."
+			hConsole := KernelLibrary default getConsoleWindow.
+			user := UserLibrary default.
+			hMenu := user getSystemMenu: hConsole bRevert: false.
+			user
+				deleteMenu: hMenu
+				uPosition: SC_CLOSE
+				uFlags: MF_BYCOMMAND]!
 
 basicShutdown
 	"Private - Perform basic system shutdown operations, just prior to the VM putting

--- a/TestDPRO.cmd
+++ b/TestDPRO.cmd
@@ -1,10 +1,7 @@
 @ECHO OFF
 ECHO Running regression tests
 echo. >DPRO.errors
-echo Fatal error terminated run: >DPRO.testlog
 Dolphin7 DPRO.img7 -u -f RegressionTestsRun.st -q
-FINDSTR /L /C:"PASSED" DPRO.testlog >nul
 set errorCode=%ERRORLEVEL%
-TYPE DPRO.testlog
 TYPE DPRO.errors
 EXIT /b %errorCode%


### PR DESCRIPTION
Added a CommandLineTestRunner that now logs to stdout (and therefore the CI build console) as it progresses, reporting the result for each test and the time it took to run. This is the verbose mode, it if gets too annoying it can easily be turned off. The use of a separate file and code in the script to detect failure/success by searching the file has been removed.