### PR TITLE
Fix #407: Cursor flash in scintilla editors

### DIFF
--- a/Core/Object Arts/Dolphin/Base/InputState.cls
+++ b/Core/Object Arts/Dolphin/Base/InputState.cls
@@ -30,7 +30,7 @@ Class Variables:
 aboutToForkUI
 	"Private - A new main UI process is being started. Reset any global UI state."
 
-	Smalltalk at: #Cursor ifPresent: [:cursorClass | cursorClass current: nil]!
+	Smalltalk at: #Cursor ifPresent: [:cursorClass | cursorClass reset]!
 
 aboutToIdle
 	"The message loop is about to go to sleep - perform any actions necessary before that

--- a/Core/Object Arts/Dolphin/IDE/Base/Splash/SeeingTheObjectsInside.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Splash/SeeingTheObjectsInside.cls
@@ -227,7 +227,7 @@ onLeftButtonPressed: aMouseEvent
 	self class splashPlayTheGame ifFalse: [^self dismiss].
 	(self isActionPoint: aMouseEvent position) 
 		ifTrue: 
-			[Cursor arrow makeCurrent.
+			[Cursor reset.
 			self dismiss]
 		ifFalse: [self showHintBubble]!
 

--- a/Core/Object Arts/Dolphin/MVP/Base/Cursor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Cursor.cls
@@ -28,6 +28,34 @@ makeCurrent
 
 	self class current: self!
 
+printOn: aStream
+	instanceHandle == 0
+		ifTrue: 
+			[(##((LookupTable new)
+				at: IDC_APPSTARTING put: #appStarting;
+				at: IDC_ARROW put: #arrow;
+				at: IDC_CROSS put: #cross;
+				at: IDC_HAND put: #hand;
+				at: IDC_HELP put: #help;
+				at: IDC_IBEAM put: #iBeam;
+				at: IDC_NO put: #no;
+				at: IDC_SIZEALL put: #sizeAll;
+				at: IDC_SIZENESW put: #sizeNESW;
+				at: IDC_SIZENS put: #sizeNS;
+				at: IDC_SIZENWSE put: #sizeNWSE;
+				at: IDC_SIZEWE put: #sizeWE;
+				at: IDC_UPARROW put: #upArrow;
+				at: IDC_WAIT put: #wait;
+				shrink) lookup: self identifier)
+				ifNotNil: 
+					[:name |
+					aStream
+						print: self class;
+						space;
+						nextPutAll: name.
+					^self]].
+	super printOn: aStream!
+
 setCursor
 	"Private - Set the receiver as the current Windows cursor. Answers the handle of the old
 	cursor."
@@ -48,6 +76,7 @@ showWhile: aBlock
 !Cursor categoriesFor: #imageType!constants!private! !
 !Cursor categoriesFor: #loadFromInstance:!private!realizing/unrealizing! !
 !Cursor categoriesFor: #makeCurrent!operations!public! !
+!Cursor categoriesFor: #printOn:!development!printing!public! !
 !Cursor categoriesFor: #setCursor!operations!private! !
 !Cursor categoriesFor: #showWhile:!operations!public! !
 
@@ -202,6 +231,11 @@ position
 	^pos asPoint
 !
 
+reset
+	"Clear the global cursor setting. Answers the previous global cursor (or nil if none)."
+
+	^self current: nil!
+
 show
 	"Shows the current cursor"
 
@@ -301,6 +335,7 @@ wait
 !Cursor class categoriesFor: #no!instance creation!public! !
 !Cursor class categoriesFor: #onPreStripImage!class hierarchy-removing!private! !
 !Cursor class categoriesFor: #position!accessing!public! !
+!Cursor class categoriesFor: #reset!initializing!public! !
 !Cursor class categoriesFor: #show!operations!public! !
 !Cursor class categoriesFor: #show:!operations!public! !
 !Cursor class categoriesFor: #sizeAll!instance creation!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/InternalDragDropSession.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/InternalDragDropSession.cls
@@ -248,7 +248,7 @@ startTrackingAt: aPoint
 	"Initially we must be over the drag source"
 	dropTarget := self dropTargetUnder: aPoint.
 	self dropTargetEnter.
-	oldCursor := Cursor current: nil.
+	oldCursor := Cursor reset.
 	self beginDragImage.
 	self giveFeedback.
 	^self dragPoint! !


### PR DESCRIPTION
Caused by the SeeingTheObjectsInside splash setting the global cursor when
it is dismissed. It should rather be clearing the global cursor it set
previously (or ideally overriding #onGetCursor:, and not setting the global
cursor at all since the global cursor mechanism is not really intended for
the purpose of setting a temporary cursor which the mouse is over a
particular area of a window). I've fixed it the cheaper way.
Also improved the printString of system cursors, as this makes it easier
to tell what is going on when such issues arise.