### PR TITLE
Add tests of ListView>>newSelectionsFromEvent:

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -50,6 +50,34 @@ getItem: anInteger
 	aListView lvmGetItem: item.
 	^item!
 
+mouseDownEventOnItem: itemIndex buttons: anArray
+	| mouseButton keys position |
+	mouseButton := anArray intersection: #(#left #right #middle).
+	self assert: mouseButton size = 1.
+	mouseButton := mouseButton anyOne.
+	keys := (anArray collect: 
+					[:each |
+					##((IdentityDictionary new)
+						at: #left put: MK_LBUTTON;
+						at: #right put: MK_RBUTTON;
+						at: #middle put: MK_MBUTTON;
+						at: #control put: MK_CONTROL;
+						at: #shift put: MK_SHIFT;
+						yourself) at: each])
+				fold: [:a :b | a bitOr: b].
+	position := itemIndex == 0
+				ifTrue: [presenter clientExtent - (1 @ 1)]
+				ifFalse: [(presenter itemRect: itemIndex) origin + (1 @ 1)].
+	^MouseEvent
+		window: presenter
+		message: (##((IdentityDictionary new)
+				at: #left put: WM_LBUTTONDOWN;
+				at: #right put: WM_RBUTTONDOWN;
+				at: #middle put: WM_MBUTTONDOWN;
+				yourself) at: mouseButton)
+		wParam: keys
+		lParam: (DWORD fromPoint: position) asInteger.!
+
 setColumns: cols 
 	| list |
 	(presenter view)
@@ -60,6 +88,11 @@ setColumns: cols
 		assert: (list collect: [:each | each text]) asArray = (cols collect: [:each | each text]) asArray.
 	self assert: presenter view columnOrder = (1 to: cols size).
 	^list!
+
+setUpForSelectionTesting
+	presenter
+		list: (1 to: 10);
+		viewMode: #list.!
 
 sortSelections
 	^self subclassResponsibility!
@@ -154,6 +187,22 @@ testLastSelectionCacheUpdatedOnRemove
 	presenter model removeAtIndex: 1.
 	self assert: (presenter instVarNamed: 'lastSelIndices') = #(1)!
 
+testNewSelectionsLeftClickOutsideList
+	| event |
+	self setUpForSelectionTesting.
+	event := self mouseDownEventOnItem: 0 buttons: #(#left).
+	self assert: (presenter newSelectionsFromEvent: event) = #().
+	presenter selectionsByIndex: #(3).
+	self assert: (presenter newSelectionsFromEvent: event) = #().!
+
+testNewSelectionsSimpleLeftClick
+	| event |
+	self setUpForSelectionTesting.
+	event := self mouseDownEventOnItem: 1 buttons: #(#left).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1).
+	presenter selectionsByIndex: #(3).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1).!
+
 testNilRow
 	"#2157"
 
@@ -225,11 +274,15 @@ testSetTextImageDoesNotAffectSelection
 !ListViewTest categoriesFor: #classToTest!helpers!private! !
 !ListViewTest categoriesFor: #getColumns!helpers!private! !
 !ListViewTest categoriesFor: #getItem:!private!unit tests! !
+!ListViewTest categoriesFor: #mouseDownEventOnItem:buttons:!helpers!private! !
 !ListViewTest categoriesFor: #setColumns:!private!unit tests! !
+!ListViewTest categoriesFor: #setUpForSelectionTesting!helpers!private! !
 !ListViewTest categoriesFor: #sortSelections!public!unit tests! !
 !ListViewTest categoriesFor: #testChangeViewMode!public!unit tests! !
 !ListViewTest categoriesFor: #testColumnsList!public!unit tests! !
 !ListViewTest categoriesFor: #testLastSelectionCacheUpdatedOnRemove!public!unit tests! !
+!ListViewTest categoriesFor: #testNewSelectionsLeftClickOutsideList!public!unit tests! !
+!ListViewTest categoriesFor: #testNewSelectionsSimpleLeftClick!public!unit tests! !
 !ListViewTest categoriesFor: #testNilRow!public!unit tests! !
 !ListViewTest categoriesFor: #testProgrammaticSelectionVisible!public!unit tests! !
 !ListViewTest categoriesFor: #testSelectionRemainsVisibleOnSort!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -17,6 +17,116 @@ initializePresenter
 sortSelections
 	^#(49 50)!
 
