### PR TITLE
Reverse order of parameters to `TestCase>>assert:equals:`

### DIFF
--- a/Core/Contributions/Camp Smalltalk/SUnit/TestCase.cls
+++ b/Core/Contributions/Camp Smalltalk/SUnit/TestCase.cls
@@ -30,7 +30,7 @@ assert: aBoolean description: aString resumable: resumableBoolean
 			ifFalse: [TestResult failure].
 		exception sunitSignalWith: aString]!
 
-assert: expectedObject equals: actualObject
+assert: actualObject equals: expectedObject
 	expectedObject = actualObject
 		ifFalse: [self fail: (self comparingStringBetween: expectedObject and: actualObject)]!
 

--- a/Core/Object Arts/Dolphin/Base/AbstractDictionaryTest.cls
+++ b/Core/Object Arts/Dolphin/Base/AbstractDictionaryTest.cls
@@ -71,7 +71,7 @@ testAtIfAbsentPutModifyingCollection
 	key2 := self makeKey: $b.
 	self assert: key3 ~= key2.
 	"For this test to work the first and third keys must collide, so verify that"
-	self assert: (dictionary findKeyOrNil: key1) equals: (dictionary findKeyOrNil: key3).
+	self assert: (dictionary findKeyOrNil: key3) equals: (dictionary findKeyOrNil: key1).
 	dictionary at: key1
 		ifAbsentPut: 
 			[dictionary at: key3 put: 4.

--- a/Core/Object Arts/Dolphin/Base/ArrayTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ArrayTest.cls
@@ -56,7 +56,7 @@ testMixedConcatenation
 						| result |
 						result := eachArray , eachEmpty.
 						self deny: eachArray == result.
-						self assert: eachArray equals: result]].
+						self assert: result equals: eachArray]].
 	(Array
 		with: 'a'
 		with: 'a' asUnicodeString

--- a/Core/Object Arts/Dolphin/Base/ByteArrayTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ByteArrayTest.cls
@@ -66,7 +66,7 @@ testMixedConcatenation
 						| result |
 						result := eachArray , eachEmpty.
 						self deny: eachArray == result.
-						self assert: eachArray equals: result]].
+						self assert: result equals: eachArray]].
 	(Array
 		with: 'a'
 		with: 'a' asUnicodeString

--- a/Core/Object Arts/Dolphin/Base/ClassBuilderTests.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassBuilderTests.cls
@@ -51,20 +51,20 @@ tearDown
 	^super tearDown!
 
 testAddRemovePools
-	self assert: #(#ClassBuilderTestPool2 #ClassBuilderTestPool1) , Object sharedPoolNames
-		equals: self classBuilderTestSubclass1 allSharedPoolNames.
-	self assert: 'ClassBuilderTestPool2.PoolVar1'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value.
+	self assert: self classBuilderTestSubclass1 allSharedPoolNames
+		equals: #(#ClassBuilderTestPool2 #ClassBuilderTestPool1) , Object sharedPoolNames.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value
+		equals: 'ClassBuilderTestPool2.PoolVar1'.
 	"PoolVar1 is defined in local pool, TestPool2, but also in inherited pool, TestPool1"
 	"PoolVar2 is inherited from ref to TestPool1 in base class"
-	self assert: 'ClassBuilderTestPool1.PoolVar2'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value
+		equals: 'ClassBuilderTestPool1.PoolVar2'.
 	"Ditto PoolVar3"
-	self assert: 'ClassBuilderTestPool1.PoolVar3'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value
+		equals: 'ClassBuilderTestPool1.PoolVar3'.
 	"And pool var 4 is from local ref to TestPool2"
-	self assert: 'ClassBuilderTestPool2.PoolVar4'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4') value.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4') value
+		equals: 'ClassBuilderTestPool2.PoolVar4'.
 	self classBuilderTestClass
 		subclass: #ClassBuilderTestSubClass
 		instanceVariableNames: 'var3 var4'
@@ -72,34 +72,34 @@ testAddRemovePools
 		poolDictionaries: 'ClassBuilderTestPool1 ClassBuilderTestPool2'
 		classInstanceVariableNames: ''.
 	"Names remain the same, but in reverse order because we added previously inherited pool first"
-	self assert: #(#ClassBuilderTestPool1 #ClassBuilderTestPool2) , Object sharedPoolNames
-		equals: self classBuilderTestSubclass1 allSharedPoolNames.
-	self assert: 'ClassBuilderTestPool1.PoolVar1'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value.
+	self assert: self classBuilderTestSubclass1 allSharedPoolNames
+		equals: #(#ClassBuilderTestPool1 #ClassBuilderTestPool2) , Object sharedPoolNames.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value
+		equals: 'ClassBuilderTestPool1.PoolVar1'.
 	"Because we have added TestPool1 before TestPool2, we will now bind to PoolVar1 from there."
-	self assert: 'ClassBuilderTestPool1.PoolVar2'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value.
-	self assert: 'ClassBuilderTestPool1.PoolVar3'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value.
-	self assert: 'ClassBuilderTestPool2.PoolVar4'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4') value.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value
+		equals: 'ClassBuilderTestPool1.PoolVar2'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value
+		equals: 'ClassBuilderTestPool1.PoolVar3'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4') value
+		equals: 'ClassBuilderTestPool2.PoolVar4'.
 	self classBuilderTestClass
 		subclass: #ClassBuilderTestSubClass
 		instanceVariableNames: 'var3 var4'
 		classVariableNames: ''
 		poolDictionaries: 'ClassBuilderTestPool2 ClassBuilderTestPool3'
 		classInstanceVariableNames: ''.
-	self assert: #(#ClassBuilderTestPool2 #ClassBuilderTestPool3 #ClassBuilderTestPool1)
-				, Object sharedPoolNames
-		equals: self classBuilderTestSubclass1 allSharedPoolNames.
-	self assert: 'ClassBuilderTestPool2.PoolVar1'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value.
-	self assert: 'ClassBuilderTestPool3.PoolVar2'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value.
-	self assert: 'ClassBuilderTestPool1.PoolVar3'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value.
-	self assert: 'ClassBuilderTestPool2.PoolVar4'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4') value.
+	self assert: self classBuilderTestSubclass1 allSharedPoolNames
+		equals: #(#ClassBuilderTestPool2 #ClassBuilderTestPool3 #ClassBuilderTestPool1)
+				, Object sharedPoolNames.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value
+		equals: 'ClassBuilderTestPool2.PoolVar1'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value
+		equals: 'ClassBuilderTestPool3.PoolVar2'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value
+		equals: 'ClassBuilderTestPool1.PoolVar3'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4') value
+		equals: 'ClassBuilderTestPool2.PoolVar4'.
 	"Remove all the locally referenced pools, so only inheriting TestPool1"
 	self classBuilderTestClass
 		subclass: #ClassBuilderTestSubClass
@@ -107,15 +107,15 @@ testAddRemovePools
 		classVariableNames: ''
 		poolDictionaries: ''
 		classInstanceVariableNames: ''.
-	self assert: #(#ClassBuilderTestPool1) , Object sharedPoolNames
-		equals: self classBuilderTestSubclass1 allSharedPoolNames.
-	self assert: 'ClassBuilderTestPool1.PoolVar1'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value.
-	self assert: 'ClassBuilderTestPool1.PoolVar2'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value.
-	self assert: 'ClassBuilderTestPool1.PoolVar3'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value.
-	self assert: nil equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4')!
+	self assert: self classBuilderTestSubclass1 allSharedPoolNames
+		equals: #(#ClassBuilderTestPool1) , Object sharedPoolNames.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value
+		equals: 'ClassBuilderTestPool1.PoolVar1'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value
+		equals: 'ClassBuilderTestPool1.PoolVar2'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value
+		equals: 'ClassBuilderTestPool1.PoolVar3'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4') equals: nil!
 
 testMoveClassToSuperclassWithInstVars
 	| newClass |
@@ -157,43 +157,43 @@ testMoveVariable
 testPoolVariablePrecedence
 	"Base class has only pool1"
 
-	self assert: #(#ClassBuilderTestPool1) , Object sharedPoolNames
-		equals: self classBuilderTestClass allSharedPoolNames.
-	self assert: 'ClassBuilderTestPool1.PoolVar1'
-		equals: (self classBuilderTestClass bindingFor: 'PoolVar1') value.
-	self assert: 'ClassBuilderTestPool1.PoolVar2'
-		equals: (self classBuilderTestClass bindingFor: 'PoolVar2') value.
-	self assert: 'ClassBuilderTestPool1.PoolVar3'
-		equals: (self classBuilderTestClass bindingFor: 'PoolVar3') value.
+	self assert: self classBuilderTestClass allSharedPoolNames
+		equals: #(#ClassBuilderTestPool1) , Object sharedPoolNames.
+	self assert: (self classBuilderTestClass bindingFor: 'PoolVar1') value
+		equals: 'ClassBuilderTestPool1.PoolVar1'.
+	self assert: (self classBuilderTestClass bindingFor: 'PoolVar2') value
+		equals: 'ClassBuilderTestPool1.PoolVar2'.
+	self assert: (self classBuilderTestClass bindingFor: 'PoolVar3') value
+		equals: 'ClassBuilderTestPool1.PoolVar3'.
 	"Subclass1 has pool2 and inherits pool1"
