### PR TITLE
Factor out test run logging in order to support other formats in future

### DIFF
--- a/Core/Object Arts/Dolphin/Base/CommandLineTestRunner.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTestRunner.cls
@@ -78,11 +78,6 @@ runSuite: aTestSuite knownSlowTests: aCollection
 					knownSlowTests: aCollection].
 	^results!
 
-slowTestThreshold
-	"Answer the execution time threshold, in milliseconds, over which tests are reported as slow."
-
-	^500!
-
 startRun: aTestSuite
 	(verbose and: [loggers isEmpty]) ifTrue: [self addLogger: self newStdOutLogger].
 	aTestSuite addDependentToHierachy: self.
@@ -122,7 +117,6 @@ verbose: anObject
 !CommandLineTestRunner categoriesFor: #resultFor:!helpers!private! !
 !CommandLineTestRunner categoriesFor: #runSuite:!operations!public! !
 !CommandLineTestRunner categoriesFor: #runSuite:knownSlowTests:!operations!public! !
-!CommandLineTestRunner categoriesFor: #slowTestThreshold!helpers!private! !
 !CommandLineTestRunner categoriesFor: #startRun:!operations!private! !
 !CommandLineTestRunner categoriesFor: #update:with:from:!private!updating! !
 !CommandLineTestRunner categoriesFor: #verbose:!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/CommandLineTestRunner.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTestRunner.cls
@@ -1,7 +1,7 @@
 "Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #CommandLineTestRunner
-	instanceVariableNames: 'results lastCase caseStart stream verbose runStart runStop timings'
+	instanceVariableNames: 'results lastCase caseStart loggers verbose'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -10,21 +10,41 @@ CommandLineTestRunner comment: ''!
 !CommandLineTestRunner categoriesForClass!Kernel-Objects! !
 !CommandLineTestRunner methodsFor!
 
-initialize
-	verbose := false!
+addLogger: aTestRunLogger
+	loggers addLast: aTestRunLogger!
 
-printRuntime: anInteger
-	| mS |
-	mS := anInteger / 1000.0.
-	mS < 1000.0
-		ifTrue: 
-			[mS printOn: stream decimalPlaces: (mS < 1.0 ifTrue: [3] ifFalse: [0]).
-			stream nextPutAll: ' mS']
-		ifFalse: 
-			[| secs |
-			secs := mS / 1000.0.
-			secs printOn: stream decimalPlaces: (secs < 10.0 ifTrue: [1] ifFalse: [0]).
-			stream nextPutAll: ' s']!
+finishRun: aTestSuite in: anInteger knownSlowTests: aCollection
+	aTestSuite removeDependentFromHierachy: self.
+	aTestSuite resources do: [:each | each reset].
+	loggers do: 
+			[:each |
+			each
+				finishedRun: results
+				in: anInteger
+				knownSlowTests: aCollection]!
+
+initialize
+	verbose := false.
+	loggers := OrderedCollection new!
+
+logFinishedCase: aTestCase runtime: microsecondsInteger
+	| result |
+	result := self resultFor: aTestCase.
+	loggers do: 
+			[:each |
+			each
+				finishedCase: aTestCase
+				result: result
+				in: microsecondsInteger]!
+
+logStartingCase: aTestCase
+	loggers do: [:each | each startingCase: aTestCase]!
+
+logStartingRun: aTestSuite
+	loggers do: [:each | each startingRun: aTestSuite]!
+
+newStdOutLogger
+	^TestRunConsoleLogger on: SessionManager current stdout!
 
 result
 	^results!
@@ -36,15 +56,12 @@ resultFor: aTestCase
 	^#indeterminate!
 
 runSuite: aTestSuite
-	self runSuyite: aTestSuite excused: #()!
+	self runSuite: aTestSuite knownSlowTests: #()!
 
-runSuite: aTestSuite baseline: aCollection
+runSuite: aTestSuite knownSlowTests: aCollection
+	| runStart |
 	runStart := Time microsecondClockValue.
