### PR TITLE
Speed up PackageBrowserShell resource card refresh

### DIFF
--- a/Core/Contributions/Camp Smalltalk/SUnit/SUnitTest.cls
+++ b/Core/Contributions/Camp Smalltalk/SUnit/SUnitTest.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6.1"!
+"Filed out from Dolphin Smalltalk 7"!
 
 TestCase subclass: #SUnitTest
 	instanceVariableNames: 'hasRun hasSetup hasRanOnce'
@@ -115,7 +115,7 @@ testResult
 		errors: 0!
 
 testRunning
-	(SUnitDelay forSeconds: 2) wait!
+	(SUnitDelay forMicroseconds: 20) wait!
 
 testShould
 	self should: [true].

--- a/Core/Object Arts/Dolphin/Base/Behavior.cls
+++ b/Core/Object Arts/Dolphin/Base/Behavior.cls
@@ -150,7 +150,7 @@ allSubclasses
 
 	| answer |
 	answer := OrderedCollection new.
-	self allSubclassesBreadthFirstDo: [:each | answer add: each].
+	self allSubclassesBreadthFirstDo: [:each | answer addLast: each].
 	^answer!
 
 allSubclassesBreadthFirstDo: aMonadicValuable 
@@ -158,7 +158,7 @@ allSubclassesBreadthFirstDo: aMonadicValuable
 	subclasses in breadth-first order. The standard #allSubclassesDo: method 
 	performs a depth-first traversal (which is quicker)."
 
-	self subclasses ifNotNil: 
+	subclasses ifNotNil: 
 			[:classes | 
 			classes do: [:each | aMonadicValuable value: each].
 			classes do: [:each | each allSubclassesBreadthFirstDo: aMonadicValuable]]!
@@ -871,7 +871,7 @@ sharedPools
 
 	| pools |
 	pools := OrderedCollection new.
-	self sharedPoolsDo: [:each | pools add: each].
+	self sharedPoolsDo: [:each | pools addLast: each].
 	^pools!
 
 sharedPoolsDo: aMonadicValuable

--- a/Core/Object Arts/Dolphin/Base/Class.cls
+++ b/Core/Object Arts/Dolphin/Base/Class.cls
@@ -860,8 +860,9 @@ allClasses
 
 	| answer roots |
 	roots := self allRoots.
-	answer := OrderedCollection withAll: roots.
-	roots do: [:root | answer addAll: root allSubclasses].
+	answer := OrderedCollection new: 2500.
+	answer addAllLast: roots.
+	roots do: [:root | root allSubclassesBreadthFirstDo: [:each | answer addLast: each]].
 	^answer.!
 
 allClassesDo: operation

--- a/Core/Object Arts/Dolphin/Base/ClassDescription.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescription.cls
@@ -757,29 +757,32 @@ renameInstVar: oldString to: newString
 	self logDefinition.
 	self environment classUpdated: self!
 
-resourceIdentifierClass
-	^Smalltalk at: #ResourceIdentifier!
-
 resourceIdentifiers
-	^self resourceSelectors collect: [:each | self resourceIdentifierClass class: self selector: each]!
+	| identifiers |
+	identifiers := OrderedCollection new.
+	self resourceIdentifiersDo: [:each | identifiers addLast: each].
+	^identifiers!
+
+resourceIdentifiersDo: aMonadicValuable
+	self
+		resourceSelectorsDo: [:each | aMonadicValuable value: (ResourceIdentifier class: self selector: each)]!
 
 resourceNames
-	^(self resourceSelectors collect: [:each | self resourceIdentifierClass nameFromSelector: each]) 
-		asSortedCollection!
+	| names |
+	names := OrderedCollection new.
+	self resourceSelectorsDo: [:each | names add: (ResourceIdentifier nameFromSelector: each)].
+	^names asSortedCollection!
 
 resources
-	^self resourceIdentifiers collect: [:each | each resource]!
+	| resources |
+	resources := OrderedCollection new.
+	self resourceIdentifiersDo: [:each | resources add: each resource].
+	^resources!
 
-resourceSelectors
-	| answer |
-	answer := IdentitySet new.
-	self resourceSelectorsDo: [:each | answer add: each].
-	^answer!
-
-resourceSelectorsDo: aMonadicValuable 
+resourceSelectorsDo: aMonadicValuable
 	| prefix |
-	prefix := self resourceIdentifierClass selectorPrefix.
-	^self class methodDictionary 
+	prefix := ResourceIdentifier selectorPrefix.
+	self class methodDictionary
 		do: [:each | (each selector beginsWith: prefix) ifTrue: [aMonadicValuable value: each selector]]!
 
 selectorsInCategory: category
@@ -944,11 +947,10 @@ whichNonVirtualCategoriesIncludeSelector: aSelector
 !ClassDescription categoriesFor: #removeSharedPool:!pool variables!public! !
 !ClassDescription categoriesFor: #removeUnsupportedProtocols:selector:!development!methods-removing!private!protocols! !
 !ClassDescription categoriesFor: #renameInstVar:to:!instance variables!private! !
-!ClassDescription categoriesFor: #resourceIdentifierClass!constants!private! !
 !ClassDescription categoriesFor: #resourceIdentifiers!accessing!public! !
+!ClassDescription categoriesFor: #resourceIdentifiersDo:!enumerating!public! !
 !ClassDescription categoriesFor: #resourceNames!accessing!public! !
 !ClassDescription categoriesFor: #resources!accessing!public! !
-!ClassDescription categoriesFor: #resourceSelectors!accessing!public! !
 !ClassDescription categoriesFor: #resourceSelectorsDo:!enumerating!public! !
 !ClassDescription categoriesFor: #selectorsInCategory:!categories-accessing!public! !
 !ClassDescription categoriesFor: #setInstanceVariables:!instance variables!private! !

--- a/Core/Object Arts/Dolphin/Base/ClassLocator.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassLocator.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 FileLocator subclass: #ClassLocator
 	instanceVariableNames: 'packageName codeBase key'
@@ -224,11 +224,6 @@ default
 	^self new
 !
 
-importedClasses
-	"Answer the LookupTable of classes that have been imported into this image."
-
-	^ImportedClasses!
-
 importedClassesMutex
 	"Private - Answer the mutex used to provide mutual exclusion to the locateClass
 	method."
@@ -241,13 +236,15 @@ initialize
 		self initialize
 	"
 
-	ImportedClasses := WeakLookupTable new haveWeakValues.
 	ImportedClassesMutex := Mutex new.
 	SessionManager current 
 		when: #sessionStarted
 		send: #onStartup
 		to: self.
 	Aliases := WeakLookupTable new haveWeakValues!
+
+isImportedClass: aClass
+	^ImportedClasses notNil and: [ImportedClasses identityIncludes: aClass]!
 
 new
 	"Answer a new, initialized, instance of the receiver."
@@ -259,7 +256,7 @@ onStartup
 
 	DefaultFileLocator := nil.
 	InstallationFileLocator := nil.
-	ImportedClasses := WeakLookupTable new haveWeakValues.
+	ImportedClasses := nil.
 !
 
 removeAlias: aSymbol
@@ -298,9 +295,9 @@ uninitialize
 !ClassLocator class categoriesFor: #codeBase:packageName:!instance creation!public! !
 !ClassLocator class categoriesFor: #codeBase:packageName:key:!instance creation!public! !
 !ClassLocator class categoriesFor: #default!accessing!public! !
-!ClassLocator class categoriesFor: #importedClasses!accessing!public! !
 !ClassLocator class categoriesFor: #importedClassesMutex!accessing!private! !
 !ClassLocator class categoriesFor: #initialize!development!initializing!private! !
+!ClassLocator class categoriesFor: #isImportedClass:!public!testing! !
 !ClassLocator class categoriesFor: #new!instance creation!public! !
 !ClassLocator class categoriesFor: #onStartup!events-session!private! !
 !ClassLocator class categoriesFor: #removeAlias:!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/DefaultSortAlgorithmTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DefaultSortAlgorithmTest.cls
@@ -51,12 +51,8 @@ sort: aCollection sortBlock: block
 				flush].
 	self assertSorted: sorted.
 	self add: aCollection sortBlock: block.
-	^sorted!
-
-testBigStringSort
-	self bigStringSort! !
+	^sorted! !
 !DefaultSortAlgorithmTest categoriesFor: #add:sortBlock:!helpers!private! !
 !DefaultSortAlgorithmTest categoriesFor: #algorithmToTest!private!unit tests! !
 !DefaultSortAlgorithmTest categoriesFor: #sort:sortBlock:!helpers!private! !
-!DefaultSortAlgorithmTest categoriesFor: #testBigStringSort!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/File.cls
+++ b/Core/Object Arts/Dolphin/Base/File.cls
@@ -546,7 +546,7 @@ commonPrefixOf: path1 and: path2
 			pathCommonPrefix: path1 
 			pszFile2: path2
 			achPath: prefix.
-	^prefix copyFrom: 1 to: len!
+	^prefix first: len!
 
 composePath: aPathString stem: aStemString extension: anExtensionString
 	"Composes a full pathname from its components. The path or extension components 

--- a/Core/Object Arts/Dolphin/Base/HeapsortAlgorithmTest.cls
+++ b/Core/Object Arts/Dolphin/Base/HeapsortAlgorithmTest.cls
@@ -11,10 +11,6 @@ HeapsortAlgorithmTest comment: ''!
 !HeapsortAlgorithmTest methodsFor!
 
 algorithmToTest
-	^HeapsortAlgorithm!
-
-testBigStringSort
-	self bigStringSort! !
+	^HeapsortAlgorithm! !
 !HeapsortAlgorithmTest categoriesFor: #algorithmToTest!private!unit tests! !
-!HeapsortAlgorithmTest categoriesFor: #testBigStringSort!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/IntrosortAlgorithmTest.cls
+++ b/Core/Object Arts/Dolphin/Base/IntrosortAlgorithmTest.cls
@@ -11,10 +11,6 @@ IntrosortAlgorithmTest comment: ''!
 !IntrosortAlgorithmTest methodsFor!
 
 algorithmToTest
-	^IntrosortAlgorithm!
-
-testBigStringSort
-	self bigStringSort! !
+	^IntrosortAlgorithm! !
 !IntrosortAlgorithmTest categoriesFor: #algorithmToTest!private!unit tests! !
-!IntrosortAlgorithmTest categoriesFor: #testBigStringSort!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/MergesortAlgorithmTest.cls
+++ b/Core/Object Arts/Dolphin/Base/MergesortAlgorithmTest.cls
@@ -13,9 +13,6 @@ MergesortAlgorithmTest comment: ''!
 algorithmToTest
 	^MergesortAlgorithm!
 
