### PR TITLE
Improve testing of `Integer>>\\` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Releases/
 Contributions/
 Core/DolphinVM/
 Projects
+*.log

--- a/Core/Object Arts/Dolphin/Base/LargeInteger.cls
+++ b/Core/Object Arts/Dolphin/Base/LargeInteger.cls
@@ -5,7 +5,7 @@ Integer variableByteSubclass: #LargeInteger
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-LargeInteger guid: (GUID fromString: '{87B4C65E-026E-11D3-9FD7-00A0CC3E4A32}')!
+LargeInteger guid: (GUID fromString: '{87b4c65e-026e-11d3-9fd7-00a0cc3e4a32}')!
 LargeInteger isIndirection: true!
 LargeInteger comment: 'Class LargeInteger is the class of Integers which are outside the range of SmallIntegers (i.e. outside (SmallInteger minimum..SmallInteger maximum). Basically any Integer requiring more than 31-bits to be represented in 2''s complement will be a LargeInteger.
 
@@ -48,7 +48,7 @@ LargeInteger includes high performance primitive implementations for the common 
 	"Answer the <integer> remainder defined by division with truncation toward negative 
 	infinity; e.g. 7 \\ 2 = 1, -7 \\ 2 = 1, 7 \\ -2 = -1. 
 	This is the modulo operation, but it is not the same as C modulo (%) which truncates 
-	towards zero (use #mod:). Report an error if the aNumber is zero."
+	towards zero. Report an error if the aNumber is zero."
 
 	<primitive: 31>
 	^super \\ operand!

--- a/Core/Object Arts/Dolphin/Base/LargeIntegerTest.cls
+++ b/Core/Object Arts/Dolphin/Base/LargeIntegerTest.cls
@@ -776,6 +776,26 @@ testMod
 	result := b * b % mod.
 	self assert: result = expected!
 
+testModulo
+	"Test #\\, which is mathetical modulo with truncation towards negative infinity (not zero"
+
+	#(-16rFFFFFFFFFFFFFFFFFFFFFFFF -16rFFFFFFFFFFFFFFF -16rFFFFFFFF ##(SmallInteger maximum + 1) ##(SmallInteger
+		maximum + 2) 16rFFFFFFFF 16rFFFFFFFFFFFFFFF 16rFFFFFFFFFFFFFFFFFFFFFFFF)
+		do: 
+			[:dividend |
+			self should: [dividend \\ 0] raise: ZeroDivide.
+			#(-16r7FFFFFFFFFFFFFFFFFFFFFFF -16r7FFFFFFFFFFFFFFF ##(SmallInteger minimum * 2 - 1) ##(SmallInteger
+				minimum / 2) -3 -2 -1 2 3 ##(SmallInteger maximum) ##(SmallInteger maximum + 1) 16r7FFFFFFF 16r7FFFFFFFFFFFFFFF 16r7FFFFFFFFFFFFFFFFFFFFFFF)
+				do: 
+					[:divisor |
+					| expected actual quotient |
+					quotient := dividend // divisor.
+					expected := dividend - (quotient * divisor).
+					actual := dividend \\ divisor.
+					self assert: actual equals: expected.
+					"Sanity check"
+					self assert: quotient * divisor + actual equals: dividend]]!
+
 testMulSmall
 	| res a |
 	a := 16r40000000.
@@ -959,6 +979,26 @@ testQuoRem3
 			"And the remainders should be less than the denominator"
 			self assert: r < v]!
 