-	verbose ifTrue: [aTestSuite addDependentToHierachy: self].
-	results := TestResult new.
-	aTestSuite resources do: [:res | res isAvailable ifFalse: [^res signalInitializationError]].
-	stream isNil ifTrue: [stream := SessionManager current stdout].
-	timings := OrderedCollection new.
+	self startRun: aTestSuite.
 	
 	[lastCase := nil.
 	aTestSuite run: results.
@@ -53,9 +70,12 @@ runSuite: aTestSuite baseline: aCollection
 		with: nil
 		from: aTestSuite]
 			ensure: 
-				[verbose ifTrue: [aTestSuite removeDependentFromHierachy: self].
-				aTestSuite resources do: [:each | each reset]].
-	self summarizeResults: aCollection.
+				[| runStop |
+				runStop := Time microsecondClockValue.
+				self
+					finishRun: aTestSuite
+					in: runStop - runStart
+					knownSlowTests: aCollection].
 	^results!
 
 slowTestThreshold
@@ -63,74 +83,12 @@ slowTestThreshold
 
 	^500!
 
-stream: aPuttableStream
-	stream := aPuttableStream!
-
-summarizeFailures
-	| failures errors |
-	failures := results failures.
-	failures notEmpty
-		ifTrue: 
-			[stream
-				cr;
-				nextPutAll: 'FAILURES:';
-				cr.
-			failures do: 
-					[:each |
-					stream
-						print: each;
-						cr]].
-	errors := results errors.
-	errors notEmpty
-		ifTrue: 
-			[stream
-				cr;
-				nextPutAll: 'ERRORS:';
-				cr.
-			errors do: 
-					[:each |
-					stream
-						print: each;
-						cr]]!
-
-summarizeResults: aCollection
-	| passed |
-	passed := results hasPassed.
-	stream
-		nextPutAll: (passed ifTrue: ['PASSED'] ifFalse: ['FAILED']);
-		cr;
-		nextPutAll: results printString;
-		nextPutAll: ' in '.
-	self printRuntime: caseStart - runStart.
-	stream cr.
-	passed
-		ifTrue: [self summarizeTimings: self slowTestThreshold * 1000 baseline: aCollection]
-		ifFalse: [self summarizeFailures].
-	stream flush!
-
-summarizeTimings: anInteger baseline: aCollection
-	| laggards newLaggards |
-	laggards := (timings select: [:each | each value >= anInteger])
-				asSortedCollectionUsing: (MergesortAlgorithm sortBlock: [:a :b | a value > b value]).
-	newLaggards := laggards reject: [:each | aCollection includes: each key].
-	newLaggards size > 0 ifFalse: [^self].
-	stream
-		print: newLaggards size;
-		nextPutAll: ' test(s) took '.
-	self printRuntime: anInteger.
-	stream
-		nextPutAll: ' or more to run, not including ';
-		print: aCollection size;
-		nextPutAll: ' known laggards:';
-		cr.
-	newLaggards do: 
-			[:each |
-			stream tab.
-			self printRuntime: each value.
-			stream
-				tab;
-				print: each key;
-				cr]!
+startRun: aTestSuite
+	(verbose and: [loggers isEmpty]) ifTrue: [self addLogger: self newStdOutLogger].
+	aTestSuite addDependentToHierachy: self.
+	results := TestResult new.
+	self logStartingRun: aTestSuite.
+	aTestSuite resources do: [:res | res isAvailable ifFalse: [res signalInitializationError]]!
 
 update: anObject with: argument from: originator
 	| stop |
@@ -143,36 +101,29 @@ update: anObject with: argument from: originator
 				from: originator].
 	lastCase isNil
 		ifFalse: 
