### PR TITLE
Restore the anchor/selectionMark and caret when recreating a ListBox/ListView

### DIFF
--- a/Core/Contributions/Solutions Software/EditableListView.cls
+++ b/Core/Contributions/Solutions Software/EditableListView.cls
@@ -469,6 +469,23 @@ itemAndColumnAt: aPoint
 		ifTrue: [itemIndex@columnIndex]
 		ifFalse: [nil]!
 
+itemIndex: anInteger hasFocus: aBoolean
+	| anLvItem |
+	#deprecated.
+	"Only one item may have focus at a time--use #caretIndex: to set it."
+	anLvItem := LVITEM new.
+	anLvItem stateMask: LVIS_FOCUSED.
+	anLvItem dwState: aBoolean.
+	self lvmSetItem: anInteger - 1 state: anLvItem.!
+
+itemIndexWithFocus
+	#deprecated.
+	^self caretIndex.!
+
+itemIndexWithFocus: anInteger
+	#deprecated.
+	self caretIndex: anInteger.!
+
 lastEditableColumn
 
 	^self allColumns reverse detect: [ :each | each isEditable]!
@@ -987,6 +1004,9 @@ wmVScroll: message wParam: wParam lParam: lParam
 !EditableListView categoriesFor: #isMultiline!public!testing! !
 !EditableListView categoriesFor: #isSelected:!public!testing! !
 !EditableListView categoriesFor: #itemAndColumnAt:!accessing!private! !
+!EditableListView categoriesFor: #itemIndex:hasFocus:!helpers!public! !
+!EditableListView categoriesFor: #itemIndexWithFocus!accessing!public! !
+!EditableListView categoriesFor: #itemIndexWithFocus:!accessing!public! !
 !EditableListView categoriesFor: #lastEditableColumn!accessing!public! !
 !EditableListView categoriesFor: #lastEditableCoordsOnOrBefore:!helpers!private! !
 !EditableListView categoriesFor: #lvmSetColumn:at:!columns!private! !

--- a/Core/Contributions/Solutions Software/EditableListView.cls
+++ b/Core/Contributions/Solutions Software/EditableListView.cls
@@ -126,13 +126,7 @@ applyImageLists
 	self lvmSetImageList: largeImList type: LVSIL_NORMAL!
 
 clearFocusItem
-
-	| anLvItem |
-
-	anLvItem := LVITEM new.
-	anLvItem stateMask: LVIS_FOCUSED.
-	anLvItem dwState: 0.
-	1 to: self itemCount do: [ :i | self lvmSetItem: i-1 state: anLvItem]!
+	self caretIndex: 0.!
 
 clearFocusRect
 
@@ -474,28 +468,6 @@ itemAndColumnAt: aPoint
 	^((itemIndex between: 1 and: self list size) and: [columnIndex between: 1 and: self allColumns size])
 		ifTrue: [itemIndex@columnIndex]
 		ifFalse: [nil]!
-
-itemIndex: anInteger hasFocus: aBoolean
-
-	| anLvItem |
-
-	anLvItem := LVITEM new.
-	anLvItem stateMask: LVIS_FOCUSED.
-	anLvItem dwState: aBoolean.
-	self lvmSetItem: anInteger-1 state: anLvItem!
-
-itemIndexWithFocus
-
-	^(1 to: self itemCount) detect: [ :i | (self lvmGetItemState: (i - 1) mask: LVIS_FOCUSED) = 1] ifNone: [nil]!
-
-itemIndexWithFocus: anInteger
-
-	| anLvItem |
-
-	anLvItem := LVITEM new.
-	anLvItem stateMask: LVIS_FOCUSED.
-	anLvItem dwState: 1.
-	self lvmSetItem: anInteger-1 state: anLvItem!
 
 lastEditableColumn
 
@@ -1015,9 +987,6 @@ wmVScroll: message wParam: wParam lParam: lParam
 !EditableListView categoriesFor: #isMultiline!public!testing! !
 !EditableListView categoriesFor: #isSelected:!public!testing! !
 !EditableListView categoriesFor: #itemAndColumnAt:!accessing!private! !