+testRem
+	#(-16rFFFFFFFFFFFFFFFFFFFFFFFF -16rFFFFFFFFFFFFFFF -16rFFFFFFFF ##(SmallInteger maximum + 1) ##(SmallInteger
+		maximum + 2) 16rFFFFFFFF 16rFFFFFFFFFFFFFFF 16rFFFFFFFFFFFFFFFFFFFFFFFF)
+		do: 
+			[:dividend |
+			#(-16r7FFFFFFFFFFFFFFFFFFFFFFF -16r7FFFFFFFFFFFFFFF ##(SmallInteger minimum * 2 - 1) ##(SmallInteger
+				minimum / 2) -3 -2 -1 2 3 ##(SmallInteger maximum) ##(SmallInteger maximum + 1) 16r7FFFFFFF 16r7FFFFFFFFFFFFFFF 16r7FFFFFFFFFFFFFFFFFFFFFFF)
+				do: 
+					[:divisor |
+					| expected actual quotient |
+					quotient := dividend quo: divisor.
+					expected := dividend - (quotient * divisor).
+					actual := dividend rem: divisor.
+					self assert: actual equals: expected.
+					"% is the operator equivalent of #rem:"
+					actual := dividend % divisor.
+					self assert: actual equals: expected.
+					"Sanity check"
+					self assert: quotient * divisor + actual equals: dividend]]!
+
 testSubtractSmall
 	| res |
 	res := 16r40000000 - 1.
@@ -1010,6 +1050,7 @@ testSubtractSmall
 !LargeIntegerTest categoriesFor: #testHighBit!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testImmutable!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testMod!public!unit tests! !
+!LargeIntegerTest categoriesFor: #testModulo!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testMulSmall!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testNegate!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testPrintLargeBase2!public!unit tests! !
@@ -1017,5 +1058,6 @@ testSubtractSmall
 !LargeIntegerTest categoriesFor: #testQuoRem!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testQuoRem2!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testQuoRem3!public!unit tests! !
+!LargeIntegerTest categoriesFor: #testRem!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testSubtractSmall!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/SmallIntegerTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SmallIntegerTest.cls
@@ -149,18 +149,27 @@ testMinMax
 testMinVal
 	self should: [SmallInteger minimum = (1 bitShift: VMConstants.IntPtrBits - 2) negated]!
 
-testMod
-	"Different forms of mod"
-
-	self assert: 6\\2 == 0.
-	self assert: -6\\2 == 0.
-	self assert: 5\\-3 == -1.
-	self assert: -5\\-3 == -2.
-
-	self assert: 7\\ 2 == 1.
-	self assert: 7\\ 2+1 == 2.
-	self assert: -7\\ 2 == 1.
-!
+testModulo
+	self should: [-1 \\ 0] raise: ZeroDivide.
+	self assert: 6 \\ 2 equals: 0.
+	self assert: -6 \\ 2 equals: 0.
+	self assert: 5 \\ -3 equals: -1.
+	self assert: -5 \\ -3 equals: -2.
+	self assert: 7 \\ 2 equals: 1.
+	self assert: 7 \\ 2 + 1 equals: 2.
+	self assert: 7 \\ 11 equals: 7.
+	self assert: 7 \\ -2 equals: -1.
+	self assert: 7 \\ -3 equals: -2.
+	self assert: 7 \\ -4 equals: -1.
+	self assert: 7 \\ -5 equals: -3.
+	self assert: 7 \\ -6 equals: -5.
+	self assert: 7 \\ -7 equals: 0.
+	self assert: 7 \\ -8 equals: -1.
+	self assert: 7 \\ -11 equals: -4.
+	self assert: -7 \\ 2 equals: 1.
+	self assert: -7 \\ 7 equals: 0.
+	self assert: -7 \\ 11 equals: 4.
+	self assert: -7 \\ -11 equals: -7!
 
 testNew
 	self should: [SmallInteger new] raise: TestResult error!
@@ -273,7 +282,7 @@ testSubtract
 !SmallIntegerTest categoriesFor: #testMaxVal!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testMinMax!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testMinVal!public!unit tests! !
-!SmallIntegerTest categoriesFor: #testMod!public!unit tests! !
+!SmallIntegerTest categoriesFor: #testModulo!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testNew!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testNoMask!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testOverflow!public!unit tests! !


### PR DESCRIPTION
The VM primitive behind `LargeInteger>>\\` is not implemented, making modulo operations on large integers relatively slow. Before implementing this the modulo unit tests need to be improved.