-			[| time |
+			[| time aTestCase |
 			time := stop - caseStart.
-			timings add: lastCase -> time.
-			stream
-				nextPutAll: (self resultFor: lastCase) asUppercase;
-				nextPutAll: ' in '.
-			self printRuntime: time.
-			stream cr].
-	anObject isNil
-		ifFalse: 
-			[stream
-				print: anObject;
-				nextPutAll: ' ... '].
-	stream flush.
+			aTestCase := lastCase.
+			self logFinishedCase: aTestCase runtime: time].
+	anObject isNil ifFalse: [self logStartingCase: anObject].
 	lastCase := anObject.
 	caseStart := Time microsecondClockValue!
 
 verbose: anObject
 	verbose := anObject! !
+!CommandLineTestRunner categoriesFor: #addLogger:!initializing!private! !
+!CommandLineTestRunner categoriesFor: #finishRun:in:knownSlowTests:!operations!private! !
 !CommandLineTestRunner categoriesFor: #initialize!initializing!private! !
-!CommandLineTestRunner categoriesFor: #printRuntime:!helpers!private! !
+!CommandLineTestRunner categoriesFor: #logFinishedCase:runtime:!private!updating! !
+!CommandLineTestRunner categoriesFor: #logStartingCase:!logging!private! !
+!CommandLineTestRunner categoriesFor: #logStartingRun:!logging!private! !
+!CommandLineTestRunner categoriesFor: #newStdOutLogger!logging!private! !
 !CommandLineTestRunner categoriesFor: #result!Accessing!public! !
 !CommandLineTestRunner categoriesFor: #resultFor:!helpers!private! !
 !CommandLineTestRunner categoriesFor: #runSuite:!operations!public! !
-!CommandLineTestRunner categoriesFor: #runSuite:baseline:!operations!public! !
+!CommandLineTestRunner categoriesFor: #runSuite:knownSlowTests:!operations!public! !
 !CommandLineTestRunner categoriesFor: #slowTestThreshold!helpers!private! !
-!CommandLineTestRunner categoriesFor: #stream:!accessing!public! !
-!CommandLineTestRunner categoriesFor: #summarizeFailures!helpers!private! !
-!CommandLineTestRunner categoriesFor: #summarizeResults:!helpers!private! !
-!CommandLineTestRunner categoriesFor: #summarizeTimings:baseline:!helpers!private! !
+!CommandLineTestRunner categoriesFor: #startRun:!operations!private! !
 !CommandLineTestRunner categoriesFor: #update:with:from:!private!updating! !
 !CommandLineTestRunner categoriesFor: #verbose:!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -105,6 +105,8 @@ package classNames
 	add: #StructureArrayTest;
 	add: #SWORDArrayTest;
 	add: #SymbolTest;
+	add: #TestRunConsoleLogger;
+	add: #TestRunLogger;
 	add: #TimeTest;
 	add: #TrueTest;
 	add: #UndefinedObjectTest;
@@ -160,7 +162,12 @@ Object subclass: #CollectionCombinator
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Object subclass: #CommandLineTestRunner
-	instanceVariableNames: 'results lastCase caseStart stream verbose runStart runStop timings'
+	instanceVariableNames: 'results lastCase caseStart loggers verbose'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+Object subclass: #TestRunLogger
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -689,6 +696,11 @@ DolphinTestClassResource subclass: #MustBeBooleanTestClasses
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
+TestRunLogger subclass: #TestRunConsoleLogger
+	instanceVariableNames: 'stream timings'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
 
 "Global Aliases"!
 
@@ -731,9 +743,9 @@ runRegressionTests
 
 runRegressionTests: aTestSuite logTo: logStream verbose: aBoolean
 	^(CommandLineTestRunner new)
-		stream: logStream;
+		addLogger: (TestRunConsoleLogger on: logStream);
 		verbose: aBoolean;
-		runSuite: aTestSuite baseline: self baselinedSlowTests! !
+		runSuite: aTestSuite knownSlowTests: self baselinedSlowTests! !
 !SmalltalkSystem categoriesFor: #regressionTestsLogFilename!public!tests! !
 !SmalltalkSystem categoriesFor: #regressionTestSuite!private!tests! !
 !SmalltalkSystem categoriesFor: #runRegressionTests!public!tests! !