-testBigStringSort
-	self bigStringSort!
-
 testTempArrayLargeEnough
 	| sorted |
 	sorted := SortedCollection sortAlgorithm: self algorithmToTest new.
@@ -24,6 +21,5 @@ testTempArrayLargeEnough
 	sorted addAll: (130 to: 200).
 	self assertSorted: sorted! !
 !MergesortAlgorithmTest categoriesFor: #algorithmToTest!private!unit tests! !
-!MergesortAlgorithmTest categoriesFor: #testBigStringSort!public!unit tests! !
 !MergesortAlgorithmTest categoriesFor: #testTempArrayLargeEnough!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/Package.cls
+++ b/Core/Object Arts/Dolphin/Base/Package.cls
@@ -145,13 +145,7 @@ allResourceIdentifiers
 	| resources |
 	resources := Set new.
 	self classesDo: [:each | each resourceIdentifiersDo: [:eachResId | resources add: eachResId]].
-	prefix := ResourceIdentifier selectorPrefix.
-	self methodNames do: 
-			[:each |
-			(each value beginsWith: prefix)
-				ifTrue: 
-					[(self behaviorFromName: each key ifAbsent: [])
-						ifNotNil: [:methodClass | resources add: (ResourceIdentifier class: methodClass instanceClass selector: each value)]]].
+	self looseResourceIdentifiersDo: [:each | resources add: each].
 	^resources!
 
 allResourceNames
@@ -1161,6 +1155,22 @@ loadPAX
 	self fileInScript: #postinstall] 
 			ensure: [filer close]!
 
+looseResourceIdentifiers
+	| rids |
+	rids := Set new.
+	self looseResourceIdentifiersDo: [:each | rids add: each].
+	^rids!
+
+looseResourceIdentifiersDo: aMonadicValuable
+	self methodNames do: 
+			[:each |
+			(each value beginsWith: ResourceIdentifier selectorPrefix)
+				ifTrue: 
+					[(self behaviorFromName: each key ifAbsent: [])
+						ifNotNil: 
+							[:methodClass |
+							aMonadicValuable value: (ResourceIdentifier class: methodClass instanceClass selector: each value)]]]!
+
 manager
 	"Answer the object responsible for managing this package."
 
@@ -1397,16 +1407,18 @@ packageFileName
 
 	^File fullPathOf: packagePathname relativeTo: SessionManager current imageBase!
 
-packageFileName: pathname 
+packageFileName: pathname
 	"Private - Set the path name (ie Path+Stem+Extension) of the file used
 	to store the binary representation of the receiver. This is always held as
 	relative to the current image base. This name should only be changed
 	through the PackageManager, and in fact it is not advisable to change
 	it any way because other packages may be dependent upon it.."
 
-	self packagePathname: (FileLocator imageRelative 
-				relativePathTo: (File default: pathname
-						extension: self class packageExtension))!
+	(self setPackageFileName: pathname)
+		ifTrue: 
+			[self isChanged: true.
+			"If a package is renamed, then the dependent packages need to be resaved to update their pre-requisite information"
+			self dependentPackages do: [:each | each isChanged: true]]!
 
 packageFolder
 	^File splitPathFrom: self packagePathname!
@@ -1414,18 +1426,15 @@ packageFolder
 packagePathname
 	^packagePathname!
 
-packagePathname: aString 
-	"Private - Set the receiver's path and name."
+packagePathname: aString
+	"Private - Set the receiver's path and name. Answer whether the name was changed."
 
 	| oldname |
 	packagePathname := aString.
-	"The name can no longer be independent of the file name, and is in fact just cached from the file stem"
+	"The name cannot be independent of the file name, and is in fact just cached from the file stem"
 	oldname := name.
 	name := File splitStemFrom: aString.
-	(oldname isNil or: [oldname sameAs: name]) ifTrue: [^self].
-	self isChanged: true.
-	"If a package is renamed, then the dependent packages need to be resaved to update their pre-requisite information"
-	self dependentPackages do: [:each | each isChanged: true]!
+	^oldname isNil or: [(oldname sameAs: name) not]!
 
 packageVersion
 	"Answer the version identification of the receiver as a String"
@@ -1619,7 +1628,7 @@ resetPrerequisites
 resourceIdentifiers
 	"Answer a collection of <ResourceIdentifier> objects owned by the receiver."
 
-	^ResourceIdentifier allResourceIdentifiers select: [:each | each owningPackage == self]!
+	^self allResourceIdentifiers!
 
 save
 	"Save the receiver to a single PAC file. This includes all of the source for the receiver's contents.
@@ -1930,6 +1939,10 @@ setManualPrerequisites: anArrayOfStrings
 	and should not be deleted**."
 
 	manualPrerequisites := anArrayOfStrings!
+
+setPackageFileName: aString
+	^self packagePathname: (FileLocator imageRelative
+				relativePathTo: (File default: aString extension: self class packageExtension))!
 
 setPrerequisites: anIdentitySet
 	"Private - Set the pre-computed pre-requisites of the receiver to specified Set of package names. 
@@ -2267,7 +2280,7 @@ untracedGlobals: aCollectionOfSymbols
 upateFileNames
 	"Private - Update the package filename to match the package name and to be a PAC."
 