-	self assert: #(#ClassBuilderTestPool2 #ClassBuilderTestPool1) , Object sharedPoolNames
-		equals: self classBuilderTestSubclass1 allSharedPoolNames.
-	self assert: 'ClassBuilderTestPool2.PoolVar1'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value.
-	self assert: 'ClassBuilderTestPool1.PoolVar2'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value.
-	self assert: 'ClassBuilderTestPool1.PoolVar3'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value.
-	self assert: 'ClassBuilderTestPool2.PoolVar4'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4') value.
-	self assert: 'ClassBuilderTestPool2.PoolVar5'
-		equals: (self classBuilderTestSubclass1 bindingFor: 'PoolVar5') value.
+	self assert: self classBuilderTestSubclass1 allSharedPoolNames
+		equals: #(#ClassBuilderTestPool2 #ClassBuilderTestPool1) , Object sharedPoolNames.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar1') value
+		equals: 'ClassBuilderTestPool2.PoolVar1'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar2') value
+		equals: 'ClassBuilderTestPool1.PoolVar2'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar3') value
+		equals: 'ClassBuilderTestPool1.PoolVar3'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar4') value
+		equals: 'ClassBuilderTestPool2.PoolVar4'.
+	self assert: (self classBuilderTestSubclass1 bindingFor: 'PoolVar5') value
+		equals: 'ClassBuilderTestPool2.PoolVar5'.
 	"Subclass2 has pools3 and 2 (in that order), and inherits pool1"
-	self assert: #(#ClassBuilderTestPool3 #ClassBuilderTestPool2 #ClassBuilderTestPool1)
-				, Object sharedPoolNames
-		equals: self classBuilderTestSubclass2 allSharedPoolNames.
-	self assert: 'ClassBuilderTestPool2.PoolVar1'
-		equals: (self classBuilderTestSubclass2 bindingFor: 'PoolVar1') value.
-	self assert: 'ClassBuilderTestPool3.PoolVar2'
-		equals: (self classBuilderTestSubclass2 bindingFor: 'PoolVar2') value.
-	self assert: 'ClassBuilderTestPool1.PoolVar3'
-		equals: (self classBuilderTestSubclass2 bindingFor: 'PoolVar3') value.
-	self assert: 'ClassBuilderTestPool3.PoolVar4'
-		equals: (self classBuilderTestSubclass2 bindingFor: 'PoolVar4') value.
-	self assert: 'ClassBuilderTestPool2.PoolVar5'
-		equals: (self classBuilderTestSubclass2 bindingFor: 'PoolVar5') value.
-	self assert: 'ClassBuilderTestPool3.PoolVar6'
-		equals: (self classBuilderTestSubclass2 bindingFor: 'PoolVar6') value!
+	self assert: self classBuilderTestSubclass2 allSharedPoolNames
+		equals: #(#ClassBuilderTestPool3 #ClassBuilderTestPool2 #ClassBuilderTestPool1)
+				, Object sharedPoolNames.
+	self assert: (self classBuilderTestSubclass2 bindingFor: 'PoolVar1') value
+		equals: 'ClassBuilderTestPool2.PoolVar1'.
+	self assert: (self classBuilderTestSubclass2 bindingFor: 'PoolVar2') value
+		equals: 'ClassBuilderTestPool3.PoolVar2'.
+	self assert: (self classBuilderTestSubclass2 bindingFor: 'PoolVar3') value
+		equals: 'ClassBuilderTestPool1.PoolVar3'.
+	self assert: (self classBuilderTestSubclass2 bindingFor: 'PoolVar4') value
+		equals: 'ClassBuilderTestPool3.PoolVar4'.
+	self assert: (self classBuilderTestSubclass2 bindingFor: 'PoolVar5') value
+		equals: 'ClassBuilderTestPool2.PoolVar5'.
+	self assert: (self classBuilderTestSubclass2 bindingFor: 'PoolVar6') value
+		equals: 'ClassBuilderTestPool3.PoolVar6'!
 
 testReparentSubClassWithSameAllInstVars
 	| testClass testInstance |

--- a/Core/Object Arts/Dolphin/Base/DictionaryTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DictionaryTest.cls
@@ -20,8 +20,8 @@ testAtIfAbsentPutValue
 	initialSize := dictionary size.
 	"Verify equal but not identical keys"
 	f := 2.0.
-	self assert: 2 hash equals: f hash.
-	self assert: 2 equals: f.
+	self assert: f hash equals: 2 hash.
+	self assert: f equals: 2.
 	self assert: (dictionary at: 2 ifAbsentPutValue: f) == f.
 	self assert: dictionary size == (initialSize + 1).
 	self assert: (dictionary at: f ifAbsentPutValue: 2) == f.

--- a/Core/Object Arts/Dolphin/Base/DolphinCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DolphinCollectionTest.cls
@@ -37,7 +37,7 @@ testAllSatisfy
 							[:e |
 							visited add: e.
 							e between: elems first and: elems last]).
-			self assert: elems asSet equals: visited asSet.
+			self assert: visited asSet equals: elems asSet.
 			"Fail on first, middle, last"
 			elems keysAndValuesDo: 
 					[:k :c |
@@ -47,7 +47,7 @@ testAllSatisfy
 									[:e |
 									visited add: e.
 									visited size < k]).
-					self assert: (subject asArray copyFrom: 1 to: k) equals: visited asArray]]!
+					self assert: visited asArray equals: (subject asArray copyFrom: 1 to: k)]]!
 
 testAnyone
 	| subject any |
@@ -77,7 +77,7 @@ testAnySatisfy
 							[:e |
 							visited add: e.
 							false]).
-			self assert: elems asSet equals: visited asSet.
+			self assert: visited asSet equals: elems asSet.
 			"Find a match on first, middle, last"
 			elems keysAndValuesDo: 
 					[:k :c |
@@ -87,7 +87,7 @@ testAnySatisfy
 									[:e |
 									visited add: e.
 									visited size = k]).
-					self assert: (subject asArray copyFrom: 1 to: k) equals: visited asArray]]!
+					self assert: visited asArray equals: (subject asArray copyFrom: 1 to: k)]]!
 
 testCount
 	| none all odd |

--- a/Core/Object Arts/Dolphin/Base/FloatTest.cls
+++ b/Core/Object Arts/Dolphin/Base/FloatTest.cls
@@ -278,8 +278,8 @@ testFractionComparisons
 		with: 1 / 3
 		with: 1 / 10) do: 
 				[:each |
-				self assert: each asFloat equals: each.
-				self assert: each asFloat hash equals: each hash].
+				self assert: each equals: each asFloat.
+				self assert: each hash equals: each asFloat hash].
 	"This will overflow on conversion to a Fraction, just a kick the tyres test really"
 	self assert: (((200 factorial - 1) / 2) hash isKindOf: SmallInteger)!
 
@@ -365,67 +365,67 @@ testOverflow
 
 testPrintOnDecimalPlaces
 	| fmax fminDenorm fmin |
-	self assert: '3.9990' equals: (self printString: 3.999 decimalPlaces: 4).
-	self assert: '3.999' equals: (self printString: 3.999 decimalPlaces: 3).
-	self assert: '4.00' equals: (self printString: 3.999 decimalPlaces: 2).
-	self assert: '4.0' equals: (self printString: 3.999 decimalPlaces: 1).
-	self assert: '4' equals: (self printString: 3.999 decimalPlaces: 0).
-	self assert: '0' equals: (self printString: Float zero decimalPlaces: 0).
-	self assert: '0.0' equals: (self printString: Float zero decimalPlaces: 1).
-	self assert: '0.00' equals: (self printString: Float zero decimalPlaces: 2).
-	self assert: '-0' equals: (self printString: Float negativeZero decimalPlaces: 0).
-	self assert: '-0.0' equals: (self printString: Float negativeZero decimalPlaces: 1).
-	self assert: '-0.000' equals: (self printString: Float negativeZero decimalPlaces: 3).
-	self assert: '3.141592653589793' equals: (self printString: Float pi decimalPlaces: 15).
-	self assert: '3.142' equals: (self printString: Float pi decimalPlaces: 3).
+	self assert: (self printString: 3.999 decimalPlaces: 4) equals: '3.9990'.
+	self assert: (self printString: 3.999 decimalPlaces: 3) equals: '3.999'.
+	self assert: (self printString: 3.999 decimalPlaces: 2) equals: '4.00'.
+	self assert: (self printString: 3.999 decimalPlaces: 1) equals: '4.0'.
+	self assert: (self printString: 3.999 decimalPlaces: 0) equals: '4'.
+	self assert: (self printString: Float zero decimalPlaces: 0) equals: '0'.
+	self assert: (self printString: Float zero decimalPlaces: 1) equals: '0.0'.
+	self assert: (self printString: Float zero decimalPlaces: 2) equals: '0.00'.
+	self assert: (self printString: Float negativeZero decimalPlaces: 0) equals: '-0'.
+	self assert: (self printString: Float negativeZero decimalPlaces: 1) equals: '-0.0'.
+	self assert: (self printString: Float negativeZero decimalPlaces: 3) equals: '-0.000'.
+	self assert: (self printString: Float pi decimalPlaces: 15) equals: '3.141592653589793'.
+	self assert: (self printString: Float pi decimalPlaces: 3) equals: '3.142'.
 	fmin := (String writeStream)
 				nextPutAll: '0.';
 				next: 308 - 1 put: $0;
 				nextPutAll: '22250738585072014';
 				contents.