--- a/Core/Object Arts/Dolphin/Base/TestRunConsoleLogger.cls
+++ b/Core/Object Arts/Dolphin/Base/TestRunConsoleLogger.cls
@@ -1,0 +1,127 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+TestRunLogger subclass: #TestRunConsoleLogger
+	instanceVariableNames: 'stream timings'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+TestRunConsoleLogger guid: (GUID fromString: '{c279d11f-90f1-4fe3-bfa6-09a2d85a208e}')!
+TestRunConsoleLogger comment: ''!
+!TestRunConsoleLogger categoriesForClass!Kernel-Objects! !
+!TestRunConsoleLogger methodsFor!
+
+finishedCase: aTestCase result: aSymbol in: microsecondsInteger
+	timings at: aTestCase put: microsecondsInteger.
+	stream
+		nextPutAll: aSymbol asUppercase;
+		nextPutAll: ' in '.
+	self printRuntime: microsecondsInteger.
+	stream cr!
+
+finishedRun: aTestResult in: anInteger knownSlowTests: aCollection
+	| passed |
+	passed := aTestResult hasPassed.
+	stream
+		nextPutAll: (passed ifTrue: ['PASSED'] ifFalse: ['FAILED']);
+		cr;
+		nextPutAll: aTestResult printString;
+		nextPutAll: ' in '.
+	self printRuntime: anInteger.
+	stream cr.
+	passed
+		ifTrue: [self summarizeTimings: self slowTestThreshold * 1000 baseline: aCollection]
+		ifFalse: [self summarizeFailures: aTestResult].
+	stream flush!
+
+printRuntime: microsecondsInteger
+	| mS |
+	mS := microsecondsInteger / 1000.0.
+	mS < 1000.0
+		ifTrue: 
+			[mS printOn: stream decimalPlaces: (mS < 1.0 ifTrue: [3] ifFalse: [0]).
+			stream nextPutAll: ' mS']
+		ifFalse: 
+			[| secs |
+			secs := mS / 1000.0.
+			secs printOn: stream decimalPlaces: (secs < 10.0 ifTrue: [1] ifFalse: [0]).
+			stream nextPutAll: ' s']!
+
+startingCase: aTestCase
+	stream
+		print: aTestCase;
+		nextPutAll: ' ... ';
+		flush!
+
+startingRun: aTestSuite
+	timings := Dictionary new!
+
+stream: anObject
+	stream := anObject!
+
+summarizeFailures: aTestResult
+	| failures errors |
+	failures := aTestResult failures.
+	failures notEmpty
+		ifTrue: 
+			[stream
+				cr;
+				nextPutAll: 'FAILURES:';
+				cr.
+			failures do: 
+					[:each |
+					stream
+						print: each;
+						cr]].
+	errors := aTestResult errors.
+	errors notEmpty
+		ifTrue: 
+			[stream
+				cr;
+				nextPutAll: 'ERRORS:';
+				cr.
+			errors do: 
+					[:each |
+					stream
+						print: each;
+						cr]]!
+
+summarizeTimings: anInteger baseline: aCollection
+	| laggards newLaggards |
+	laggards := (timings associations select: [:each | each value >= anInteger])
+				asSortedCollectionUsing: (MergesortAlgorithm sortBlock: [:a :b | a value > b value]).
+	newLaggards := laggards reject: [:each | aCollection includes: each key].
+	newLaggards size > 0 ifFalse: [^self].
+	stream
+		print: newLaggards size;
+		nextPutAll: ' test(s) took '.
+	self printRuntime: anInteger.
+	stream
+		nextPutAll: ' or more to run, not including ';
+		print: aCollection size;
+		nextPutAll: ' known laggards:';
+		cr.
+	newLaggards do: 
+			[:each |
+			stream tab.
+			self printRuntime: each value.
+			stream
+				tab;
+				print: each key;
+				cr]! !
+!TestRunConsoleLogger categoriesFor: #finishedCase:result:in:!logging!public! !
+!TestRunConsoleLogger categoriesFor: #finishedRun:in:knownSlowTests:!helpers!logging!public! !
+!TestRunConsoleLogger categoriesFor: #printRuntime:!helpers!private! !
+!TestRunConsoleLogger categoriesFor: #startingCase:!logging!public! !
+!TestRunConsoleLogger categoriesFor: #startingRun:!logging!public! !
+!TestRunConsoleLogger categoriesFor: #stream:!accessing!private! !
+!TestRunConsoleLogger categoriesFor: #summarizeFailures:!helpers!private! !
+!TestRunConsoleLogger categoriesFor: #summarizeTimings:baseline:!helpers!private! !
+
+!TestRunConsoleLogger class methodsFor!
+
+on: aPuttableStream
+	^(self new)
+		stream: aPuttableStream;
+		yourself! !
+!TestRunConsoleLogger class categoriesFor: #on:!public! !
+

