### PR TITLE
Don't complete keyword-selector symbol literals as if they were keyword message sends

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
@@ -952,13 +952,13 @@ modifiedModel: aValueModel
 newVariablePool
 	workspacePool := PoolDictionary new!
 
-onAutoComplete: aString startingAt: anInteger accept: aValueHolder 
+onAutoComplete: aString startingAt: anInteger accept: aValueHolder
 	"Private - "
 
-	(aString first ~~ $# and: [aString includes: $:]) 
+	((view styleAt: anInteger) name ~~ #literalSymbol and: [aString includes: $:])
 		ifTrue: [self insertKeywordCompletion: aString startingAt: anInteger]
 		ifFalse: [self insertCompletion: aString at: anInteger].
-	aValueHolder value: false!
+	aValueHolder value: false.!
 
 onCharAdded: aCharacter 
 	(self isAutoCompletionEnabled and: [self isSyntaxColoringEnabled]) ifFalse: [^self].


### PR DESCRIPTION
Decide whether to perform keyword completion based on the view's style rather than the presence or absence of a leading $#. With the addition of images to autocompletion lists, there will never be one, though this has always been an issue when completing keyword symbol literals using ST80 syntax inside a literal array.