### PR TITLE
Show current product info on SmalltalkSystemShell

### DIFF
--- a/Core/Object Arts/Dolphin/Base/VMLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/VMLibrary.cls
@@ -141,7 +141,7 @@ defaultProductDetails
 		at: 5 put: self basePatchLevel;
 		at: 6 put: 'D7';
 		at: 7 put: nil; "Serial #"
-		at: 8 put: nil; "Boot info"
+		at: 8 put: version productVersionString; "Boot info"
 		yourself!
 
 dump: msgString path: pathString stackDepth: slotsInteger walkbackDepth: framesInteger

--- a/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
@@ -674,6 +674,10 @@ tertiaryStartup
 
 	"Flush any output accumulated in the transcript buffer during startup."
 	TranscriptShell current flush.
+
+	"Force redetermination of product details"
+	productDetails := nil.
+
 	self mainShellClass onStartup.
 	self processCommandLine!
 


### PR DESCRIPTION
The VM info displayed in the title of SmalltalkSystemShell is not the current VM (but probably the one that the boot image was created with). Here an example for an image booted with the latest VM:

![image](https://cloud.githubusercontent.com/assets/16484211/22725662/a564883c-ed83-11e6-87a8-b45b95555ead.png)


This fix forces a redetermination of the product details on system startup and adds a small adjustment in VMLibrary to provide (once again?) the productVersionString:

![image](https://cloud.githubusercontent.com/assets/16484211/22749171/3afc16f0-ede1-11e6-9862-9ea00aa6d7ef.png)


