### PR TITLE
Fix nil DNU #identityIncludes: error adding classes to the BCL

### DIFF
--- a/PreBoot.st
+++ b/PreBoot.st
@@ -1,6 +1,18 @@
 "This file contains patches to base system classes that are required in order to be able to reload the base class library, but which are not yet consolidated into the boot image. Note that the BCL is reloaded anyway (see Boot.st), so most BCL changes do not require pre-patching; try without first"!
 
 ClassLocator.ImportedClasses := nil!
+!ClassLocator class methodsFor!
+
+isImportedClass: aClass
+	^ImportedClasses notNil and: [ImportedClasses identityIncludes: aClass]! !
+!ClassLocator class categoriesFor: #isImportedClass:!public!testing! !
+!Package methodsFor!
+
+isImportedClass: aClass
+	"Private - Answer true if aClass is an imported binary class"
+
+	^ClassLocator isImportedClass: aClass! !
+!Package categoriesFor: #isImportedClass:!private!testing! !
 
 "Switch to new identity hash - which is tricky"!
 


### PR DESCRIPTION
The change to PreBoot.st in [this commit](https://github.com/dolphinsmalltalk/Dolphin/commit/282be5fd22a0040ef29f8678ab9ea0dc8b78a62a) seems incomplete—until the new implementations of `#isImportedClass:` are loaded when ClassLocator.cls and Package.cls are filed in, trying to package a new BCL class hits a nil where a collection was previously expected. Seems reasonable to just update those methods in PreBoot.st along with nilling the variable.