-	self packageFileName: (File 
+	self setPackageFileName: (File
 				composePath: self path
 				stem: self name
 				extension: self class packageExtension).
@@ -2444,6 +2457,8 @@ If you experience subsequent problems please contact the package supplier for an
 !Package categoriesFor: #loadPAC!private!source filing! !
 !Package categoriesFor: #loadPAC:!private!source filing! !
 !Package categoriesFor: #loadPAX!private!source filing-pax! !
+!Package categoriesFor: #looseResourceIdentifiers!accessing!public! !
+!Package categoriesFor: #looseResourceIdentifiersDo:!enumerating!public! !
 !Package categoriesFor: #manager!accessing!public! !
 !Package categoriesFor: #manualPrerequisites!accessing!public! !
 !Package categoriesFor: #manualPrerequisites:!accessing!public! !
@@ -2516,6 +2531,7 @@ If you experience subsequent problems please contact the package supplier for an
 !Package categoriesFor: #scripts!accessing!private! !
 !Package categoriesFor: #setEvents:!events!private! !
 !Package categoriesFor: #setManualPrerequisites:!accessing!private! !
+!Package categoriesFor: #setPackageFileName:!accessing!private! !
 !Package categoriesFor: #setPrerequisites:!accessing!private! !
 !Package categoriesFor: #sourceDescriptor!accessing!private! !
 !Package categoriesFor: #sourceDescriptor:!accessing!private! !
@@ -2590,7 +2606,7 @@ fromFile: path
 	answer := ((File splitExtensionFrom: pathname) sameAs: self sourcePackageExtension) 
 		ifTrue: [self fromPAXFile: pathname]
 		ifFalse: [self fromPACFile: pathname].
-	answer packageFileName: pathname.
+	answer setPackageFileName: pathname.
 	^answer!
 
 fromPACFile: pathname 
@@ -2652,7 +2668,7 @@ name: nameString
 	"Answer a new instance of the receiver with the <readableString> name, nameString."
 
 	^self new
-		packageFileName: nameString;
+		setPackageFileName: nameString;
 		yourself
 !
 

--- a/Core/Object Arts/Dolphin/Base/Package.cls
+++ b/Core/Object Arts/Dolphin/Base/Package.cls
@@ -142,9 +142,9 @@ allResourceIdentifiers
 	"Answer a Set of all the ResourceIdentifiers directly owned by
 	the receiver or by owning the class in which it is situated."
 
-	| resources prefix |
+	| resources |
 	resources := Set new.
-	self classesDo: [:each | resources addAll: each resourceIdentifiers].
+	self classesDo: [:each | each resourceIdentifiersDo: [:eachResId | resources add: eachResId]].
 	prefix := ResourceIdentifier selectorPrefix.
 	self methodNames do: 
 			[:each |
@@ -175,7 +175,7 @@ allSourceObjects
 
 	| answer |
 	answer := OrderedCollection new.
-	self allSourceObjectsDo: [:each | answer add: each].
+	self allSourceObjectsDo: [:each | answer addLast: each].
 	^answer!
 
 allSourceObjectsDo: operation 
@@ -1025,7 +1025,7 @@ isGlobalAlias: anAssociation
 isImportedClass: aClass
 	"Private - Answer true if aClass is an imported binary class"
 
-	^ClassLocator importedClasses identityIncludes: aClass!
+	^ClassLocator isImportedClass: aClass!
 
 isInstalled
 	"Answer whether the receiver is currently installed in the system."

--- a/Core/Object Arts/Dolphin/Base/PackageManager.cls
+++ b/Core/Object Arts/Dolphin/Base/PackageManager.cls
@@ -218,7 +218,7 @@ allPackagedClasses
 
 	| answer |
 	answer := OrderedCollection new: 2000.
-	self packages do: [:eachPackage | eachPackage classesDo: [:eachClass | answer add: eachClass]].
+	self packages do: [:eachPackage | eachPackage classesDo: [:eachClass | answer addLast: eachClass]].
 	^answer!
 
 allPackagedGlobalNames

--- a/Core/Object Arts/Dolphin/Base/PackageManager.cls
+++ b/Core/Object Arts/Dolphin/Base/PackageManager.cls
@@ -665,7 +665,7 @@ looseResourceIdentifiers
 
 	| answer |
 	answer := Set new: 25.
-	self packages do: [:p | answer addAll: p resourceIdentifiers].
+	self packages do: [:p | answer addAll: p looseResourceIdentifiers].
 	^answer!
 
 markAllPackagesAsBase

--- a/Core/Object Arts/Dolphin/Base/PackageTest.cls
+++ b/Core/Object Arts/Dolphin/Base/PackageTest.cls
@@ -227,7 +227,7 @@ tearDown
 			| package |
 			package := DolphinTestPackages current perform: each.
 			(Array with: package packageFileName with: package fileOutName) do: [:filename | (File exists: filename) ifTrue: [File delete: filename]]].
-	loadedPackages notNil ifTrue: [loadedPackages do: [:each | Package manager basicUninstall: each]].
+	loadedPackages notNil ifTrue: [loadedPackages do: [:each | Package manager basicUninstall: each]. loadedPackages  := nil].
 	DolphinTestPackages reset!
 
 testForwardRefLoadPac

--- a/Core/Object Arts/Dolphin/Base/PackageTest.cls
+++ b/Core/Object Arts/Dolphin/Base/PackageTest.cls
@@ -20,31 +20,32 @@ checkNoTestPackageContents
 	self assert: (scribbleClass class compiledMethodAt: #resource_Scribble_test ifAbsent: []) isNil!
 
 checkTestPackageContents
-	| scribbleTestPackage scribbleTestClass scribbleTest scribbleTestResourceMethod scribbleTestDefaultViewId scribbleTestViewId scribbleClass |
+	| scribbleTestPackage scribbleTestClass scribbleTest scribbleTestResourceMethod scribbleTestDefaultViewId scribbleTestViewId scribbleClass resourceIds |
 	scribbleTestPackage := loadedPackages first.
 	self assert: (scribbleTestPackage name beginsWith: 'ScribbleTest').
 	scribbleTestClass := Smalltalk at: #ScribbleTest.
 	self assert: scribbleTestClass notNil.
 	self assert: (scribbleTestPackage classes identityIncludes: scribbleTestClass).
-	scribbleTestResourceMethod := scribbleTestClass class 
+	scribbleTestResourceMethod := scribbleTestClass class
 				compiledMethodAt: #resource_Default_scribble_test_view.
 	self assert: scribbleTestResourceMethod owningPackage = scribbleTestPackage.
 	scribbleClass := Smalltalk at: #Scribble.
 	self assert: (scribbleClass compiledMethodAt: #looseA) owningPackage = scribbleTestPackage.
 	self assert: (scribbleClass compiledMethodAt: #looseC) owningPackage = scribbleTestPackage.
-	self assert: (scribbleClass class compiledMethodAt: #resource_Scribble_test) owningPackage 
+	self assert: (scribbleClass class compiledMethodAt: #resource_Scribble_test) owningPackage
 				= scribbleTestPackage.
-	self assert: scribbleTestPackage resourceIdentifiers size = 2.
+	resourceIds := scribbleTestPackage allResourceIdentifiers.
+	self assert: resourceIds size = 2.
 	scribbleTestDefaultViewId := ResourceIdentifier class: scribbleTestClass
 				name: 'Default scribble test view'.
-	self assert: (scribbleTestPackage resourceIdentifiers includes: scribbleTestDefaultViewId).
+	self assert: (resourceIds includes: scribbleTestDefaultViewId).
 	self assert: scribbleTestDefaultViewId owningPackage = scribbleTestPackage.
 	scribbleTestViewId := ResourceIdentifier class: scribbleClass name: 'Scribble test'.
-	self assert: (scribbleTestPackage resourceIdentifiers includes: scribbleTestViewId).
+	self assert: (resourceIds includes: scribbleTestViewId).
 	self assert: scribbleTestViewId owningPackage = scribbleTestPackage.
 	
 	[scribbleTest := scribbleTestClass show.
-	self assert: scribbleTest a = 'A'] 
+	self assert: scribbleTest a = 'A']
 			ensure: [scribbleTest view topView destroy]!
 
 d5ForwardRefTestPacContents
@@ -201,6 +202,12 @@ b2xwaGluZHIwMDUuZGxsAAAAAA==''))!!
 
 '!
 
+dolphinTestPackages
+	^Array
+		with: DolphinTestPackages current a
+		with: DolphinTestPackages current b
+		with: DolphinTestPackages current c!
+
 filenameFor: aString 
 	^FileLocator installRelative localFileSpecFor: 'Resources\Tests\' , aString!
 
@@ -211,7 +218,7 @@ loadAndTestPackage: filename
 
 setUp
 	Package classPool at: 'CheckTimestamps' put: true.
-	self testPackages do: [:each | each updateTimestamp]!
+	self dolphinTestPackages do: [:each | each updateTimestamp]!
 
 tearDown
 	Package classPool at: 'CheckTimestamps' put: false.
@@ -254,20 +261,24 @@ testLoad60Pac
 testLoad60Pax
 	self loadAndTestPackage: 'ScribbleTestPackages\6.0\ScribbleTest6.pax'!
 
-testPackages
-	^Array 
-		with: DolphinTestPackages current a
-		with: DolphinTestPackages current b
-		with: DolphinTestPackages current c!
+testLooseResourceIdentifiers
+	| all loose notLoose |
+	loose := Package manager looseResourceIdentifiers.
+	self assert: (loose allSatisfy: [:each | each owningClass owningPackage ~= each owningPackage]).
+	all := ResourceIdentifier allResourceIdentifiers.
+	self assert: (loose difference: all) isEmpty.
+	notLoose := all difference: loose.
+	self assert: (notLoose allSatisfy: [:each | each owningClass owningPackage = each owningPackage])!
 
 testTimestampInitialized
 	self assert: Package new timestamp asInteger = 0! !
 !PackageTest categoriesFor: #checkNoTestPackageContents!private!unit tests! !
 !PackageTest categoriesFor: #checkTestPackageContents!private!unit tests! !
 !PackageTest categoriesFor: #d5ForwardRefTestPacContents!private!unit tests! !
-!PackageTest categoriesFor: #filenameFor:!private!unit tests! !
-!PackageTest categoriesFor: #loadAndTestPackage:!private!unit tests! !
-!PackageTest categoriesFor: #setUp!private!unit tests! !
+!PackageTest categoriesFor: #dolphinTestPackages!helpers!private! !
+!PackageTest categoriesFor: #filenameFor:!helpers!private! !
+!PackageTest categoriesFor: #loadAndTestPackage:!helpers!private! !
+!PackageTest categoriesFor: #setUp!initializing!private!unit tests! !
 !PackageTest categoriesFor: #tearDown!private!unit tests! !
 !PackageTest categoriesFor: #testForwardRefLoadPac!public!unit tests! !
 !PackageTest categoriesFor: #testLoad21Pac!public!unit tests! !
@@ -277,7 +288,7 @@ testTimestampInitialized
 !PackageTest categoriesFor: #testLoad51Pax!public!unit tests! !
 !PackageTest categoriesFor: #testLoad60Pac!public!unit tests! !
 !PackageTest categoriesFor: #testLoad60Pax!public!unit tests! !
-!PackageTest categoriesFor: #testPackages!public!unit tests! !
+!PackageTest categoriesFor: #testLooseResourceIdentifiers!public! !
 !PackageTest categoriesFor: #testTimestampInitialized!public!unit tests! !
 
 !PackageTest class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/PropertyManager.cls
+++ b/Core/Object Arts/Dolphin/Base/PropertyManager.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #PropertyManager
 	instanceVariableNames: 'register'
@@ -23,11 +23,13 @@ propertyOf: anObject at: aSymbol
 		at: aSymbol
 		ifAbsent: [anObject errorNotFound: aSymbol]!
 
-propertyOf: anObject at: aSymbol ifAbsent: aBlock 
+propertyOf: anObject at: aSymbol ifAbsent: aBlock
 	"Answers a property value matching aSymbol for anObject. If no such property
 	exists then aBlock will be evaluated"
 
-	^(register at: anObject ifAbsent: [^aBlock value]) at: aSymbol ifAbsent: aBlock!
+	^(register at: anObject ifAbsent: [])
+		ifNil: [aBlock value]
+		ifNotNil: [:properties | properties at: aSymbol ifAbsent: aBlock]!
 
 propertyOf: anObject at: aSymbol ifAbsentPut: valueOperation 
 	"Answers a property value matching aSymbol for anObject. If no such property

--- a/Core/Object Arts/Dolphin/Base/ResourceIdentifier.cls
+++ b/Core/Object Arts/Dolphin/Base/ResourceIdentifier.cls
@@ -230,10 +230,12 @@ storeOn: aStream
 
 allResourceIdentifiers
 	| rids |
-	rids:= OrderedCollection new: 512. 
-	Object withAllSubclassesDo: [:each | rids addAll: each resourceIdentifiers].
-	^rids asSortedCollection
-!
+	rids := OrderedCollection new: 512.
+	self allResourceIdentifiersDo: [:rid | rids addLast: rid].
+	^rids!
+
+allResourceIdentifiersDo: aMonadicValuable
+	Object withAllSubclassesDo: [:each | each resourceIdentifiersDo: aMonadicValuable]!
 
 class: aClass 
 	^self class: aClass name: 'Default view'!
@@ -267,25 +269,38 @@ icon
 
 	^(self environment at: #Icon) fromId: 'Resource.ico'!
 
-nameFromSelector: aSymbol 
+nameFromSelector: aSymbol
+	| resname prefixSize nameSize |
 	(aSymbol beginsWith: self selectorPrefix) ifFalse: [^nil].
-	^(aSymbol rightString: aSymbol size - self selectorPrefix size) copyReplacing: $_
-		withObject: Character space!
+	prefixSize := self selectorPrefix size.
+	resname := String new: (nameSize := aSymbol size - prefixSize).
+	1 to: nameSize
+		do: 
+			[:i |
+			| ch |
+			ch := aSymbol at: i + prefixSize.
+			resname at: i put: (ch == $_ ifTrue: [$\x20] ifFalse: [ch])].
+	^resname!
 
 onPreStripImage
 	"Private -  Allow the receiver to be stripped by clearing lazy initialized class variable
 	which holds an instance of the receiver."
 
-	self allResourceIdentifiers do: [:each | each icon: nil]!
+	self allResourceIdentifiersDo: [:each | each icon: nil]!
 
 removeResource: aResourceIdentifier 
 	^aResourceIdentifier owningClass class removeSelector: aResourceIdentifier selector ifAbsent: []!
 
-selectorFromName: aString 
-	| selector |
-	selector := (aString copyReplacing: Character space withObject: $_) 
-				select: [:each | each isAlphaNumeric or: [each = $_]].
-	^('resource_' , selector) asSymbol!
+selectorFromName: aString
+	| selector prefix |
+	prefix := self selectorPrefix.
+	selector := WriteStream on: (String new: prefix size + aString size).
+	aString do: 
+			[:each |
+			each == $\x20
+				ifTrue: [selector nextPut: $_]
+				ifFalse: [each isAlphaNumeric ifTrue: [selector nextPut: each]]].
+	^(prefix , selector contents) asSymbol!
 
 selectorPrefix
 	^'resource_'!
@@ -301,6 +316,7 @@ value: a value: b
 viewResourceCategoryName
 	^'resources-views'! !
 !ResourceIdentifier class categoriesFor: #allResourceIdentifiers!accessing!public! !
+!ResourceIdentifier class categoriesFor: #allResourceIdentifiersDo:!accessing!enumerating!public! !
 !ResourceIdentifier class categoriesFor: #class:!instance creation!public! !
 !ResourceIdentifier class categoriesFor: #class:name:!instance creation!public! !
 !ResourceIdentifier class categoriesFor: #class:selector:!instance creation!public! !

--- a/Core/Object Arts/Dolphin/Base/SortAlgorithmTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SortAlgorithmTest.cls
@@ -99,7 +99,7 @@ sort: aCollection sortBlock: block
 											[:a :b | 
 											comp := comp + 1.
 											block value: a value: b])].
-	aCollection size >= 500 
+	aCollection size > 2000 
 		ifTrue: 
 			[Transcript
 				print: self algorithmToTest;

--- a/Core/Object Arts/Dolphin/Base/SystemDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/SystemDictionary.cls
@@ -27,7 +27,7 @@ allBehaviors
 	metaclasses."
 
 	| answer |
-	answer := OrderedCollection new: 4000.
+	answer := OrderedCollection new: 5000.
 	self allBehaviorsDo: [:behavior | answer addLast: behavior].
 	^answer!
 

--- a/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
@@ -843,27 +843,27 @@ testNestedWhileTrueAtStartOfCleanBlock
 	self assert: block initialIP = 3!
 
 testRadixInteger
-	0 to: 72
+	2 to: 36
 		do: 
-			[:eachVal | 
-			2 to: 36
-				do: [:eachRadix | (self evaluateExpression: (eachVal printStringRadix: eachRadix)) = eachVal]].
+			[:eachRadix |
+			0 to: eachRadix * 2 - 1
+				by: 3
+				do: [:eachVal | (self evaluateExpression: (eachVal printStringRadix: eachRadix)) = eachVal]].
 	0 to: 35
 		do: 
-			[:eachRadix | 
+			[:eachRadix |
 			"Test invalid radix integers cause an MNU of #rN"
-
 			| suffix |
 			suffix := String with: $r with: (Character digitValue: eachRadix).
-			self 
+			self
 				should: 
 					[| expr |
 					expr := eachRadix printString , suffix.
 					self evaluateExpression: expr]
 				raise: MessageNotUnderstood
 				matching: 
-					[:ex | 
-					(ex receiver = eachRadix and: [ex selector equals: suffix]) 
+					[:ex |
+					(ex receiver = eachRadix and: [ex selector equals: suffix])
 						ifFalse: 
 							[self halt.
 							false]

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -1434,11 +1434,11 @@ allMethods
 
 	| methods |
 	methods := OrderedCollection new: 256.
-	self methodsDo: [:each | methods add: each].
+	self methodsDo: [:each | methods addLast: each].
 	^methods!
 
 allResourcesDo: aBlock 
-	ResourceIdentifier allResourceIdentifiers do: aBlock!
+	ResourceIdentifier allResourceIdentifiersDo: aBlock!
 
 browse
 	^self openEditor!

--- a/Core/Object Arts/Dolphin/IDE/Base/PackageBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/PackageBrowserShell.cls
@@ -259,7 +259,7 @@ clearPrerequisites
 clearResources
 	"Private - Clear the resources list."
 
-	resourcesPresenter filterBlock: [:each | each isNil]!
+	resourcesPresenter clear!
 
 clearScriptNames
 	"Private - Clear the scripts list."
@@ -587,7 +587,7 @@ onClassRepackaged: aClass from: oldPackage to: newPackage
 	kind of update if the classes card is actually displayed. If not we just mark the classes
 	card as dirty to reduce overhead."
 
-	self 
+	self
 		objectRepackaged: aClass
 		from: oldPackage
 		to: newPackage
@@ -1215,6 +1215,7 @@ updatePrerequisites
 updateResources
 	"Private - Update the resources list for this package."
 
+	Package manager looseMethods.
 	resourcesPresenter showResourcesOwnedByPackages: self packages!
 
 updateScriptNames

--- a/Core/Object Arts/Dolphin/IDE/Base/ResourceListPresenter.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/ResourceListPresenter.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 ListPresenter subclass: #ResourceListPresenter
 	instanceVariableNames: 'filterBlock resourcesPresenter previewPresenter resourceIdModel'
@@ -45,6 +45,13 @@ browseSystem
 
 caption
 	^''!
+
+clear
+	"Empty the resource list."
+
+	filterBlock := [:each | false].
+	self list: #()
+	!
 
 clearSelection
 	"Remove the selected resource from the ResourceManager."
@@ -296,6 +303,7 @@ systemModel
 !ResourceListPresenter categoriesFor: #browseReferences!commands!public! !
 !ResourceListPresenter categoriesFor: #browseSystem!commands!public! !
 !ResourceListPresenter categoriesFor: #caption!accessing!public! !
+!ResourceListPresenter categoriesFor: #clear!commands!public! !
 !ResourceListPresenter categoriesFor: #clearSelection!commands!public! !
 !ResourceListPresenter categoriesFor: #createComponents!initializing!public! !
 !ResourceListPresenter categoriesFor: #createSchematicWiring!initializing!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkToolShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkToolShell.cls
@@ -47,17 +47,17 @@ canSaveState
 
 	^false!
 
-configureFromSavedStateString: aSavedStateString 
+configureFromSavedStateString: aSavedStateString
 	"Configures the receiver using the monadic block source in aSavedStateString"
 
 	| result |
-	result := Compiler 
+	result := Compiler
 				compileForEvaluation: aSavedStateString
 				in: UndefinedObject
 				evaluationPools: #()
 				logged: false
 				flags: 0.
-	(result method value: nil) value: self!
+	self view noRedrawDo: [(result method value: nil) value: self]!
 
 createComponents
 	"Private - Create the presenters contained by the receiver"

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
@@ -761,14 +761,14 @@ initialize
 	self indicatorStyles: self class indicatorStyles.
 	self isAutoCompletionEnabled: self class isAutoCompletionEnabled!
 
-insertCompletion: aString at: anInteger 
+insertCompletion: aString at: anInteger
 	"Private-"
 
+	| word |
 	"Special case for insertions of unquoted symbols in Smalltalk-80 style literal arrays. Since
 	this is deprecated syntax, correct it..."
-	| word |
-	word := ((view styleAt: anInteger) name == #literalSymbol 
-				and: [(view characterAt: anInteger) ~~ $#]) ifTrue: ['#' , aString] ifFalse: [aString].
+	word := ((view styleAt: anInteger) name == #literalSymbol
+				and: [(view characterAt: anInteger - 1) ~~ $#]) ifTrue: ['#' , aString] ifFalse: [aString].
 	view performUndoableAction: [self completeWordAt: anInteger with: word]!
 
 insertKeywordCompletion: aString startingAt: anInteger 

--- a/Core/Object Arts/Dolphin/IDE/ClassBrowserAbstractTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/ClassBrowserAbstractTest.cls
@@ -194,7 +194,7 @@ tearDown
 	methods := packageA methods.
 	browser destroy.
 	self deleteTestMethods: methods.
-	packageA := nil!
+	browser := methodsPresenter := packageA := nil!
 
 testAddRemoveOfInheritedMethods
 	browser toggleShowInheritedMethods.

--- a/Core/Object Arts/Dolphin/IDE/Dolphin IDE Tests.pax
+++ b/Core/Object Arts/Dolphin/IDE/Dolphin IDE Tests.pax
@@ -93,7 +93,7 @@ DolphinTest subclass: #IdeaSpaceShellTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #PackageBrowserTest
-	instanceVariableNames: 'packageA packageB packageC dolphinTestA dolphinTestB dolphinTestC shell cardsPresenter classesPresenter methodsPresenter globalsPresenter resourcesPresenter dependencyPresenters methodAA methodAB methodAC methodBA methodBB methodCA resourceAA resourceAB resourceAC resourceBA resourceBB resourceCA resourceCC'
+	instanceVariableNames: 'packageA packageB packageC dolphinTestA dolphinTestB dolphinTestC shell cardsPresenter classesPresenter methodsPresenter globalsPresenter resourcesPresenter dependencyPresenters methodAA methodAB methodAC methodBA methodBB methodCA'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/IDE/IdeaSpaceShellTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/IdeaSpaceShellTest.cls
@@ -16,6 +16,20 @@ create: aClassSymbol subclassOf: aClass
 	self assert: (newClass notNil and: [newClass isKindOf: Class]).
 	^newClass!
 
+createThreeCards
+	| tools |
+	tools := Array new: 3.
+	ideaShell view noRedrawDo: 
+			[tools at: 1 put: self newSystemBrowserCard.
+			tools at: 2 put: self newClassBrowserCard.
+			tools at: 3 put: self newViewComposerCard].
+	self assert: ideaShell cards size = 3.
+	tools do: 
+			[:each |
+			self assert: each view parentView == ideaShell cardsPresenter view.
+			self assert: each parentPresenter == ideaShell cardsPresenter].
+	^tools!
+
 newClassBrowserCard
 	^ideaShell newEmbeddedCardOfClass: ClassBrowserShell!
 
@@ -43,6 +57,7 @@ setUp
 
 tearDown
 	ideaShell destroy.
+	ideaShell := nil.
 	super tearDown!
 
 testAbsorbCard
@@ -93,45 +108,41 @@ testAbsorbedCardRemoval
 	self assert: ideaShell cards isEmpty!
 
 testBreakoutCard
-	| vc sb cb vcToolbar vcCardToolbar |
-	sb := self newSystemBrowserCard.
-	cb := self newClassBrowserCard.
-	vc := self newViewComposerCard.
-	self assert: ideaShell cards size = 3.
-	self assert: vc view parentView==ideaShell cardsPresenter view.
-	self assert: vc parentPresenter==ideaShell cardsPresenter.
+	| toolToolbar cardToolbar tools |
+	tools := self createThreeCards.
 
-	"Find the original VC toolbar nd the newly installed card toolbar"
-	vcToolbar := vc view viewNamed: 'toolbar'.
-	vcCardToolbar := vcToolbar parentView.
-	self assert: vcCardToolbar isOpen.
-	self assert: vcCardToolbar parentView == vc view.
+	"Find the original toolbar and the newly installed card toolbar"
+	toolToolbar := tools third view viewNamed: 'toolbar'.
+	cardToolbar := toolToolbar parentView.
+	self assert: cardToolbar isOpen.
+	self assert: cardToolbar parentView == tools third view.
 
-	"Breakout the VC onto the desktop"
+	"Breakout the card onto the desktop"
 	ideaShell breakoutCurrentCard.
 
 	"There should only be two cards left in the IS"
 	self assert: ideaShell cards size = 2.
 	self assert: ideaShell cardsPresenter subPresenters size = 2.
 
-	"The VC card should now be a child of the desktop"
-	self assert: (vc view isKindOf: ShellView).
-	self assert: vc view isOpen.
-	self assert: vc view parentView == View desktop.
+	"The card should now be a child of the desktop"
+	self assert: (tools third view isKindOf: ShellView).
+	self assert: tools third view isOpen.
+	self assert: tools third view parentView == View desktop.
 
-	"The VC toolbar should have been restored and the card toolbar destroyed"
-	self assert: vcToolbar parentView == vc view.
-	self deny: vcCardToolbar isOpen.
-	vc exit.
-	self assert: vc view isClosed.
+	"The  toolbar should have been restored and the card toolbar destroyed"
+	self assert: toolToolbar parentView == tools third view.
+	self deny: cardToolbar isOpen.
 
 	"Breakout the other cards to leave the IdeaSpace empty"
+	ideaShell hide.
 	ideaShell
 		breakoutCurrentCard;
 		breakoutCurrentCard.
-	sb exit.
-	cb exit.
-
+	tools do: 
+			[:each |
+			each exit.
+			self assert: each view isClosed].
+	ideaShell show.
 	"There should no cards left in the IS"
 	self assert: ideaShell cards isEmpty.
 	self assert: ideaShell cardsPresenter subPresenters isEmpty.
@@ -151,18 +162,16 @@ testBreakoutCardOrdering
 	sb exit!
 
 testHistoryRemove
-	| vc sb cb hist |
-	sb := self newSystemBrowserCard.
-	cb := self newClassBrowserCard.
-	vc := self newViewComposerCard.
-	self assert: ideaShell cards size = 3.
+	| hist cards |
+	ideaShell view disableRedraw.
+	cards := self createThreeCards.
 	hist := ideaShell instVarNamed: 'cardHistory'.
 	self assert: hist position = 3.
 	self deny: hist hasFuture.
-	cb view ensureVisible.
-	sb view ensureVisible.
-	cb view ensureVisible.
-	vc view ensureVisible.
+	cards second view ensureVisible.
+	cards first view ensureVisible.
+	cards second view ensureVisible.
+	cards third view ensureVisible.
 	self assert: hist position = 7.
 	self deny: hist hasFuture.
 	ideaShell closeCard.
@@ -178,25 +187,23 @@ testHistoryRemove
 	self assert: hist isEmpty.
 	"Similar but with non-sequential visit history - idea here is to test that removing cards
 	pops back to the previous visit and does not in itself generate more visits"
-	sb := self newSystemBrowserCard.
-	cb := self newClassBrowserCard.
-	vc := self newViewComposerCard.
+	cards := self createThreeCards.
 	self assert: ideaShell cards size = 3.
 	hist := ideaShell instVarNamed: 'cardHistory'.
 	self assert: hist position = 3.
 	self deny: hist hasFuture.
-	sb view ensureVisible.
-	vc view ensureVisible.
+	cards first view ensureVisible.
+	cards third view ensureVisible.
 	self assert: hist position = 5.
 	self deny: hist hasFuture.
 	ideaShell closeCard.
-	self assert: ideaShell currentCard == sb.
+	self assert: ideaShell currentCard == cards first.
 	self assert: ideaShell cards size = 2.
 	self assert: hist position = 3.
 	self deny: hist hasFuture.
 	self assert: hist hasPast.
 	ideaShell closeCard.
-	self assert: ideaShell currentCard == cb.
+	self assert: ideaShell currentCard == cards second.
 	self assert: ideaShell cards size = 1.
 	self assert: hist position = 1.
 	self deny: hist hasFuture.
@@ -217,9 +224,12 @@ testRemoveCard
 testSaveRestore
 	"Test Save and Restore of various Ideaspace tools"
 
-	"System Browser on False"
-
 	| sb cb eb ws vc rb saveString newIdeaShell newSb newCb newEb newWs newVc newRb definitionPresenter |
+	"This test is pretty slow, but we can speed it up by ~30% by disabling redraw while populating the test subject"
+	(ideaShell view)
+		hide;
+		disableRedraw.
+	"System Browser on False"
 	sb := self newSystemBrowserCard.
 	sb packages: (Array with: False owningPackage with: ClassBrowserShell owningPackage).
 	sb actualClass: False.
@@ -233,8 +243,7 @@ testSaveRestore
 
 	"Environment Browser on Object subclassses"
 	eb := self newEnvironmentBrowserCard.
-	eb 
-		browserEnvironment: (Smalltalk developmentSystem browserEnvironmentForClasses: Object subclasses).
+	eb browserEnvironment: (Smalltalk developmentSystem browserEnvironmentForClasses: Object subclasses).
 	eb method: (Presenter compiledMethodAt: #createComponents).
 
 	"Workspace"
@@ -243,18 +252,22 @@ testSaveRestore
 
 	"View Composer"
 	vc := self newViewComposerCard.
-	vc resourceIdentifier: (ResourceIdentifier class: ClassBrowserShell).
+	vc resourceIdentifier: (ResourceIdentifier class: Shell).
 
 	"View Browser"
 	rb := self newViewBrowserCard.
-	rb resource: (ResourceIdentifier class: ClassBrowserShell).
+	rb resource: (ResourceIdentifier class: Shell).
 
 	"Make the system browser the current card"
 	sb ensureVisible.
+	"Enabling redraw will also unhide"
+	ideaShell view enableRedraw.
 
 	"Save it"
 	saveString := ideaShell saveStateString.
-	newIdeaShell := IdeaSpaceShell show configureFromSavedStateString: saveString.
+	"Restore state into a new idea space"
+	newIdeaShell := IdeaSpaceShell create.
+	newIdeaShell configureFromSavedStateString: saveString.
 	self assert: newIdeaShell cards size = 6.
 	newSb := newIdeaShell cards first.
 	newCb := newIdeaShell cards second.
@@ -262,24 +275,24 @@ testSaveRestore
 	newWs := newIdeaShell cards fourth.
 	newVc := newIdeaShell cards fifth.
 	newRb := newIdeaShell cards sixth.
+	self assert: newIdeaShell currentCard == newSb.
 	self assert: (newSb isKindOf: SystemBrowserShell).
 	self assert: newSb actualClass == sb actualClass.
 	self assert: newSb packages = sb packages.
 	self assert: (newCb isKindOf: ClassBrowserShell).
 	self assert: newCb actualClass == cb actualClass.
+	self assert: newCb method == cb method.
 	self deny: (newCb getPinStateFor: 'filtersSlidey').
 	self assert: (newEb isKindOf: EnvironmentBrowserShell).
-	self assert: (newWs isKindOf: SmalltalkWorkspaceDocument).
-	self assert: (newVc isKindOf: ViewComposer).
-	self assert: (newRb isKindOf: ResourceBrowser).
-	self assert: newCb method == cb method.
-	self assert: newIdeaShell currentCard == newSb.
 	self assert: newEb method == eb method.
+	self assert: (newWs isKindOf: SmalltalkWorkspaceDocument).
 	self assert: newWs getDocumentData = ws getDocumentData.
 	self assert: newWs filename = ws filename.
 	self assert: newWs workspace evaluationPools = ws workspace evaluationPools.
 	self assert: newWs workspace evaluationPools first == ws workspace evaluationPools first.
+	self assert: (newVc isKindOf: ViewComposer).
 	self assert: newVc resourceIdentifier = vc resourceIdentifier.
+	self assert: (newRb isKindOf: ResourceBrowser).
 	self assert: newRb resource = rb resource.
 	newIdeaShell view destroy!
 
@@ -288,7 +301,9 @@ testSaveRestoreEmpty
 
 	| saveString newIdeaShell |
 	saveString := ideaShell saveStateString.
-	newIdeaShell := IdeaSpaceShell show configureFromSavedStateString: saveString.
+	newIdeaShell := IdeaSpaceShell create.
+	newIdeaShell configureFromSavedStateString: saveString.
+	newIdeaShell show.
 	self assert: newIdeaShell cards isEmpty.
 	newIdeaShell view destroy!
 
@@ -306,6 +321,7 @@ testSaveRestoreErrors
 		raise: Compiler notificationClass.
 	newIdeaShell view destroy! !
 !IdeaSpaceShellTest categoriesFor: #create:subclassOf:!helpers!private! !
+!IdeaSpaceShellTest categoriesFor: #createThreeCards!helpers!private! !
 !IdeaSpaceShellTest categoriesFor: #newClassBrowserCard!private!unit tests! !
 !IdeaSpaceShellTest categoriesFor: #newEnvironmentBrowserCard!private!unit tests! !
 !IdeaSpaceShellTest categoriesFor: #newSystemBrowserCard!private!unit tests! !

--- a/Core/Object Arts/Dolphin/IDE/PackageBrowserTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/PackageBrowserTest.cls
@@ -1,7 +1,7 @@
 "Filed out from Dolphin Smalltalk 7"!
 
 DolphinTest subclass: #PackageBrowserTest
-	instanceVariableNames: 'packageA packageB packageC dolphinTestA dolphinTestB dolphinTestC shell cardsPresenter classesPresenter methodsPresenter globalsPresenter resourcesPresenter dependencyPresenters methodAA methodAB methodAC methodBA methodBB methodCA resourceAA resourceAB resourceAC resourceBA resourceBB resourceCA resourceCC'
+	instanceVariableNames: 'packageA packageB packageC dolphinTestA dolphinTestB dolphinTestC shell cardsPresenter classesPresenter methodsPresenter globalsPresenter resourcesPresenter dependencyPresenters methodAA methodAB methodAC methodBA methodBB methodCA'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -13,26 +13,38 @@ PackageBrowserTest comment: ''!
 addRemoveRenameClasses
 	"Remove classes"
 
-	self updateAll.
+	self assertCurrentCardInSync.
 	self
 		createClassesABC;
 		createMethods.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true.
+	self assertCurrentCardInSync.
 	self renameClass.
 	dolphinTestC removeFromSystem.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true.
+	self assertCurrentCardInSync.
 	dolphinTestB removeFromSystem.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true.
+	self assertCurrentCardInSync.
 	dolphinTestA removeFromSystem.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true!
+	self assertCurrentCardInSync!
+
+assertClassesInSync
+	| classes |
+	classes := OrderedCollection new.
+	shell packages do: [:each | classes addAll: each classes].
+	self assert: (classesPresenter model noDifference: classes)!
+
+assertCurrentCardInSync
+	| card |
+	cardsPresenter view update.
+	card := self currentCard.
+	"PB should think the current card is up to date"
+	self assert: (shell isCardUpToDate: card).
+	card == #classes ifTrue: [^self assertClassesInSync].
+	card == #methods ifTrue: [^self assertMethodsInSync].
+	card == #globals ifTrue: [^self assertGlobalsInSync].
+	card == #dependents ifTrue: [^self assertDependencyCard: #dependents inSync: true].
+	card == #prerequisites ifTrue: [^self assertDependencyCard: #prerequisites inSync: true].
+	card == #resources ifTrue: [^self assertResourcesInSync].
+	self assert: false description: 'Unknown card: ' , card!
 
 assertDependencyCard: aSymbol inSync: aBoolean 
 	| dependencyPresenter tree |
@@ -48,27 +60,11 @@ assertDependencyCard: aSymbol inSync: aBoolean
 			self assert: (tree model rootNodes allSatisfy: [:each | each getChildren isNil])]
 		ifFalse: [self assert: tree model roots isEmpty]!
 
-assertInSync: aBoolean 
-	cardsPresenter view update.
-	aBoolean | (shell isCardUpToDate: #classes) 
-		ifTrue: 
-			[| classes |
-			classes := OrderedCollection new.
-			shell packages do: [:each | classes addAll: each classes].
-			self assert: (classesPresenter model noDifference: classes)]
-		ifFalse: [self assert: classesPresenter model isEmpty].
-	aBoolean | (shell isCardUpToDate: #methods) 
-		ifTrue: [self assertMethodsInSync]
-		ifFalse: [self assert: methodsPresenter model isEmpty].
-	aBoolean | (shell isCardUpToDate: #globals) 
-		ifTrue: 
-			[| globals |
-			globals := OrderedCollection new.
-			shell packages do: [:each | globals addAll: each globalNames].
-			self assert: (globalsPresenter model noDifference: globals)]
-		ifFalse: [self assert: globalsPresenter model isEmpty].
-	dependencyPresenters keysDo: [:each | self assertDependencyCard: each inSync: aBoolean].
-	self assertResourcesUpToDate!
+assertGlobalsInSync
+	| globals |
+	globals := OrderedCollection new.
+	shell packages do: [:each | globals addAll: each globalNames].
+	self assert: (globalsPresenter model noDifference: globals)!
 
 assertMethodsInSync
 	(shell isCardUpToDate: #methods) 
@@ -80,8 +76,8 @@ assertMethodsInSync
 			self assert: (methodsPresenter model noDifference: methods)]
 		ifFalse: [self assert: methodsPresenter model isEmpty]!
 
-assertResourcesUpToDate
-	(shell isCardUpToDate: #resources) 
+assertResourcesInSync
+	(shell isCardUpToDate: #resources)
 		ifTrue: 
 			[| resources |
 			resources := OrderedCollection new.
@@ -196,9 +192,7 @@ renameClass
 	self assert: methodAB methodClass == (Smalltalk at: testA2).
 	self assert: methodCA isLoose.
 	self assert: methodCA methodClass == dolphinTestC.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true.
+	self assertCurrentCardInSync.
 	ClassBuilder renameClass: (Smalltalk at: testA2) to: testA.
 	self assert: methodAB isLoose.
 	self assert: methodAB methodClass == (Smalltalk at: testA).
@@ -206,48 +200,40 @@ renameClass
 	self assert: methodAB methodClass == (Smalltalk at: testA).
 	self assert: methodCA isLoose.
 	self assert: methodCA methodClass == dolphinTestC.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true!
+	self assertCurrentCardInSync
+!
 
 repackageClasses
 	"Remove classes"
 
+	self assertCurrentCardInSync.
 	self removeClasses.
-	self updateAll.
+	self assertCurrentCardInSync.
 	self
 		createClassesABC;
 		createMethods.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true.
+	self assertCurrentCardInSync.
 	"Move a displayed class (with loose and non-loose methods) to a non-displayed package"
 	packageB addClass: dolphinTestC.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true.
+	self assertCurrentCardInSync.
 	"Move a class with loose methods in A into A"
 	packageA addClass: dolphinTestB.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true.
+	self assertCurrentCardInSync.
 	"Move a class between displayed packages"
 	packageC addClass: dolphinTestA.
-	self assertInSync: false.
-	self updateAll.
-	self assertInSync: true!
+	self assertCurrentCardInSync.
+!
 
 resourceManager
 	^SessionManager current resourceManager!
 
 setUp
-	| hasDependentsTab |
 	super setUp.
 	self assert: Package manager defaultPackage isNil.
 	packageA := DolphinTestPackages current a.
 	packageB := DolphinTestPackages current b.
 	packageC := DolphinTestPackages current c.
-	(Array 
+	(Array
 		with: packageA
 		with: packageB
 		with: packageC) do: [:each | self assert: each globalNames isEmpty].
@@ -260,11 +246,8 @@ setUp
 	dependencyPresenters := IdentityDictionary new.
 	dependencyPresenters at: #prerequisites
 		put: (shell instVarAt: (shell class indexOfInstVar: 'prerequisitesPresenter')).
-	hasDependentsTab := SessionManager current productVersion >= 6.
-	hasDependentsTab 
-		ifTrue: 
-			[dependencyPresenters at: #dependents
-				put: (shell instVarAt: (shell class indexOfInstVar: 'dependentsPresenter'))].
+	dependencyPresenters at: #dependents
+		put: (shell instVarAt: (shell class indexOfInstVar: 'dependentsPresenter')).
 	self createGlobals!
 
 showClassesPane
@@ -275,6 +258,7 @@ showClassesPane
 tearDown
 	super tearDown.
 	shell destroy.
+	shell := cardsPresenter := classesPresenter := methodsPresenter := globalsPresenter := resourcesPresenter := dependencyPresenters := nil.
 	self removeClasses.
 	self removeGlobals.
 	packageA := packageB := packageC := nil!
@@ -514,19 +498,14 @@ testRepackageMethods
 	classesPresenter view update.
 	self assertMethodsInSync.
 	methodsPresenter ensureVisible.
-	self assertMethodsInSync!
-
-updateAll
-	#(#classes #methods #globals #resources) , dependencyPresenters keys asArray do: 
-			[:each | 
-			shell updateCardNow: each.
-			self assert: (shell isCardUpToDate: each)].
-	self assertInSync: true! !
+	self assertMethodsInSync! !
 !PackageBrowserTest categoriesFor: #addRemoveRenameClasses!private!unit tests! !
+!PackageBrowserTest categoriesFor: #assertClassesInSync!private!unit tests! !
+!PackageBrowserTest categoriesFor: #assertCurrentCardInSync!private!unit tests! !
 !PackageBrowserTest categoriesFor: #assertDependencyCard:inSync:!private!unit tests! !
-!PackageBrowserTest categoriesFor: #assertInSync:!private!unit tests! !
+!PackageBrowserTest categoriesFor: #assertGlobalsInSync!private!unit tests! !
 !PackageBrowserTest categoriesFor: #assertMethodsInSync!private!unit tests! !
-!PackageBrowserTest categoriesFor: #assertResourcesUpToDate!private!unit tests! !
+!PackageBrowserTest categoriesFor: #assertResourcesInSync!private!unit tests! !
 !PackageBrowserTest categoriesFor: #create:subclassOf:!helpers!private! !
 !PackageBrowserTest categoriesFor: #create:subclassOf:inPackage:!helpers!private! !
 !PackageBrowserTest categoriesFor: #createClassesABC!helpers!private! !
@@ -546,5 +525,4 @@ updateAll
 !PackageBrowserTest categoriesFor: #testGlobals!public!unit tests! !
 !PackageBrowserTest categoriesFor: #testRepackageClasses!public!unit tests! !
 !PackageBrowserTest categoriesFor: #testRepackageMethods!public!unit tests! !
-!PackageBrowserTest categoriesFor: #updateAll!private!unit tests! !
 

--- a/Core/Object Arts/Dolphin/IDE/PackageBrowserTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/PackageBrowserTest.cls
@@ -261,7 +261,8 @@ tearDown
 	shell := cardsPresenter := classesPresenter := methodsPresenter := globalsPresenter := resourcesPresenter := dependencyPresenters := nil.
 	self removeClasses.
 	self removeGlobals.
-	packageA := packageB := packageC := nil!
+	packageA := packageB := packageC := nil.
+	MemoryManager current collectGarbage!
 
 testAddRemoveClasses
 	"Test adding and removing classes"

--- a/Core/Object Arts/Dolphin/IDE/PublishedAspectInspectorTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/PublishedAspectInspectorTest.cls
@@ -139,10 +139,11 @@ seqCollMoveUpTest: testClass
 !
 
 tearDown
-	inspector isNil 
+	inspector isNil
 		ifFalse: 
 			[inspector view topView destroy.
 			inspector := nil].
+	treePresenter := displayPresenter := nil.
 	super tearDown!
 
 testAddRemoveCollectionElement

--- a/Core/Object Arts/Dolphin/IDE/SmalltalkStylerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/SmalltalkStylerTest.cls
@@ -65,7 +65,10 @@ setUp
 	mock textStyles: SmalltalkWorkspace defaultTextStyles!
 
 tearDown
-	scintilla ifNotNil: [scintilla topView destroy].
+	scintilla
+		ifNotNil: 
+			[scintilla topView destroy.
+			scintilla := nil].
 	super tearDown!
 
 testArrayNoSpace

--- a/Core/Object Arts/Dolphin/IDE/SmalltalkSystemShellTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/SmalltalkSystemShellTest.cls
@@ -19,6 +19,7 @@ systemFolderPresenter
 
 tearDown
 	systemShell topShell view destroy.
+	systemShell := nil.
 	super tearDown!
 
 testIconOrdering

--- a/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
@@ -10,15 +10,22 @@ ViewComposerTest comment: ''!
 !ViewComposerTest categoriesForClass!Unclassified! !
 !ViewComposerTest methodsFor!
 
-dragResourceFor: resourceName operation: op 
+doArenaDropOf: subPresenterType operation: aSymbol
+	| overShell ddSession |
+	ddSession := self dragResourceFor: subPresenterType.
+	aSymbol ifNotNil: [ddSession defaultOperation: aSymbol].
+	overShell := vc arena mapPoint: 50 @ 50 to: View desktop.
+	ddSession continueTrackingAt: overShell from: ddSession dragPoint.
+	ddSession endTrackingAt: overShell.
+	^ddSession!
+
+dragResourceFor: resourceName
 	| session toolbox |
 	toolbox := vc instVarNamed: 'toolboxPresenter'.
 	session := InternalDragDropSession dragSource: toolbox view
 				item: (ResourceIdentifier class: resourceName).
 	toolbox resourcesPresenter onDragResource: session.
-	session
-		startTrackingAt: 20 @ 20;
-		operation: op.
+	session startTrackingAt: 20 @ 20.
 	^session!
 
 getButtonResource
@@ -43,8 +50,10 @@ setUp
 				classInstanceVariableNames: ''!
 
 tearDown
+	DragDropSession current ifNotNil: [:dd | dd cancelTrackingAt: 0 @ 0].
 	testClass removeFromSystem.
-	^vc destroy!
+	vc destroy.
+	vc := nil!
 
 testBasicEdit
 	| sampleResourceIdentifier |
@@ -117,23 +126,24 @@ testCutCopyPaste
 
 testDragResourceOverEmptyArena
 	| session |
-	vc onDragOverArena: (session := self dragResourceFor: Shell operation: #copy).
+	vc onDragOverArena: (session := self dragResourceFor: Shell).
 	self assert: session operation == #copy.
-	self assert: session suggestedTarget == vc arena.
-!
+	self assert: session suggestedTarget == vc arena!
 
 testDropResourceLinkOverShell
 	"Drop a Checkbox link onto a shell"
 
+	| ddSession |
 	vc newShellView.
-	vc onDropOverArena: (self dragResourceFor: TextPresenter operation: #link).
+	ddSession := self doArenaDropOf: TextPresenter operation: #link.
 	self assert: (vc primarySelection isKindOf: ReferenceView).
-	self assert: vc primarySelection resourceIdentifier = (ResourceIdentifier class: TextPresenter)!
+	self assert: vc primarySelection resourceIdentifier = (ResourceIdentifier class: TextPresenter).
+	ddSession!
 
 testDropResourceOverEmptyArena
 	"Drop a shell onto an empty arena"
 
-	vc onDropOverArena: (self dragResourceFor: Shell operation: #copy).
+	self doArenaDropOf: Shell operation: #copy.
 	self assert: (vc composingView isKindOf: ShellView)!
 
 testDropResourceOverHierarchy
@@ -141,16 +151,17 @@ testDropResourceOverHierarchy
 
 	| session |
 	vc newShellView.
-	session := self dragResourceFor: TextPresenter operation: #copy.
-	session suggestedTarget: vc viewHierarchyPresenter model roots first.
+	session := self dragResourceFor: TextPresenter.
+	session
+		operation: #copy;
+		suggestedTarget: vc viewHierarchyPresenter model roots first.
 	vc onDropOverHierarchy: session.
 	self assert: (vc primarySelection isKindOf: TextEdit)!
 
 testDropResourceOverShell
 	"Drop a Checkbox onto a shell"
 
-	vc newShellView.
-	vc onDropOverArena: (self dragResourceFor: TextPresenter operation: #copy).
+	self doArenaDropOf: TextPresenter operation: #copy.
 	self assert: (vc primarySelection isKindOf: TextEdit)!
 
 testIgnoreShellPreferredExtent
@@ -238,7 +249,8 @@ testZOrderPreservedByMutate
 	vc selection: shell.
 	vc mutateTo: ContainerView.
 	self assert: (shell subViews collect: [:each | each name]) asArray = #('1' '2' '3')! !
-!ViewComposerTest categoriesFor: #dragResourceFor:operation:!private!unit tests! !
+!ViewComposerTest categoriesFor: #doArenaDropOf:operation:!private!unit tests! !
+!ViewComposerTest categoriesFor: #dragResourceFor:!private!unit tests! !
 !ViewComposerTest categoriesFor: #getButtonResource!private!unit tests! !
 !ViewComposerTest categoriesFor: #getContainerResource!private!unit tests! !
 !ViewComposerTest categoriesFor: #getShellResource!private!unit tests! !

--- a/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
@@ -880,7 +880,7 @@ logRemainingResources
 	self startElement: 'RemainingResources'.
 	total := 0.
 	resman := self resourceManager.
-	resman allResourceIdentifiers do: 
+	resman allResourceIdentifiersDo: 
 			[:each | 
 			self startElement: 'Resource'.
 			self logElement: 'OwningClass' value: each owningClass name.
@@ -1292,7 +1292,7 @@ resizeStubFile: exeFilePath
 resourceManager
 	^ResourceIdentifier!
 
-resourcesForClasses: classes 
+resourcesForClasses: classes
 	"Private - Answer a <collection> of the <ResourceIdentifiers> for all resources that are potentially 
 	referenced from the specified <Set> of classes"
 
@@ -1310,14 +1310,12 @@ resourcesForClasses: classes
 		do: [:m | m literalsDo: [:l | l class == String ifTrue: [literalStrings add: l]]].
 	resourceIds := Set new.
 	classes do: 
-			[:class | 
-			| resources |
-			resources := class resourceIdentifiers .
-			resources do: 
-							[:each | 
-							(literalStrings includes: each name) 
-								ifTrue: [resourceIds add: (ResourceIdentifier class: class name: each name)]]].
-	self ignoreViewReferences 
+			[:class |
+			class resourceIdentifiersDo: 
+					[:each |
+					(literalStrings includes: each name)
+						ifTrue: [resourceIds add: (ResourceIdentifier class: class name: each name)]]].
+	self ignoreViewReferences
 		ifFalse: [resourceIds addAll: (self scanResourcesForViewReferences: resourceIds)].
 	^resourceIds!
 

--- a/Core/Object Arts/Dolphin/MVP/AbstractContainerViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/AbstractContainerViewTest.cls
@@ -111,8 +111,9 @@ setUp
 	containerView rectangle: self initialParentRect.
 	containerView backcolor: self backgroundColor!
 
-tearDown	
-	containerView topView destroy!
+tearDown
+	containerView topView destroy.
+	containerView := nil!
 
 testBorderedNcRectangle
 	"Check that applying a border correctly changes the NC and Client rectagle calcs"

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -4990,7 +4990,11 @@ cursor
 defaultId
 	"Private - Answer a new id to use for a View"
 
-	^NextId := NextId + 1!
+	"We start some distance away from the standard Windows IDs for command buttons such as IDOK,
+	etc, to avoid any clashes now or in future. Note that these id's need to fit in16-bits
+	because of DM_GETDEFID."
+
+	^4096 + (NextId := NextId + 1) bitAnd: 16rFFFF!
 
 defaultModel
 	"Answer a default model to be assigned to the receiver when it
@@ -5115,7 +5119,7 @@ initialize
 		View initialize
 	"
 
-	NextId := 4096.
+	NextId := 0.
 	ViewClosedError := Signal description: 'View closed'.
 	self initializeMessageMap.
 	VMLibrary default primRegistryAt: 54 put: #subclassWindow:!
@@ -5244,20 +5248,18 @@ onStartup
 	"Perform post startup processing to initialize the View system"
 
 	WndClassAtom := nil.
-
-	self allSubclassesDo: [:c |
-		(c class includesSelector: #onStartup) ifTrue: [c onStartup]].
+	self allSubclassesDo: [:c | (c class includesSelector: #onStartup) ifTrue: [c onStartup]].
 
 	"Load the Common Control Library."
 	CommCtrlLibrary openDefault.
-
-	"We start some distance away from the standard Windows IDs for command buttons
-	such as IDOK, etc, to avoid any clashes now or in future."
-	NextId := 4096.
+	NextId := 0.
 
 	"Register a hot key so that Ctrl+Break does not cancel dialogs (closes user interrupt walkback)"
-	UserLibrary default registerHotKey: nil id: 0 fsModifiers: MOD_CONTROL vk: VK_CANCEL.
-
+	UserLibrary default
+		registerHotKey: nil
+		id: 0
+		fsModifiers: MOD_CONTROL
+		vk: VK_CANCEL.
 	ThemeLibrary default onStartup!
 
 registerClass

--- a/Core/Object Arts/Dolphin/MVP/MoenTreeViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MoenTreeViewTest.cls
@@ -1006,7 +1006,7 @@ setUp
 
 tearDown
 	useShell ifTrue: [shell destroy] ifFalse: [treeView isNil ifFalse: [treeView destroy]].
-	shell := scroller := treeView := nil!
+	shell := scroller := treeView := treeModel := nil!
 
 testMoveChildToChildlessRoot
 	"Tests: NNC x RNC, NCC x RNC,

--- a/Core/Object Arts/Dolphin/MVP/MultipleSelectionListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultipleSelectionListBoxTest.cls
@@ -24,7 +24,8 @@ setUp
 	box := self classToTest show!
 
 tearDown
-	box topView destroy!
+	box topView destroy.
+	box := nil!
 
 testSelection
 	"Test legacy selection behaviour is maintained (even though it is incorrect)"

--- a/Core/Object Arts/Dolphin/MVP/PresenterTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/PresenterTest.cls
@@ -45,8 +45,8 @@ setUp
 	self initializePresenter!
 
 tearDown
-	presenter topShell close
-	!
+	presenter topShell close.
+	presenter := nil!
 
 waitForInputIdle
 	SessionManager inputState pumpMessages! !

--- a/Core/Object Arts/Dolphin/MVP/RadioButtonSetPresenterTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/RadioButtonSetPresenterTest.cls
@@ -25,7 +25,8 @@ setUp
 	radioSet := RadioButtonSetPresenter showOn: #option1!
 
 tearDown
-	radioSet topShell destroy!
+	radioSet topShell destroy.
+	radioSet := nil!
 
 testDisableEnableAll
 	radioSet radioButtons do: [:each | self assert: each isEnabled].

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -6,6 +6,7 @@ IconicListAbstract subclass: #ListView
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!
 ListView guid: (GUID fromString: '{87B4C730-026E-11D3-9FD7-00A0CC3E4A32}')!
+ListView addClassConstant: 'LvnMap' value: #(#lvnItemChanging: #lvnItemChanged: #lvnInsertItem: #nmDeleteItem: #lvnDeleteAllItems: #nmBeginLabelEdit: #nmEndLabelEdit: #nmDummy: #lvnColumnClick: #nmBeginDrag: #nmDummy: #nmBeginRDrag: #nmDummy: #nmDummy: #lvnItemActivate: #lvnODStateChanged: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmDummy: #nmGetDispInfo: #nmSetDispInfo: #lvnFindItem: #nmDummy: #nmDummy: #nmKeyDown: #lvnMarqueeBegin: #lvnGetInfoTip:)!
 ListView comment: 'ListView is the <listView> implementing the Windows "SysListView32" common control. It is for single selection use and, therefore, implements the <selectableItems> protocol for use with any <listModel>.
 
 A ListView is capable of displaying it items in one of four modes (#smallIcons, #largeIcons, #list, #report) which can be set using the #viewMode aspect. In the first three of these modes the list effectively has only one column being displayed; this is the primary column. Columns are described using instances of ListViewColumn. See the comment for this class for details on how to set up a column to display the appropriate information for a list item.
@@ -1479,15 +1480,18 @@ nmClick: pNMHDR
 	self isMultiSelect ifTrue: [self maybeSelChanging: #mouse].
 	^super nmClick: pNMHDR!
 
-nmNotify: pNMHDR 
+nmNotify: pNMHDR
 	"Private - Handler for a redirected ListView WM_NOTIFY message.
 	Implementation Note: Rather than create the appropriate header structure
 	object here, we delay that until the handler, because most of the time
 	we don't need to look at the notification at all."
 
-	^(LvnMap at: LVN_FIRST - (pNMHDR sdwordAtOffset: 8) + 1 ifAbsent: []) 
-		ifNil: [super nmNotify: pNMHDR]
-		ifNotNil: [:action | self perform: action with: pNMHDR]!
+	| code |
+	code := pNMHDR sdwordAtOffset: 8.
+	"Note that the notification codes are negative"
+	^(code <= LVN_FIRST and: [code >= LVN_GETINFOTIPA])
+		ifTrue: [self perform: (LvnMap at: ##(LVN_FIRST + 1) - code) with: pNMHDR]
+		ifFalse: [super nmNotify: pNMHDR]!
 
 nmRClick: pNMHDR 
 	"Private - Handler for a NM_RCLICK notification message.
@@ -2398,7 +2402,6 @@ initialize
 		self initialize
 	"
 
-	self initializeNotificationMap.
 	LvModes := (IdentityDictionary new)
 				at: #thumbnails put: LVS_ICON;
 				at: #smallIcons put: LVS_SMALLICON;
@@ -2420,7 +2423,8 @@ initializeNotificationMap
 	"Implementation Note: Use an Array for best lookup performance since the notification
 	nodes are in a contiguous range, even if it is a little sparse"
 
-	LvnMap := (Array new: 58)
+	| lvnMap |
+	lvnMap := (Array new: 58)
 				at: LVN_FIRST - LVN_ITEMCHANGING + 1 put: #lvnItemChanging:;
 				at: LVN_FIRST - LVN_ITEMCHANGED + 1 put: #lvnItemChanged:;
 				at: LVN_FIRST - LVN_INSERTITEM + 1 put: #lvnInsertItem:;
@@ -2442,7 +2446,8 @@ initializeNotificationMap
 				at: LVN_FIRST - LVN_MARQUEEBEGIN + 1 put: #lvnMarqueeBegin:;
 				at: LVN_FIRST - LVN_GETINFOTIPA + 1 put: #lvnGetInfoTip:;
 				yourself.
-	LvnMap := LvnMap collect: [:each | each isNil ifTrue: [#nmDummy:] ifFalse: [each]]!
+	lvnMap := lvnMap collect: [:each | each isNil ifTrue: [#nmDummy:] ifFalse: [each]].
+	self addClassConstant: 'LvnMap' value: lvnMap!
 
 onStartup
 	"The system is starting: Register a message to be used for cancelling a selection after

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
@@ -2681,11 +2681,13 @@ hasVisibleLineEndings: visibleBoolean
 hideIndicators
 	"Private - Reconfigure all indicator styles to hidden apart from the default 3 pre-configured styles."
 
+	| lib |
 	this ifNil: [^self].
+	lib := ScintillaLibrary default.
 	3 to: INDIC_MAX
 		do: 
-			[:each | 
-			ScintillaLibrary default 
+			[:each |
+			lib
 				directFunction: this
 				msg: SCI_INDICSETSTYLE
 				wParam: each

--- a/Core/Object Arts/Dolphin/System/Compiler/SmalltalkScanner.cls
+++ b/Core/Object Arts/Dolphin/System/Compiler/SmalltalkScanner.cls
@@ -512,18 +512,18 @@ scanSymbol
 	startPosition := lastPosition := stream position.
 	[characterType == #alphabetic] whileTrue: 
 			[self scanName.
-			currentCharacter == $: 
+			currentCharacter == $:
 				ifTrue: 
 					[buffer nextPut: $:.
 					hasColon := true.
 					lastPosition := stream position.
 					self step]].
 	value := buffer contents.
-	(hasColon and: [value last ~~ $:]) 
+	(hasColon and: [value last ~~ $:])
 		ifTrue: 
 			[stream position: lastPosition.
 			self step.
-			value := value copyFrom: 1 to: lastPosition - startPosition + 1].
+			value := value first: lastPosition - startPosition + 1].
 	^self literalTokenClass
 		value: value asSymbol
 		start: tokenStart

--- a/Core/Object Arts/Dolphin/Tests/Long Running Tests.pax
+++ b/Core/Object Arts/Dolphin/Tests/Long Running Tests.pax
@@ -12,6 +12,10 @@ package methodNames
 	add: #CompilerTest -> #knownTextMapIssues;
 	add: #CompilerTest -> #testTempMapOuterDepthExhaustive;
 	add: #CompilerTest -> #testTextMapsExhaustive;
+	add: #DefaultSortAlgorithmTest -> #testBigStringSort;
+	add: #HeapsortAlgorithmTest -> #testBigStringSort;
+	add: #IntrosortAlgorithmTest -> #testBigStringSort;
+	add: #MergesortAlgorithmTest -> #testBigStringSort;
 	add: #VMTest -> #assertLoopInterruptible:;
 	add: #VMTest -> #testLoopsInterruptible;
 	add: #VMTest -> #testQuiesceWhenUIBlocked;
@@ -26,6 +30,7 @@ package globalAliases: (Set new
 package setPrerequisites: (IdentitySet new
 	add: '..\IDE\Base\Development System Tests';
 	add: '..\Base\Dolphin';
+	add: '..\Base\Dolphin Base Tests';
 	add: '..\..\..\Contributions\Refactory\Refactoring Browser\Change Objects\RBChangeObjects';
 	add: '..\..\..\Contributions\Refactory\Refactoring Browser\Environments\RBEnvironments';
 	yourself).
@@ -177,6 +182,30 @@ testTextMapsExhaustive
 !CompilerTest categoriesFor: #knownTextMapIssues!private! !
 !CompilerTest categoriesFor: #testTempMapOuterDepthExhaustive!public!unit tests-long running! !
 !CompilerTest categoriesFor: #testTextMapsExhaustive!public!unit tests-long running! !
+
+!DefaultSortAlgorithmTest methodsFor!
+
+testBigStringSort
+	self bigStringSort! !
+!DefaultSortAlgorithmTest categoriesFor: #testBigStringSort!public!unit tests! !
+
+!HeapsortAlgorithmTest methodsFor!
+
+testBigStringSort
+	self bigStringSort! !
+!HeapsortAlgorithmTest categoriesFor: #testBigStringSort!public!unit tests! !
+
+!IntrosortAlgorithmTest methodsFor!
+
+testBigStringSort
+	self bigStringSort! !
+!IntrosortAlgorithmTest categoriesFor: #testBigStringSort!public!unit tests! !
+
+!MergesortAlgorithmTest methodsFor!
+
+testBigStringSort
+	self bigStringSort! !
+!MergesortAlgorithmTest categoriesFor: #testBigStringSort!public!unit tests! !
 
 !VMTest methodsFor!
 

--- a/Core/Object Arts/Dolphin/Web/Applets/Web Deployment Kit.pax
+++ b/Core/Object Arts/Dolphin/Web/Applets/Web Deployment Kit.pax
@@ -56,6 +56,7 @@ package methodNames
 	add: #Presenter -> #site;
 	add: #View -> #fileLocator;
 	add: #View -> #site;
+	add: 'ClassLocator class' -> #importedClasses;
 	add: 'ExternalLibrary class' -> #stbModifyExportProxy:;
 	add: 'Image class' -> #fromURL:;
 	add: 'Presenter class' -> #show:inPlugin:;
@@ -229,34 +230,45 @@ findOrImportForeignClass
 	| class classKey |
 	classKey := self fullClassKey.
 	self class importedClassesMutex critical: 
-			["To avoid leaving the class loader mutex locked if an error occurs we must
-		 establish a guard block - #ifCurtailed: will not do because the mutex will
-	 	still be locked when the walkback appears"
+			["Lazily initialize the ImportedClasses table on first attempt to import a class"
+			ImportedClasses isNil ifTrue: [ImportedClasses := WeakLookupTable new haveWeakValues].
+
+			"To avoid leaving the class loader mutex locked if an error occurs we must
+			establish a guard block - #ifCurtailed: will not do because the mutex will
+			still be locked when the walkback appears"
 			
 			[class := ImportedClasses at: classKey
 						ifAbsent: 
-							[self hasPackageName 
+							[self hasPackageName
 								ifFalse: 
 									["The receiver does not contain a package name. Hence, there is no point	
 				in continuing and trying to load a binary package."
 									self errorClassNotFound].
 							BinaryPackage loadUsing: self copyWithCodeBase.
-							ImportedClasses at: classKey ifAbsent: []]] 
+							ImportedClasses at: classKey ifAbsent: []]]
 					on: Error
 					do: 
-						[:e | 
+						[:e |
 						self class importedClassesMutex signal.
 						e pass]].
 
 	"You won't get here if an exception occurs - this is where we detect
 	an impending endless recursion."
-	class isNil 
+	class isNil
 		ifTrue: 
 			[ImportedClasses removeKey: classKey ifAbsent: [].
 			self errorClassCircularityDetected].
 	^class! !
 !ClassLocator categoriesFor: #binaryPackageFilename!accessing!private! !
 !ClassLocator categoriesFor: #findOrImportForeignClass!operations!private! !
+
+!ClassLocator class methodsFor!
+
+importedClasses
+	"Answer the LookupTable of classes that have been imported into this image."
+
+	^ImportedClasses! !
+!ClassLocator class categoriesFor: #importedClasses!accessing!public! !
 
 !ExternalLibrary class methodsFor!
 

--- a/PreBoot.st
+++ b/PreBoot.st
@@ -1,2 +1,3 @@
 "This file contains patches to base system classes that are required in order to be able to reload the base class library, but which are not yet consolidated into the boot image. Note that the BCL is reloaded anyway (see Boot.st), so most BCL changes do not require pre-patching; try without first"!
 
+ClassLocator.ImportedClasses := nil!


### PR DESCRIPTION
The slowest of the regressions tests is
PackageBrowserShell>>testPackagedClasses. The test itself is inefficient,
but the underlying resource card refresh is the real issue. This improves
it by about 5x, also improving the package load perf by 10-15%, and takes
7 (of 25) tests out of the "longer than 1 second to run" list.