### PR TITLE
Scale 16-bit identity hash value to avoid poor perf in large Sets (#289)

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Character.cls
@@ -170,11 +170,6 @@ hash
 
 	^self asInteger!
 
-identityHash
-	"Answer the <integer> identity hash value for the receiver."
-
-	^self asInteger!
-
 isAlphaNumeric
 	"Answer whether the receiver is a letter or a digit."
 
@@ -336,7 +331,6 @@ species
 !Character categoriesFor: #digitValue!accessing!public! !
 !Character categoriesFor: #displayOn:!printing!public! !
 !Character categoriesFor: #hash!comparing!public! !
-!Character categoriesFor: #identityHash!comparing!public! !
 !Character categoriesFor: #isAlphaNumeric!public!testing! !
 !Character categoriesFor: #isAtomic!public!testing! !
 !Character categoriesFor: #isControl!public!testing! !

--- a/Core/Object Arts/Dolphin/Base/CompiledCode.cls
+++ b/Core/Object Arts/Dolphin/Base/CompiledCode.cls
@@ -244,9 +244,9 @@ getSource
 	^self subclassResponsibility!
 
 hash
-	"Answer the <SmallInteger> hash value for the receiver. We use only the selector at the moment."
+	"Answer the <SmallInteger> hash value for the receiver."
 
-	^(selector hash bitShift: 4) bitXor: methodClass hash!
+	^selector identityHash bitXor: methodClass basicIdentityHash!
 
 header
 	^header!

--- a/Core/Object Arts/Dolphin/Base/IdentityDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/IdentityDictionary.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 LookupTable variableSubclass: #IdentityDictionary
 	instanceVariableNames: ''
@@ -31,9 +31,7 @@ findKeyOrNil: anObject
 	^index!
 
 hash: anObject max: anInteger
-	^anInteger < 8192 
-		ifTrue: [anObject identityHash \\ anInteger + 1]
-		ifFalse: [anObject identityHash * (anInteger bitShift: -12) \\ anInteger + 1]!
+	^anObject identityHash \\ anInteger + 1!
 
 keysClass
 	"Answer the class of <collection> to be used for collecting the keys of the receiver"

--- a/Core/Object Arts/Dolphin/Base/IdentitySearchPolicy.cls
+++ b/Core/Object Arts/Dolphin/Base/IdentitySearchPolicy.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 SingletonSearchPolicy subclass: #IdentitySearchPolicy
 	instanceVariableNames: ''
@@ -23,13 +23,9 @@ hash: operand
 
 hash: operand max: maximum
 	"Answer a suitable hash value for the <Object>, operand, under this search policy, 
-	between 1 and the <integer>, maximum.
-	Implementation Note: The identityHash range is limited to 16-bits, so we must scale for large 
-	collections to avoid excessive collisions causing a dramatic fall off in performance."
+	between 1 and the <integer>, maximum."
 
-	^maximum < 8192
-		ifTrue: [operand identityHash \\ maximum + 1]
-		ifFalse: [(operand identityHash * (maximum bitShift: -12)) \\ maximum + 1]!
+	^operand identityHash \\ maximum + 1!
 
 keyAtValue: value in: collection ifAbsent: operation
 	"Answer the <Object> key of the <Object> argument, value in the keyed

--- a/Core/Object Arts/Dolphin/Base/IdentitySet.cls
+++ b/Core/Object Arts/Dolphin/Base/IdentitySet.cls
@@ -29,9 +29,7 @@ findElementOrNil: anObject
 	^index!
 
 hash: anObject max: anInteger
-	^anInteger < 8192 
-		ifTrue: [anObject identityHash \\ anInteger + 1]
-		ifFalse: [anObject identityHash * (anInteger bitShift: -12) \\ anInteger + 1]!
+	^anObject identityHash \\ anInteger + 1!
 
 identityIncludes: anObject
 	"Answer whether the <Object> argument is one of the receiver's elements."

--- a/Core/Object Arts/Dolphin/Base/MethodDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/MethodDictionary.cls
@@ -26,7 +26,7 @@ fullCheck
 hash: anObject max: anInteger
 	"Implementation Note: This must match the selector hashing implementation used by the VM."
 
-	^(anObject hash bitAnd: anInteger - 1) + 1!
+	^(anObject basicIdentityHash bitAnd: anInteger - 1) + 1!
 
 removeKey: key ifAbsent: exceptionHandler 
 	"Remove the key (and its associated value), from the receiver. If key is not in the 

--- a/Core/Object Arts/Dolphin/Base/Object.cls
+++ b/Core/Object Arts/Dolphin/Base/Object.cls
@@ -261,6 +261,36 @@ basicDoesNotUnderstand: failedMessage
 
 	^MessageNotUnderstood receiver: self message: failedMessage!
 
+basicIdentityHash
+	"Answer the <integer> identity hash value for the receiver. This is
+	currently a 16-bit SmallInteger value, which is always positive (although
+	note that SmallInteger's override this implementation to answer 
+	themselves and hence an arbitrary object's identity hash is only 
+	guaranteed to be an integer). The value is a pseudo-random number 
+	assigned on first request, and it never changes (i.e. it is temporally 
+	invariant). Because the range is limited to 16-bits, very large collections 
+	hashed by identity using this value alone may be slow to access. One could 
+	consider including the identityHash of the objects class e.g. 
+		^((self class basicIdentityHash bitAnd: 16r3FFFFFFF) bitShift: 16) 
+			bitOr: self basicIdentityHash
+	However, this would not be safe in general, because #become: and #becomeA:
+	might change an object's class, (an object's class is an attribute of the object
+	not it's identity).
+
+	Although this implementation is temporally invariant while an object remains
+	in memory, a binary filed object is re-incarnated with a different identity,
+	and so identity hash collections must be rebuilt or rehashed on load (the 
+	standard Collections do this already).
+
+	This need not be reimplemented (except by immediate subclasses), because 
+	it is not possible to override #==, indeed reimplementation is jolly unwise.
+	
+	N.B. The primitive does not fail, but will raise a benign invalid memory access 
+	exception if called for immediate subclasses such as SmallInteger."
+	
+	<primitive: 75>
+	^self primitiveFailed!
+
 basicIdentityIndexOf: anElement from: start to: stop
 	"Private - Answer the index of the next occurrence of anElement in the receiver's indexable
 	variables between startIndex and stopIndex inclusive. If there are no such occurrences, answer 0.
@@ -691,20 +721,19 @@ getSpecialBehavior
 	^self setSpecialBehavior: _GetSpecialMask!
 
 hash
-	"Answer the <integer> hash value for the receiver. By default use the identity hash
-	assigned at object creation time, which is temporally invariant.
+	"Answer the <integer> hash value for the receiver. By default use the identity hash assigned
+	at object creation time, which is temporally invariant. See #identityHash for more details.
 
-	Equivalent objects (i.e. those that answer true for #=) MUST
-	answer the same hash value, in order that they can be stored and
-	retrieved successfully from hashed collections. Therefore, classes 
-	which reimplement either #= or #hash, will probably need to 
-	reimplement both.
+	Equivalent objects (i.e. those that answer true for #=) MUST answer the same hash value,
+	in order that they can be stored and retrieved successfully from hashed collections.
+	Therefore, classes which reimplement either #= or #hash, will probably need to reimplement
+	both.
 
-	N.B. The primitive does not fail, but will raise an invalid memory access 
-	exception if called for immediate subclasses such as SmallInteger."
-	
-	<primitive: 75>
-	^self primitiveFailed!
+	N.B. The primitive does not fail, but will raise an invalid memory access exception if
+	called for immediate subclasses such as SmallInteger."
+
+	<primitive: 147>
+	^self identityHash!
 
 icon
 	"Answer an Icon representing the receiver."
@@ -715,35 +744,14 @@ iconImageIndex
 	^self icon imageIndex!
 
 identityHash
-	"Answer the <integer> identity hash value for the receiver. This is
-	currently a 16-bit SmallInteger value, which is always positive (although
-	note that SmallInteger's override this implementation to answer 
-	themselves and hence an arbitrary object's identity hash is only 
-	guaranteed to be an integer). The value is a pseudo-random number 
-	assigned when the object is created, and it never changes (i.e. it is temporally 
-	invariant). Because the range is limited to 16-bits, very large collections 
-	hashed by identity using this value alone are likely to be slow. One could 
-	consider including the identityHash of the objects class e.g. 
-		^((self class identityHash bitAnd: 16r3FFFFFFF) bitShift: 16) 
-			bitOr: self identityHash
-		or: <primitive: 147> which is similar.
-	However, this would not be safe in general, because #become: and #becomeA:
-	might change an object's class, (an object's class is an attribute of the object
-	not it's identity).
-
-	Although this implementation is temporally invariant while an object remains
-	in memory, a binary filed object is re-incarnated with a different identity,
-	and so identity hash collections must be rebuilt or rehashed on load (the 
-	standard Collections do this already).
-
-	This need not be reimplemented (except by immediate subclasses), because 
-	it is not possible to override #==, indeed reimplementation is jolly unwise.
+	"Answer the <integer> identity hash value for the receiver. Be aware that this is based on a
+	16-bit integer randomly generated for each object on first request, so there are only 65536
+	unique values. The hash is scaled to a 30-bit positive SmallInteger to avoid closely grouped
+	objects in large hashed collections with internal overflow, which causes extremely poor
+	performance. See #basicIdentityHash for further details."
 	
-	N.B. The primitive does not fail, but will raise a benign invalid memory access 
-	exception if called for immediate subclasses such as SmallInteger."
-	
-	<primitive: 75>
-	^self primitiveFailed!
+	<primitive: 147>
+	^self basicIdentityHash bitShift: 14!
 
 ifNil: nilBlock 
 	"If the receiver is the nil object, then answer the result of evaluating the
@@ -1531,6 +1539,7 @@ yourself
 !Object categoriesFor: #basicAt:put:!accessing!private! !
 !Object categoriesFor: #basicClass!accessing!public! !
 !Object categoriesFor: #basicDoesNotUnderstand:!exceptions!public! !
+!Object categoriesFor: #basicIdentityHash!comparing!public! !
 !Object categoriesFor: #basicIdentityIndexOf:from:to:!private!searching! !
 !Object categoriesFor: #basicPrintOn:!printing!public! !
 !Object categoriesFor: #basicPrintString!printing!public! !

--- a/Core/Object Arts/Dolphin/Base/ProtoObject.cls
+++ b/Core/Object Arts/Dolphin/Base/ProtoObject.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 nil subclass: #ProtoObject
 	instanceVariableNames: ''
@@ -40,6 +40,16 @@ basicClass
 	"Answer the class of the receiver. The primitive should not fail."
 
 	<primitive: 111>
+	^self primitiveFailed!
+
+basicIdentityHash
+	"Answer the <integer> identity hash value for the receiver. This is
+	currently a 16-bit SmallInteger value, which is always positive. The value is a pseudo-random number 
+	assigned on first request, and it never changes (i.e. it is temporally 
+	invariant). Because the range is limited to 16-bits, very large collections 
+	hashed by identity using this value alone may be slow to access."
+
+	<primitive: 75>
 	^self primitiveFailed!
 
 basicPrintOn: aStream
@@ -108,33 +118,13 @@ error: signalerText
 	^Error signal: signalerText!
 
 identityHash
-	"Answer the <integer> identity hash value for the receiver. This is
-	currently a 16-bit SmallInteger value, which may be negative.
-	This value is assigned when the object is created, and never changes
-	(i.e. it is temporally invariant). Because the range is limited
-	to 16-bits, very large collections hashed by identity using this value
-	alone are likely to be slow (consider including the identityHash of
-	the objects class e.g. 
-		^((self class identityHash bitAnd: 16r3FFFFFFF) bitShift: 16) 
-			bitOr: self identityHash
-		or: <primitive: 147> which is similar.
-	However, this would not be safe in general, because #become: and #becomeA:
-	might change an object's class, because it is not associated with the
-	identity, but the object itself.
+	"Answer the <integer> identity hash value for the receiver. Be aware that this is based on a
+	16-bit integer randomly generated for each object on first request, so there are only 65536
+	unique values. The 16-bit hash is scaled to 30-bits to avoid closely grouped objects in large
+	hashed collections with internal overflow causing extremely poor performance. See
+	#basicIdentityHash for further details."
 
-	Although this implementation is temporally invariant while an object remains
-	in memory, a binary filed object is re-incarnated with a different identity,
-	and so identity hash collections must be rebuilt or rehashed on load (the 
-	standard Collections do this already).
-
-	This need not be reimplemented (except by immediate subclasses), because 
-	it is not possible to override #==, indeed reimplementation is jolly unwise.
-	
-	N.B. The primitive does not fail, but will raise a benign invalid memory access 
-	exception if called for immediate subclasses such as SmallInteger."
-	
-	<primitive: 75>
-	^self primitiveFailed!
+	^self basicIdentityHash bitShift: 14!
 
 instVarAt: index
 	"Private - Answer a variable in the receiver. The numbering of the variables begins with 
@@ -196,6 +186,7 @@ primitiveFailed
 !ProtoObject categoriesFor: #==!comparing!public! !
 !ProtoObject categoriesFor: #allReferences!enumerating!public! !
 !ProtoObject categoriesFor: #basicClass!accessing!public! !
+!ProtoObject categoriesFor: #basicIdentityHash!comparing!public! !
 !ProtoObject categoriesFor: #basicPrintOn:!printing!public! !
 !ProtoObject categoriesFor: #basicPrintString!printing!public! !
 !ProtoObject categoriesFor: #basicSize!accessing!private! !

--- a/Core/Object Arts/Dolphin/Base/SessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SessionManager.cls
@@ -372,7 +372,7 @@ initialize
 	Answer the receiver."
 
 	state := 6.
-	servers := SharedIdentitySet new.
+	servers := nil.
 	imagePath := '.\Dolphin'.
 	^self!
 

--- a/Core/Object Arts/Dolphin/Base/SharedIdentityDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/SharedIdentityDictionary.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 SharedLookupTable variableSubclass: #SharedIdentityDictionary
 	instanceVariableNames: ''
@@ -23,9 +23,7 @@ findKeyOrNil: anObject
 	^index!
 
 hash: anObject max: anInteger
-	^anInteger < 8192 
-		ifTrue: [anObject identityHash \\ anInteger + 1]
-		ifFalse: [anObject identityHash * (anInteger bitShift: -12) \\ anInteger + 1]!
+	^anObject identityHash \\ anInteger + 1!
 
 keysClass
 	"Answer the class of Collection to be used for collecting the keys of the receiver"

--- a/Core/Object Arts/Dolphin/Base/SharedIdentitySet.cls
+++ b/Core/Object Arts/Dolphin/Base/SharedIdentitySet.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 SharedSet variableSubclass: #SharedIdentitySet
 	instanceVariableNames: ''
@@ -23,9 +23,7 @@ findElementOrNil: anObject
 	^index!
 
 hash: anObject max: anInteger
-	^anInteger < 8192 
-		ifTrue: [anObject identityHash \\ anInteger + 1]
-		ifFalse: [anObject identityHash * (anInteger bitShift: -12) \\ anInteger + 1]! !
+	^anObject identityHash \\ anInteger + 1! !
 !SharedIdentitySet categoriesFor: #findElementOrNil:!private!searching! !
 !SharedIdentitySet categoriesFor: #hash:max:!private!searching! !
 

--- a/Core/Object Arts/Dolphin/Base/SmallInteger.cls
+++ b/Core/Object Arts/Dolphin/Base/SmallInteger.cls
@@ -174,6 +174,14 @@ basicAt: index put: value
 
 	^self shouldNotImplement!
 
+basicIdentityHash
+	"Answer the <integer> identity hash value for the receiver (itself)."
+
+	"Implementation Note: We must override because the identity hash primitives do not work for
+	immediate objects."
+
+	^self!
+
 basicShallowCopy
 	"SmallIntegers have an immediate representation - i.e. they have only
 	one representation for a particular value - and are immutable."
@@ -297,8 +305,8 @@ highBit
 identityHash
 	"Answer the <integer> identity hash value for the receiver (itself)."
 
-	"Implementation Note: We must override because the identity hash primitive does not work
-	for immediate objects."
+	"Implementation Note: We must override because the identity hash primitives do not work for
+	immediate objects."
 
 	^self!
 
@@ -446,6 +454,7 @@ yourAddress
 !SmallInteger categoriesFor: #asFloat!converting!public! !
 !SmallInteger categoriesFor: #basicAt:!accessing!private! !
 !SmallInteger categoriesFor: #basicAt:put:!accessing!private! !
+!SmallInteger categoriesFor: #basicIdentityHash!comparing!public! !
 !SmallInteger categoriesFor: #basicShallowCopy!copying!public! !
 !SmallInteger categoriesFor: #basicSize!accessing!private! !
 !SmallInteger categoriesFor: #basicYourAddress!accessing!private! !

--- a/Core/Object Arts/Dolphin/Base/Symbol.cls
+++ b/Core/Object Arts/Dolphin/Base/Symbol.cls
@@ -85,14 +85,11 @@ forwardTo: anObject
 	^anObject perform: self!
 
 hash
-	"Answer the <integer> hash value for the receiver.
-	Override back to the 16-bit identity hash which is temporally invariant,
-	and very fast to calculate).
-	The primitve should not fail (but must not be used for immediate objects).
-	N.B. It is critical that this implementation is not changed."
+	"Answer the <integer> hash value for the receiver. Override back to the identity hash (which
+	is temporally invariant, and very fast to calculate)."
 
-	<primitive: 75>
-	^self primitiveFailed!
+	<primitive: 147>
+	^self identityHash!
 
 initialiseFrom: aString
 	"Private - Initialize the receiver to contain the characters of aString.

--- a/Core/Object Arts/Dolphin/Base/WeakIdentityDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/WeakIdentityDictionary.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 WeakLookupTable variableSubclass: #WeakIdentityDictionary
 	instanceVariableNames: ''
@@ -23,9 +23,7 @@ findKeyOrNil: anObject
 	^index!
 
 hash: anObject max: anInteger
-	^anInteger < 8192 
-		ifTrue: [anObject identityHash \\ anInteger + 1]
-		ifFalse: [anObject identityHash * (anInteger bitShift: -12) \\ anInteger + 1]!
+	^anObject identityHash \\ anInteger + 1!
 
 keysClass
 	"Answer the class of Collection to be used for collecting the keys of the receiver"

--- a/Core/Object Arts/Dolphin/Base/WeakIdentitySet.cls
+++ b/Core/Object Arts/Dolphin/Base/WeakIdentitySet.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 WeakSet variableSubclass: #WeakIdentitySet
 	instanceVariableNames: ''
@@ -23,9 +23,7 @@ findElementOrNil: anObject
 	^index!
 
 hash: anObject max: anInteger
-	^anInteger < 8192 
-		ifTrue: [anObject identityHash \\ anInteger + 1]
-		ifFalse: [anObject identityHash * (anInteger bitShift: -12) \\ anInteger + 1]! !
+	^anObject identityHash \\ anInteger + 1! !
 !WeakIdentitySet categoriesFor: #findElementOrNil:!private!searching! !
 !WeakIdentitySet categoriesFor: #hash:max:!private!searching! !
 

--- a/PreBoot.st
+++ b/PreBoot.st
@@ -1,3 +1,66 @@
 "This file contains patches to base system classes that are required in order to be able to reload the base class library, but which are not yet consolidated into the boot image. Note that the BCL is reloaded anyway (see Boot.st), so most BCL changes do not require pre-patching; try without first"!
 
 ClassLocator.ImportedClasses := nil!
+
+"Switch to new identity hash - which is tricky"!
+
+!Object methodsFor!
+
+basicIdentityHash
+	<primitive: 75>
+	^self primitiveFailed! !
+
+!SmallInteger methodsFor!
+
+basicIdentityHash
+	^self! !
+
+!MethodDictionary methodsFor!
+
+hash: anObject max: anInteger
+	"Implementation Note: This must match the selector hashing implementation used by the VM."
+
+	^(anObject basicIdentityHash bitAnd: anInteger - 1) + 1! !
+
+!IdentitySet methodsFor!
+
+hash: anObject max: anInteger
+	^anObject identityHash \\ anInteger + 1! !
+
+!SharedIdentitySet methodsFor!
+
+hash: anObject max: anInteger
+	^anObject identityHash \\ anInteger + 1! !
+
+!IdentityDictionary methodsFor!
+
+hash: anObject max: anInteger
+	^anObject identityHash \\ anInteger + 1! !
+
+!SharedIdentityDictionary methodsFor!
+
+hash: anObject max: anInteger
+	^anObject identityHash \\ anInteger + 1! !
+
+!WeakIdentityDictionary methodsFor!
+
+hash: anObject max: anInteger
+	^anObject identityHash \\ anInteger + 1! !
+
+!IdentitySearchPolicy methodsFor!
+
+hash: operand max: maximum
+	^operand identityHash \\ maximum + 1! !
+
+!Object methodsFor!
+
+identityHash
+	^self basicIdentityHash bitShift: 14! !
+
+| m st | 
+st := Smalltalk.
+m := Symbol basicCompile: 'hash ^self identityHash'.
+"As soon as we replace Symbol>>hash, the Smalltalk dictionary is invalidated"
+st rehash!
+
+Set allSubinstances do: [:each | each size > 0 ifTrue: [each rehash]]!


### PR DESCRIPTION
The 16-bit identity hash is now allocated on demand using a simple pseudo
random number generator to give reasonable distribution, but it is still
limited to 65535 values. When used as the hash for large collections this
can cause very poor performance because the objects compete for the first
64k slots, requiring a linear search through many thousands of items on
average to find the matching element. Although we cannot increase the
number of variations (since only 16-bits are available to store the
identity hash in the object memory), we can scale the value to better
distribute objects in large collections and reduce the number of probes
by orders of magnitude in the worst cases.