### PR TITLE
Fix #372: Unable to load "Dolphin Sockets Tests.pax"

### DIFF
--- a/Core/Object Arts/Dolphin/Sockets/AbstractSocketTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/AbstractSocketTest.cls
@@ -1,0 +1,33 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #AbstractSocketTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+AbstractSocketTest guid: (GUID fromString: '{4b35f00d-f9e0-442d-84fd-4721213f82fd}')!
+AbstractSocketTest comment: ''!
+!AbstractSocketTest categoriesForClass!Unclassified! !
+!AbstractSocketTest methodsFor!
+
+serverSocketClass
+	^self subclassResponsibility!
+
+testQueryPort
+	"See #1317"
+
+	| s |
+	s := self serverSocketClass port: 1000.
+	[self assert: s queryPort = 1000] ensure: [s close]! !
+!AbstractSocketTest categoriesFor: #serverSocketClass!private!unit tests! !
+!AbstractSocketTest categoriesFor: #testQueryPort!public!unit tests! !
+
+!AbstractSocketTest class methodsFor!
+
+isAbstract
+	"Override to true if a TestCase subclass is Abstract and should not have
+	TestCase instances built from it"
+
+	^self == ##(self)! !
+!AbstractSocketTest class categoriesFor: #isAbstract!public!Testing! !
+

--- a/Core/Object Arts/Dolphin/Sockets/InternetAddressTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/InternetAddressTest.cls
@@ -1,0 +1,60 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #InternetAddressTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+InternetAddressTest guid: (GUID fromString: '{3d606958-5c0e-4788-a978-70bf30cf372d}')!
+InternetAddressTest comment: ''!
+!InternetAddressTest categoriesForClass!Unclassified! !
+!InternetAddressTest methodsFor!
+
+testAllForHost
+	| addresses oacom |
+	self isOnline ifFalse: [^self].
+
+	"Microsoft should have more than one IP associated with microsoft.com"
+	addresses := InternetAddress allForHost: 'microsoft.com'.
+	self assert: addresses size > 1.
+	self assert: (addresses anySatisfy: [:each | each ipAddress beginsWith: #[191 239]]).
+
+	"OA central"
+	addresses := InternetAddress allForHost: 'object-arts.com'.
+	self assert: addresses size = 1.
+	self assert: (addresses first host endsWith: 'cable.virginm.net')!
+
+testHost
+	| name ip |
+	self isOnline ifFalse: [^self].
+	name := InternetAddress host: 'uk2.net'.
+	ip := InternetAddress ipAddress: name ipAddress.
+	self assert: ip host = name host!
+
+testIsIPString
+	self deny: (InternetAddress isIPString: '').
+	self deny: (InternetAddress isIPString: '.').
+	self deny: (InternetAddress isIPString: 'a').
+	self deny: (InternetAddress isIPString: 'a.').
+	self deny: (InternetAddress isIPString: 'invalid').
+	self deny: (InternetAddress isIPString: 'www.foo.org').
+	self deny: (InternetAddress isIPString: 'www.foo.org.').
+	self deny: (InternetAddress isIPString: 'www.foo.or1.').
+	self deny: (InternetAddress isIPString: '1foo.or1.').
+	self deny: (InternetAddress isIPString: '1.2.3.-').
+	self assert: (InternetAddress isIPString: 'invalid.invalid.invalid.4invalid').
+	self assert: (InternetAddress isIPString: '1.2.3.4')
+!
+
+testLocalHost
+	| local computerName |
+	computerName := SessionManager current computerName asLowercase.
+	local := InternetAddress localHost.
+	self assert: local host asUppercase = computerName asUppercase.
+	self assert: (((InternetAddress ipAddress: local ipAddress) host subStrings: $.) first 
+				sameAs: computerName)! !
+!InternetAddressTest categoriesFor: #testAllForHost!public!unit tests! !
+!InternetAddressTest categoriesFor: #testHost!public!unit tests! !
+!InternetAddressTest categoriesFor: #testIsIPString!public!unit tests! !
+!InternetAddressTest categoriesFor: #testLocalHost!public!unit tests! !
+

--- a/Core/Object Arts/Dolphin/Sockets/Socket2Test.cls
+++ b/Core/Object Arts/Dolphin/Sockets/Socket2Test.cls
@@ -1,0 +1,16 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+AbstractSocketTest subclass: #Socket2Test
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+Socket2Test guid: (GUID fromString: '{25407553-d303-4d50-ad3d-b05b28a27c47}')!
+Socket2Test comment: ''!
+!Socket2Test categoriesForClass!Unclassified! !
+!Socket2Test methodsFor!
+
+serverSocketClass
+	^ServerSocket2! !
+!Socket2Test categoriesFor: #serverSocketClass!public!unit tests! !
+

--- a/Core/Object Arts/Dolphin/Sockets/SocketErrorTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/SocketErrorTest.cls
@@ -1,0 +1,24 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #SocketErrorTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: 'WinSocketErrors'
+	classInstanceVariableNames: ''!
+SocketErrorTest guid: (GUID fromString: '{a421a921-77e2-485a-b403-fc20d4c13a43}')!
+SocketErrorTest comment: ''!
+!SocketErrorTest categoriesForClass!Unclassified! !
+!SocketErrorTest methodsFor!
+
+testSocketClosed
+	self should: [SocketError signalWith: WSAECONNRESET] raise: SocketClosed!
+
+testSocketWaitCancelled
+	self should: [SocketError signalWith: WSAEINTR] raise: SocketWaitCancelled!
+
+testSocketWouldBlock
+	self should: [SocketError signalWith: WSAEWOULDBLOCK] raise: SocketWouldBlock! !
+!SocketErrorTest categoriesFor: #testSocketClosed!public!unit tests! !
+!SocketErrorTest categoriesFor: #testSocketWaitCancelled!public!unit tests! !
+!SocketErrorTest categoriesFor: #testSocketWouldBlock!public!unit tests! !
+

--- a/Core/Object Arts/Dolphin/Sockets/SocketTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/SocketTest.cls
@@ -1,0 +1,16 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+AbstractSocketTest subclass: #SocketTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+SocketTest guid: (GUID fromString: '{e47fc871-27aa-4e1f-8b11-5fc27c9237a4}')!
+SocketTest comment: ''!
+!SocketTest categoriesForClass!Unclassified! !
+!SocketTest methodsFor!
+
+serverSocketClass
+	^ServerSocket! !
+!SocketTest categoriesFor: #serverSocketClass!public!unit tests! !
+


### PR DESCRIPTION
Add back missing class files from D6 and restore InternetAddressTest.cls (deleted by commit 27aab12bade26e8e05c8b20f660a6b969819670d)