+testNewSelectionsClickOutsideListWithModifiers
+	| event |
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(1).
+	(OrderedCollection new)
+		add: #(#control);
+		add: #(#shift);
+		add: #(#control #shift);
+		do: 
+				[:modifiers |
+				event := self mouseDownEventOnItem: 0 buttons: (modifiers copyWith: #left).
+				self assert: (presenter newSelectionsFromEvent: event) = #(1)].!
+
+testNewSelectionsCtrlClickOnSelectedItem
+	| event |
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(1 2).
+	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
+	self assert: (presenter newSelectionsFromEvent: event) = #(2).
+	presenter selectionsByIndex: #(1).
+	self assert: (presenter newSelectionsFromEvent: event) = #().!
+
+testNewSelectionsCtrlClickOnUnselectedItem
+	| event |
+	self setUpForSelectionTesting.
+	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1).
+	presenter selectionsByIndex: #(2).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1 2).!
+
+testNewSelectionsCtrlShiftClickAdditive
+	| event |
+	self setUpForSelectionTesting.
+	presenter
+		selectionsByIndex: #(1 3);
+		selectionMarkIndex: 3.
+	event := self mouseDownEventOnItem: 7 buttons: #(#left #control #shift).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1 3 4 5 6 7).
+	presenter selectionsByIndex: #(1 3 5 7).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1 3 4 5 6 7).!
+
+testNewSelectionsCtrlShiftClickSubtractive
+	| event |
+	self setUpForSelectionTesting.
+	presenter
+		selectionsByIndex: #(1 2 3 4 5 7);
+		selectionMarkIndex: 6.
+	event := self mouseDownEventOnItem: 2 buttons: #(#left #control #shift).
+	"In Windows Explorer and other applications that use ListView or a similar control,
+	(2) would not be selected at this point. Why is it in Dolphin?
+	(See comment at the end of #newSelectionsFromEvent:.)"
+	self assert: (presenter newSelectionsFromEvent: event) = #(1 2 7).
+	presenter selectionsByIndex: #(1 3 5 7).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1 2 7).!
+
+testNewSelectionsInitialShiftClick
+	| event |
+	self setUpForSelectionTesting.
+	event := self mouseDownEventOnItem: 1 buttons: #(#left #shift).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1).
+	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
+	self assert: (presenter newSelectionsFromEvent: event) = #(3).!
+
+testNewSelectionsNonLeftClicksWithModifiers
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(1 3 5).
+	"Right or middle clicks with any modifiers will never modify the selection. Just cover a few example cases."
+	(OrderedCollection new)
+		add: 1 -> #(#right #control);
+		add: 2 -> #(#middle #shift);
+		add: 3 -> #(#right #control #shift);
+		add: 0 -> #(#middle #control);
+		do: 
+				[:assoc |
+				| event |
+				event := self mouseDownEventOnItem: assoc key buttons: assoc value.
+				self assert: (presenter newSelectionsFromEvent: event) = #(1 3 5)].!
+
+testNewSelectionsRightClickOutsideSelection
+	| event |
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(1 3 5).
+	event := self mouseDownEventOnItem: 2 buttons: #(#right).
+	self assert: (presenter newSelectionsFromEvent: event) = #(2).!
+
+testNewSelectionsRightClickWithinSelection
+	| event |
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(1 3 5).
+	event := self mouseDownEventOnItem: 3 buttons: #(#right).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1 3 5).!
+
+testNewSelectionsShiftClickWithSelectionMark
+	| event |
+	self setUpForSelectionTesting.
+	presenter selectionMarkIndex: 3.
+	event := self mouseDownEventOnItem: 5 buttons: #(#left #shift).
+	"It does not really matter what is currently selected, only what is marked and what is clicked"
+	(OrderedCollection new)
+		add: #();
+		add: #(3);
+		add: #(1 2 3);
+		add: #(3 4 5 6);
+		do: 
+				[:oldSelections |
+				presenter selectionsByIndex: oldSelections.
+				self assert: (presenter newSelectionsFromEvent: event) = #(3 4 5)].
+	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
+	self assert: (presenter newSelectionsFromEvent: event) = #(3).!
+
 testSelectionsByIndex
 	| objects sel |
 	objects := self objectsToTest.
@@ -71,5 +181,15 @@ testSelectionsByIndex
 	self assert: sel equals: presenter selectionsByIndex! !
 !MultiSelectListViewTest categoriesFor: #initializePresenter!public!Running! !
 !MultiSelectListViewTest categoriesFor: #sortSelections!private!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlClickOnSelectedItem!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlClickOnUnselectedItem!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickAdditive!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickSubtractive!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsInitialShiftClick!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsNonLeftClicksWithModifiers!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsRightClickOutsideSelection!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsRightClickWithinSelection!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testNewSelectionsShiftClickWithSelectionMark!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testSelectionsByIndex!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -1922,6 +1922,15 @@ selectionMarkIndex
 
 	^(self sendMessage: LVM_GETSELECTIONMARK) + 1.!
 
+selectionMarkIndex: anInteger
+	"Private - Set the one-based <integer> index of the item from which
+	a multiple selection will start, or clear it if <anInteger> is 0."
+
+	self
+		sendMessage: LVM_SETSELECTIONMARK
+		wParam: 0
+		lParam: anInteger - 1.!
+
 selections: aCollection ifAbsent: aNiladicOrMonadicValuable 
 	"Select the first occurrences of the specified collection of <Object>s in the receiver and
 	answer the new selection. If any of the elements of the collection are not present in the
@@ -2404,6 +2413,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #selectedCount!private!selection! !
 !ListView categoriesFor: #selectIndex:set:!private!selection!wine fix! !
 !ListView categoriesFor: #selectionMarkIndex!private!selection! !
+!ListView categoriesFor: #selectionMarkIndex:!private!selection! !
 !ListView categoriesFor: #selections:ifAbsent:!public!selection! !
 !ListView categoriesFor: #selectionsByIndex:ifAbsent:!public!selection! !
 !ListView categoriesFor: #setColumnIcon:atIndex:!helpers!private! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -1474,41 +1474,51 @@ moreParamsAt: n put: anObject
 	^self moreParams at: n put: anObject!
 
 newSelectionsFromEvent: event
-	"Private - Answer the <integer> selection that would occur if the <MouseEvent>,
+	"Private - Answer a collection of the <integer> selections that would occur if the <MouseEvent>,
 	event, was was passed to the control."
 
 	| itemClicked anyKeysDown newSelections markIndex markRange markIsSelected |
 	itemClicked := self itemFromPoint: event position.
+	"In single-select mode, the new selection is always the item clicked, or nothing if the click is outside all items."
 	self isMultiSelect ifFalse: [^itemClicked ifNil: [#()] ifNotNil: [:item | Array with: item]].
 	newSelections := self selectionsByIndex.
-	""
 	anyKeysDown := event isShiftDown or: [event isCtrlDown].
-	((itemClicked isNil and: [anyKeysDown])
-		or: [event button ~= #left and: [anyKeysDown or: [newSelections includes: itemClicked]]])
-			ifTrue: [^newSelections].
-	""
+	"If the click is outside all items, and ctrl or shift is down, nothing changes."
+	(itemClicked isNil and: [anyKeysDown]) ifTrue: [^newSelections].
+	"A right or middle click on an already-selected item also does not change the selection,
+	otherwise it would be very frustrating to open the context menu with multiple items selected.
+	The control also chooses to leave the selection alone if modifiers are held during a right/middle click."
+	(event button ~= #left and: [anyKeysDown or: [newSelections includes: itemClicked]])
+		ifTrue: [^newSelections].
+	"Having taken care of the above edge cases, if no keys are down, the behavior is equivalent to the single-select case."
 	anyKeysDown ifFalse: [^itemClicked ifNil: [#()] ifNotNil: [:item | Array with: item]].
-	"Only Ctrl"
+	"Only Ctrl is down, so we flip the selection state of the clicked item."
 	event isShiftDown ifFalse: 
 			[newSelections := newSelections asSortedCollection.
 			newSelections remove: itemClicked ifAbsent: [newSelections add: itemClicked].
 			^newSelections asArray].
-	"At least Shift, start dealing with the selection mark"
+	"At least Shift is down, so we must start examining the 'selection mark'. This is the last item
+	that was clicked with no modifiers, only ctrl, or ctrl + shift (shift-clicks do *not* move the
+	selection mark). It acts as the 'start point' for operations where shift is held--they affect
+	the range of items from the selection mark to the click point, inclusive. Initially it is zero,
+	i.e. out-of-bounds, in which case holding shift essentially has no effect, and we act only on
+	the item actually clicked."
 	markIndex := self selectionMarkIndex.
 	markRange := markIndex == 0
 				ifTrue: [itemClicked to: itemClicked]
 				ifFalse: [(markIndex min: itemClicked) to: (markIndex max: itemClicked)].
-	"Only Shift"
+	"Only shift is down, not ctrl, so the current selection will be entirely replaced by the marked range."
 	event isCtrlDown ifFalse: [^markRange asArray].
-	"Ctrl and Shift"
+	"Both ctrl and shift are down, so we set the selection state of the marked range to that of the
+	selection mark itself. Note that this ignores the selection state of the item actually clicked
+	and everything in between it and the selection mark."
 	newSelections := newSelections asSet.
 	markIsSelected := newSelections includes: markIndex.
 	markRange do: (markIsSelected
 				ifTrue: [[:i | newSelections add: i]]
 				ifFalse: [[:i | newSelections remove: i ifAbsent: []]]).
-	"For some reason, the item clicked is always left selected,
-	even if we are deselecting the range (markIsSelected == false).
-	This is not true in e.g. Windows Explorer--why?"
+	"For some reason, the item clicked is always left selected, even if we are deselecting the rest
+	of the marked range. This is not true in e.g. Windows Explorer--why is it in Dolphin?"
 	newSelections add: itemClicked.
 	^newSelections asSortedCollection asArray.!
 


### PR DESCRIPTION
Finally got around to writing these. I also fleshed out the comments in the method itself. I started trying to write a "spec" at the top as you suggested, but then as I went to comment the individual statements I found I was repeating myself. Hopefully those comments make the behavior sufficiently clear.

This seems like a good time to mention something I found in the process of writing the method initially. In a comment at the bottom, I note that the behavior of ListViews in Dolphin differs from that in e.g. Windows Explorer in one particular case. When using a Ctrl+Shift+click to _de_select a range, in Dolphin the item clicked is left selected (whether or not it previously was). I would intuitively expect it to be deselected along with everything else, and indeed this is how other programs behave. Do you have any idea why Dolphin differs in this regard?