--- a/Core/Object Arts/Dolphin/Base/TestRunLogger.cls
+++ b/Core/Object Arts/Dolphin/Base/TestRunLogger.cls
@@ -1,0 +1,32 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+Object subclass: #TestRunLogger
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+TestRunLogger guid: (GUID fromString: '{00fd980b-da74-44be-888f-6735ffb8e96b}')!
+TestRunLogger comment: ''!
+!TestRunLogger categoriesForClass!Kernel-Objects! !
+!TestRunLogger methodsFor!
+
+finishedCase: aTestCase result: aSymbol in: microsecondsInteger
+	^self subclassResponsibility!
+
+finishedCase: aTestCase runtime: anInteger
+	^self subclassResponsibility!
+
+finishedRun: aTestResult in: anInteger knownSlowTests: aCollection
+	self subclassResponsibility!
+
+startingCase: aTestCase
+	"By default, do nothing"!
+
+startingRun: aTestSuite
+	^self subclassResponsibility! !
+!TestRunLogger categoriesFor: #finishedCase:result:in:!private! !
+!TestRunLogger categoriesFor: #finishedCase:runtime:!public! !
+!TestRunLogger categoriesFor: #finishedRun:in:knownSlowTests:!helpers!public! !
+!TestRunLogger categoriesFor: #startingCase:!public! !
+!TestRunLogger categoriesFor: #startingRun:!public! !
+

--- a/Core/Object Arts/Dolphin/Base/TestRunLogger.cls
+++ b/Core/Object Arts/Dolphin/Base/TestRunLogger.cls
@@ -19,6 +19,11 @@ finishedCase: aTestCase runtime: anInteger
 finishedRun: aTestResult in: anInteger knownSlowTests: aCollection
 	self subclassResponsibility!
 
+slowTestThreshold
+	"Answer the execution time threshold, in milliseconds, over which tests are reported as slow."
+
+	^500!
+
 startingCase: aTestCase
 	"By default, do nothing"!
 
@@ -27,6 +32,7 @@ startingRun: aTestSuite
 !TestRunLogger categoriesFor: #finishedCase:result:in:!private! !
 !TestRunLogger categoriesFor: #finishedCase:runtime:!public! !
 !TestRunLogger categoriesFor: #finishedRun:in:knownSlowTests:!helpers!public! !
+!TestRunLogger categoriesFor: #slowTestThreshold!helpers!private! !
 !TestRunLogger categoriesFor: #startingCase:!public! !
 !TestRunLogger categoriesFor: #startingRun:!public! !
 


### PR DESCRIPTION
Move the logging functionality of CommandLineTestRunner out into a separate
hierarchy and support multiple loggers. This is to enable the introduction
of loggers that can emit test result files that can be uploaded to
AppVeyor, e.g in the junit xml format.