-!EditableListView categoriesFor: #itemIndex:hasFocus:!helpers!public! !
-!EditableListView categoriesFor: #itemIndexWithFocus!accessing!public! !
-!EditableListView categoriesFor: #itemIndexWithFocus:!accessing!public! !
 !EditableListView categoriesFor: #lastEditableColumn!accessing!public! !
 !EditableListView categoriesFor: #lastEditableCoordsOnOrBefore:!helpers!private! !
 !EditableListView categoriesFor: #lvmSetColumn:at:!columns!private! !

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -33,9 +33,9 @@ testNewSelectionsClickOutsideListWithModifiers
 testNewSelectionsCtrlClickOnSelectedItem
 	| event |
 	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(1 2).
+	presenter selectionsByIndex: #(1 3).
 	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
-	self assert: (presenter newSelectionsFromEvent: event) = #(2).
+	self assert: (presenter newSelectionsFromEvent: event) = #(3).
 	presenter selectionsByIndex: #(1).
 	self assert: (presenter newSelectionsFromEvent: event) = #().!
 
@@ -44,8 +44,8 @@ testNewSelectionsCtrlClickOnUnselectedItem
 	self setUpForSelectionTesting.
 	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
 	self assert: (presenter newSelectionsFromEvent: event) = #(1).
-	presenter selectionsByIndex: #(2).
-	self assert: (presenter newSelectionsFromEvent: event) = #(1 2).!
+	presenter selectionsByIndex: #(3).
+	self assert: (presenter newSelectionsFromEvent: event) = #(1 3).!
 
 testNewSelectionsCtrlShiftClickAdditive
 	| event |
@@ -56,6 +56,8 @@ testNewSelectionsCtrlShiftClickAdditive
 	event := self mouseDownEventOnItem: 7 buttons: #(#left #control #shift).
 	self assert: (presenter newSelectionsFromEvent: event) = #(1 3 4 5 6 7).
 	presenter selectionsByIndex: #(1 3 5 7).
+	"Programatically changing selection does not change the selection mark."
+	self assert: presenter selectionMarkIndex = 3.
 	self assert: (presenter newSelectionsFromEvent: event) = #(1 3 4 5 6 7).!
 
 testNewSelectionsCtrlShiftClickSubtractive

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -5,7 +5,7 @@ ListViewTest subclass: #MultiSelectListViewTest
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-MultiSelectListViewTest guid: (GUID fromString: '{67F073DF-D832-4F4F-A5C1-57D8730E3515}')!
+MultiSelectListViewTest guid: (GUID fromString: '{67f073df-d832-4f4f-a5c1-57d8730e3515}')!
 MultiSelectListViewTest comment: ''!
 !MultiSelectListViewTest categoriesForClass!Unclassified! !
 !MultiSelectListViewTest methodsFor!
@@ -52,12 +52,12 @@ testNewSelectionsCtrlShiftClickAdditive
 	self setUpForSelectionTesting.
 	presenter
 		selectionsByIndex: #(1 3);
-		selectionMarkIndex: 3.
+		anchorIndex: 3.
 	event := self mouseDownEventOnItem: 7 buttons: #(#left #control #shift).
 	self assert: (presenter newSelectionsFromEvent: event) = #(1 3 4 5 6 7).
 	presenter selectionsByIndex: #(1 3 5 7).
-	"Programatically changing selection does not change the selection mark."
-	self assert: presenter selectionMarkIndex = 3.
+	"Programatically changing selection does not change the anchor."
+	self assert: presenter anchorIndex = 3.
 	self assert: (presenter newSelectionsFromEvent: event) = #(1 3 4 5 6 7).!
 
 testNewSelectionsCtrlShiftClickSubtractive
@@ -65,7 +65,7 @@ testNewSelectionsCtrlShiftClickSubtractive
 	self setUpForSelectionTesting.
 	presenter
 		selectionsByIndex: #(1 2 3 4 5 7);
-		selectionMarkIndex: 6.
+		anchorIndex: 6.
 	event := self mouseDownEventOnItem: 2 buttons: #(#left #control #shift).
 	"In Windows Explorer and other applications that use ListView or a similar control,
 	(2) would not be selected at this point. Why is it in Dolphin?
