### PR TITLE
Cleanup runtime deployment problems with EditableListView

### DIFF
--- a/Core/Contributions/Solutions Software/EditableListView.cls
+++ b/Core/Contributions/Solutions Software/EditableListView.cls
@@ -5,7 +5,7 @@ ListView subclass: #EditableListView
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-EditableListView guid: (GUID fromString: '{E2B66E41-55E0-4105-A492-B9DEFD40CD23}')!
+EditableListView guid: (GUID fromString: '{e2b66e41-55e0-4105-a492-b9defd40cd23}')!
 EditableListView comment: ''!
 !EditableListView categoriesForClass!Unclassified! !
 !EditableListView methodsFor!
@@ -707,7 +707,7 @@ onValueChangedIn: aColumn
 	aColumn updateValueIn: self selection.
 
 	"attempt to ensure that changes are triggered off the list model"
-	self model updateAtIndex: (self selectionByIndex)!
+	self model refreshAtIndex: (self selectionByIndex)!
 
 onViewOpened
 

--- a/Core/Contributions/Solutions Software/EditableListViewColumn.cls
+++ b/Core/Contributions/Solutions Software/EditableListViewColumn.cls
@@ -5,7 +5,7 @@ ListViewColumn subclass: #EditableListViewColumn
 	classVariableNames: ''
 	poolDictionaries: 'CommCtrlConstants'
 	classInstanceVariableNames: ''!
-EditableListViewColumn guid: (GUID fromString: '{787A1FF5-1809-4381-AB64-22F338ECAA37}')!
+EditableListViewColumn guid: (GUID fromString: '{787a1ff5-1809-4381-ab64-22f338ecaa37}')!
 EditableListViewColumn comment: ''!
 !EditableListViewColumn categoriesForClass!Unclassified! !
 !EditableListViewColumn methodsFor!

--- a/Core/Contributions/Solutions Software/EmbeddedCheckBox.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedCheckBox.cls
@@ -5,7 +5,7 @@ CheckBox subclass: #EmbeddedCheckBox
 	classVariableNames: ''
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!
-EmbeddedCheckBox guid: (GUID fromString: '{611F80AE-2E05-4E6F-B0C8-A0ADBD00FF31}')!
+EmbeddedCheckBox guid: (GUID fromString: '{611f80ae-2e05-4e6f-b0c8-a0adbd00ff31}')!
 EmbeddedCheckBox comment: ''!
 !EmbeddedCheckBox categoriesForClass!MVP-Views! !
 !EmbeddedCheckBox methodsFor!

--- a/Core/Contributions/Solutions Software/EmbeddedComboBox.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedComboBox.cls
@@ -5,7 +5,7 @@ ComboBox subclass: #EmbeddedComboBox
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-EmbeddedComboBox guid: (GUID fromString: '{37AD4011-9526-4F00-ADBB-A2E73C6B5EBC}')!
+EmbeddedComboBox guid: (GUID fromString: '{37ad4011-9526-4f00-adbb-a2e73c6b5ebc}')!
 EmbeddedComboBox comment: ''!
 !EmbeddedComboBox categoriesForClass!Unclassified! !
 !EmbeddedComboBox methodsFor!

--- a/Core/Contributions/Solutions Software/EmbeddedFormattedTextEdit.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedFormattedTextEdit.cls
@@ -5,7 +5,7 @@ FormattedTextEdit subclass: #EmbeddedFormattedTextEdit
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-EmbeddedFormattedTextEdit guid: (GUID fromString: '{4EF6ADF7-0642-4BAC-970D-10E4A69EC7F0}')!
+EmbeddedFormattedTextEdit guid: (GUID fromString: '{4ef6adf7-0642-4bac-970d-10e4a69ec7f0}')!
 EmbeddedFormattedTextEdit comment: ''!
 !EmbeddedFormattedTextEdit categoriesForClass!Unclassified! !
 !EmbeddedFormattedTextEdit methodsFor!

--- a/Core/Contributions/Solutions Software/EmbeddedMultilineTextEdit.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedMultilineTextEdit.cls
@@ -5,7 +5,7 @@ MultilineTextEdit subclass: #EmbeddedMultilineTextEdit
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-EmbeddedMultilineTextEdit guid: (GUID fromString: '{F464E637-7C1A-4A4A-A066-653A45DA17FD}')!
+EmbeddedMultilineTextEdit guid: (GUID fromString: '{f464e637-7c1a-4a4a-a066-653a45da17fd}')!
 EmbeddedMultilineTextEdit comment: ''!
 !EmbeddedMultilineTextEdit categoriesForClass!Unclassified! !
 !EmbeddedMultilineTextEdit methodsFor!

--- a/Core/Contributions/Solutions Software/EmbeddedPushButton.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedPushButton.cls
@@ -5,7 +5,7 @@ EmulatedPushButton subclass: #EmbeddedPushButton
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-EmbeddedPushButton guid: (GUID fromString: '{B1D223A1-89B7-41CD-9057-4B9D84F774C7}')!
+EmbeddedPushButton guid: (GUID fromString: '{b1d223a1-89b7-41cd-9057-4b9d84f774c7}')!
 EmbeddedPushButton comment: ''!
 !EmbeddedPushButton categoriesForClass!Unclassified! !
 !EmbeddedPushButton methodsFor!

--- a/Core/Contributions/Solutions Software/EmbeddedRadioButton.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedRadioButton.cls
@@ -5,7 +5,7 @@ RadioButton subclass: #EmbeddedRadioButton
 	classVariableNames: ''
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!
-EmbeddedRadioButton guid: (GUID fromString: '{326BF942-1142-4A1D-A365-F4B0DDA88FFE}')!
+EmbeddedRadioButton guid: (GUID fromString: '{326bf942-1142-4a1d-a365-f4b0dda88ffe}')!
 EmbeddedRadioButton comment: ''!
 !EmbeddedRadioButton categoriesForClass!MVP-Views! !
 !EmbeddedRadioButton methodsFor!

