### PR TITLE
Ignore packages Contributions and DolphinVM in package Dolphin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Releases/
 *.testlog
 *.~html
 *.adu
+Contributions/
+Core/DolphinVM/


### PR DESCRIPTION
The suggested setup for all three packages is something like this:

Dolphin:          < parentPath >\Dolphin\
DolphinVM:     < parentPath >\Dolphin\Core\DolphinVM\
Contributions: < parentPath >\Dolphin\Contributions\

In this setup DolphinVM and Contributions also appear as untracked changes in Dolphin. This change excludes those paths from tracking in Dolphin.