-	self assert: fmin equals: (self printString: Float fminNormalized decimalPlaces: 308 + 16).
-	self assert: '-' , fmin
-		equals: (self printString: Float fminNormalized negated decimalPlaces: 308 + 16).
-	self assert: '0.00' equals: (self printString: Float fminNormalized decimalPlaces: 2).
+	self assert: (self printString: Float fminNormalized decimalPlaces: 308 + 16) equals: fmin.
+	self assert: (self printString: Float fminNormalized negated decimalPlaces: 308 + 16)
+		equals: '-' , fmin.
+	self assert: (self printString: Float fminNormalized decimalPlaces: 2) equals: '0.00'.
 	fminDenorm := (String writeStream)
 				nextPutAll: '0.';
 				next: 324 - 1 put: $0;
 				nextPutAll: '5';
 				contents.
-	self assert: fminDenorm equals: (self printString: Float fminDenormalized decimalPlaces: 324).
-	self assert: '-' , fminDenorm
-		equals: (self printString: Float fminDenormalized negated decimalPlaces: 324).
+	self assert: (self printString: Float fminDenormalized decimalPlaces: 324) equals: fminDenorm.
+	self assert: (self printString: Float fminDenormalized negated decimalPlaces: 324)
+		equals: '-' , fminDenorm.
 	fmax := (String writeStream)
 				nextPutAll: '17976931348623157';
 				next: 308 - 16 put: $0;
 				nextPutAll: '.00000';
 				contents.
-	self assert: fmax equals: (self printString: Float fmax decimalPlaces: 5).
-	self assert: '-' , fmax equals: (self printString: Float fmax negated decimalPlaces: 5).
-	self assert: 'Infinity' equals: (self printString: self infinity decimalPlaces: 2).
-	self assert: 'Infinity' equals: (self printString: self infinity decimalPlaces: 0).
-	self assert: '-Infinity' equals: (self printString: self negativeInfinity decimalPlaces: 2).
-	self assert: '-Infinity' equals: (self printString: self negativeInfinity decimalPlaces: 0).
-	self assert: 'NaN' equals: (self printString: self nan decimalPlaces: 1).
-	self assert: 'NaN' equals: (self printString: self nan decimalPlaces: 0).
-	self assert: 'NaN' equals: (self printString: self nan negated decimalPlaces: 2)!
+	self assert: (self printString: Float fmax decimalPlaces: 5) equals: fmax.
+	self assert: (self printString: Float fmax negated decimalPlaces: 5) equals: '-' , fmax.
+	self assert: (self printString: self infinity decimalPlaces: 2) equals: 'Infinity'.
+	self assert: (self printString: self infinity decimalPlaces: 0) equals: 'Infinity'.
+	self assert: (self printString: self negativeInfinity decimalPlaces: 2) equals: '-Infinity'.
+	self assert: (self printString: self negativeInfinity decimalPlaces: 0) equals: '-Infinity'.
+	self assert: (self printString: self nan decimalPlaces: 1) equals: 'NaN'.
+	self assert: (self printString: self nan decimalPlaces: 0) equals: 'NaN'.
+	self assert: (self printString: self nan negated decimalPlaces: 2) equals: 'NaN'!
 
 testPrintString
-	self assert: '1.3' equals: 1.3 printString.
-	self assert: '1.3333333333333333' equals: (4.0 / 3.0) printString.
-	self assert: '0.0' equals: Float zero printString.
-	self assert: '-0.0' equals: Float negativeZero printString.
-	self assert: '3.141592653589793' equals: Float pi printString.
-	self assert: '2.2250738585072014e-308' equals: Float fminNormalized printString.
-	self assert: '-2.2250738585072014e-308' equals: Float fminNormalized negated printString.
-	self assert: '5.0e-324' equals: Float fminDenormalized printString.
-	self assert: '-5.0e-324' equals: Float fminDenormalized negated printString.
-	self assert: '1.7976931348623157e308' equals: Float fmax printString.
-	self assert: '-1.7976931348623157e308' equals: Float fmax negated printString.
-	self assert: 'Infinity' equals: self infinity printString.
-	self assert: '-Infinity' equals: self negativeInfinity printString.
-	self assert: 'NaN' equals: self nan printString.
-	self assert: 'NaN' equals: self nan negated printString!
+	self assert: 1.3 printString equals: '1.3'.
+	self assert: (4.0 / 3.0) printString equals: '1.3333333333333333'.
+	self assert: Float zero printString equals: '0.0'.
+	self assert: Float negativeZero printString equals: '-0.0'.
+	self assert: Float pi printString equals: '3.141592653589793'.
+	self assert: Float fminNormalized printString equals: '2.2250738585072014e-308'.
+	self assert: Float fminNormalized negated printString equals: '-2.2250738585072014e-308'.
+	self assert: Float fminDenormalized printString equals: '5.0e-324'.
+	self assert: Float fminDenormalized negated printString equals: '-5.0e-324'.
+	self assert: Float fmax printString equals: '1.7976931348623157e308'.
+	self assert: Float fmax negated printString equals: '-1.7976931348623157e308'.
+	self assert: self infinity printString equals: 'Infinity'.
+	self assert: self negativeInfinity printString equals: '-Infinity'.
+	self assert: self nan printString equals: 'NaN'.
+	self assert: self nan negated printString equals: 'NaN'!
 
 testPrintStringAndReadBack
 	"Debug reading/printing a Floating point number without accumulating round off errors"

--- a/Core/Object Arts/Dolphin/Base/MethodDictionaryTest.cls
+++ b/Core/Object Arts/Dolphin/Base/MethodDictionaryTest.cls
@@ -35,8 +35,8 @@ testMaintainsLoadFactor
 
 	| subject method |
 	subject := self collectionClass new.
-	self assert: 0 equals: subject size.
-	self assert: 2 equals: subject basicSize.
+	self assert: subject size equals: 0.
+	self assert: subject basicSize equals: 2.
 	method := Object >> #size.
 	"The capacity is increased to the next power of 2 that holds double the current size when the collection grows"
 	#(#(#a 2) #(#b 4) #(#c 4) #(#d 8) #(#e 8) #(#f 8) #(#g 16) #(#h 16) #(#i 16) #(#j 16) #(#k 16) #(#l 16) #(#m 32))
@@ -49,9 +49,9 @@ testMaintainsLoadFactor
 			actualSlots := subject basicSize.
 			actualSize := subject size.
 			self assert: actualSlots >= minimumSlots.
-			self assert: expectedSize equals: actualSize.
+			self assert: actualSize equals: expectedSize.
 			self assert: actualSlots / 2 <= minimumSlots.
-			self assert: expectedSlots equals: actualSlots]! !
+			self assert: actualSlots equals: expectedSlots]! !
 !MethodDictionaryTest categoriesFor: #collectionClass!helpers!private! !
 !MethodDictionaryTest categoriesFor: #loadFactor!constants!private! !
 !MethodDictionaryTest categoriesFor: #testClassSizeFor!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/OrderedCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/OrderedCollectionTest.cls
@@ -17,11 +17,11 @@ testFirst2
 	| subject |
 	subject := self collectionClass withAll: (1 to: 4).
 	subject removeLast.
-	self assert: 1 equals: subject first.
+	self assert: subject first equals: 1.
 	subject removeFirst.
-	self assert: 2 equals: subject first.
+	self assert: subject first equals: 2.
 	subject removeFirst.
-	self assert: 3 equals: subject first.
+	self assert: subject first equals: 3.
 	subject removeFirst.
 	self
 		should: [subject first]
@@ -66,11 +66,11 @@ testLast2
 	| subject |
 	subject := self collectionClass withAll: (1 to: 4).
 	subject removeFirst.
-	self assert: 4 equals: subject last.
+	self assert: subject last equals: 4.
 	subject removeLast.
-	self assert: 3 equals: subject last.
+	self assert: subject last equals: 3.
 	subject removeLast.
-	self assert: 2 equals: subject last.
+	self assert: subject last equals: 2.
 	subject removeLast.
 	self
 		should: [subject last]

--- a/Core/Object Arts/Dolphin/Base/PositionableStreamTest.cls
+++ b/Core/Object Arts/Dolphin/Base/PositionableStreamTest.cls
@@ -39,7 +39,7 @@ testNextLine
 			[:each |
 			| stream |
 			stream := self streamOn: each.
-			self assert: each equals: stream nextLine.
+			self assert: stream nextLine equals: each.
 			self assert: stream atEnd.
 			self closeTempStream: stream].
 