@@ -114,7 +114,7 @@ testNewSelectionsRightClickWithinSelection
 testNewSelectionsShiftClickWithSelectionMark
 	| event |
 	self setUpForSelectionTesting.
-	presenter selectionMarkIndex: 3.
+	presenter anchorIndex: 3.
 	event := self mouseDownEventOnItem: 5 buttons: #(#left #shift).
 	"It does not really matter what is currently selected, only what is marked and what is clicked"
 	(OrderedCollection new)

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
@@ -17,6 +17,16 @@ Class Variables:
 !ListBox categoriesForClass!MVP-Views! !
 !ListBox methodsFor!
 
+anchorIndex
+	"Answer the 1-based index of the anchor (the item from which a multiple selection will start)."
+
+	^(self sendMessage: LB_GETANCHORINDEX) + 1.!
+
+anchorIndex: anInteger
+	"Private - Set the 1-based index of the anchor (the item from which a multiple selection will start)."
+
+	self sendMessage: LB_SETANCHORINDEX wParam: anInteger - 1.!
+
 basicAdd: anObject 
 	"Private - Adds a string for the <Object> argument to the listbox control at the end of the
 	list. Answers the argument."
@@ -443,13 +453,29 @@ showDropHighlight: anItem
 
 state
 	"Private - Answer a MessageSequence which, when replayed, will restore the receiver 
-	to its current state. Add the horizonatl extent aspect since it is not otherwise cached in an
-	instance variable"
+	to its current state."
 
