### PR TITLE
ByteArray>>itcAsInteger uses wrong endian order

### DIFF
--- a/Core/Contributions/ITC Gorisek/Dialect Abstraction Layer.pax
+++ b/Core/Contributions/ITC Gorisek/Dialect Abstraction Layer.pax
@@ -373,7 +373,12 @@ itcAsHexString
 	^stream contents!
 
 itcAsInteger
-	^self inject: 0 into: [:sum :each | sum * 256 + each]! !
+	"Since the LSB is at index 1, we need to reverse iterate over the receiver"
+
+	| answer |
+	answer := 0.
+	self reverseDo: [:each | answer := answer * 256 + each].
+	^answer! !
 !ByteArray categoriesFor: #itcAsHexString!accessing!public! !
 !ByteArray categoriesFor: #itcAsInteger!accessing!public! !
 


### PR DESCRIPTION
This commit fixes issue #294 

P.S.: My first pull request on github. Please let me know, if it needs to be done differently