@@ -48,7 +48,7 @@ testNextLine
 			[:each |
 			| stream |
 			stream := self streamOn: each.
-			self assert: '' equals: stream nextLine.
+			self assert: stream nextLine equals: ''.
 			self assert: stream atEnd.
 			self closeTempStream: stream].
 	"Finishes with line delimiter"
@@ -68,10 +68,10 @@ testNextLine
 					[:each |
 					| stream |
 					stream := self streamOn: each , eachDelim , eachDelim.
-					self assert: each equals: stream nextLine.
+					self assert: stream nextLine equals: each.
 					self assert: stream atEnd not.
 					"Empty line"
-					self assert: '' equals: stream nextLine.
+					self assert: stream nextLine equals: ''.
 					self assert: stream atEnd.
 					self closeTempStream: stream]].
 	"Starts with line delimiter, delimiter between lines, two delimiters between lines"
@@ -81,15 +81,15 @@ testNextLine
 					[:each |
 					| stream |
 					stream := self streamOn: eachDelim , each , eachDelim , each , eachDelim , eachDelim , each.
-					self assert: '' equals: stream nextLine.
+					self assert: stream nextLine equals: ''.
 					self deny: stream atEnd.
-					self assert: each equals: stream nextLine.
+					self assert: stream nextLine equals: each.
 					self deny: stream atEnd.
-					self assert: each equals: stream nextLine.
+					self assert: stream nextLine equals: each.
 					self deny: stream atEnd.
-					self assert: '' equals: stream nextLine.
+					self assert: stream nextLine equals: ''.
 					self deny: stream atEnd.
-					self assert: each equals: stream nextLine.
+					self assert: stream nextLine equals: each.
 					self assert: stream atEnd.
 					self closeTempStream: stream]].
 
@@ -102,7 +102,7 @@ testNextLine
 			stream := self streamOn: chars.
 			stream reset.
 			line := stream nextLine.
-			self assert: each equals: line.
+			self assert: line equals: each.
 			self assert: stream atEnd.
 			self closeTempStream: stream]!
 
@@ -115,9 +115,9 @@ testNextLineCrOnly
 			chars := each , (String with: Character cr) , each.
 			stream := self streamOn: chars.
 			stream reset.
-			self assert: each equals: stream nextLine.
+			self assert: stream nextLine equals: each.
 			self deny: stream atEnd.
-			self assert: each equals: stream nextLine.
+			self assert: stream nextLine equals: each.
 			self assert: stream atEnd.
 			self closeTempStream: stream]!
 
@@ -165,6 +165,7 @@ testPeekFor
 	"Test PositionableStream>>peekFor:"
 
 	"Empty stream (initlially at end)"
+
 	| stream |
 	stream := self streamOn: ''.
 	self deny: (stream peekFor: $a).
@@ -174,13 +175,13 @@ testPeekFor
 	stream := self streamOn: 'ab'.
 	"Not at end but mismatch"
 	self deny: (stream peekFor: $b).
-	self assert: 0 equals: stream position.
+	self assert: stream position equals: 0.
 	"Successful match"
 	self assert: (stream peekFor: $a).
-	self assert: 1 equals: stream position.
+	self assert: stream position equals: 1.
 	"Another mismatch"
 	self deny: (stream peekFor: $c).
-	self assert: 1 equals: stream position.
+	self assert: stream position equals: 1.
 	"Another Successful match"
 	self deny: stream atEnd.
 	self assert: (stream peekFor: $b).

--- a/Core/Object Arts/Dolphin/Base/STLFilerTest.cls
+++ b/Core/Object Arts/Dolphin/Base/STLFilerTest.cls
@@ -18,7 +18,7 @@ checkSimpleReadWriteOf: value context: anObject
 	streamContents := self writeLiteralsFor: value.
 	in := STLInFiler on: streamContents readStream.
 	in context: anObject.
-	self assert: value equals: in next.
+	self assert: in next equals: value.
 	^streamContents!
 
 simpleReadWriteOf: value 
@@ -39,7 +39,7 @@ testClassReadWrite
 	"Check multiple references "
 	data := Array with: STLFilerTest with: STLFilerTest.
 	answer := self simpleReadWriteOf: data.
-	self assert: data equals: answer.
+	self assert: answer equals: data.
 	self assert: answer first == STLFilerTest.
 	self assert: answer first == answer last!
 
@@ -113,7 +113,7 @@ testSymbolReadWrite
 				with: testSymbol
 				with: 'otherSymbol' asSymbol.
 	deserialized := self simpleReadWriteOf: data.
-	self assert: data equals: deserialized.
+	self assert: deserialized equals: data.
 
 	"Check that muliple references are identical"
 	self assert: deserialized first == testSymbol.
@@ -125,7 +125,7 @@ testSystemDictionaryReadWrite
 	self assert: sysdict == Smalltalk.
 	array := Array with: Smalltalk.
 	array2 := self simpleReadWriteOf: array.
-	self assert: array equals: array2.
+	self assert: array2 equals: array.
 	self assert: array first == Smalltalk!
 
 writeLiteralsFor: value

--- a/Core/Object Arts/Dolphin/Base/SequenceableCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollectionTest.cls
@@ -50,10 +50,10 @@ testAt
 	subject := self newCollection: #().
 	-1 to: 1 do: [:i | self should: [subject at: i] raise: BoundsError].
 	subject := self newCollection: #(65).
-	self assert: (self assimilate: 65) equals: (subject at: 1).
+	self assert: (subject at: 1) equals: (self assimilate: 65).
 	#(-1 0 2) do: [:i | self should: [subject at: i] raise: BoundsError].
 	subject := self newCollection: #(65 66 67).
-	1 to: subject size do: [:i | self assert: (self assimilate: 65 + i - 1) equals: (subject at: i)].
+	1 to: subject size do: [:i | self assert: (subject at: i) equals: (self assimilate: 65 + i - 1)].
 	(Array
 		with: -1
 		with: 0
@@ -642,10 +642,10 @@ verifyConcatenation: b with: a
 	result := a , b.
 	aSize := a size.
 	bSize := b size.
-	self assert: aSize + bSize equals: result size.
-	1 to: aSize do: [:i | self assert: (a at: i) equals: (result at: i)].
+	self assert: result size equals: aSize + bSize.
+	1 to: aSize do: [:i | self assert: (result at: i) equals: (a at: i)].
 	1 to: bSize
-		do: [:i | self assert: (self assimilateResultElement: (b at: i)) equals: (result at: i + aSize)].
+		do: [:i | self assert: (result at: i + aSize) equals: (self assimilateResultElement: (b at: i))].
 	^result!
 
 verifyIndexOfAnyOf: searchFor startingAt: startInteger in: searchee is: foundInteger 

--- a/Core/Object Arts/Dolphin/Base/SequencedGrowableCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SequencedGrowableCollectionTest.cls
@@ -144,7 +144,7 @@ testAddFirst
 	interval := 1 to: 30.
 	"Collection may have to grow a few times"
 	interval do: [:each | subject addFirst: each].
-	self assert: interval reverse equals: subject asArray! !
+	self assert: subject asArray equals: interval reverse! !
 !SequencedGrowableCollectionTest categoriesFor: #testAddAllFirst!public!unit tests! !
 !SequencedGrowableCollectionTest categoriesFor: #testAddAllFirst2!public!unit tests! !
 !SequencedGrowableCollectionTest categoriesFor: #testAddAllLast!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/SetTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SetTest.cls
@@ -144,8 +144,8 @@ testMaintainsLoadFactor
 
 	| subject expectedSlots |
 	subject := self collectionClass new.
-	self assert: 0 equals: subject size.
-	self assert: self minimumCapacity equals: subject basicSize.
+	self assert: subject size equals: 0.
+	self assert: subject basicSize equals: self minimumCapacity.
 	expectedSlots := self minimumCapacity.
 	(1 to: 1024) keysAndValuesDo: 
 			[:expectedSize :each |
@@ -162,8 +162,8 @@ testMaintainsLoadFactor
 			minGrownSlots := (expectedSize - 1) * 2 / self loadFactor.
 			originalSlots < minimumSlots ceiling
 				ifTrue: [expectedSlots := primes detect: [:p | p >= minGrownSlots]].
-			self assert: expectedSize equals: actualSize.
-			self assert: expectedSlots equals: actualSlots]!
+			self assert: actualSize equals: expectedSize.
+			self assert: actualSlots equals: expectedSlots]!
 
 testNil
 	| set |

--- a/Core/Object Arts/Dolphin/Base/StdioFileStreamTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StdioFileStreamTest.cls
@@ -23,7 +23,7 @@ testNextLineCrOnly
 			stream := self streamOn: chars.
 			stream reset.
 			"CRT I/O stream in translated text mode does not recognise single CR as a line ending"
-			self assert: chars equals: stream nextLine.
+			self assert: stream nextLine equals: chars.
 			self assert: stream atEnd.
 			self closeTempStream: stream]! !
 !StdioFileStreamTest categoriesFor: #streamClass!helpers!private! !

