### PR TITLE
Fix problem with empty display of non-empty lists

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
@@ -451,7 +451,8 @@ nmEndLabelEdit: pNMHDR
 	changed. N.B. This notification is not necessarily sent by all subclasses."
 
 	| item object text |
-	item := self dispInfoClass itemFromNMHDR: pNMHDR.
+	"item := self dispInfoClass itemFromNMHDR: pNMHDR."
+	item := (self dispInfoClass fromAddress: pNMHDR) item.
 	text := item pszText.
 	self canEditLabels ifFalse: [self disableLabelEdit].
 	text isNil
@@ -466,7 +467,8 @@ nmGetDispInfo: pNMHDR
 	"Private - Handler for a ?VN_GETDISPINFO notification message.
 	N.B. This notification is not necessarily sent by all subclasses."
 
-	^self onDisplayDetailsRequired: (self dispInfoClass itemFromNMHDR: pNMHDR)!
+	^self onDisplayDetailsRequired: (self dispInfoClass fromAddress: pNMHDR) item
+	"^self onDisplayDetailsRequired: (self dispInfoClass itemFromNMHDR: pNMHDR)"!
 
 nmSelChanged: anExternalAddress 
 	"Private - Default handler for the ??N_SELCHANGED notification message.
@@ -478,7 +480,8 @@ nmSetDispInfo: pNMHDR
 	"Private - Default handler for the ?VN_SETDISPINFO notification message.
 	Forward as an onDisplayDetailsChanged: event."
 
-	^self onDisplayDetailsChanged: (self dispInfoClass itemFromNMHDR: pNMHDR)!
+	^self onDisplayDetailsChanged: (self dispInfoClass fromAddress: pNMHDR) item
+	"^self onDisplayDetailsChanged: (self dispInfoClass itemFromNMHDR: pNMHDR)"!
 
 notificationClass
 	"Private - Answer the class of NMHDR associated with certain notifications sent


### PR DESCRIPTION
Commit 8d95d58edbbc2d036e03b54e8411a9362c5d5955 includes the comment "Micro-optimization of LV/TVDISPINFO notifications". Unfortunately, this change causes some lists to display as empty in a runtime. Edits to the code to use both the old code and the new code and compare the results confirms the problem. It would be nice to revert the behavior unless the "micro-optimization" can be fixed.

{1A660E84: cf 1A660E65, sp 1A660E98, bp 1A660E80, ip 4, ListView(Object)>>error:}
	receiver: a ListView
	arg[0]: 'nmGetDispInfo: - expected 0 (with old method) but got nil (with new method)'

{1A660E64: cf 1A660E3D, sp 1A660E78, bp 1A660E58, ip 30, ListView(IconicListAbstract)>>nmGetDispInfo:}
	receiver: a ListView
	arg[0]: a ExternalAddress
	stack temp[0]: 0
	stack temp[1]: nil

{1A660E3C: cf 1A660E19, sp 1A660E50, bp 1A660E34, ip 27, ListView>>nmNotify:}
	receiver: a ListView
	arg[0]: a ExternalAddress
	stack temp[0]: -150

{1A660E18: cf 1A660DE9, sp 1A660E2C, bp 1A660E04, ip 17, SlidingCardTray(View)>>wmNotify:wParam:lParam:}
	receiver: a SlidingCardTray
	arg[0]: 78
	arg[1]: 4194
	arg[2]: 1370264
	stack temp[0]: a ExternalAddress
	stack temp[1]: a ListView

{1A660DE8: cf 1A660DB9, sp 1A660DFC, bp 1A660DD4, ip 23, SlidingCardTray(View)>>dispatchMessage:wParam:lParam:}
	receiver: a SlidingCardTray
	arg[0]: 78
	arg[1]: 4194
	arg[2]: 1370264
	stack temp[0]: nil
	stack temp[1]: wmNotify:wParam:lParam:

{1A660DB8: cf 1A660D85, sp 1A660DCC, bp 1A660DA8, ip 70, [] in InputState>>wndProc:message:wParam:lParam:cookie:}
	receiver: nil

{1A660D84: cf 1A660D5D, sp 1A660D98, bp 1A660D80, ip 18, BlockClosure>>ifCurtailed:}
	receiver: [] @ 0 in nil
	arg[0]: [] @ 11 in ProcessorScheduler>>callback:evaluate:

{1A660D5C: cf 1A660D39, sp 1A660D78, bp 1A660D54, ip 15, ProcessorScheduler>>callback:evaluate:}
	receiver: a ProcessorScheduler
	arg[0]: 684742
	arg[1]: [] @ 64 in InputState>>wndProc:message:wParam:lParam:cookie:

