### PR TITLE
Fix "Array should not implement #remove:ifAbsent:" error during image-stripping process

### DIFF
--- a/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
@@ -167,9 +167,7 @@ buildManifest: assemblyNameString description: assemblyDescriptionString version
 	^manifest contents!
 
 buildMessageMap
-	^self referencesFromObjectsInClasses: ((Class allClasses)
-				removeAll: ImageStripper withAllSubclasses;
-				yourself)!
+	^self referencesFromObjectsInClasses: (Class allClasses difference: ImageStripper withAllSubclasses).!
 
 buildPreservedMessages
 	"Private - Build the set of all the message selectors that are to be preserved


### PR DESCRIPTION
Seemed reasonable to just switch to using #difference: instead.

Is there a reasonable way to write a test for this, or due to the nature of the image-stripping process is it too difficult? Would it make sense to add stripping one of the example applications to the AppVeyor build as a substitute for SUnit tests?