### PR TITLE
Pen and Touch not working in Windows 8.1 and 10 #404 

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Win32Constants.st
+++ b/Core/Object Arts/Dolphin/Base/Win32Constants.st
@@ -575,7 +575,7 @@ Win32Constants at: 'PS_SOLID' put: 16r0!
 Win32Constants at: 'PS_STYLEMASK' put: 16rF!
 Win32Constants at: 'PS_TYPEMASK' put: 16rF0000!
 Win32Constants at: 'PS_USERSTYLE' put: 16r7!
-Win32Constants at: 'QS_ALLINPUT' put: 16rFF!
+Win32Constants at: 'QS_ALLINPUT' put: 16r1CFF!
 Win32Constants at: 'RDW_ALLCHILDREN' put: 16r80!
 Win32Constants at: 'RDW_ERASE' put: 16r4!
 Win32Constants at: 'RDW_ERASENOW' put: 16r200!

--- a/FetchVM.ps1
+++ b/FetchVM.ps1
@@ -4,7 +4,7 @@
 
 param 
 (
-    [string]$VMversion="v7.0.41"
+    [string]$VMversion="v7.0.42"
 )
 
 Try 


### PR DESCRIPTION
Apply @andygraham's suggestion of updating the QS_ALLINPUT constant. This also needs to be done in the VM, so there is a new v7.0.42 build.