--- a/Core/Object Arts/Dolphin/Base/StreamTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StreamTest.cls
@@ -25,18 +25,18 @@ testUpTo
 	| chars stream |
 	chars := 'abcdefghij'.
 	stream := self streamOn: chars.
-	self assert: '' equals: (stream upTo: $a).
-	self assert: '' equals: (stream upTo: $b).
-	self assert: 'c' equals: (stream upTo: $d).
-	self assert: 'ef' equals: (stream upTo: $g).
-	self assert: 'hij' equals: (stream upTo: $z).
+	self assert: (stream upTo: $a) equals: ''.
+	self assert: (stream upTo: $b) equals: ''.
+	self assert: (stream upTo: $d) equals: 'c'.
+	self assert: (stream upTo: $g) equals: 'ef'.
+	self assert: (stream upTo: $z) equals: 'hij'.
 	self assert: stream atEnd.
-	self assert: '' equals: (stream upTo: $z).
+	self assert: (stream upTo: $z) equals: ''.
 	stream reset.
-	self assert: 'abcdefghi' equals: (stream upTo: $j).
+	self assert: (stream upTo: $j) equals: 'abcdefghi'.
 	self assert: stream atEnd.
 	stream reset.
-	self assert: chars equals: (stream upTo: $z).
+	self assert: (stream upTo: $z) equals: chars.
 	self assert: stream atEnd.
 	self closeTempStream: stream! !
 !StreamTest categoriesFor: #closeTempStream:!helpers!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
@@ -237,7 +237,7 @@ testCompileTimeExpressions
 	(Array with: self with: self class) do: 
 			[:each |
 			result := (self compileExpression: '##(self)' in: each class) method value: each.
-			self assert: each class instanceClass equals: result]!
+			self assert: result equals: each class instanceClass]!
 
 testConstExpressionReferences
 	"Test that references in a compile-time evaluated expression are retained in the literal frame 
@@ -287,7 +287,7 @@ testDecrementPushTempOptimisation
 	18	Pop; Push Temp[0]
 	19	Return '
 				expandMacrosWith: expr literalCount.
-	self assert: expected equals: disasm.
+	self assert: disasm equals: expected.
 	self assert: (expr value: nil) = 1.
 	expr := (self
 				compileExpression: '| t1 t2 t3 t4 t5 t6 t7 j | t1 := t2 := t3 := t4 := t5 := t6 := t7 := 1. 5 to: 1 by: -1 do: [:i | j := i]. j')
@@ -320,7 +320,7 @@ testDecrementPushTempOptimisation
 	33	Push Temp[7]
 	34	Return '
 				expandMacrosWith: expr literalCount.
-	self assert: expected equals: disasm.
+	self assert: disasm equals: expected.
 	self assert: (expr value: nil) = 1.
 	"Overflow"
 	expr := (self compileExpression: '| i | i := SmallInteger minimum. i class. i := i - 1. i*1')
@@ -353,7 +353,7 @@ testDecrementTempOptimisation
 	14	Push Temp[0]
 	15	Return '
 				expandMacrosWith: expr literalCount.
-	self assert: expected equals: disasm.
+	self assert: disasm equals: expected.
 	self assert: (expr value: nil) = 0.
 	expr := (self
 				compileExpression: '| t1 t2 t3 t4 t5 t6 t7 t8 i | t1 := t2 := t3 := t4 := t5 := t6 := t7 := t8 := 1. i := 5. [i < 1] whileFalse: [i := i - 1]. i')
@@ -729,7 +729,7 @@ testIncrementTempOptimisation
 	14	Push Temp[0]
 	15	Return '
 				expandMacrosWith: method literalCount.
-	self assert: expected equals: disasm.
+	self assert: disasm equals: expected.
 	self assert: (self evalTestMethod: method) = 6.
 	method := self getTestMethod: #testIncrementTempOptimisationLong.
 	self assert: (method byteCodes at: 24) = IncTemp.
@@ -934,7 +934,7 @@ testReturnImmediate
 			[:each |
 			method := (self compileExpression: (each printStringRadix: 2)) method.
 			self assert: method extraIndex = 5.
-			self assert: (ByteArray with: ShortPushConst + 0 with: ReturnFromMessage) equals: method byteCodes]!
+			self assert: method byteCodes equals: (ByteArray with: ShortPushConst + 0 with: ReturnFromMessage)]!
 
 testReturnPseudoVar
 	| method |
@@ -947,8 +947,8 @@ testReturnPseudoVar
 			bytecodes := retInstr odd
 						ifTrue: [ByteArray with: retInstr]
 						ifFalse: [ByteArray with: Nop with: retInstr].