{1A660D38: cf 1A660CED, sp 1A660D4C, bp 1A660D20, ip 73, InputState>>wndProc:message:wParam:lParam:cookie:}
	receiver: a InputState
	arg[0]: 13372602
	arg[1]: 78
	arg[2]: 4194
	arg[3]: 1370264
	arg[4]: 684742
	stack temp[0]: a SlidingCardTray

{1A660CEC: cf 1A660CC5, sp 1A660D18, bp 1A660CE0, ip 10, ListView(ControlView)>>defaultWindowProcessing:wParam:lParam:}
	receiver: a ListView
	arg[0]: 4139
	arg[1]: 0
	arg[2]: 444532648

{1A660CC4: cf 1A660C95, sp 1A660CD8, bp 1A660CB0, ip 58, ListView(View)>>dispatchMessage:wParam:lParam:}
	receiver: a ListView
	arg[0]: 4139
	arg[1]: 0
	arg[2]: 444532648
	stack temp[0]: nil
	stack temp[1]: nil

{1A660C94: cf 1A660C61, sp 1A660CA8, bp 1A660C84, ip 70, [] in InputState>>wndProc:message:wParam:lParam:cookie:}
	receiver: nil

{1A660C60: cf 1A660C39, sp 1A660C74, bp 1A660C5C, ip 18, BlockClosure>>ifCurtailed:}
	receiver: [] @ 0 in nil
	arg[0]: [] @ 11 in ProcessorScheduler>>callback:evaluate:

{1A660C38: cf 1A660C15, sp 1A660C54, bp 1A660C30, ip 15, ProcessorScheduler>>callback:evaluate:}
	receiver: a ProcessorScheduler
	arg[0]: 686102
	arg[1]: [] @ 64 in InputState>>wndProc:message:wParam:lParam:cookie:

{1A660C14: cf 1A660BCD, sp 1A660C28, bp 1A660BFC, ip 73, InputState>>wndProc:message:wParam:lParam:cookie:}
	receiver: a InputState
	arg[0]: 12453154
	arg[1]: 4139
	arg[2]: 0
	arg[3]: 444532648
	arg[4]: 686102
	stack temp[0]: a ListView

{1A660BCC: cf 1A660BA5, sp 1A660BF4, bp 1A660BC0, ip 9, ListView(View)>>sendMessage:wParam:lpParam:}
	receiver: a ListView
	arg[0]: 4139
	arg[1]: 0
	arg[2]: a ByteArray

{1A660BA4: cf 1A660B81, sp 1A660BB8, bp 1A660B9C, ip 10, ListView>>lvmSetItem:state:}
	receiver: a ListView
	arg[0]: 0
	arg[1]: a LVITEM

{1A660B80: cf 1A660B55, sp 1A660B94, bp 1A660B70, ip 28, ListView>>selectIndex:set:}
	receiver: a ListView
	arg[0]: 1
	arg[1]: true
	stack temp[0]: a LVITEM
	stack temp[1]: 3

{1A660B54: cf 1A660B29, sp 1A660B68, bp 1A660B4C, ip 16, [] in ListView(IconicListAbstract)>>selectIndices:set:}
	receiver: a ListView
	arg[0]: 1

{1A660B28: cf 1A660B05, sp 1A660B44, bp 1A660B20, ip 11, OrderedCollection>>do:}
	receiver: a OrderedCollection
	arg[0]: [] @ 13 in IconicListAbstract>>selectIndices:set:
	stack temp[0]: 1

{1A660B04: cf 1A660AE1, sp 1A660B18, bp 1A660AFC, ip 18, ListView(IconicListAbstract)>>selectIndices:set:}
	receiver: a ListView
	arg[0]: a OrderedCollection
	arg[1]: true

{1A660AE0: cf 1A660AC1, sp 1A660AF4, bp 1A660ADC, ip 8, ListView(ListControlView)>>basicSelectionsByIndex:}
	receiver: a ListView
	arg[0]: a OrderedCollection

{1A660AC0: cf 1A660AA1, sp 1A660AD4, bp 1A660ABC, ip 9, ListView>>setSelectionsByIndex:}
	receiver: a ListView
	arg[0]: a OrderedCollection

{1A660AA0: cf 1A660A75, sp 1A660AB4, bp 1A660A90, ip 21, ListView>>selections:ifAbsent:}
	receiver: a ListView
	arg[0]: a Array
	arg[1]: [] @ 11 in SelectableItemsPresenter>>selections:
	stack temp[0]: a OrderedCollection
	stack temp[1]: a OrderedCollection

{1A660A74: cf 1A660A55, sp 1A660A88, bp 1A660A70, ip 19, ListPresenter(SelectableItemsPresenter)>>selections:}
	receiver: a ListPresenter
	arg[0]: a Array
