### PR TITLE
Fix MessageBox #warning iconStyle appearing as the question-mark icon instead of exclamation-point

### DIFF
--- a/Core/Object Arts/Dolphin/Base/UserLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/UserLibrary.cls
@@ -533,7 +533,7 @@ messageBox: anExternalHandle text: textString caption: captionString style: styl
 	iconId isNil
 		ifTrue: 
 			["Windows no longer supports MB_ICONQUESTION, so set it as a user icon instead."
-			(styleInteger allMask: MB_ICONQUESTION)
+			(styleInteger bitAnd: MB_ICONMASK) = MB_ICONQUESTION
 				ifTrue: 
 					[struct lpszIcon: IDI_QUESTION.
 					dwStyle := (dwStyle maskClear: MB_ICONMASK) maskSet: MB_USERICON]]


### PR DESCRIPTION
Check if the icon is *exactly* MB_ICONQUESTION instead of merely #allMask: when deciding whether to apply Vista workaround--the icon "field" takes up multiple style bits, and some icons are "supersets" of each other.