### PR TITLE
Don’t strip ExternalStructure class>>#’offsetOf:’.

### DIFF
--- a/Core/Object Arts/Dolphin/Lagoon/BasicImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/BasicImageStripper.cls
@@ -5,7 +5,7 @@ Model subclass: #BasicImageStripper
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-BasicImageStripper guid: (GUID fromString: '{51CE4971-61E8-431F-9823-437CF7293E8A}')!
+BasicImageStripper guid: (GUID fromString: '{51ce4971-61e8-431f-9823-437cf7293e8a}')!
 BasicImageStripper comment: 'Base image stripping methods. These can safely be encrypted during release.'!
 !BasicImageStripper categoriesForClass!MVP-Models! !
 !BasicImageStripper methodsFor!
@@ -153,7 +153,7 @@ prepareExternalStructuresNotifying: notifier
 	ExternalStructure class withAllSubclasses do: 
 			[:each |
 			self
-				removeSelectors: #(#shrink #defineTemplate #byteSize: #offsetOf:)
+				removeSelectors: #(#shrink #defineTemplate #byteSize:)
 				of: each
 				notifying: notifier].
 	self endElement.

--- a/Core/Object Arts/Dolphin/Lagoon/BasicImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/BasicImageStripper.cls
@@ -156,6 +156,12 @@ prepareExternalStructuresNotifying: notifier
 				removeSelectors: #(#shrink #defineTemplate #byteSize:)
 				of: each
 				notifying: notifier].
+	self compileExternalStructures
+		ifTrue: 
+			[self
+				removeSelector: #offsetOf:
+				of: ExternalStructure class
+				notifying: notifier].
 	self endElement.
 
 	"We no longer need this method. Referenced methods will become eligible to be stripped also"

--- a/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
@@ -5,7 +5,7 @@ BasicImageStripper subclass: #ImageStripper
 	classVariableNames: 'AllResourcesStripped ClearGuidsMask CompileStructsMask EmptyMethodDictsMask FoldBytecodesMask FoldMethodDictsMask FoldStringsMask IgnoreViewReferencesMask LogPrerequisitesMask LogReferencesMask NoXPManifestMask PreserveAspectsMask RetainInstVarNamesMask RetainSubclassRespMask StripClassBuilderMask StripClassesMask StripClassInfoMask StripDeprecatedMask StripMethodsMask StripPackagesMask StripResourcesMask StripShouldNotImplMask ToGoMask UnattendedMask WriteLogMask'
 	poolDictionaries: 'MessageBoxConstants Win32Constants'
 	classInstanceVariableNames: ''!
-ImageStripper guid: (GUID fromString: '{87B4C667-026E-11D3-9FD7-00A0CC3E4A32}')!
+ImageStripper guid: (GUID fromString: '{87b4c667-026e-11d3-9fd7-00a0cc3e4a32}')!
 ImageStripper addClassConstant: 'AllResourcesStripped' value: 4194304!
 ImageStripper addClassConstant: 'ClearGuidsMask' value: 1!
 ImageStripper addClassConstant: 'CompileStructsMask' value: 256!

--- a/Core/Object Arts/Dolphin/Lagoon/ImageStripperProgress.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/ImageStripperProgress.cls
@@ -5,7 +5,7 @@ Object subclass: #ImageStripperProgress
 	classVariableNames: 'CaptionId ExplanationId MessageMap ProgressId StatusId'
 	poolDictionaries: 'Win32Constants'
 	classInstanceVariableNames: ''!
-ImageStripperProgress guid: (GUID fromString: '{3645214B-FFF1-40C6-91D4-32740D2F6A66}')!
+ImageStripperProgress guid: (GUID fromString: '{3645214b-fff1-40c6-91d4-32740d2f6a66}')!
 ImageStripperProgress comment: 'ImageStripperProgress is a <topPresenter> used by the <ImageStripper> to display the progress of an image stripping operation.
 
 Instance Variables:

--- a/Core/Object Arts/Dolphin/Lagoon/VS_VERSION_INFO_HEADER.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/VS_VERSION_INFO_HEADER.cls
@@ -1,11 +1,11 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Win32Structure subclass: #VS_VERSION_INFO_HEADER
 	instanceVariableNames: 'key valueOffset'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-VS_VERSION_INFO_HEADER guid: (GUID fromString: '{EFC64C05-AA07-41B8-BA73-60F7974C6E3F}')!
+VS_VERSION_INFO_HEADER guid: (GUID fromString: '{efc64c05-aa07-41b8-ba73-60f7974c6e3f}')!
 VS_VERSION_INFO_HEADER comment: 'VS_VERSION_INFO_HEADER is an ExternalStructure class to represent the headers for version resource blocks. It is not a real Win32 structure.
 
 See the VersionResource class.'!

--- a/Core/Object Arts/Dolphin/Lagoon/VersionResource.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/VersionResource.cls
@@ -1,11 +1,11 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #VersionResource
 	instanceVariableNames: 'fixedInfo stringTables translations'
 	classVariableNames: ''
 	poolDictionaries: 'Win32Constants'
 	classInstanceVariableNames: ''!
-VersionResource guid: (GUID fromString: '{B76AB5BC-4BA7-40D2-88FE-6A76D28FC30B}')!
+VersionResource guid: (GUID fromString: '{b76ab5bc-4ba7-40d2-88fe-6a76d28fc30b}')!
 VersionResource comment: ''!
 !VersionResource categoriesForClass!System-Support! !
 !VersionResource methodsFor!


### PR DESCRIPTION
A recent commit (619963bb3261408afc6a821ce8c540a94f7b9cc5) changed BasicImageStripper>>#prepareExternalStructuresNotifying: to remove #'offsetOf:' from ExternalStructure class. Unfortunately it is still sent by NMLVDISPINFO class>>#'itemFromNMHDR:' so we get a runtime error on certain operations.

{1A791118: cf 1A7910F1, sp 1A79112C, bp 1A791114, ip 4, NMLVDISPINFO class(Object)>>doesNotUnderstand:}
	receiver: NMLVDISPINFO
	arg[0]: Message selector: offsetOf: arguments: #(lvItem )

{1A7910F0: cf 1A7910CD, sp 1A79110C, bp 1A7910EC, ip 7, NMLVDISPINFO class>>itemFromNMHDR:}
	receiver: NMLVDISPINFO
	arg[0]: a ExternalAddress

{1A7910CC: cf 1A7910AD, sp 1A7910E4, bp 1A7910C8, ip 5, ListView(IconicListAbstract)>>nmGetDispInfo:}
	receiver: a ListView
	arg[0]: a ExternalAddress

{1A7910AC: cf 1A791089, sp 1A7910C0, bp 1A7910A4, ip 27, ListView>>nmNotify:}
	receiver: a ListView
	arg[0]: a ExternalAddress
	stack temp[0]: -150