-	^super state
-		add: (MessageSend receiver: self selector: #horizontalExtent: argument: self horizontalExtent);
-		yourself
-!
+	| messages |
+	messages := super state.
+	"Add the horizontal extent aspect since it is not otherwise cached in an instance variable."
+	messages add: (MessageSend
+				receiver: self
+				selector: #horizontalExtent:
+				argument: self horizontalExtent).
+	"The caret and anchor only need to be restored separately in multi-select mode--
+	in single-select mode they are always equal to the selected item."
+	self isMultiSelect ifTrue: 
+			[self anchorIndex = 0 ifFalse: 
+					[messages add: (MessageSend
+								receiver: self
+								selector: #anchorIndex:
+								argument: self anchorIndex)].
+			self caretIndex = 0 ifFalse: 
+					[messages add: (MessageSend
+								receiver: self
+								selector: #caretIndex:
+								argument: self caretIndex)]].
+	^messages.!
 
 wmRButtonDown: message wParam: wParam lParam: lParam 
 	"Handle a WM_RBUTTONDOWN. We select the item under the mouse before
@@ -462,6 +488,8 @@ wmRButtonDown: message wParam: wParam lParam: lParam
 		wmRButtonDown: message
 		wParam: wParam
 		lParam: lParam! !
+!ListBox categoriesFor: #anchorIndex!public!selection! !
+!ListBox categoriesFor: #anchorIndex:!public!selection! !
 !ListBox categoriesFor: #basicAdd:!adding!private! !
 !ListBox categoriesFor: #basicAdd:atIndex:!adding!private! !
 !ListBox categoriesFor: #basicClear!private!removing! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
@@ -453,29 +453,13 @@ showDropHighlight: anItem
 
 state
 	"Private - Answer a MessageSequence which, when replayed, will restore the receiver 
-	to its current state."
+	to its current state. Add the horizonatl extent aspect since it is not otherwise cached in an
+	instance variable"
 
-	| messages |
-	messages := super state.
-	"Add the horizontal extent aspect since it is not otherwise cached in an instance variable."
-	messages add: (MessageSend
-				receiver: self
-				selector: #horizontalExtent:
-				argument: self horizontalExtent).
-	"The caret and anchor only need to be restored separately in multi-select mode--
-	in single-select mode they are always equal to the selected item."
-	self isMultiSelect ifTrue: 
-			[self anchorIndex = 0 ifFalse: 
-					[messages add: (MessageSend
-								receiver: self
-								selector: #anchorIndex:
-								argument: self anchorIndex)].
-			self caretIndex = 0 ifFalse: 
-					[messages add: (MessageSend
-								receiver: self
-								selector: #caretIndex:
-								argument: self caretIndex)]].
-	^messages.!
+	^super state
+		add: (MessageSend receiver: self selector: #horizontalExtent: argument: self horizontalExtent);
+		yourself
+!
 
 wmRButtonDown: message wParam: wParam lParam: lParam 
 	"Handle a WM_RBUTTONDOWN. We select the item under the mouse before

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
@@ -522,7 +522,23 @@ state
 	| messages |
 	messages := super state.
 	self hasSelection ifTrue: [messages add: self selectionState].
-	^messages!
+	"Controls in a multi-select mode (if supported) have two additional concepts which we must restore.
+	In single-select mode, or if multi-select is not supported, these are both equal to the selected item."
+	self isMultiSelect ifTrue: 
+			[| caret anchor |
+			caret := self caretIndex.
+			caret = 0 ifFalse: 
+					[messages add: (MessageSend
+								receiver: self
+								selector: #caretIndex:
+								argument: caret)].
+			anchor := self anchorIndex.
+			anchor = 0 ifFalse: 
+					[messages add: (MessageSend
+								receiver: self
+								selector: #anchorIndex:
+								argument: anchor)]].
+	^messages.!
 
 updateAll
 	"Re-render the model's contents. This is a similar operation to #refreshContents, except

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -349,6 +349,18 @@ caretIndex
 
 	^(self lvmGetNextItem: -1 flags: LVNI_FOCUSED) + 1!
 
+caretIndex: anInteger
+	"Set the 1-based <integer> index of the item in the list that has focus,
+	or clear the focus if <anInteger> is 0."
+
+	| lvItem |
+	lvItem := LVITEM new.
+	lvItem stateMask: LVIS_FOCUSED.
+	"If we pass -1 to LVM_SETITEMSTATE, the change applies to *all* items in the list,
+	but we must also tell the control to clear the focus state rather than set it."
+	anInteger == 0 ifFalse: [lvItem dwState: LVIS_FOCUSED].
+	self lvmSetItem: anInteger - 1 state: lvItem.!
+
 clearSelectionsByIndex: collection 
 	"Removes selection from the items in the receiver with the Integer
 	indices in collection"
@@ -2053,18 +2065,31 @@ state
 	self isReportMode 
 		ifTrue: 
 			["Ensure the actual column widths are cached"
-			self allColumns 
+			self allColumns
 				keysAndValuesDo: [:eachKey :eachValue | eachValue basicWidth: (self lvmGetColumnWidth: eachKey - 1)]].
 	"Record the column order if anything other than ascending"
 	(order := self columnOrder) = (1 to: self columnCount) 
 		ifFalse: 
-			[sequence add: (MessageSend 
+			[sequence add: (MessageSend
 						receiver: self
 						selector: #columnOrder:
 						argument: order)].
-	self backImage notNil 
+	self backImage notNil
 		ifTrue: [sequence add: (MessageSend receiver: self selector: #backImageChanged)].
-	^sequence!
+	"The caret and selection mark only need to be restored separately in multi-select mode--
+	in single-select mode they are always equal to the selected item."
+	self isMultiSelect ifTrue: 
+			[self caretIndex = 0 ifFalse: 
+					[sequence add: (MessageSend
+								receiver: self
+								selector: #caretIndex:
+								argument: self caretIndex)].
+			self selectionMarkIndex = 0 ifFalse: 
+					[sequence add: (MessageSend
+								receiver: self
+								selector: #selectionMarkIndex:
+								argument: self selectionMarkIndex)]].
+	^sequence.!
 
 stateImageList: aWinImageList
 	"Private - Set the receiver's state image list to aWinImageList."
@@ -2239,6 +2264,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #buildViewsPopup!helpers!private! !
 !ListView categoriesFor: #cancelLabelEdit!operations!private! !
 !ListView categoriesFor: #caretIndex!public!selection! !
+!ListView categoriesFor: #caretIndex:!public!selection! !
 !ListView categoriesFor: #clearSelectionsByIndex:!public!selection! !
 !ListView categoriesFor: #columnAtIndex:!columns!public! !
 !ListView categoriesFor: #columnClass!constants!private! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -116,6 +116,29 @@ allColumns
 
 	^columns!
 
+anchorIndex
+	"Answer the one-based <integer> index of the item
+	from which a multiple selection will start, or 0 if there is none.
+	
+	N.B. The ListView documentation calls this concept the 'selection mark',
+	while that for the older ListBox refers to it as the 'anchor'. Since they behave the same,
+	we standardize on what seems like the shorter, clearer name."
+
+	^(self sendMessage: LVM_GETSELECTIONMARK) + 1.!
+
+anchorIndex: anInteger
+	"Set the one-based <integer> index of the item from which
+	a multiple selection will start, or clear it if <anInteger> is 0.
+
+	N.B. The ListView documentation calls this concept the 'selection mark',
+	while that for the older ListBox refers to it as the 'anchor'. Since they behave the same,
+	we standardize on what seems like the shorter, clearer name."
+
+	self
+		sendMessage: LVM_SETSELECTIONMARK
+		wParam: 0
+		lParam: anInteger - 1.!
+
 applyImageLists
 	"Private - Set the receiver's image lists from the image managers."
 
@@ -1489,7 +1512,7 @@ newSelectionsFromEvent: event
 	"Private - Answer a collection of the <integer> selections that would occur if the <MouseEvent>,
 	event, was was passed to the control."
 
-	| itemClicked anyKeysDown newSelections markIndex markRange markIsSelected |
+	| itemClicked anyKeysDown newSelections anchorIndex shiftRange anchorIsSelected |
 	itemClicked := self itemFromPoint: event position.
 	"In single-select mode, the new selection is always the item clicked, or nothing if the click is outside all items."
 	self isMultiSelect ifFalse: [^itemClicked ifNil: [#()] ifNotNil: [:item | Array with: item]].
@@ -1509,24 +1532,24 @@ newSelectionsFromEvent: event
 			[newSelections := newSelections asSortedCollection.
 			newSelections remove: itemClicked ifAbsent: [newSelections add: itemClicked].
 			^newSelections asArray].
-	"At least Shift is down, so we must start examining the 'selection mark'. This is the last item
+	"At least Shift is down, so we must start examining the 'anchor'. This is the last item
 	that was clicked with no modifiers, only ctrl, or ctrl + shift (shift-clicks do *not* move the
-	selection mark). It acts as the 'start point' for operations where shift is held--they affect
-	the range of items from the selection mark to the click point, inclusive. Initially it is zero,
+	anchor). It acts as the 'start point' for operations where shift is held--they affect
+	the range of items from the anchor to the click point, inclusive. Initially it is zero,
 	i.e. out-of-bounds, in which case holding shift essentially has no effect, and we act only on
 	the item actually clicked."
-	markIndex := self selectionMarkIndex.
-	markRange := markIndex == 0
+	anchorIndex := self anchorIndex.
+	shiftRange := anchorIndex == 0
 				ifTrue: [itemClicked to: itemClicked]
-				ifFalse: [(markIndex min: itemClicked) to: (markIndex max: itemClicked)].
+				ifFalse: [(anchorIndex min: itemClicked) to: (anchorIndex max: itemClicked)].
 	"Only shift is down, not ctrl, so the current selection will be entirely replaced by the marked range."
-	event isCtrlDown ifFalse: [^markRange asArray].
-	"Both ctrl and shift are down, so we set the selection state of the marked range to that of the
-	selection mark itself. Note that this ignores the selection state of the item actually clicked
-	and everything in between it and the selection mark."
+	event isCtrlDown ifFalse: [^shiftRange asArray].
+	"Both ctrl and shift are down, so we set the selection state of the affected range to that of the
+	anchor itself. Note that this ignores the selection state of the item actually clicked
+	and everything in between it and the anchor."
 	newSelections := newSelections asSet.
-	markIsSelected := newSelections includes: markIndex.
-	markRange do: (markIsSelected
+	anchorIsSelected := newSelections includes: anchorIndex.
+	shiftRange do: (anchorIsSelected
 				ifTrue: [[:i | newSelections add: i]]
 				ifFalse: [[:i | newSelections remove: i ifAbsent: []]]).
 	"For some reason, the item clicked is always left selected, even if we are deselecting the rest
@@ -1928,21 +1951,6 @@ selectIndex: anInteger set: aBoolean
 	aBoolean ifTrue: [anLvItem dwState: mask].
 	self lvmSetItem: anInteger - 1 state: anLvItem!
 
-selectionMarkIndex
-	"Private - Answer the one-based <integer> index of the item
-	from which a multiple selection will start, or 0 if there is none."
-
-	^(self sendMessage: LVM_GETSELECTIONMARK) + 1.!
-
-selectionMarkIndex: anInteger
-	"Private - Set the one-based <integer> index of the item from which
-	a multiple selection will start, or clear it if <anInteger> is 0."
-
-	self
-		sendMessage: LVM_SETSELECTIONMARK
-		wParam: 0
-		lParam: anInteger - 1.!
-
 selections: aCollection ifAbsent: aNiladicOrMonadicValuable 
 	"Select the first occurrences of the specified collection of <Object>s in the receiver and
 	answer the new selection. If any of the elements of the collection are not present in the
@@ -2065,31 +2073,18 @@ state
 	self isReportMode 
 		ifTrue: 
 			["Ensure the actual column widths are cached"
-			self allColumns
+			self allColumns 
 				keysAndValuesDo: [:eachKey :eachValue | eachValue basicWidth: (self lvmGetColumnWidth: eachKey - 1)]].
 	"Record the column order if anything other than ascending"
 	(order := self columnOrder) = (1 to: self columnCount) 
 		ifFalse: 
-			[sequence add: (MessageSend
+			[sequence add: (MessageSend 
 						receiver: self
 						selector: #columnOrder:
 						argument: order)].
-	self backImage notNil
+	self backImage notNil 
 		ifTrue: [sequence add: (MessageSend receiver: self selector: #backImageChanged)].
-	"The caret and selection mark only need to be restored separately in multi-select mode--
-	in single-select mode they are always equal to the selected item."
-	self isMultiSelect ifTrue: 
-			[self caretIndex = 0 ifFalse: 
-					[sequence add: (MessageSend
-								receiver: self
-								selector: #caretIndex:
-								argument: self caretIndex)].
-			self selectionMarkIndex = 0 ifFalse: 
-					[sequence add: (MessageSend
-								receiver: self
-								selector: #selectionMarkIndex:
-								argument: self selectionMarkIndex)]].
-	^sequence.!
+	^sequence!
 
 stateImageList: aWinImageList
 	"Private - Set the receiver's state image list to aWinImageList."
@@ -2237,6 +2232,8 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #addColumn:atIndex:!adding!columns!public! !
 !ListView categoriesFor: #addOrUpdate:nonVirtualItems:afterIndex:!private!updating! !
 !ListView categoriesFor: #allColumns!columns!public! !
+!ListView categoriesFor: #anchorIndex!public!selection! !
+!ListView categoriesFor: #anchorIndex:!public!selection! !
 !ListView categoriesFor: #applyImageLists!image management!private! !
 !ListView categoriesFor: #autoResizeColumns!operations!private! !
 !ListView categoriesFor: #autoResizeColumns:!helpers!private! !
@@ -2438,8 +2435,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #selectAll!public!selection! !
 !ListView categoriesFor: #selectedCount!private!selection! !
 !ListView categoriesFor: #selectIndex:set:!private!selection!wine fix! !
-!ListView categoriesFor: #selectionMarkIndex!private!selection! !
-!ListView categoriesFor: #selectionMarkIndex:!private!selection! !
 !ListView categoriesFor: #selections:ifAbsent:!public!selection! !
 !ListView categoriesFor: #selectionsByIndex:ifAbsent:!public!selection! !
 !ListView categoriesFor: #setColumnIcon:atIndex:!helpers!private! !


### PR DESCRIPTION
Add `anchorIndex[:]` accessors to ListBox (this is its name for what ListView calls `selectionMarkIndex`). Add `caretIndex:` setter to ListView. Modify `state` to include restoring those if needed.

Not sure if I got `ListView>>caretIndex:` quite right...what do you think? It does seem to work in my messing around with it.