-			self assert: bytecodes equals: method byteCodes.
-			self assert: eachValue equals: (method value: DolphinCompilerTestMethods new withArguments: #())]!
+			self assert: method byteCodes equals: bytecodes.
+			self assert: (method value: DolphinCompilerTestMethods new withArguments: #()) equals: eachValue]!
 
 testScanningScaledDecimals
 	"Test Number>>readFrom: with ScaledDecimals"
@@ -1160,30 +1160,29 @@ testTextMapOfEmptyBlock
 	block := Compiler evaluate: '| x | x := []. x'.
 	self assert: block == VMLibrary default emptyBlock.
 	method := block method.
-	self assert: (ByteArray
+	self assert: method byteCodes
+		equals: (ByteArray
 				with: ShortPushConst + 0
 				with: ReturnFromMessage
 				with: ShortPushNil
-				with: ReturnFromBlock)
-		equals: method byteCodes.
+				with: ReturnFromBlock).
 	debugMethod := block method asDebugMethod.
-	self
-		assert: (ByteArray
+	self assert: debugMethod byteCodes
+		equals: (ByteArray
 				with: ShortPushConst + 0
 				with: Break
 				with: ReturnFromMessage) , (ByteArray
 							with: ShortPushNil
 							with: Break
-							with: ReturnFromBlock)
-		equals: debugMethod byteCodes.
-	self assert: method textMap size equals: debugMethod textMap size.
+							with: ReturnFromBlock).
+	self assert: debugMethod textMap size equals: method textMap size.
 	2 to: 4
 		do: 
 			[:ip |
 			| debugIp |
 			debugIp := self findIP: ip inTextMap: method textMap.
-			self assert: (method byteCodes at: ip)
-				equals: (debugMethod byteCodes at: (debugMethod textMap at: debugIp) key)]!
+			self assert: (debugMethod byteCodes at: (debugMethod textMap at: debugIp) key)
+				equals: (method byteCodes at: ip)]!
 
 testTextMapsOfCleanBlocks
 	#('[:a|a > 5 ifTrue: [''Many''] ifFalse: [a printString]]' '[1]' '[]')
@@ -1198,7 +1197,7 @@ testTimesRepeat
 	self assert: method notNil.
 	self deny: method needsContext.
 	self deny: (method byteCodeSegments anySatisfy: [:each | each first = BlockCopy]).
-	self assert: 5 equals: (method value: nil withArguments: #()).
+	self assert: (method value: nil withArguments: #()) equals: 5.
 	self
 		shouldnt: [result := self compileExpression: '| a | a := 0. 10 + (5 timesRepeat: [a := a + 1]). a']
 		raise: self compilationWarningClass.
@@ -1206,7 +1205,7 @@ testTimesRepeat
 	self assert: method notNil.
 	self deny: method needsContext.
 	self deny: (method byteCodeSegments anySatisfy: [:each | each first = BlockCopy]).
-	self assert: 5 equals: (method value: nil withArguments: #()).
+	self assert: (method value: nil withArguments: #()) equals: 5.
 
 	"Test case which cannot be inlined"
 	src := '| aBlock i | i := 0. aBlock := [i := i + 1]. 5 timesRepeat: aBlock. i.'.
@@ -1229,12 +1228,12 @@ testTimesRepeat
 	method := result method.
 	self assert: method notNil.
 	self assert: method isPacked.
-	self assert: (ByteArray
+	self assert: method byteCodes
+		equals: (ByteArray
 				with: Nop
 				with: ShortPushZero
-				with: ReturnFromMessage)
-		equals: method byteCodes.
-	self assert: 0 equals: (method value: nil withArguments: #()).
+				with: ReturnFromMessage).
+	self assert: (method value: nil withArguments: #()) equals: 0.
 
 	"Test 0 iterations, which compiler can remove (should come down to just a Return Zero, or at least return literal constant zero"
 	self shouldnt: [result := self compileExpression: '-1 timesRepeat: [Sound bell]']
@@ -1242,18 +1241,20 @@ testTimesRepeat
 	method := result method.
 	self assert: method notNil.
 	self assert: method isPacked.
-	self assert: -1 equals: (method value: nil withArguments: #())!
+	self assert: (method value: nil withArguments: #()) equals: -1!
 
 testTimesRepeatResult
 	#(0 1 2 127 16383 32767 32768) do: 
 			[:each |
-			self assert: each
-				equals: ((self compileExpression: ('<1p> timesRepeat: []' expandMacrosWith: each)) method value: nil
-						withArguments: #()).
-			self assert: each
-				equals: ((self
+			self
+				assert: ((self compileExpression: ('<1p> timesRepeat: []' expandMacrosWith: each)) method value: nil
+						withArguments: #())
+				equals: each.
+			self
+				assert: ((self
 						compileExpression: ('| i | i := 0. <1p> timesRepeat: [i := i + 1]. i' expandMacrosWith: each))
-							method value: nil withArguments: #())]!
+							method value: nil withArguments: #())
+				equals: each]!
 
 testToByDo
 	| result method src |
@@ -1384,7 +1385,7 @@ verifyTempsMapOf: aCompiledMethod
 	"First check that all ip's are covered by the method scope"
 	ipRange := 1 to: method byteCodes size.
 	tempsMap := info tempsMap.
-	self assert: ipRange equals: tempsMap first key.
+	self assert: tempsMap first key equals: ipRange.
 	"All temps map entries should be for ip's that represent some subset of the method's ip's"
 	tempsMap do: 
 			[:each |
@@ -1433,7 +1434,7 @@ verifyTextMapsOf: each
 	textMap := each debugInfo textMap.
 	debugTextMap := debugMethod textMap.
 	"The text maps should contain exactly the same number of entries, and the text range for each entry should be the same"
-	self assert: textMap size equals: debugTextMap size.
+	self assert: debugTextMap size equals: textMap size.
 	textMap with: debugTextMap do: [:a :b | self assert: a value = b value].
 	^debugTextMap do: 
 			[:assoc |

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkParserTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkParserTest.cls
@@ -42,12 +42,12 @@ testCharacterScanning
 	self assertToken: subject next isChar: (Character value: 92).
 	tok := subject next.
 	self assert: tok isIdentifier.
-	self assert: 'c' equals: tok value.
+	self assert: tok value equals: 'c'.
 	subject := self scannerClass on: '$\xAG' readStream.
 	self assertToken: subject next isChar: (Character value: 16rA).
 	tok := subject next.
 	self assert: tok isIdentifier.
-	self assert: 'G' equals: tok value!
+	self assert: tok value equals: 'G'!
 
 testExpressionSolver
 	#(#('y := 3' nil) #('x := 3' 'x := 3') #('y := x' 'x := y') #('y := x + 1' 'x := y - 1') #('y := x >> 2 - 1' 'x := y + 1 << 2') #('y := 1+z/x' 'x := (1 + z) / y') #('y := a - ((b / x) * c)' 'x := b / ((a - y) / c)') #('y := (m*x)+b' 'x := (y - b) / m') #('y := (m/x)-b' 'x := m / (y + b)' #('y:=a-c*x/(d-e)-f')))
@@ -63,7 +63,7 @@ testExpressionSolver
 			solution := expr solveFor: 'x'.
 			pair second
 				ifNil: [self assert: solution isNil]
-				ifNotNil: [:expected | self assert: expected equals: solution formattedCode]]!
+				ifNotNil: [:expected | self assert: solution formattedCode equals: expected]]!
 
 testExternalCallEquality
 	| strings |

--- a/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
@@ -420,15 +420,15 @@ testExtCallRetHRESULT
 			[:each |
 			| result |
 			result := method value: VMLibrary default withArguments: (Array with: each).
-			self assert: each equals: result.
+			self assert: result equals: each.
 			self assert: each class == result class].
 	"Negative HRESULTs should cause the primitive to fail with the failure data set to the HR code."
 	#(-1 -16r40000000 -16r40000001 -16r80000000) do: 
 			[:each |
 			| result |
 			result := method value: VMLibrary default withArguments: (Array with: each).
-			self assert: -1 equals: result key.
-			self assert: each equals: result value.
+			self assert: result key equals: -1.
+			self assert: result value equals: each.
 			self assert: each class == result value class]!
 
 testFPFaultInPrimitive
@@ -597,10 +597,10 @@ testIndirectByteAtOffsetPrimitives
 	#(0 1 127 128 255) do: 
 			[:each |
 			"Should be able to write any 32-bit integer value, and read it back"
-			self assert: each equals: (p byteAtOffset: 1 put: each).
-			self assert: each equals: (b byteAtOffset: 1).
-			self assert: 0 equals: (b byteAtOffset: 0).
-			self assert: 0 equals: (b byteAtOffset: 2)].
+			self assert: (p byteAtOffset: 1 put: each) equals: each.
+			self assert: (b byteAtOffset: 1) equals: each.
+			self assert: (b byteAtOffset: 0) equals: 0.
+			self assert: (b byteAtOffset: 2) equals: 0].
 
 	"Arg must be in range 0..255"
 	#(-1 256) do: [:each | self should: [p byteAtOffset: 1 put: each] raise: Error].
@@ -648,10 +648,10 @@ testIndirectDwordAtOffsetPrimitives
 		do: 
 			[:each |
 			"Should be able to write any 32-bit integer value, and read it back"
-			self assert: each equals: (p dwordAtOffset: 4 put: each).
-			self assert: each asDword equals: (b dwordAtOffset: 4).
-			self assert: 0 equals: (b dwordAtOffset: 0).
-			self assert: 0 equals: (b dwordAtOffset: 8)].
+			self assert: (p dwordAtOffset: 4 put: each) equals: each.
+			self assert: (b dwordAtOffset: 4) equals: each asDword.
+			self assert: (b dwordAtOffset: 0) equals: 0.
+			self assert: (b dwordAtOffset: 8) equals: 0].
 
 	"Error if arg requires more that 32-bits to represent as an unsigned int"
 	#(16r100000000 -16r80000001) do: [:each | self should: [p sdwordAtOffset: 0 put: each] raise: Error].
@@ -701,10 +701,10 @@ testIndirectSdwordAtOffsetPrimitives
 		do: 
 			[:each |
 			"Should be able to write any 32-bit integer value, and read it back"
-			self assert: each equals: (p sdwordAtOffset: 4 put: each).
-			self assert: each equals: (b sdwordAtOffset: 4).
-			self assert: 0 equals: (b sdwordAtOffset: 0).
-			self assert: 0 equals: (b sdwordAtOffset: 8)].
+			self assert: (p sdwordAtOffset: 4 put: each) equals: each.
+			self assert: (b sdwordAtOffset: 4) equals: each.
+			self assert: (b sdwordAtOffset: 0) equals: 0.
+			self assert: (b sdwordAtOffset: 8) equals: 0].
 
 	"If arg requires more than 32-bits to represent in 2's complement, then should be an error"
 	#(16r80000000 -16r80000001) do: [:each | self should: [p sdwordAtOffset: 0 put: each] raise: Error].
@@ -753,10 +753,10 @@ testIndirectSwordAtOffsetPrimitives
 	#(0 -1 1 16r7FFF -16r8000) do: 
 			[:each |
 			"Should be able to write any 32-bit integer value, and read it back"
-			self assert: each equals: (p swordAtOffset: 2 put: each).
-			self assert: each equals: (b swordAtOffset: 2).
-			self assert: 0 equals: (b swordAtOffset: 0).
-			self assert: 0 equals: (b swordAtOffset: 4)].
+			self assert: (p swordAtOffset: 2 put: each) equals: each.
+			self assert: (b swordAtOffset: 2) equals: each.
+			self assert: (b swordAtOffset: 0) equals: 0.
+			self assert: (b swordAtOffset: 4) equals: 0].
 
 	"Error if arg requires more that 16-bits to represent as 2's complement signed int"
 	#(16r10000 -16r8001) do: [:each | self should: [p swordAtOffset: 0 put: each] raise: Error].
@@ -802,10 +802,10 @@ testIndirectWordAtOffsetPrimitives
 	#(0 1 16r7FFF 16r8000 16rFFFF) do: 
 			[:each |
 			"Should be able to write any 32-bit integer value, and read it back"
-			self assert: each equals: (p wordAtOffset: 2 put: each).
-			self assert: each equals: (b wordAtOffset: 2).
-			self assert: 0 equals: (b wordAtOffset: 0).
-			self assert: 0 equals: (b wordAtOffset: 4)].
+			self assert: (p wordAtOffset: 2 put: each) equals: each.
+			self assert: (b wordAtOffset: 2) equals: each.
+			self assert: (b wordAtOffset: 0) equals: 0.
+			self assert: (b wordAtOffset: 4) equals: 0].
 
 	"Error if arg is negative or requires more that 16-bits to represent as an unsigned int"
 	#(-1 16r10000 -16r8001) do: [:each | self should: [p wordAtOffset: 0 put: each] raise: Error].
@@ -851,7 +851,7 @@ testIntDivideByZero
 			[123 perform: op with: 0] on: ZeroDivide
 				do: 
 					[:ex |
-					self assert: 123 equals: ex tag.
+					self assert: ex tag equals: 123.
 					self assert: (self
 								isFault: ex
 								raisedIn: SmallInteger >> op
@@ -1077,14 +1077,14 @@ testPrimitiveBytesIsNull
 	subject := DWORDBytes fromInteger: 1.
 	self deny: (method value: subject withArguments: #()).
 	subject := ExternalIntegerBytes newFixed: 8.
-	self assert: 'failed0' equals: (method value: subject withArguments: #())!
+	self assert: (method value: subject withArguments: #()) equals: 'failed0'!
 
 testPrimitiveEnableInterrupts
 	| enabled method |
 	method := self createPrimitiveMethodLike: ProcessorScheduler >> #enableAsyncEvents:
 				setsFailCode: true.
-	self assert: 'failed0' equals: (method value: Processor withArguments: #(1)).
-	self assert: 'failed0' equals: (method value: Processor withArguments: #('abc')).
+	self assert: (method value: Processor withArguments: #(1)) equals: 'failed0'.
+	self assert: (method value: Processor withArguments: #('abc')) equals: 'failed0'.
 	enabled := method value: Processor withArguments: #(false).
 	self assert: enabled description: 'Interrupts unexpectedly disabled before test'.
 	enabled := method value: Processor withArguments: #(false).
@@ -1113,12 +1113,12 @@ testPrimitiveInstanceCounts
 			class isMetaclass
 				ifTrue: 
 					["Metaclasses should have only a single instance"
-					self assert: 1 equals: (stats at: i + 1)].
-			class == SmallInteger ifTrue: [self assert: 0 equals: (stats at: i + 1)]].
+					self assert: (stats at: i + 1) equals: 1].
+			class == SmallInteger ifTrue: [self assert: (stats at: i + 1) equals: 0]].
 	#(1 'a') do: 
 			[:each |
-			self assert: 'failed0'
-				equals: (method value: MemoryManager current withArguments: (Array with: each))]!
+			self assert: (method value: MemoryManager current withArguments: (Array with: each))
+				equals: 'failed0']!
 
 testPrimitiveIsNullBytes
 	| addr handle |
@@ -1189,7 +1189,7 @@ testPrimitiveMakePoint
 						setsFailCode: true.
 			expected := (1 to: i) asArray.
 			result := method value: Array withArguments: expected.
-			self assert: expected equals: result].
+			self assert: result equals: expected].
 	"Non-indexable type, e.g. Point3D"
 	0 to: 3
 		do: 
@@ -1202,7 +1202,7 @@ testPrimitiveMakePoint
 			expected := Point3D basicNew.
 			1 to: i do: [:j | expected instVarAt: j put: j].
 			result := method value: Point3D withArguments: (1 to: i) asArray.
-			self assert: expected equals: result].
+			self assert: result equals: expected].
 	"Indexable type with fixed fields too, e.g. Context"
 	0 to: 4
 		do: 
@@ -1219,7 +1219,7 @@ testPrimitiveMakePoint
 							startingAt: 1;
 						yourself.
 			result := method value: Context withArguments: (1 to: i) asArray.
-			1 to: expected size do: [:j | self assert: (expected at: j) equals: (result instVarAt: j)]]!
+			1 to: expected size do: [:j | self assert: (result instVarAt: j) equals: (expected at: j)]]!
 
 testPrimitiveObjectCount
 	"Test primitive that returns object instance count."
@@ -1229,7 +1229,7 @@ testPrimitiveObjectCount
 	subject := MemoryManager current.
 	count1 := method value: subject withArguments: #().
 	count2 := method value: subject withArguments: #().
-	self assert: count2 equals: count1.
+	self assert: count1 equals: count2.
 	self assert: count1 > 0!
 
 testPrimitiveReplaceElements
@@ -1264,46 +1264,46 @@ testPrimitiveResume
 			Processor suspendActive.
 			state := state , ', a5']
 					forkAt: Processor userInterruptPriority.
-	self assert: 'a1' equals: state.
+	self assert: state equals: 'a1'.
 	self assert: a isWaiting.
-	self assert: a equals: sem first.
+	self assert: sem first equals: a.
 	a suspend.
 	self assert: a isSuspended.
 	self assert: sem isEmpty.
-	self assert: 'a1' equals: state.
+	self assert: state equals: 'a1'.
 	b := 
 			[a resume: sem.
 			state := state , ', b'] forkAt: Processor userInterruptPriority.
 	"Regression test for #Process>>resume: suspends calling/active process #89"
 	self assert: b isDead.
-	self assert: 'a1, b' equals: state.
+	self assert: state equals: 'a1, b'.
 	"Check that the process was 'resumed' correctly onto the requested list"
 	self assert: a isWaiting.
-	self assert: a equals: sem first.
+	self assert: sem first equals: a.
 	"And that it is runnable."
 	sem signal.
-	self assert: 'a1, b, a2' equals: state.
+	self assert: state equals: 'a1, b, a2'.
 	self assert: a isSuspended.
 	list := (Processor instVarNamed: 'processLists') at: a priority.
 	"Resumed process is schedulable, but lower priority than the active process, so waits."
 	c := 
 			[a resume: list.
 			state := state , ', c'] forkAt: Processor lowIOPriority.
-	self assert: 'a1, b, a2, c, a3' equals: state.
+	self assert: state equals: 'a1, b, a2, c, a3'.
 	self assert: a isSuspended.
 	self assert: c isDead.
 	"Resumed process is same priority, and although we expect a rescheduling it is pushed on the back of the list, so still waits"
 	d := 
 			[a resume: list.
 			state := state , ', d'] forkAt: a priority.
-	self assert: 'a1, b, a2, c, a3, d, a4' equals: state.
+	self assert: state equals: 'a1, b, a2, c, a3, d, a4'.
 	self assert: d isDead.
 	self assert: a isSuspended.
 	"Resumed process is higher priority, so resumes immediately."
 	e := 
 			[a resume: list.
 			state := state , ', e'] forkAt: a priority - 1.
-	self assert: 'a1, b, a2, c, a3, d, a4, a5, e' equals: state.
+	self assert: state equals: 'a1, b, a2, c, a3, d, a4, a5, e'.
 	self assert: e isDead.
 	self assert: a isDead!
 
@@ -1359,27 +1359,27 @@ testPrimitiveStringAtPut
 	method := self createPrimitiveMethodLike: String >> #at:put: setsFailCode: true.
 	subject := String new: 2.
 	"Valid case"
-	self assert: $\0 equals: (subject at: 1).
-	self assert: $\0 equals: (subject at: 2).
-	self assert: $a equals: (method value: subject withArguments: #(1 $a)).
-	self assert: $a equals: (subject at: 1).
-	self assert: $b equals: (method value: subject withArguments: #(2 $b)).
-	self assert: $b equals: (subject at: 2).
+	self assert: (subject at: 1) equals: $\0.
+	self assert: (subject at: 2) equals: $\0.
+	self assert: (method value: subject withArguments: #(1 $a)) equals: $a.
+	self assert: (subject at: 1) equals: $a.
+	self assert: (method value: subject withArguments: #(2 $b)) equals: $b.
+	self assert: (subject at: 2) equals: $b.
 	"Invalid index argument"
-	self assert: 'failed0' equals: (method value: subject withArguments: #($a $b)).
+	self assert: (method value: subject withArguments: #($a $b)) equals: 'failed0'.
 	"Bounds errors"
 	subject := String new: 2.
 	#(0 3 -1 ##(SmallInteger maximum) ##(SmallInteger minimum)) do: 
 			[:each |
-			self assert: $\0 equals: (subject at: 1).
-			self assert: $\0 equals: (subject at: 2).
-			self assert: 'failed1' equals: (method value: subject withArguments: (Array with: each with: $a))].
+			self assert: (subject at: 1) equals: $\0.
+			self assert: (subject at: 2) equals: $\0.
+			self assert: (method value: subject withArguments: (Array with: each with: $a)) equals: 'failed1'].
 	"Objects that strings can't hold, including some special cases that have no object body (issue #234)"
 	#(0 ##(Object new) nil '' #'' true false #() #[]) do: 
 			[:each |
-			self assert: $\0 equals: (subject at: 1).
-			self assert: $\0 equals: (subject at: 2).
-			self assert: 'failed2' equals: (method value: subject withArguments: (Array with: 1 with: each))]!
+			self assert: (subject at: 1) equals: $\0.
+			self assert: (subject at: 2) equals: $\0.
+			self assert: (method value: subject withArguments: (Array with: 1 with: each)) equals: 'failed2']!
 
 testPrimitiveStringCmp
 	"Test case sensitive string comparison primitive"
@@ -1396,7 +1396,7 @@ testPrimitiveStringCmp
 			expected := each third.
 			result := method value: subject withArguments: (Array with: operand).
 			self assert: result class == expected class.
-			self assert: expected equals: result]!
+			self assert: result equals: expected]!
 
 testPrimitiveSubtract
 	"Test the SmallInteger subtract primitive for normal, overflow and failure cases."
@@ -1414,7 +1414,7 @@ testPrimitiveSubtract
 			expected := each third.
 			result := method value: subject withArguments: (Array with: operand).
 			self assert: result class == expected class.
-			self assert: expected equals: result]!
+			self assert: result equals: expected]!
 
 testPrimitiveYourAddress
 	| method |
@@ -1430,7 +1430,7 @@ testPrimitiveYourAddress
 			addr := method value: each withArguments: #().
 			self deny: addr == 0.
 			self assert: (ByteArray fromAddress: addr length: each size) equals: each].
-	self assert: 0 equals: (method value: nil withArguments: #()).
+	self assert: (method value: nil withArguments: #()) equals: 0.
 !
 
 testSignedFromUnsigned
@@ -1495,20 +1495,20 @@ testWeakMournerNotifications
 	obj1 := obj3 := nil.
 	MemoryManager current collectGarbage.
 	"Weak array should have been notified of loss of obj1 and obj3"
-	self assert: 2 equals: (losses at: id1).
+	self assert: (losses at: id1) equals: 2.
 	self assert: subject1 first == DeadObject current.
 	self assert: subject1 second == obj2.
 	self assert: subject1 third == DeadObject current.
-	self assert: 2 equals: (losses at: id2).
+	self assert: (losses at: id2) equals: 2.
 	self assert: subject2 first == DeadObject current.
 	self assert: subject2 second == obj2.
 	self assert: subject2 third == DeadObject current.
 	obj2 := subject1 := subject2 := nil.
 	MemoryManager current collectGarbage.
 	"Garbage weak array should not have been notified of loss of obj2 as it was collected in same GC cycle"
-	self assert: 2 equals: (losses at: id1).
+	self assert: (losses at: id1) equals: 2.
 	"Garbage but finalizable weak array should have been notified of loss of obj2"
-	self assert: 3 equals: (losses at: id2)! !
+	self assert: (losses at: id2) equals: 3! !
 !VMTest categoriesFor: #assertImmutableAtPut:!private!unit tests! !
 !VMTest categoriesFor: #assertImmutableBasicAtPut:!private!unit tests! !
 !VMTest categoriesFor: #assertImmutableInstVarAtPut:!private!unit tests! !

--- a/Core/Object Arts/Dolphin/IDE/ClassBrowserAbstractTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/ClassBrowserAbstractTest.cls
@@ -231,7 +231,7 @@ testBrowseItOpensSystemBrowserOnPackageOfLooseMethod
 testEvaluationContext
 	"#832"
 
-	self assert: self browser actualClass equals: methodsPresenter evaluationContext.
+	self assert: methodsPresenter evaluationContext equals: self browser actualClass.
 	browser actualClass: Behavior.
 	self assert: methodsPresenter evaluationContext == Behavior.
 	browser method: (Association compiledMethodAt: #key).

--- a/Core/Object Arts/Dolphin/IDE/ClassBrowserAbstractTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/ClassBrowserAbstractTest.cls
@@ -231,7 +231,9 @@ testBrowseItOpensSystemBrowserOnPackageOfLooseMethod
 testEvaluationContext
 	"#832"
 
-	self assert: methodsPresenter evaluationContext equals: self browser actualClass.
+	| browserClass |
+	browserClass := self browser actualClass.
+	self assert: methodsPresenter evaluationContext equals: browserClass.
 	browser actualClass: Behavior.
 	self assert: methodsPresenter evaluationContext == Behavior.
 	browser method: (Association compiledMethodAt: #key).

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListBoxTest.cls
@@ -49,47 +49,47 @@ testSelectionsByIndex
 		should: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting same element should be a no-op"
 	self
 		shouldnt: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting a pair including the existing selection"
 	sel := Array with: 1 with: objects size.
 	self
 		should: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting same pair should be a no-op"
 	self
 		shouldnt: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting single item from existing selection should remove other selections"
 	sel := #(1).
 	self
 		should: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting a different pair not including the existing single selection"
 	sel := Array with: 2 with: objects size - 1.
 	self
 		should: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"#selectionByIndex: should also clear other selections"
 	sel := sel copyFrom: 2.
 	self
 		should: [presenter selectionByIndex: sel first]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex! !
+	self assert: presenter selectionsByIndex equals: sel! !
 !MultiSelectListBoxTest categoriesFor: #initializePresenter!public!Running! !
 !MultiSelectListBoxTest categoriesFor: #testLastSelectionCacheUpdatedOnRemove!public!unit tests! !
 !MultiSelectListBoxTest categoriesFor: #testSelectionsByIndex!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -140,47 +140,47 @@ testSelectionsByIndex
 		should: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting same element should be a no-op"
 	self
 		shouldnt: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting a pair including the existing selection"
 	sel := Array with: 1 with: objects size.
 	self
 		should: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting same pair should be a no-op"
 	self
 		shouldnt: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting single item from existing selection should remove other selections"
 	sel := #(1).
 	self
 		should: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"Selecting a different pair not including the existing single selection"
 	sel := Array with: 2 with: objects size - 1.
 	self
 		should: [presenter selectionsByIndex: sel]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: sel.
 	"#selectionByIndex: should also clear other selections"
 	sel := sel copyFrom: 2.
 	self
 		should: [presenter selectionByIndex: sel first]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: sel equals: presenter selectionsByIndex! !
+	self assert: presenter selectionsByIndex equals: sel! !
 !MultiSelectListViewTest categoriesFor: #initializePresenter!public!Running! !
 !MultiSelectListViewTest categoriesFor: #sortSelections!private!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/SelectableListItemsTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/SelectableListItemsTest.cls
@@ -281,13 +281,13 @@ testSelectionByIndex
 				should: [presenter selectionByIndex: n]
 				trigger: #selectionChanged
 				against: presenter.
-			self assert: n equals: presenter selectionByIndex.
+			self assert: presenter selectionByIndex equals: n.
 			"Setting same selection should be a no-op"
 			self
 				shouldnt: [presenter selectionByIndex: n]
 				trigger: #selectionChanged
 				against: presenter.
-			self assert: (objects at: n) equals: presenter selection].
+			self assert: presenter selection equals: (objects at: n)].
 	self
 		should: [presenter selectionByIndex: 0]
 		trigger: #selectionChanged

--- a/Core/Object Arts/Dolphin/MVP/SingleSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/SingleSelectListViewTest.cls
@@ -24,17 +24,17 @@ testSelectionModeChange
 		trigger: #selectionChanged
 		against: presenter.
 	self assert: presenter view isMultiSelect.
-	self assert: #(1) equals: presenter selectionsByIndex.
+	self assert: presenter selectionsByIndex equals: #(1).
 	presenter selectionsByIndex: #(2 3).
 	caret := presenter view caretIndex.
-	self assert: 3 equals: caret.
+	self assert: caret equals: 3.
 	self
 		should: [presenter view isMultiSelect: false]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: caret equals: presenter selectionByIndex.
+	self assert: presenter selectionByIndex equals: caret.
 	presenter view selectionsByIndex: #(1 2).
-	self assert: #(1) equals: presenter selectionsByIndex! !
+	self assert: presenter selectionsByIndex equals: #(1)! !
 !SingleSelectListViewTest categoriesFor: #sortSelections!private!unit tests! !
 !SingleSelectListViewTest categoriesFor: #testSelectionModeChange!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/DpApiTest.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/DpApiTest.cls
@@ -19,14 +19,14 @@ verifyRoundTrip: aByteObject
 	encrypted := Crypt32Library protectData: aByteObject.
 	encryptedExtra := Crypt32Library protectData: aByteObject additionalEntropy: entropy.
 	decrypted := Crypt32Library unprotectData: encrypted.
-	self assert: aByteObject equals: decrypted.
+	self assert: decrypted equals: aByteObject.
 	"Unprotect with entropy not used on protect should fail."
 	self
 		should: [Crypt32Library unprotectData: encryptedExtra]
 		raise: Win32Error
 		matching: [:ex | ex tag statusCode = Win32Errors.ERROR_INVALID_DATA].
 	decrypted := Crypt32Library unprotectData: encryptedExtra additionalEntropy: entropy.
-	self assert: aByteObject equals: decrypted.
+	self assert: decrypted equals: aByteObject.
 	"Unprotect without entropy used on protect should fail."
 	self
 		should: [Crypt32Library unprotectData: encryptedExtra]

--- a/Core/Object Arts/Dolphin/System/Win32/MemoryMappedFileTest.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/MemoryMappedFileTest.cls
@@ -52,7 +52,7 @@ testMaximumSize
 	view := mmf mapView.
 	array := DWORDArray fromAddress: view length: count.
 	1 to: count do: [:each | array at: each put: each].
-	self assert: (1 to: count) equals: array asArray.
+	self assert: array asArray equals: (1 to: count).
 	mmf free.
 	view free.
 	self
@@ -63,9 +63,9 @@ testMaximumSize
 		collectGarbage;
 		administerLastRites.
 	file := FileStream read: fname text: false.
-	self assert: count * 4 equals: file size.
+	self assert: file size equals: count * 4.
 	array := (1 to: count) collect: [:each | file nextDWORD].
-	self assert: (1 to: count) equals: array.
+	self assert: array equals: (1 to: count).
 	file close.
 	"If this fails then one or other thing is holding the file open"
 	File delete: fname!


### PR DESCRIPTION
The order of the parameters to `assert:equals:` was (expected, actual), which is not what most people expect. This commit reverses the order and most existing uses (except some which were the "wrong" way round)