--- a/Core/Contributions/Solutions Software/EmbeddedTextEdit.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedTextEdit.cls
@@ -5,7 +5,7 @@ TextEdit subclass: #EmbeddedTextEdit
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-EmbeddedTextEdit guid: (GUID fromString: '{B24A4423-0072-4380-BD67-1E317410EBF8}')!
+EmbeddedTextEdit guid: (GUID fromString: '{b24a4423-0072-4380-bd67-1e317410ebf8}')!
 EmbeddedTextEdit comment: ''!
 !EmbeddedTextEdit categoriesForClass!Unclassified! !
 !EmbeddedTextEdit methodsFor!

--- a/Core/Contributions/Solutions Software/EmulatedPushButton.cls
+++ b/Core/Contributions/Solutions Software/EmulatedPushButton.cls
@@ -5,7 +5,7 @@ TextAndImageButton subclass: #EmulatedPushButton
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-EmulatedPushButton guid: (GUID fromString: '{66E0B0C3-9ACD-43DB-A3AE-C353958F614B}')!
+EmulatedPushButton guid: (GUID fromString: '{66e0b0c3-9acd-43db-a3ae-c353958f614b}')!
 EmulatedPushButton comment: 'EmulatedPushButtons appear near-identical to standard PushButtons, but their drawing is implemented in Dolphin.
  - allows themed buttons with images on XP (under XP, buttons with images always show non-themed)
  - supports buttons with an image and text side-by-side (standard buttons show image or text)

--- a/Core/Contributions/Solutions Software/FormattedTextEdit.cls
+++ b/Core/Contributions/Solutions Software/FormattedTextEdit.cls
@@ -5,7 +5,7 @@ TextEdit subclass: #FormattedTextEdit
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-FormattedTextEdit guid: (GUID fromString: '{DA7E43DA-5D5C-4332-A6D6-756996F820EE}')!
+FormattedTextEdit guid: (GUID fromString: '{da7e43da-5d5c-4332-a6d6-756996f820ee}')!
 FormattedTextEdit comment: ''!
 !FormattedTextEdit categoriesForClass!Unclassified! !
 !FormattedTextEdit methodsFor!

--- a/Core/Contributions/Solutions Software/IconWithExtent.cls
+++ b/Core/Contributions/Solutions Software/IconWithExtent.cls
@@ -5,7 +5,7 @@ Icon subclass: #IconWithExtent
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-IconWithExtent guid: (GUID fromString: '{429114BB-12F2-41AB-8FE0-7585364AC305}')!
+IconWithExtent guid: (GUID fromString: '{429114bb-12f2-41ab-8fe0-7585364ac305}')!
 IconWithExtent comment: ''!
 !IconWithExtent categoriesForClass!Graphics-Tools! !
 !IconWithExtent methodsFor!

--- a/Core/Contributions/Solutions Software/OwnerDrawnButton.cls
+++ b/Core/Contributions/Solutions Software/OwnerDrawnButton.cls
@@ -5,7 +5,7 @@ PushButton subclass: #OwnerDrawnButton
 	classVariableNames: ''
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!
-OwnerDrawnButton guid: (GUID fromString: '{B1B80A82-7D68-47AA-B70A-D079B92FCA12}')!
+OwnerDrawnButton guid: (GUID fromString: '{b1b80a82-7d68-47aa-b70a-d079b92fca12}')!
 OwnerDrawnButton comment: 'Abstract superclass for implementing custom-look buttons with standard Windows behavior, including support for animated transitions.
 As a minimum, subclasses need to implement drawOn:'!
 !OwnerDrawnButton categoriesForClass!Unclassified! !

--- a/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
+++ b/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
@@ -272,14 +272,14 @@ resendTo: aView
 lpszText
 
 	^bytes uintPtrAtOffset: ##(self offsetOf: #lpszText)! !
-!NMTTDISPINFOA categoriesFor: #lpszText!**compiled accessors**!public! !
+!NMTTDISPINFOA categoriesFor: #lpszText!accessing!public! !
 
 !NMTTDISPINFOW methodsFor!
 
 lpszText
 
 	^bytes uintPtrAtOffset: ##(self offsetOf: #lpszText)! !
-!NMTTDISPINFOW categoriesFor: #lpszText!**compiled accessors**!public! !
+!NMTTDISPINFOW categoriesFor: #lpszText!accessing!public! !
 
 !PointEvent methodsFor!
 

--- a/Core/Contributions/Solutions Software/TextAndImageButton.cls
+++ b/Core/Contributions/Solutions Software/TextAndImageButton.cls
@@ -5,7 +5,7 @@ OwnerDrawnButton subclass: #TextAndImageButton
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-TextAndImageButton guid: (GUID fromString: '{7AB8C439-056D-4B01-A5BF-1B454EC864B5}')!
+TextAndImageButton guid: (GUID fromString: '{7ab8c439-056d-4b01-a5bf-1b454ec864b5}')!
 TextAndImageButton comment: ''!
 !TextAndImageButton categoriesForClass!Unclassified! !
 !TextAndImageButton methodsFor!


### PR DESCRIPTION
EditableListView>>onValueChangedIn: called ListModel>>updateAtIndex: which is deprecated so can be stripped from a runtime deployment. This commit changes EditableListView to use #'refreshAtIndex:', which is the recommended replacement.

Next, SSW Widget Enhancements added #'lpszText' as an accessor but left it in a category that got silently stripped during runtime deployment. The second commit changes the method category.