### PR TITLE
Unpackage STBPrefixConstants in PreBoot

### DIFF
--- a/PreBoot.st
+++ b/PreBoot.st
@@ -1,5 +1,6 @@
 "This file contains patches to base system classes that are required in order to be able to reload the base class library, but which are not yet consolidated into the boot image. Note that the BCL is reloaded anyway (see Boot.st), so most BCL changes do not require pre-patching; try without first"!
 
+Package manager systemPackage removeGlobalNamed: #STBPrefixConstants!
 ClassLocator.ImportedClasses := nil!
 
 "Switch to new identity hash - which is tricky"!


### PR DESCRIPTION
Otherwise the package still thinks it's there (it is still listed in `globalNames`), when of course it has actually been removed. Since the original removal was done in PreBoot.st, it seemed reasonable to do this cleanup there also.