### PR TITLE
Workaround for intermittent crash on image shutdown (VM issue #128)

### DIFF
--- a/Boot.st
+++ b/Boot.st
@@ -71,6 +71,6 @@ devsesh onPreSaveImage.
 "Remove unnecessary .chg files"
 File delete: 'DBOOT.chg'!
 
-SessionManager current quit!
+SessionManager current onExit; primQuit: 0!
 
 

--- a/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
@@ -5,7 +5,7 @@ SessionManager subclass: #BootSessionManager
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-BootSessionManager guid: (GUID fromString: '{9DBC5FA6-DACE-4809-88B9-83242B7F7D72}')!
+BootSessionManager guid: (GUID fromString: '{9dbc5fa6-dace-4809-88b9-83242b7f7d72}')!
 BootSessionManager comment: 'BootSessionManager is the class of <SessionManager>s installed when the Dolphin image is booting from sources.'!
 !BootSessionManager categoriesForClass!Development! !
 !BootSessionManager methodsFor!

--- a/Core/Object Arts/Dolphin/Base/SessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SessionManager.cls
@@ -5,7 +5,7 @@ Object subclass: #SessionManager
 	classVariableNames: 'Current EmbeddingMask PreStartFile'
 	poolDictionaries: 'Win32Constants Win32Errors'
 	classInstanceVariableNames: ''!
-SessionManager guid: (GUID fromString: '{87B4C4B7-026E-11D3-9FD7-00A0CC3E4A32}')!
+SessionManager guid: (GUID fromString: '{87b4c4b7-026e-11d3-9fd7-00a0cc3e4a32}')!
 SessionManager addClassConstant: 'EmbeddingMask' value: 1!
 SessionManager comment: 'SessionManager is the class of objects responsible for managing the lifecyle of an application, from startup to shutdown. SessionManagers are also responsible for determining the global policy for dealing with unhandled Exceptions. 
 
@@ -822,7 +822,7 @@ quit
 quit: anInteger
 	"Private - Force a close down of the session with the specified exit code."
 
-	self onExit == true ifTrue: [self primQuit: anInteger].
+	self onExit == true ifTrue: [[self primQuit: anInteger] postToInputQueue].
 	^false	"cancelled"!
 
 registerConsoleCtrlHandler

--- a/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
@@ -5,7 +5,7 @@ DolphinTest subclass: #VMTest
 	classVariableNames: ''
 	poolDictionaries: 'CRTConstants'
 	classInstanceVariableNames: ''!
-VMTest guid: (GUID fromString: '{D03F75A2-8C1C-4559-8177-EFF37D37A6E8}')!
+VMTest guid: (GUID fromString: '{d03f75a2-8c1c-4559-8177-eff37d37a6e8}')!
 VMTest comment: 'Test the VM primitives and other VM related operations.
 
 SUnitBrowser openOnTestCase: self'!
@@ -83,7 +83,7 @@ earlyTermination: aBoolean
 			[a := 1.
 			
 			[a := 2.
-			KernelLibrary default sleep: 50] ifCurtailed: [a := 0].
+			KernelLibrary default sleep: 30] ifCurtailed: [a := 0].
 			a := 3] 
 					forkAt: Processor userInterruptPriority.	"High priority background proc runs but then blocks..."
 	self assert: proc isWaiting description: 'Proc should be blocked on the overlapped call semaphore'.
@@ -108,8 +108,8 @@ earlyTermination: aBoolean
 
 			"Let the sleep: complete (allow a reasonable period so we can be fairly sure  it does)"
 			count := 0.
-			[a ~= 0 and: [count < 100]] whileTrue: 
-					[Processor sleep: 5.
+			[a ~= 0 and: [count < 500]] whileTrue: 
+					[Processor sleep: 1.
 					count := count + 1].
 			"The curtailment block should now have run"
 			self assert: a == 0.
@@ -921,9 +921,9 @@ testOverlappedCallTermination
 	problems in the VM, so debugging at the Smalltalk level is not terribly useful anyway."
 
 	"1) Call is terminated before completion, before it has even started in fact"
-	1 to: 10 do: [:i | self earlyTermination: false].
+	1 to: 5 do: [:i | self earlyTermination: false].
 	"2) Call is terminated before completion, but is allowed to start"
-	1 to: 10 do: [:i | self earlyTermination: true]!
+	1 to: 5 do: [:i | self earlyTermination: true]!
 
 testPrimitiveAt
 	"First some error cases - accessing non-indexable objects"


### PR DESCRIPTION
The VM quit primitive works by throwing a Win32 exception that is trapped
in the main entry point function of the VM. This is done to unwind the
stack cleanly running any clean-up blocks on the way (mainly important
when running in-proc). Or at least that is the theory.
When Dolphin was originally written this worked fine because Windows
allowed exceptions to be thrown over user->kernel->user mode transitions
and be caught in the user mode code on the other side. Since Windows 7
(I think) the OS hasn't allowed this, so if Dolphin is (for example)
inside a callback to process a windows message, then the exit attempt
fails causing another unhandled exception.
This workaround defers the exit attempt to be processed by the main UI
process when the input queue is empty. There are some cases where this will
still fail, but it significantly reduces the likelihood.