### PR TITLE
Some CRTLibrary functions are insecure and deprecated #416

### DIFF
--- a/Core/Object Arts/Dolphin/Base/CRTConstants.st
+++ b/Core/Object Arts/Dolphin/Base/CRTConstants.st
@@ -40,6 +40,7 @@ CRTConstants at: '_PC_64' put: 16r0!
 CRTConstants at: '_S_IEXEC' put: 16r40!
 CRTConstants at: '_S_IREAD' put: 16r100!
 CRTConstants at: '_S_IWRITE' put: 16r80!
+CRTConstants at: '_TRUNCATE' put: -16r1!
 CRTConstants at: 'EBADF' put: 16r9!
 CRTConstants at: 'EINVAL' put: 16r16!
 CRTConstants at: 'RAND_MAX' put: 16r7FFF!

--- a/Core/Object Arts/Dolphin/Base/CRTError.cls
+++ b/Core/Object Arts/Dolphin/Base/CRTError.cls
@@ -5,7 +5,7 @@ Error subclass: #CRTError
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-CRTError guid: (GUID fromString: '{259AE719-09C3-4401-A9BE-6F089698B6F7}')!
+CRTError guid: (GUID fromString: '{259ae719-09c3-4401-a9be-6f089698b6f7}')!
 CRTError comment: 'Exception to represent C-runtime library errors.'!
 !CRTError categoriesForClass!System-Exception Handling! !
 !CRTError methodsFor!
@@ -44,7 +44,14 @@ messageText
 strerror
 	"Answer a <readableString> description of the receiver's error number."
 
-	^CRTLibrary default strerror: self errno! !
+	| buf |
+	buf := String newFixed: 80.
+	^(CRTLibrary default
+		strerror_s: buf
+		bufferSize: buf size + 1
+		errnum: self errno) == 0
+		ifTrue: [buf trimNulls]
+		ifFalse: [self errno printString]! !
 !CRTError categoriesFor: #_descriptionArguments!displaying!public! !
 !CRTError categoriesFor: #_descriptionFormat!displaying!public! !
 !CRTError categoriesFor: #errno!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/CRTLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/CRTLibrary.cls
@@ -60,9 +60,8 @@ _close: anInteger
 	<cdecl: sdword _close sdword>
 	^self invalidCall!
 
-_controlfp: newInteger mask: maskInteger
-	<cdecl: dword _controlfp dword dword>
-	#deprecated.	"Insecure - see MSDN"
+_controlfp_s: currentControl newControl: newInteger mask: maskInteger
+	<cdecl: sdword _controlfp_s dword* dword dword>
 	^self invalidCall!
 
 _dup: anInteger 
@@ -120,9 +119,8 @@ _fpclass: aFloat
 	<cdecl: sdword _fpclass double>
 	^self invalidCall!
 
-_gcvt: aFloat count: anInteger buffer: aString
-	<cdecl: char* _gcvt double sdword char*>
-	#deprecated.	"Insecure - see MSDN"
+_gcvt_s: aString bufferSize: sizeInteger value: aFloat digits: digitsInteger
+	<cdecl: sdword _gcvt_s char* intptr double sdword>
 	^self invalidCall!
 
 _get_osfhandle: anInteger
@@ -142,9 +140,8 @@ _logb: aFloat
 	<cdecl: double _logb double>
 	^self invalidCall!
 
-_makepath: path drive: drive dir: dir fname: fname ext: ext
-	<cdecl: void _makepath char* char* char* char* char*>
-	#deprecated.	"Insecure - see MSDN"
+_makepath_s: path bufferSize: sizeInBytes drive: drive dir: dir fname: fname ext: ext
+	<cdecl: sdword _makepath_s char* intptr char* char* char* char*>
 	^self invalidCall!
 
 _open_osfhandle: osfhandle flags: flags
@@ -183,9 +180,8 @@ _spawnvp: mode cmdname: aString argv: argv
 [CRTLibrary default _spawnvp: 0 cmdname: 'command.com' argv: DWORD new.0] fork
 "!
 
-_splitpath: path drive: drive dir: dir fname: fname ext: ext
-	<cdecl: void _splitpath char* char* char* char* char*>
-	#deprecated.	"Insecure - see MSDN"
+_splitpath_s: path drive: drive driveLen: driveInteger dir: dir dirLen: dirInteger fname: fname fnameLen: nameInteger ext: ext extLen: extInteger
+	<cdecl: sdword _splitpath_s char* char* intptr char* intptr char* intptr char* intptr>
 	^self invalidCall!
 
 _stricmp: string1 string2: string2
@@ -342,23 +338,16 @@ floor: aFloat
 	<cdecl: double floor double>
 	^self invalidCall!
 
-fopen: nameString mode: modeString
-	<cdecl: handle fopen lpstr lpstr>
-	#deprecated.	"Insecure - see MSDN"
+fopen_s: pFile filename: nameString mode: modeString
+	<cdecl: sdword fopen_s handle* lpstr lpstr>
 	^self invalidCall!
 
 fputc: charValue stream: aFILE
 	<cdecl: sdword fputc sdword handle>
 	^self invalidCall!
 
-fread: buffer size: size count: count stream: aFILE
-	<overlap cdecl: sdword fread lpvoid intptr intptr handle>
-	#deprecated.	"Insecure - see MSDN"
-	^self invalidCall!
-
-freopen: pathString mode: modeString stream: anExternalHandle
-	<cdecl: handle freopen char* char* handle>
-	#deprecated.	"Insecure - see MSDN"
+fread_s: buffer bufferSize: bufsizeInteger elementSize: elemSizeInteger count: countInteger stream: aFILE
+	<overlap cdecl: sdword fread_s lpvoid intptr intptr intptr handle>
 	^self invalidCall!
 
 frexp: x expptr: expptr
@@ -507,11 +496,8 @@ srand: anInteger
 	<cdecl: void srand dword>
 	^self invalidCall!
 
-strcat: strDestination strSource: strSource
-	"Be careful: Buffer overruns a distinct possibility if you use this function!!"
-
-	<cdecl: lpstr strcat lpstr lpstr>
-	#deprecated.	"Insecure - see MSDN"
+strcat_s: destString bufferSize: anInteger strSource: sourceString
+	<cdecl: sdword strcat_s lpstr intptr lpstr>
 	^self invalidCall!
 
 strcmp: string1 string2: string2 
@@ -527,11 +513,8 @@ strcspn: string strCharSet: strCharSet
 	<cdecl: dword strcspn lpvoid char*>
 	^self invalidCall!
 
-strerror: errno
-	"Answer a <readableString> description of the specified <integer> CRT error number."
-
-	<cdecl: lpstr strerror sdword>
-	#deprecated.	"Insecure - see MSDN"
+strerror_s: aString bufferSize: sizeInteger errnum: errnoInteger
+	<cdecl: sdword strerror_s lpstr intptr sdword>
 	^self invalidCall!
 
 strncmp: string1 string2: string2 count: count
@@ -544,9 +527,8 @@ strncmp: string1 string2: string2 count: count
 	<cdecl: sdword strncmp lpstr lpstr intptr>
 	^self invalidCall!
 
-strncpy: strDest strSource: strSource count: count
-	<cdecl: lpvoid strncpy lpvoid lpvoid intptr>
-	#deprecated.	"Insecure - see MSDN"
+strncpy_s: desString bufferSize: anInteger strSource: sourceString count: countInteger
+	<cdecl: lpvoid strncpy_s lpvoid intptr lpvoid intptr>
 	^self invalidCall!
 
 strpbrk: string strCharSet: strCharSet
@@ -565,13 +547,13 @@ synchronizeLocale
 
 	| buf |
 	self setlocale: 0 locale: ''.
-	buf := String new: 10.
-	buf := self _gcvt: 0 count: 2 buffer: buf.
-	decimalSeparator := buf copyFrom: 2
-
-
-
-!
+	buf := String newFixed: 10.
+	self
+		_gcvt_s: buf
+		bufferSize: buf size + 1
+		value: 0.0
+		digits: 2.
+	decimalSeparator := buf copyFrom: 2 to: 2!
 
 tan: aFloat
 	"Answer the Tangent of the argument, aFloat."
@@ -602,7 +584,7 @@ wcscspn: aUnicodeString strCharSet: strCharSet
 !CRTLibrary categoriesFor: #_chmod:pmode:!CRT functions-file handling!public! !
 !CRTLibrary categoriesFor: #_clearfp!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_close:!CRT functions-low level I/O!public! !
-!CRTLibrary categoriesFor: #_controlfp:mask:!CRT functions-floating point support!public! !
+!CRTLibrary categoriesFor: #_controlfp_s:newControl:mask:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_dup:!CRT functions-low level I/O!public! !
 !CRTLibrary categoriesFor: #_dup2:handle2:!CRT functions-low level I/O!public! !
 !CRTLibrary categoriesFor: #_eof:!CRT functions-file handling!public! !
@@ -612,17 +594,17 @@ wcscspn: aUnicodeString strCharSet: strCharSet
 !CRTLibrary categoriesFor: #_fileno:!CRT functions-stream I/O!public! !
 !CRTLibrary categoriesFor: #_finite:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_fpclass:!CRT functions-floating point support!public! !
-!CRTLibrary categoriesFor: #_gcvt:count:buffer:!CRT functions-floating point support!public! !
+!CRTLibrary categoriesFor: #_gcvt_s:bufferSize:value:digits:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_get_osfhandle:!CRT functions-file handling!public! !
 !CRTLibrary categoriesFor: #_getcwd:maxlen:!CRT functions-directory control!public! !
 !CRTLibrary categoriesFor: #_logb:!CRT functions-floating point support!public! !
-!CRTLibrary categoriesFor: #_makepath:drive:dir:fname:ext:!CRT functions-file handling!public! !
+!CRTLibrary categoriesFor: #_makepath_s:bufferSize:drive:dir:fname:ext:!CRT functions-file handling!public! !
 !CRTLibrary categoriesFor: #_open_osfhandle:flags:!CRT functions-file handling!public! !
 !CRTLibrary categoriesFor: #_rotl:shift:!CRT functions-bit manipulation!public! !
 !CRTLibrary categoriesFor: #_rotr:shift:!CRT functions-bit manipulation!public! !
 !CRTLibrary categoriesFor: #_setmode:mode:!CRT functions-file handling!public! !
 !CRTLibrary categoriesFor: #_spawnvp:cmdname:argv:!CRT functions-process and environment control!public! !
-!CRTLibrary categoriesFor: #_splitpath:drive:dir:fname:ext:!CRT functions-file handling!public! !
+!CRTLibrary categoriesFor: #_splitpath_s:drive:driveLen:dir:dirLen:fname:fnameLen:ext:extLen:!CRT functions-file handling!public! !
 !CRTLibrary categoriesFor: #_stricmp:string2:!CRT functions-string manipulation!public! !
 !CRTLibrary categoriesFor: #_stricoll:string2:!CRT functions-string manipulation!public! !
 !CRTLibrary categoriesFor: #_strnicmp:string2:count:!CRT functions-string manipulation!public! !
@@ -645,10 +627,9 @@ wcscspn: aUnicodeString strCharSet: strCharSet
 !CRTLibrary categoriesFor: #fgetc:!CRT functions-stream I/O!public! !
 !CRTLibrary categoriesFor: #fgets:n:stream:!CRT functions-stream I/O!public! !
 !CRTLibrary categoriesFor: #floor:!CRT functions-floating point support!public! !
-!CRTLibrary categoriesFor: #fopen:mode:!CRT functions-stream I/O!public! !
+!CRTLibrary categoriesFor: #fopen_s:filename:mode:!CRT functions-stream I/O!public! !
 !CRTLibrary categoriesFor: #fputc:stream:!CRT functions-stream I/O!public! !
-!CRTLibrary categoriesFor: #fread:size:count:stream:!CRT functions-stream I/O!public! !
-!CRTLibrary categoriesFor: #freopen:mode:stream:!CRT functions-stream I/O!public! !
+!CRTLibrary categoriesFor: #fread_s:bufferSize:elementSize:count:stream:!CRT functions-stream I/O!public! !
 !CRTLibrary categoriesFor: #frexp:expptr:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #fseek:offset:origin:!CRT functions-stream I/O!public! !
 !CRTLibrary categoriesFor: #ftell:!CRT functions-stream I/O!public! !
@@ -671,12 +652,12 @@ wcscspn: aUnicodeString strCharSet: strCharSet
 !CRTLibrary categoriesFor: #sin:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #sqrt:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #srand:!CRT functions-floating point support!public! !
-!CRTLibrary categoriesFor: #strcat:strSource:!CRT functions-string manipulation!public! !
+!CRTLibrary categoriesFor: #strcat_s:bufferSize:strSource:!CRT functions-string manipulation!public! !
 !CRTLibrary categoriesFor: #strcmp:string2:!CRT functions-string manipulation!public! !
 !CRTLibrary categoriesFor: #strcspn:strCharSet:!CRT functions-string manipulation!public! !
-!CRTLibrary categoriesFor: #strerror:!CRT functions-string manipulation!public! !
+!CRTLibrary categoriesFor: #strerror_s:bufferSize:errnum:!CRT functions-string manipulation!public! !
 !CRTLibrary categoriesFor: #strncmp:string2:count:!CRT functions-string manipulation!public! !
-!CRTLibrary categoriesFor: #strncpy:strSource:count:!CRT functions-string manipulation!public! !
+!CRTLibrary categoriesFor: #strncpy_s:bufferSize:strSource:count:!CRT functions-string manipulation!public! !
 !CRTLibrary categoriesFor: #strpbrk:strCharSet:!CRT functions-string manipulation!public! !
 !CRTLibrary categoriesFor: #synchronizeLocale!CRT functions-localization!private! !
 !CRTLibrary categoriesFor: #tan:!CRT functions-floating point support!public! !

--- a/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
@@ -27,13 +27,23 @@ package methodNames
 	add: #Behavior -> #makeIndirect;
 	add: #Behavior -> #makeNullTerminated;
 	add: #Class -> #addClassVarName:;
+	add: #CRTLibrary -> #_controlfp:mask:;
 	add: #CRTLibrary -> #_ecvt:count:dec:sign:;
+	add: #CRTLibrary -> #_gcvt:count:buffer:;
 	add: #CRTLibrary -> #_i64toa:string:radix:;
 	add: #CRTLibrary -> #_ltoa:string:radix:;
+	add: #CRTLibrary -> #_makepath:drive:dir:fname:ext:;
 	add: #CRTLibrary -> #_putenv:;
+	add: #CRTLibrary -> #_splitpath:drive:dir:fname:ext:;
+	add: #CRTLibrary -> #fopen:mode:;
+	add: #CRTLibrary -> #fread:size:count:stream:;
+	add: #CRTLibrary -> #freopen:mode:stream:;
 	add: #CRTLibrary -> #getenv:;
 	add: #CRTLibrary -> #memcpy:src:count:;
 	add: #CRTLibrary -> #memmove:src:count:;
+	add: #CRTLibrary -> #strcat:strSource:;
+	add: #CRTLibrary -> #strerror:;
+	add: #CRTLibrary -> #strncpy:strSource:count:;
 	add: #ExternalStructure -> #do:;
 	add: #ExternalStructure -> #do:separatedBy:;
 	add: #Integer -> #digitSize;
@@ -49,6 +59,7 @@ package methodNames
 	add: 'ExternalCallback class' -> #receiver:selector:;
 	add: 'ExternalCallback class' -> #receiver:selector:closure:;
 	add: 'ExternalDescriptor class' -> #oneStringArg;
+	add: 'File class' -> #change:extension:;
 	add: 'File class' -> #for:inAndBelow:do:;
 	yourself.
 
@@ -152,9 +163,19 @@ addClassVarName: aString
 
 !CRTLibrary methodsFor!
 
+_controlfp: newInteger mask: maskInteger
+	<cdecl: dword _controlfp dword dword>
+	#deprecated.	"Insecure - use _controlfp_s"
+	^self invalidCall!
+
 _ecvt: aFloat count: anInteger dec: decInteger sign: signInteger
 	<cdecl: lpstr _ecvt double sdword sdword* sdword*>
-	#deprecated.	"Insecure - see MSDN"
+	#deprecated.	"This function is considered insecure and should not be used - see MSDN"
+	^self invalidCall!
+
+_gcvt: aFloat count: anInteger buffer: aString
+	<cdecl: char* _gcvt double sdword char*>
+	#deprecated.	"Insecure - use _gcvt_s"
 	^self invalidCall!
 
 _i64toa: aSmallInteger string: aString radix: anInteger
@@ -167,9 +188,34 @@ _ltoa: aSmallInteger string: aString radix: anInteger
 	#deprecated.	"Insecure - see MSDN"
 	^self invalidCall!
 
+_makepath: path drive: drive dir: dir fname: fname ext: ext
+	<cdecl: void _makepath char* char* char* char* char*>
+	#deprecated.	"Insecure. Use #_makepath_s:sizeInBytes:drive:dir:fname:ext:"
+	^self invalidCall!
+
 _putenv: aString
 	<cdecl: sdword _putenv lpstr>
 	#deprecated.	"Insecure - see MSDN"
+	^self invalidCall!
+
+_splitpath: path drive: drive dir: dir fname: fname ext: ext
+	<cdecl: void _splitpath char* char* char* char* char*>
+	#deprecated.	"Insecure - use _splitpath_s"
+	^self invalidCall!
+
+fopen: nameString mode: modeString
+	<cdecl: handle fopen lpstr lpstr>
+	#deprecated.	"Insecure - use fopen_s"
+	^self invalidCall!
+
+fread: buffer size: size count: count stream: aFILE
+	<overlap cdecl: sdword fread lpvoid intptr intptr handle>
+	#deprecated.	"Insecure - use fread_s"
+	^self invalidCall!
+
+freopen: pathString mode: modeString stream: anExternalHandle
+	<cdecl: handle freopen char* char* handle>
+	#deprecated.	"Insecured - see MSDN"
 	^self invalidCall!
 
 getenv: varname
@@ -185,14 +231,39 @@ memcpy: dest src: src count: count
 memmove: dest src: src count: count
 	<cdecl: void* memmove void* void* intptr>
 	#deprecated.	"Insecure - see MSDN"
+	^self invalidCall!
+
+strcat: strDestination strSource: strSource
+	<cdecl: lpstr strcat lpstr lpstr>
+	#deprecated.	"This function may cause buffer overruns so is insecure. Use strcat_s instead."
+	^self invalidCall!
+
+strerror: errno
+	<cdecl: lpstr strerror sdword>
+	#deprecated.	"Insecure - see MSDN"
+	^self invalidCall!
+
+strncpy: strDest strSource: strSource count: count
+	<cdecl: lpvoid strncpy lpvoid lpvoid intptr>
+	#deprecated.	"Insecure - see MSDN"
 	^self invalidCall! !
+!CRTLibrary categoriesFor: #_controlfp:mask:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_ecvt:count:dec:sign:!CRT functions-floating point support!public! !
+!CRTLibrary categoriesFor: #_gcvt:count:buffer:!CRT functions-floating point support!public! !
 !CRTLibrary categoriesFor: #_i64toa:string:radix:!CRT functions-data conversion!public! !
 !CRTLibrary categoriesFor: #_ltoa:string:radix:!CRT functions-data conversion!public! !
+!CRTLibrary categoriesFor: #_makepath:drive:dir:fname:ext:!CRT functions-file handling!public! !
 !CRTLibrary categoriesFor: #_putenv:!CRT functions-process and environment control!public! !
+!CRTLibrary categoriesFor: #_splitpath:drive:dir:fname:ext:!CRT functions-file handling!public! !
+!CRTLibrary categoriesFor: #fopen:mode:!CRT functions-stream I/O!public! !
+!CRTLibrary categoriesFor: #fread:size:count:stream:!CRT functions-stream I/O!public! !
+!CRTLibrary categoriesFor: #freopen:mode:stream:!CRT functions-stream I/O!public! !
 !CRTLibrary categoriesFor: #getenv:!CRT functions-process and environment control!public! !
 !CRTLibrary categoriesFor: #memcpy:src:count:!CRT functions-buffer manipulation!public! !
 !CRTLibrary categoriesFor: #memmove:src:count:!CRT functions-buffer manipulation!public! !
+!CRTLibrary categoriesFor: #strcat:strSource:!CRT functions-string manipulation!public! !
+!CRTLibrary categoriesFor: #strerror:!CRT functions-string manipulation!public! !
+!CRTLibrary categoriesFor: #strncpy:strSource:count:!CRT functions-string manipulation!public! !
 
 !ExternalCallback class methodsFor!
 
@@ -247,12 +318,17 @@ do: operation separatedBy: separator
 
 !File class methodsFor!
 
+change: aPathnameString extension: anExtensionString
+	#deprecated.	"use #path:extension:"
+	^self path: aPathnameString extension: anExtensionString!
+
 for: matchString inAndBelow: dirString do: operation
 	#deprecated.	"Use #forAll:in:do:"
 	^self 
 		forAll: matchString
 		in: dirString
 		do: [:each | operation value: each directory value: each]! !
+!File class categoriesFor: #change:extension:!filename manipulation!public! !
 !File class categoriesFor: #for:inAndBelow:do:!enumerating!public! !
 
 !Integer methodsFor!

--- a/Core/Object Arts/Dolphin/Base/DiskVolumeInformation.cls
+++ b/Core/Object Arts/Dolphin/Base/DiskVolumeInformation.cls
@@ -1,11 +1,11 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #DiskVolumeInformation
 	instanceVariableNames: 'path rootPath label serialNumber maxComponentLength fileSystemFlags fileSystemName sectorsPerCluster bytesPerSector freeClusters totalClusters freeBytes totalBytes totalFreeBytes'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-DiskVolumeInformation guid: (GUID fromString: '{3DE35CEE-9281-49C6-9BD5-7141432D16E4}')!
+DiskVolumeInformation guid: (GUID fromString: '{3de35cee-9281-49c6-9bd5-7141432d16e4}')!
 DiskVolumeInformation comment: 'DiskVolumeInformation can be used to access various statistics and various other items of information available through the Win32 API about disk volumes, for example the disk volumne label and serial number of the disk in a particular drive.
 
 Example Usage:
@@ -222,7 +222,8 @@ printOn: target
 rootPath
 	"Answer the value of the receiver's ''rootPath'' instance variable."
 
-	rootPath isNil ifTrue: [rootPath :=  (File splitPath: path) first asUppercase copyWith: File pathDelimiter].
+	rootPath isNil
+		ifTrue: [rootPath := (File splitDriveFrom: path) asUppercase copyWith: File pathDelimiter].
 	^rootPath!
 
 sectorsPerCluster

--- a/Core/Object Arts/Dolphin/Base/File.cls
+++ b/Core/Object Arts/Dolphin/Base/File.cls
@@ -5,7 +5,7 @@ Object subclass: #File
 	classVariableNames: 'CheckModes NoCheckModes OpenFlagsMask ShareModes'
 	poolDictionaries: 'CRTConstants Win32Constants Win32Errors'
 	classInstanceVariableNames: ''!
-File guid: (GUID fromString: '{87B4C48A-026E-11D3-9FD7-00A0CC3E4A32}')!
+File guid: (GUID fromString: '{87b4c48a-026e-11d3-9fd7-00a0cc3e4a32}')!
 File comment: ''!
 !File categoriesForClass!System-Support! !
 !File methodsFor!
@@ -528,15 +528,6 @@ appendPathDelimiter: aString
 attributes: aFileNameString
 	^KernelLibrary default getFileAttributes: aFileNameString!
 
-change: aPathnameString extension: anExtensionString
- 	"Changes the extension of aPathnameString to anExtensionString.
-	Answers the new filename"
-
-	| components |
-	components := self splitPath: aPathnameString.
-	components at: 4 put: anExtensionString.
-	^self makePath: components!
-
 commonPrefixOf: path1 and: path2
 	"Answer the <readableString> common prefix shared between the two paths.
 	This will be empty if the paths share no common prefix."
@@ -953,19 +944,35 @@ locateFilename: aFilenameString in: searchPath
 	^aFilenameString!
 
 makePath: anArray
-	"Private - Composes a full pathname from its path, stem and extension components.
+	"Composes a full pathname from its path, stem and extension components.
 	The path and extension components can be nil or the empty string if the path
 	does not have either of these components. The stem must be a non-empty String."
 
-	| path |
-	path := self pathBuffer.
-	CRTLibrary default 
-		_makepath: path 
-			drive: (anArray at: 1) 
-			dir: (anArray at: 2) 
-			fname: (anArray at: 3) 
-			ext: (anArray at: 4).
-	^path trimNulls!
+	| size drive dir fname ext path errno |
+	size := 0.
+	(drive := anArray at: 1)
+		ifNotNil: 
+			["Assume the drive doesn't have the colon and that _makepath_s will add it"
+			size := drive size + 1].
+	(dir := anArray at: 2)
+		ifNotNil: 
+			["Assume the terminating path separator is missing"
+			size := size + dir size + 1].
+	(fname := anArray at: 3) ifNotNil: [size := size + fname size].
+	(ext := anArray at: 4)
+		ifNotNil: 
+			["Assume the dot is missing"
+			size := size + ext size + 1].
+	path := String newFixed: size.
+	^(errno := CRTLibrary default
+				_makepath_s: path
+				bufferSize: size + 1
+				drive: drive
+				dir: dir
+				fname: fname
+				ext: ext) == 0
+		ifTrue: [path trimNulls]
+		ifFalse: [CRTError signalWith: errno]!
 
 maxPath
 	"Answers the maximum number of characters in a file pathname"
@@ -1062,24 +1069,29 @@ removeDirectory: aString
 removeExtension: aString
 	"Answer a <readableString> which is the path argument with the extension component removed."
 
-	| drive dir fname path |
-	aString isNil ifTrue: [^self error: 'nil path'].
-	drive := String new: _MAX_DRIVE.
-	dir := String new: _MAX_DIR.
-	fname := String new: _MAX_FNAME.
-	path := String new: aString size.
-	(CRTLibrary default)
-		_splitpath: aString
-			drive: drive
-			dir: dir
-			fname: fname
-			ext: nil;
-		_makepath: path
-			drive: drive
-			dir: dir
-			fname: fname
-			ext: nil.
-	^path trimNulls!
+	| drive dir fname errno max |
+	max := aString size.
+	(errno := CRTLibrary default
+				_splitpath_s: aString
+				drive: (drive := String new: _MAX_DRIVE)
+				driveLen: ##(_MAX_DRIVE + 1)
+				dir: (dir := String new: max)
+				dirLen: max + 1
+				fname: (fname := String new: max)
+				fnameLen: max + 1
+				ext: nil
+				extLen: 0) == 0
+		ifTrue: 
+			[| path |
+			(errno := CRTLibrary default
+						_makepath_s: (path := String new: max)
+						bufferSize: max + 1
+						drive: drive
+						dir: dir
+						fname: fname
+						ext: nil) == 0
+				ifTrue: [^path trimNulls]].
+	^CRTError signalWith: errno!
 
 removePathDelimiter: aString
 	"Answer a <readableString> that is the argument with a path separator at its end, if any, removed."
@@ -1154,54 +1166,98 @@ shortPathOf: aPathnameString
 			KernelLibrary default systemError].
 	^shortpath trimNulls!
 
+splitDriveFrom: aString
+	"Splits the pathname, aString, and answers the drive portion.
+	Answers an empty string if there is no drive component in the path."
+
+	| drive errno |
+	^(errno := CRTLibrary default
+				_splitpath_s: aString
+				drive: (drive := String new: _MAX_DRIVE)
+				driveLen: ##(_MAX_DRIVE + 1)
+				dir: nil
+				dirLen: 0
+				fname: nil
+				fnameLen: 0
+				ext: nil
+				extLen: 0) == 0
+		ifTrue: [drive trimNulls]
+		ifFalse: [CRTError signalWith: errno]!
+
 splitExtensionFrom: aString
 	"Splits aPathname string and answers the extension portion.
 	Answers the empty string if there is no extension."
 
-	^(self splitPath: aString) at: 4
-!
+	| ext errno |
+	ext := String new: aString size.
+	(errno := CRTLibrary default
+				_splitpath_s: aString
+				drive: nil
+				driveLen: 0
+				dir: nil
+				dirLen: 0
+				fname: nil
+				fnameLen: 0
+				ext: ext
+				extLen: ext size + 1) == 0
+		ifFalse: [^CRTError signalWith: errno].
+	"CRT function includes leading period on extension, which we don't"
+	ext := ext trimNulls.
+	^(ext notEmpty and: [ext first == $.]) ifTrue: [ext copyFrom: 2] ifFalse: [ext]!
 
 splitFilenameFrom: aString
-	"Splits aPathname string and answers the file name portion (including extension). Answers an
-	empty string if there is no file stem."
+	"Splits the pathname, aString, and answers the file name portion (including extension).
+	Answers an empty string if there is no filename component in the path."
 
-	| splits |
-	splits := self splitPath: aString.
-	splits
-		at: 1 put: nil;
-		at: 2 put: nil.
-	^self makePath: splits!
+	| fname ext errno max |
+	max := aString size.
+	(errno := CRTLibrary default
+				_splitpath_s: aString
+				drive: nil
+				driveLen: 0
+				dir: nil
+				dirLen: 0
+				fname: (fname := String new: aString size)
+				fnameLen: max + 1
+				ext: (ext := String new: max)
+				extLen: max + 1) == 0
+		ifTrue: 
+			[(errno := CRTLibrary default
+						strcat_s: fname
+						bufferSize: max + 1
+						strSource: ext) == 0
+				ifTrue: [^fname trimNulls]].
+	^CRTError signalWith: errno!
 
-splitPath: aString 
-	"Private - Splits aPathname string into its path, stem and extension components and answers 
+splitPath: aString
+	"Splits the pathname, aString, into its path, stem and extension components and answers 
 	a four element Array of these.
 	Note: We use the C-runtime library to implement this, hence either backward or forward
 	slashes (i.e. $\ or $/) are acceptable as pathname delimiters."
 
-	"Prevent GPF for common error case of nil argument"
+	| drive dir fname ext errno |
+	^(errno := CRTLibrary default
+				_splitpath_s: aString
+				drive: (drive := String new: _MAX_DRIVE)
+				driveLen: ##(_MAX_DRIVE + 1)
+				dir: (dir := String new: _MAX_DIR)
+				dirLen: ##(_MAX_DIR + 1)
+				fname: (fname := String new: _MAX_FNAME)
+				fnameLen: ##(_MAX_FNAME + 1)
+				ext: (ext := String new: _MAX_EXT)
+				extLen: ##(_MAX_EXT + 1)) == 0
+		ifTrue: 
+			["CRT function includes leading period on extension, which we don't"
+			ext := ext trimNulls.
+			(ext notEmpty and: [ext first == $.]) ifTrue: [ext := ext copyFrom: 2].
+			Array
+				with: drive trimNulls
+				with: dir trimNulls
+				with: fname trimNulls
+				with: ext]
+		ifFalse: [CRTError signalWith: errno]!
 
-	| drive dir fname ext |
-	aString isNil ifTrue: [^self error: 'nil path'].
-	drive := String new: _MAX_DRIVE.
-	dir := String new: _MAX_DIR.
-	fname := String new: _MAX_FNAME.
-	ext := String new: _MAX_EXT.	"may be more than 3 chars now"
-	CRTLibrary default 
-		_splitpath: aString
-		drive: drive
-		dir: dir
-		fname: fname
-		ext: ext.
-	"CRT function includes leading period on extension, which we don't"
-	ext := ext trimNulls.
-	(ext notEmpty and: [ext first == $.]) ifTrue: [ext := ext copyFrom: 2].
-	^Array 
-		with: drive trimNulls
-		with: dir trimNulls
-		with: fname trimNulls
-		with: ext!
-
-splitPathFrom: aPathnameString 
+splitPathFrom: aPathnameString
 	"Splits aPathname string and answers the path portion (including the drive letter, if any).
 	Answers an  empty <String> if there is no path."
 
@@ -1209,26 +1265,42 @@ splitPathFrom: aPathnameString
 	API call, PathRemoveFileSpec() does not treat $/ as a path delimiter (only backslash).
 	Also this is carefully implemented to minimise allocations and maximise speed."
 
-	| drive dir |
-	aPathnameString isNil 
+	| drive dir errno |
+	(errno := CRTLibrary default
+				_splitpath_s: aPathnameString
+				drive: (drive := String new: _MAX_PATH)
+				driveLen: ##(_MAX_DRIVE + 1)
+				dir: (dir := String new: _MAX_DIR)
+				dirLen: ##(_MAX_DIR + 1)
+				fname: nil
+				fnameLen: 0
+				ext: nil
+				extLen: 0) == 0
 		ifTrue: 
-			["Passing a null pointer to _splitpath() will cause an unfriendly GPF"
-			self error: 'nil path'].
-	drive := String new: _MAX_DRIVE + aPathnameString size.
-	dir := String new: aPathnameString size.
-	^(CRTLibrary default)
-		_splitpath: aPathnameString
-			drive: drive
-			dir: dir
-			fname: nil
-			ext: nil;
-		strcat: drive strSource: dir!
+			[(errno := CRTLibrary default
+						strcat_s: drive
+						bufferSize: ##(_MAX_PATH + 1)
+						strSource: dir) == 0
+				ifTrue: [^drive trimNulls]].
+	^CRTError signalWith: errno!
 
-splitStemFrom: aString 
+splitStemFrom: aString
 	"Answers the file stem component of the path <String> argument, or an empty string if there
 	is none."
 
-	^(self splitPath: aString) at: 3!
+	| fname errno |
+	^(errno := CRTLibrary default
+				_splitpath_s: aString
+				drive: nil
+				driveLen: 0
+				dir: nil
+				dirLen: 0
+				fname: (fname := String new: _MAX_FNAME)
+				fnameLen: ##(_MAX_FNAME + 1)
+				ext: nil
+				extLen: 0) == 0
+		ifTrue: [fname trimNulls]
+		ifFalse: [CRTError signalWith: errno]!
 
 temporary
 	"Open a temporary file with a unique name generated by the system, for
@@ -1284,7 +1356,6 @@ workingDirectory: aString
 	^CRTLibrary default _chdir: aString! !
 !File class categoriesFor: #appendPathDelimiter:!filename manipulation!public!testing! !
 !File class categoriesFor: #attributes:!file operations!public! !
-!File class categoriesFor: #change:extension:!filename manipulation!public! !
 !File class categoriesFor: #commonPrefixOf:and:!filename manipulation!public! !
 !File class categoriesFor: #composePath:stem:extension:!filename manipulation!public! !
 !File class categoriesFor: #composePath:subPath:!filename manipulation!public! !
@@ -1317,7 +1388,7 @@ workingDirectory: aString
 !File class categoriesFor: #isWriteable:set:!file operations!public! !
 !File class categoriesFor: #lastWriteTime:!enquiries!public! !
 !File class categoriesFor: #locateFilename:in:!filename manipulation!public! !
-!File class categoriesFor: #makePath:!filename manipulation!private! !
+!File class categoriesFor: #makePath:!filename manipulation!public! !
 !File class categoriesFor: #maxPath!constants!public! !
 !File class categoriesFor: #new!instance creation!public! !
 !File class categoriesFor: #open:!instance creation!public! !
@@ -1336,9 +1407,10 @@ workingDirectory: aString
 !File class categoriesFor: #replacePath:with:!filename manipulation!public! !
 !File class categoriesFor: #shortenComponent:max:!helpers!private! !
 !File class categoriesFor: #shortPathOf:!filename manipulation!public! !
+!File class categoriesFor: #splitDriveFrom:!filename manipulation!public! !
 !File class categoriesFor: #splitExtensionFrom:!filename manipulation!public! !
 !File class categoriesFor: #splitFilenameFrom:!filename manipulation!public! !
-!File class categoriesFor: #splitPath:!filename manipulation!private! !
+!File class categoriesFor: #splitPath:!filename manipulation!public! !
 !File class categoriesFor: #splitPathFrom:!filename manipulation!public! !
 !File class categoriesFor: #splitStemFrom:!filename manipulation!public! !
 !File class categoriesFor: #temporary!instance creation!public! !

--- a/Core/Object Arts/Dolphin/Base/FileTest.cls
+++ b/Core/Object Arts/Dolphin/Base/FileTest.cls
@@ -10,6 +10,17 @@ FileTest comment: ''!
 !FileTest categoriesForClass!Unclassified! !
 !FileTest methodsFor!
 
+buildTestPathOfLength: anInteger
+	| maxPath |
+	maxPath := String writeStream.
+	maxPath nextPutAll: 'c:\'.
+	0 to: anInteger - 8 do: [:i | maxPath nextPut: ('abcdefghij\' at: i % 11 + 1)].
+	maxPath := maxPath contents.
+	maxPath last = $\ ifTrue: [maxPath := maxPath allButLast , 'a'].
+	maxPath := maxPath , '.txt'.
+	self assert: maxPath size equals: anInteger.
+	^maxPath!
+
 createTestDirectories
 	| dir |
 	File createDirectoryPath: 'c:\FileTest1\EmptyLeaf'.
@@ -69,6 +80,12 @@ deleteDirectory: aString
 
 deleteTestDirectories
 	File deleteDirectory: 'c:\FileTest1\'!
+
+printFilenameOfLength: anInteger on: path
+	(1 to: anInteger) do: [:i | path nextPut: (Character codePoint: $a codePoint + (i % 10))].
+	path nextPut: $..
+	(1 to: CRTConstants._MAX_EXT - 1)
+		do: [:i | path nextPut: (Character codePoint: $a codePoint + (i % 10))]!
 
 relativePathOf: a to: b
 	^File relativePathOf: a to: b!
@@ -263,6 +280,36 @@ testForDirectoriesIn
 			dirPath := File composePath: windir subPath: each.
 			self assert: (File isDirectory: dirPath)]!
 
+testMakePath
+	| filename split |
+	self assert: (File makePath: #('c:' 'a/b 2/c/' 'a file' '.anextension'))
+		equals: 'c:a/b 2/c/a file.anextension'.
+	self assert: (File makePath: #('c' '\dir' 'file' 'txt')) equals: 'c:\dir\file.txt'.
+	self assert: (File makePath: #(nil nil nil nil)) equals: ''.
+	self assert: (File makePath: #('' '' '' '')) equals: ''.
+	self assert: (File makePath: #('c' '' '' '')) equals: 'c:'.
+	self assert: (File makePath: #('c' 'abc' '' '')) equals: 'c:abc\'.
+	self assert: (File makePath: #('c' '' 'file' '')) equals: 'c:file'.
+	self assert: (File makePath: #('c' '' '' 'txt')) equals: 'c:.txt'.
+	self assert: (File makePath: #('c' '' 'a b c' 'txt')) equals: 'c:a b c.txt'.
+	self assert: (File makePath: #('c' 'a/b' 'file' '')) equals: 'c:a/b\file'.
+	self assert: (File makePath: #('c' '\' '' '')) equals: 'c:\'.
+	self assert: (File makePath: #('' 'a\b' '' '')) equals: 'a\b\'.
+	self assert: (File makePath: #('' '' 'file' '')) equals: 'file'.
+	self assert: (File makePath: #('' '' '' 'txt')) equals: '.txt'.
+	"Shouldn't matter if the filename is notionally too long"
+	filename := String writeStream.
+	self printFilenameOfLength: CRTConstants._MAX_FNAME * 2 on: filename.
+	filename := filename contents.
+	split := filename subStrings: $..
+	self
+		assert: (File makePath: (Array
+						with: nil
+						with: nil
+						with: split first
+						with: split second))
+		equals: filename!
+
 testRemoveDirectory
 	self createTestDirectories.
 	
@@ -278,8 +325,25 @@ testRemoveDirectory
 !
 
 testRemoveExtension
-	#(#('a.exe' 'a') #('a.' 'a') #('.exe' '') #('.' '') #('' '') #('1234.1234.exe' '1234.1234') #('1234.1234.+' '1234.1234') #('a.b\c' 'a.b\c') #('a.b\' 'a.b\')) 
-		do: [:eachPair | self assert: (File removeExtension: eachPair first) = eachPair last]!
+	| path |
+	self should: [File removeExtension: nil] raise: CRTError.
+	self assert: (File removeExtension: 'a.') = 'a'.
+	self assert: (File removeExtension: '.exe') = ''.
+	self assert: (File removeExtension: '.') = ''.
+	self assert: (File removeExtension: '') = ''.
+	self assert: (File removeExtension: '1234.1234.exe') = '1234.1234'.
+	self assert: (File removeExtension: '1234.1234.+') = '1234.1234'.
+	self assert: (File removeExtension: 'a.b\c') = 'a.b\c'.
+	self assert: (File removeExtension: 'a.b\') = 'a.b\'.
+	self assert: (File removeExtension: 'c:/a/b.txt') = 'c:/a/b'.
+	path := String writeStream.
+	path nextPutAll: 'c:\'.
+	self printFilenameOfLength: CRTConstants._MAX_FNAME on: path.
+	path := path contents.
+	self assert: (File removeExtension: path) equals: (path subStrings: $.) first.
+	"Doesn't matter if the path is notionally too long"
+	path := self buildTestPathOfLength: CRTConstants._MAX_PATH * 2.
+	self assert: (File removeExtension: path) equals: (path subStrings: $.) first!
 
 testRemovePathDelimiter
 	self assert: (File removePathDelimiter: '') = ''.
@@ -301,10 +365,81 @@ testRemovePathDelimiter
 
 
 
-! !
+!
+
+testSplitDriveFrom
+	self should: [File splitDriveFrom: nil] raise: CRTError.
+	self assert: (File splitDriveFrom: 'c:\a\a2/b.txt') = 'c:'.
+	self assert: (File splitDriveFrom: 'a\b.txt') = ''.
+	self assert: (File splitDriveFrom: 'b.txt') = ''.
+	self assert: (File splitDriveFrom: '.txt') = ''.
+	self assert: (File splitDriveFrom: '.') = ''.
+	self assert: (File splitDriveFrom: '') = ''.
+	self assert: (File splitDriveFrom: 'c:/a b\c d.txt') = 'c:'.
+	self assert: (File splitDriveFrom: 'd:\') = 'd:'.
+	self assert: (File splitDriveFrom: 'e:') = 'e:'.
+	self assert: (File splitDriveFrom: 'cons:') = ''!
+
+testSplitExtensionFrom
+	| path ext |
+	self should: [File splitExtensionFrom: nil] raise: CRTError.
+	self assert: (File splitExtensionFrom: 'c:\a\a2/b.txt') equals: 'txt'.
+	self assert: (File splitExtensionFrom: 'a\b.txt') equals: 'txt'.
+	self assert: (File splitExtensionFrom: 'b.txt') equals: 'txt'.
+	self assert: (File splitExtensionFrom: 'b.') equals: ''.
+	self assert: (File splitExtensionFrom: '.txt') equals: 'txt'.
+	self assert: (File splitExtensionFrom: '.') equals: ''.
+	self assert: (File splitExtensionFrom: '') equals: ''.
+	self assert: (File splitExtensionFrom: 'c:\a\b\') equals: ''.
+	self assert: (File splitExtensionFrom: 'c:/a b\c d.txt') equals: 'txt'.
+	self assert: (File splitExtensionFrom: '1234.1234.exe') equals: 'exe'.
+	self assert: (File splitExtensionFrom: 'a.b\c') equals: ''.
+	self assert: (File splitExtensionFrom: 'a.b\') equals: ''.
+	path := self buildTestPathOfLength: CRTConstants._MAX_PATH.
+	self assert: (File splitExtensionFrom: path) equals: 'txt'.
+	"The CRT functions works even if the path is too long because we ignore everything but the extension"
+	path := path , 'x'.
+	self assert: (File splitExtensionFrom: path) equals: 'txtx'.
+	path := self buildTestPathOfLength: CRTConstants._MAX_PATH * 2.
+	self assert: (File splitExtensionFrom: path) equals: 'txt'.
+	"Try a very filename with very long extension (of max length)."
+	path := String writeStream.
+	self printFilenameOfLength: CRTConstants._MAX_FNAME * 2 on: path.
+	path := path contents.
+	ext := (path subStrings: $.) last.
+	self assert: (File splitExtensionFrom: path) equals: ext.
+	"Works even if extension is notionally too large"
+	path := path , ext.
+	self assert: (File splitExtensionFrom: path) equals: ext , ext!
+
+testSplitFilenameFrom
+	| path |
+	self should: [File splitFilenameFrom: nil] raise: CRTError.
+	self assert: (File splitFilenameFrom: '.') equals: '.'.
+	self assert: (File splitFilenameFrom: 'c:\a\a2/b.txt') equals: 'b.txt'.
+	self assert: (File splitFilenameFrom: 'a\b.txt') equals: 'b.txt'.
+	self assert: (File splitFilenameFrom: 'b.txt') equals: 'b.txt'.
+	self assert: (File splitFilenameFrom: 'b.') equals: 'b.'.
+	self assert: (File splitFilenameFrom: '.txt') equals: '.txt'.
+	self assert: (File splitFilenameFrom: '') equals: ''.
+	self assert: (File splitFilenameFrom: 'c:\a\b\') equals: ''.
+	self assert: (File splitFilenameFrom: 'c:/a b\c d.txt') equals: 'c d.txt'.
+	self assert: (File splitFilenameFrom: '1234.1234.exe') equals: '1234.1234.exe'.
+	self assert: (File splitFilenameFrom: 'a.b\c') equals: 'c'.
+	self assert: (File splitFilenameFrom: 'a.b\') equals: ''.
+	path := self buildTestPathOfLength: CRTConstants._MAX_PATH.
+	self assert: (File splitFilenameFrom: path) equals: (path subStrings: $\) last.
+	"Try a very long filename (> max length), this will still work."
+	path := String writeStream.
+	path nextPutAll: 'c:\'.
+	self printFilenameOfLength: CRTConstants._MAX_FNAME * 2 on: path.
+	path := path contents.
+	self assert: (File splitFilenameFrom: path) equals: (path copyFrom: 4)! !
+!FileTest categoriesFor: #buildTestPathOfLength:!helpers!private! !
 !FileTest categoriesFor: #createTestDirectories!helpers!private! !
 !FileTest categoriesFor: #deleteDirectory:!helpers!public! !
 !FileTest categoriesFor: #deleteTestDirectories!private!Running! !
+!FileTest categoriesFor: #printFilenameOfLength:on:!helpers!private! !
 !FileTest categoriesFor: #relativePathOf:to:!helpers!public! !
 !FileTest categoriesFor: #removeDirectory:!helpers!private! !
 !FileTest categoriesFor: #tearDown!private!Running! !
@@ -313,7 +448,11 @@ testRemovePathDelimiter
 !FileTest categoriesFor: #testClassRelativePathOfTo!public!unit tests! !
 !FileTest categoriesFor: #testDeleteDirectory!public!unit tests! !
 !FileTest categoriesFor: #testForDirectoriesIn!public!unit tests! !
+!FileTest categoriesFor: #testMakePath!public!unit tests! !
 !FileTest categoriesFor: #testRemoveDirectory!public!unit tests! !
 !FileTest categoriesFor: #testRemoveExtension!public!unit tests! !
 !FileTest categoriesFor: #testRemovePathDelimiter!public!unit tests! !
+!FileTest categoriesFor: #testSplitDriveFrom!public!unit tests! !
+!FileTest categoriesFor: #testSplitExtensionFrom!public!unit tests! !
+!FileTest categoriesFor: #testSplitFilenameFrom!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/Float.cls
+++ b/Core/Object Arts/Dolphin/Base/Float.cls
@@ -5,7 +5,7 @@ Number variableByteSubclass: #Float
 	classVariableNames: 'EMin FpClassInfinite FpClassNaN FpClassNegative FpClassStrictlyPositive FpClassZero Ln2 MinValLogBase2 Precision SignificantDifference'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-Float guid: (GUID fromString: '{87B4C65A-026E-11D3-9FD7-00A0CC3E4A32}')!
+Float guid: (GUID fromString: '{87b4c65a-026e-11d3-9fd7-00a0cc3e4a32}')!
 Float addClassConstant: 'EMin' value: -1022!
 Float addClassConstant: 'FpClassInfinite' value: 516!
 Float addClassConstant: 'FpClassNaN' value: 3!
@@ -667,12 +667,13 @@ printOn: aStream significantFigures: anInteger
 
 	| buf ptPos |
 	self isFinite ifFalse: [self printOn: aStream].
-	buf := String new: (anInteger bitShift: 1) + 10.
-	buf := CRTLibrary default
-				_gcvt: self
-				count: anInteger
-				buffer: buf.
-
+	buf := String newFixed: (anInteger bitShift: 1) + 10.
+	CRTLibrary default
+		_gcvt_s: buf
+		bufferSize: buf size + 1
+		value: self
+		digits: anInteger.
+	buf := buf trimNulls.
 	"Ensure decimal separator is always a $. for printOn:, which outputs Smalltalk real syntax"
 	ptPos := buf findString: CRTLibrary default decimalSeparator.
 	ptPos == 0
@@ -1030,13 +1031,20 @@ reset
 	self resetPrecision!
 
 resetPrecision
-	CRTLibrary default _controlfp: CRTConstants._PC_64 mask: CRTConstants._MCW_PC!
+	CRTLibrary default
+		_controlfp_s: nil
+		newControl: CRTConstants._PC_64
+		mask: CRTConstants._MCW_PC!
 
 setExceptionMask: anInteger
-	"Private - Set the current floating point exception mask
-	to anInteger. Answer the previous mask."
+	"Private - Set the current floating point exception mask to anInteger."
 
-	^CRTLibrary default _controlfp: anInteger mask: CRTConstants._MCW_EM!
+	| errno |
+	(errno := CRTLibrary default
+				_controlfp_s: nil
+				newControl: anInteger
+				mask: CRTConstants._MCW_EM) == 0
+		ifFalse: [CRTError signalWith: errno]!
 
 zero
 	"Answer the receiver's representation of zero."

--- a/Core/Object Arts/Dolphin/Base/ShlwapiLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/ShlwapiLibrary.cls
@@ -5,7 +5,7 @@ ExternalLibrary subclass: #ShlwapiLibrary
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-ShlwapiLibrary guid: (GUID fromString: '{64674074-3A82-101B-8181-00AA003743D3}')!
+ShlwapiLibrary guid: (GUID fromString: '{64674074-3a82-101b-8181-00aa003743d3}')!
 ShlwapiLibrary comment: 'ShlwapiLibrary is the <ExternalLibrary> class to represent the Win32 "Shell Lightweight API Library", SHLWAPI.DLL.'!
 !ShlwapiLibrary categoriesForClass!External-Libraries-Win32! !
 !ShlwapiLibrary methodsFor!
@@ -161,6 +161,16 @@ pathSetDlgItemPath: hDlg id: id pszPath: pszPath
 	<stdcall: void PathSetDlgItemPathA handle sdword lpstr>
 	^self invalidCall!
 
+pathStripPath: pszPath
+	"Invoke the PathStripPath () function of the module wrapped by the receiver.
+	Helpstring: Removes the path portion of a fully qualified path and file.
+
+		void __stdcall PathStripPath(
+			LPCSTR pszPath);"
+
+	<stdcall: void PathStripPathA lpstr>
+	^self invalidCall!
+
 shMessageBoxCheck: hwnd pszText: pszText pszTitle: pszTitle uType: uType iDefault: iDefault pszRegVal: pszRegVal
 	"Invoke the SHMessageBoxCheck() function of the module wrapped by the receiver.
 	Helpstring: Displays a message box that gives the user the option of suppressing further occurrences
@@ -188,6 +198,7 @@ shMessageBoxCheck: hwnd pszText: pszText pszTitle: pszTitle uType: uType iDefaul
 !ShlwapiLibrary categoriesFor: #pathParseIconLocation:!**auto generated**!public! !
 !ShlwapiLibrary categoriesFor: #pathRelativePathTo:pszFrom:dwAttrFrom:pszTo:dwAttrTo:!**auto generated**!public! !
 !ShlwapiLibrary categoriesFor: #pathSetDlgItemPath:id:pszPath:!**auto generated**!public! !
+!ShlwapiLibrary categoriesFor: #pathStripPath:!**auto generated**!public! !
 !ShlwapiLibrary categoriesFor: #shMessageBoxCheck:pszText:pszTitle:uType:iDefault:pszRegVal:!**auto generated**!public! !
 
 !ShlwapiLibrary class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/StdioFileStream.cls
+++ b/Core/Object Arts/Dolphin/Base/StdioFileStream.cls
@@ -5,7 +5,7 @@ SequencedStream subclass: #StdioFileStream
 	classVariableNames: ''
 	poolDictionaries: 'CRTConstants'
 	classInstanceVariableNames: ''!
-StdioFileStream guid: (GUID fromString: '{7B8405B3-0819-421F-8110-CA2763BCB59A}')!
+StdioFileStream guid: (GUID fromString: '{7b8405b3-0819-421f-8110-ca2763bcb59a}')!
 StdioFileStream comment: 'StdioFileStream is a <FileStream> implemented over C runtime library stdio streams. Its main purpose is to wrap the stdin, stdout, and stderr streams in console applications, and it is not intended for general use. In order to avoid blocking the main Dolphin thread when attempting to read from stdin, the CRT stream I/O calls are overlapped (i.e. run on a threadpool thread), which makes them rather slow. FileStream itself should be used by preference in most cases.
 
 Instance Variables:
@@ -171,16 +171,19 @@ next
 		ifTrue: [self errorEndOfStream]
 		ifFalse: [isText ifTrue: [Character value: ch] ifFalse: [ch]]!
 
-next: countInteger into: aSequenceableCollection startingAt: startInteger 
+next: countInteger into: aSequenceableCollection startingAt: startInteger
 	"Destructively replace the elements of the argument, aSequenceableCollection,
 	(which must be some sort of byte object or <ExternalStructure> type object
 	which holds bytes) in the interval (startAt..startAt+count-1) with the next, count, 
 	elements of the receiver. Answer aSequenceableCollection."
 
-	| read |
-	read := CRTLibrary default 
-				fread: aSequenceableCollection yourAddress + startInteger - 1
-				size: aSequenceableCollection class elementSize
+	| read elemSize offset |
+	elemSize := aSequenceableCollection class elementSize.
+	offset := (startInteger - 1) * elemSize.
+	read := CRTLibrary default
+				fread_s: aSequenceableCollection yourAddress + offset
+				bufferSize: aSequenceableCollection byteSize - offset
+				elementSize: elemSize
 				count: countInteger
 				stream: stream.
 	read = countInteger ifFalse: [^self errorEndOfStream].
@@ -204,7 +207,7 @@ next: countInteger putAll: aSequenceableCollection startingAt: startInteger
 		stream: stream.
 	^aSequenceableCollection!
 
-nextAvailable: anInteger 
+nextAvailable: anInteger
 	"Answer up to anInteger elements of the receiver's collection. The answer will be a
 	collection of the same species as the one accessed by the receiver, and will contain anInteger
 	elements, or as many as are left in the receiver's collection."
@@ -214,14 +217,16 @@ nextAvailable: anInteger
 	feof() returns false until one has read off the end of the stream (or read the Ctrl+Z
 	character)."
 
-	| read buf |
-	buf := self contentsSpecies new: anInteger.
-	read := CRTLibrary default 
-				fread: buf yourAddress
-				size: 1
+	| read buf bufClass |
+	bufClass := self contentsSpecies.
+	buf := bufClass newFixed: anInteger.
+	read := CRTLibrary default
+				fread_s: buf
+				bufferSize: buf byteSize
+				elementSize: bufClass elementSize
 				count: anInteger
 				stream: stream.
-	^read < anInteger ifTrue: [buf copyFrom: 1 to: read] ifFalse: [buf].!
+	^read < anInteger ifTrue: [buf copyFrom: 1 to: read] ifFalse: [buf]!
 
 nextLine
 	"Answer a Collection consisting of the receiver contents up to (but not including) the 
@@ -468,11 +473,18 @@ read: aString text: aBoolean
 	based or binary, depending on the <boolean> argument. Raise an exception
 	if the file does not exist."
 
-	^self basicNew 
-		setStream: (CRTLibrary default fopen: aString
-				mode: (aBoolean ifTrue: ['rt'] ifFalse: ['rb']))
-		isText: aBoolean
-		name: aString!
+	| handle errno |
+	handle := ExternalHandle new.
+	^(errno := CRTLibrary default
+				fopen_s: handle
+				filename: aString
+				mode: (aBoolean ifTrue: ['rt'] ifFalse: ['rb'])) == 0
+		ifTrue: 
+			[self basicNew
+				setStream: handle
+				isText: aBoolean
+				name: aString]
+		ifFalse: [CRTError signalWith: errno]!
 
 read: aString type: aSymbol 
 	"Answer an instance of the receiver whose future sequence values consist
@@ -500,7 +512,7 @@ write: aString mode: aSymbol
 		check: false
 		text: true!
 
-write: aString mode: aSymbol check: checkBoolean text: textBoolean 
+write: aString mode: aSymbol check: checkBoolean text: textBoolean
 	"Answer a new instance of the receiver open on the contents of
 	the file identified by the <readableString> argument.
 	The <symbol> argument identifies the manner in which the file is opened.
@@ -514,22 +526,26 @@ write: aString mode: aSymbol check: checkBoolean text: textBoolean
 	The final <boolean> argument specifies the external type (#binary or #text) 
 	for which the new instance is initially configured."
 
-	| answer |
-	checkBoolean 
+	| answer handle |
+	checkBoolean
 		ifTrue: 
 			[| exists |
 			exists := File exists: aString.
-			aSymbol == #create 
+			aSymbol == #create
 				ifTrue: [exists ifTrue: [self error: 'File already exists']]
 				ifFalse: [exists ifFalse: [self error: 'File does not exist']]].
 	"Note that Smalltalk #append mode is unlike the 'a' and 'a+' fopen() modes, because
 	in Smalltalk the mode only controls the initial file position, and it is possible to overwrite
 	the existing data by moving the stream pointer backwards. With the fopen() append
 	modes it is not possible to overwrite the existing data."
+	handle := ExternalHandle new.
+	CRTLibrary default
+		fopen_s: handle
+		filename: aString
+		mode: (aSymbol == #append ifTrue: ['r+'] ifFalse: ['w+'])
+				, (textBoolean ifTrue: ['t'] ifFalse: ['b']).
 	answer := (self basicNew)
-				setStream: (CRTLibrary default fopen: aString
-							mode: (aSymbol == #append ifTrue: ['r+'] ifFalse: ['w+']) 
-									, (textBoolean ifTrue: ['t'] ifFalse: ['b']))
+				setStream: handle
 					isText: textBoolean
 					name: aString;
 				yourself.

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -5,7 +5,7 @@ ArrayedCollection variableByteSubclass: #String
 	classVariableNames: 'LineDelimiter NullPrintCharacter'
 	poolDictionaries: 'Win32Constants'
 	classInstanceVariableNames: ''!
-String guid: (GUID fromString: '{87B4C514-026E-11D3-9FD7-00A0CC3E4A32}')!
+String guid: (GUID fromString: '{87b4c514-026e-11d3-9fd7-00a0cc3e4a32}')!
 String isNullTerminated: true!
 String comment: 'String is the class of <ArrayedCollection>s whose elements are <Character>s.
 
@@ -846,12 +846,13 @@ sprintfWith: arg1
 	size := self size + 64.
 	
 	[buf := String new: size.
-	n := crt 
-				_snprintf: buf
+	n := crt
+				_snprintf_s: buf
+				bufferSize: size + 1
 				count: size
 				format: self
 				with: arg1.
-	n < 0] 
+	n < 0]
 			whileTrue: [size := size * 2].
 	^buf copyFrom: 1 to: n!
 
@@ -865,17 +866,18 @@ sprintfWith: arg1 with: arg2
 	Note: This is much faster than formatWith:with:."
 
 	| written lib buf size |
-	lib :=  VMLibrary default.
+	lib := VMLibrary default.
 	size := self size + 128.
 	
 	[buf := String new: size.
-	written := lib 
-				_snprintf: buf
+	written := lib
+				_snprintf_s: buf
+				bufferSize: size + 1
 				count: size
 				format: self
 				with: arg1
 				with: arg2.
-	written < 0] 
+	written < 0]
 			whileTrue: [size := size * 2].
 	^buf copyFrom: 1 to: written!
 

--- a/Core/Object Arts/Dolphin/Base/VMLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/VMLibrary.cls
@@ -23,18 +23,18 @@ Class Variables:
 !VMLibrary categoriesForClass!External-Libraries! !
 !VMLibrary methodsFor!
 
-_snprintf: buffer count: maxbuf format: format with: arg
+_snprintf_s: buffer bufferSize: sizeInteger count: countInteger format: format with: arg
 	"Private - Write data formatted by the format string into the buffer.
 	see _snprintf:count:format:with:with:with: for further information."
 
-	<cdecl: sdword _snprintf lpvoid intptr lpstr lpvoid>
+	<cdecl: sdword _snprintf_s lpvoid intptr intptr lpstr lpvoid>
 	^self invalidCall!
 
-_snprintf: buffer count: maxbuf format: format with: arg1 with: arg2
+_snprintf_s: buffer bufferSize: sizeInteger count: countInteger format: format with: arg1 with: arg2
 	"Private - Write data formatted by the format string into the buffer.
 	see _snprintf:count:format:with:with:with: for further information."
 
-	<cdecl: sdword _snprintf lpvoid intptr lpstr lpvoid lpvoid>
+	<cdecl: sdword _snprintf_s lpvoid intptr intptr lpstr lpvoid lpvoid>
 	^self invalidCall!
 
 addressFromInteger: anInteger
@@ -517,8 +517,8 @@ versionFormatString
 	"Private - Answer a String containing the version format used by the receiver."
 
 	^'%3!!d!!.%4!!d!!%5!!d!!'! !
-!VMLibrary categoriesFor: #_snprintf:count:format:with:!helpers!private! !
-!VMLibrary categoriesFor: #_snprintf:count:format:with:with:!helpers!private! !
+!VMLibrary categoriesFor: #_snprintf_s:bufferSize:count:format:with:!helpers!private! !
+!VMLibrary categoriesFor: #_snprintf_s:bufferSize:count:format:with:with:!helpers!private! !
 !VMLibrary categoriesFor: #addressFromInteger:!helpers!private! !
 !VMLibrary categoriesFor: #applicationHandle!accessing-handles!public! !
 !VMLibrary categoriesFor: #argc!accessing!private! !

--- a/Core/Object Arts/Dolphin/IDE/ClassBrowserAbstractTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/ClassBrowserAbstractTest.cls
@@ -192,13 +192,17 @@ inheritedMethodAddRemoveTests
 	self assertIsOnlyMethodVisible: (TestCase compiledMethodAt: method selector)!
 
 setUp
-	plugins := self browserClass plugins.
-	self browserClass plugins: #().
+	plugins := ClassBrowserAbstract allSubclasses collect: 
+					[:each |
+					| a |
+					a := each -> each plugins.
+					each plugins: #().
+					a].
 	packageA := DolphinTestPackages current a!
 
 tearDown
 	| methods |
-	self browserClass plugins: plugins.
+	plugins do: [:a | a key plugins: a value].
 	methods := packageA methods.
 	browser destroy.
 	self deleteTestMethods: methods.

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
@@ -27,7 +27,7 @@ of SciLexer.dll from it into the Dolphin directory."
 	| scilexer locator currentVer version filename zip dest temp shell scintilla url exists |
 	locator := FileLocator installRelative.
 	version := ScintillaLibrary versionString.
-	scilexer := locator localFileSpecFor: (File change: ScintillaLibrary fileName extension: ''dll'').
+	scilexer := locator localFileSpecFor: (File path: ScintillaLibrary fileName extension: ''dll'').
 	exists := File exists: scilexer.
 	currentVer := exists ifTrue: [(VersionInfo forPath: scilexer) productVersionString].
 	version = currentVer ifTrue: [^self].

--- a/Core/Object Arts/Dolphin/Lagoon/ApplicationDeploymentWizard.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/ApplicationDeploymentWizard.cls
@@ -69,17 +69,17 @@ browseForExecutableName
 	| filename defaultExtension |
 	defaultExtension := self defaultExtension.
 	filename := executableName value.
-	(filename isEmpty and: [rootPackage value notNil]) ifTrue: [
-		"Suggest a sensible default name"
-		defaultExtension := self value exeFileExtension.
-		filename := File change: rootPackage value packageFileName extension: defaultExtension].
-
+	(filename isEmpty and: [rootPackage value notNil])
+		ifTrue: 
+			["Suggest a sensible default name"
+			defaultExtension := self value exeFileExtension.
+			filename := File path: rootPackage value packageFileName extension: defaultExtension].
 	filename := (FileSaveDialog on: filename)
-		fileTypes: (self exeFileTypes copyWith: FileDialog allFilesType);
-		defaultExtension: defaultExtension;
-		caption: 'Choose target';
-		showModal.
-	filename notNil ifTrue: [ executableName value: filename].!
+				fileTypes: (self exeFileTypes copyWith: FileDialog allFilesType);
+				defaultExtension: defaultExtension;
+				caption: 'Choose target';
+				showModal.
+	filename notNil ifTrue: [executableName value: filename]!
 
 canDeploy
 	"Answer true if the receiver can currently deploy"

--- a/Core/Object Arts/Dolphin/Lagoon/CRTLibraryImportTest.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/CRTLibraryImportTest.cls
@@ -11,8 +11,8 @@ CRTLibraryImportTest comment: ''!
 !CRTLibraryImportTest methodsFor!
 
 devOnlyCrtFunctions
-	^#('_get_osfhandle') , ((MethodCategory deprecatedMethods methodsInBehavior: CRTLibrary)
-				collect: [:each | each functionName])!
+	^(MethodCategory deprecatedMethods methodsInBehavior: CRTLibrary)
+		collect: [:each | each functionName]!
 
 stubNames
 	^#('ConsoleToGo.exe' 'GUIToGo.exe' 'IPDolphinToGo.dll')!

--- a/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/ImageStripper.cls
@@ -735,7 +735,7 @@ logFileExtension
 logFileName
 	"Answers the file name to use for logging strip info"
 
-	^File change: self executablePath extension: self logFileExtension!
+	^File path: self executablePath extension: self logFileExtension!
 
 logFold: aString folded: count total: total 
 	self startElement: aString.
@@ -1448,7 +1448,7 @@ saveExecutable: exePath
 	unattended := self isUnattended.
 	retainImage := self keepImageFile.
 	self finalActions.
-	image := File change: exePath extension: 'tmp'.
+	image := File path: exePath extension: 'tmp'.
 	self snapshotImage: image.
 
 	"We can't send any more messages to the receiver after this point as its method dictionary

--- a/Core/Object Arts/Dolphin/MVP/Gdiplus/Tests/GdiplusBitmapTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/Gdiplus/Tests/GdiplusBitmapTest.cls
@@ -72,7 +72,7 @@ testPixelAfterSave
 	extensions with: supportsAlpha
 		do: 
 			[:ext :supported | 
-			toFile := File change: baseFile extension: ext.
+			toFile := File path: baseFile extension: ext.
 			bitmap saveToFile: toFile.
 			image := GdiplusBitmap fromFile: toFile.
 			self assert: (image pixelAt: 1 @ 1) = (ARGB fromArray: #(0 0 0 0)) = supported]! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/CCITEM.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/CCITEM.cls
@@ -185,10 +185,11 @@ textInBuffer: aString
 	"Writes aString into a system buffer pointed to by pszText
 	and of size cchTextMax."
 
-	CRTLibrary default 
-		strncpy: self pszTextAddress	"Raw address of text buffer allocated by control"
-		strSource: aString 
-		count: self cchTextMax!
+	CRTLibrary default
+		strncpy_s: self pszTextAddress
+		bufferSize: self cchTextMax
+		strSource: aString
+		count: CRTConstants._TRUNCATE!
 
 textPointerOffset
 	"Private - Answer the offset of the text pointer in the receiver. "

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMLVGETINFOTIPA.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMLVGETINFOTIPA.cls
@@ -48,10 +48,13 @@ text: text
 	| t max |
 	t := text asString.
 	max := self cchTextMax.
-	t size >= max ifTrue: [t := (t copyFrom: 1 to: max-4), '...'].
-	CRTLibrary default strncpy: self pszText strSource: t count: max.
-	^t
-! !
+	t size >= max ifTrue: [t := (t copyFrom: 1 to: max - 4) , '...'].
+	CRTLibrary default
+		strncpy_s: self pszText
+		bufferSize: max
+		strSource: t
+		count: CRTConstants._TRUNCATE.
+	^t! !
 !NMLVGETINFOTIPA categoriesFor: #cchTextMax!**compiled accessors**!public! !
 !NMLVGETINFOTIPA categoriesFor: #dwFlags!**compiled accessors**!public! !
 !NMLVGETINFOTIPA categoriesFor: #iItem!**compiled accessors**!public! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMTVGETINFOTIPA.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMTVGETINFOTIPA.cls
@@ -41,8 +41,11 @@ text: text
 	text, but only up to the maximum number of characters specified by the receiver's
 	#cchTextMax field."
 
-	CRTLibrary default strncpy: self pszText strSource: text displayString count: self cchTextMax
-! !
+	CRTLibrary default
+		strncpy_s: self pszText
+		bufferSize: self cchTextMax
+		strSource: text displayString
+		count: CRTConstants._TRUNCATE! !
 !NMTVGETINFOTIPA categoriesFor: #cchTextMax!**compiled accessors**!public! !
 !NMTVGETINFOTIPA categoriesFor: #hItem!**compiled accessors**!public! !
 !NMTVGETINFOTIPA categoriesFor: #itemHandle!accessing!public! !

--- a/Core/Object Arts/Dolphin/System/Compiler/ParseTreeSearch.cls
+++ b/Core/Object Arts/Dolphin/System/Compiler/ParseTreeSearch.cls
@@ -1,0 +1,271 @@
+"Filed out from Dolphin Smalltalk 2000 release 4.01"!
+
+SmalltalkParseNodeVisitor subclass: #SmalltalkParseTreeSearcher
+	instanceVariableNames: 'searches answer argumentSearches context messages'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+SmalltalkParseTreeSearcher comment: 'ParseTreeSearcher walks over a normal source code parse tree using the visitor pattern, and then matches these nodes against the meta-nodes using the match:inContext: methods defined for the meta-nodes.
+
+Instance Variables:
+	answer	<Object>	the "answer" that is propagated between matches
+	argumentSearches	<Collection of: (Association key: BRProgramNode value: BlockClosure)>	argument searches (search for the BRProgramNode and perform the BlockClosure when its found)
+	context	<BRSmallDictionary>	a dictionary that contains what each meta-node matches against. This could be a normal Dictionary that is created for each search, but is created once and reused (efficiency).
+	searches	<Collection of: (Association key: BRProgramNode value: BlockClosure)>	non-argument searches (search for the BRProgramNode and perform the BlockClosure when its found)'!
+
+SmalltalkParseTreeSearcher guid: (GUID fromString: '{88F9B089-E658-4426-8D0A-F18303952CAD}')!
+
+!SmalltalkParseTreeSearcher categoriesForClass!Refactory-ParseTree Matching! !
+!SmalltalkParseTreeSearcher methodsFor!
+
+addArgumentRule: aParseTreeRule 
+	argumentSearches add: aParseTreeRule.
+	aParseTreeRule owner: self!
+
+addArgumentRules: ruleCollection 
+	ruleCollection do: [:each | self addArgumentRule: each]!
+
+addRule: aParseTreeRule 
+	searches add: aParseTreeRule.
+	aParseTreeRule owner: self!
+
+addRules: ruleCollection 
+	ruleCollection do: [:each | self addRule: each]!
+
+answer
+	^answer!
+
+answer: anObject
+	answer := anObject!
+
+canMatchMethod: aCompiledMethod 
+	^self messages isEmpty or: 
+			[(self messages detect: [:each | aCompiledMethod sendsSelector: each]
+				ifNone: [nil]) notNil]!
+
+context
+	^context!
+
+executeMethod: aParseTree initialAnswer: anObject 
+	answer := anObject.
+	searches detect: [:each | (each performOn: aParseTree) notNil] ifNone: [].
+	^answer!
+
+executeTree: aParseTree 
+	"Save our current context, in case someone is performing another search inside a match."
+
+	| oldContext |
+	oldContext := context.
+	context := SmallDictionary new.
+	self visitNode: aParseTree.
+	context := oldContext.
+	^answer!
+
+executeTree: aParseTree initialAnswer: aValue 
+	answer := aValue.
+	^self executeTree: aParseTree!
+
+foundMatch!
+
+initialize
+	super initialize.
+	context := SmallDictionary new.
+	searches := OrderedCollection new.
+	argumentSearches := OrderedCollection new: 0.
+	answer := nil!
+
+lookForMoreMatchesInContext: oldContext 
+	oldContext keysAndValuesDo: 
+			[:key :value | 
+			((key isKindOf: String) not and: [key recurseInto]) 
+				ifTrue: [value do: [:each | self visitNode: each]]]!
+
+matches: aString do: aBlock 
+	self addRule: (SmalltalkParseTreeSearchRule searchFor: aString thenDo: aBlock)!
+
+matchesAnyArgumentOf: stringCollection do: aBlock 
+	stringCollection do: [:each | self matchesArgument: each do: aBlock]!
+
+matchesAnyMethodOf: aStringCollection do: aBlock 
+	aStringCollection do: [:each | self matchesMethod: each do: aBlock]!
+
+matchesAnyOf: aStringCollection do: aBlock 
+	aStringCollection do: [:each | self matches: each do: aBlock]!
+
+matchesAnyTreeOf: treeCollection do: aBlock 
+	treeCollection do: [:each | self matchesTree: each do: aBlock]!
+
+matchesArgument: aString do: aBlock 
+	self addArgumentRule: (SmalltalkParseTreeSearchRule searchFor: aString thenDo: aBlock)!
+
+matchesArgumentTree: aBRProgramNode do: aBlock 
+	self 
+		addArgumentRule: (SmalltalkParseTreeSearchRule searchForTree: aBRProgramNode thenDo: aBlock)!
+
+matchesMethod: aString do: aBlock 
+	self addRule: (SmalltalkParseTreeSearchRule searchForMethod: aString thenDo: aBlock)!
+
+matchesTree: aBRProgramNode do: aBlock 
+	self addRule: (SmalltalkParseTreeSearchRule searchForTree: aBRProgramNode thenDo: aBlock)!
+
+messages
+	messages notNil ifTrue: [^messages].
+	argumentSearches isEmpty ifFalse: [^messages := #()].
+	messages := Set new.
+	searches do: 
+			[:each | 
+			| searchMessages |
+			searchMessages := each sentMessages.
+			SmalltalkParserNode optimizedSelectors 
+				do: [:sel | searchMessages remove: sel ifAbsent: []].
+			searchMessages isEmpty ifTrue: [^messages := #()].
+			messages addAll: searchMessages].
+	^messages := messages asArray!
+
+performSearches: aSearchCollection on: aNode 
+	| value |
+	1 to: aSearchCollection size
+		do: 
+			[:i | 
+			value := (aSearchCollection at: i) performOn: aNode.
+			value notNil 
+				ifTrue: 
+					[self foundMatch.
+					^value]].
+	^nil!
+
+recusivelySearchInContext
+	"We need to save the matched context since the other searches might overwrite it."
+
+	| oldContext |
+	oldContext := context.
+	context := SmallDictionary new.
+	self lookForMoreMatchesInContext: oldContext.
+	context := oldContext!
+
+visitArgument: aNode 
+	| value |
+	value := self performSearches: argumentSearches on: aNode.
+	^value isNil 
+		ifTrue: 
+			[aNode acceptVisitor: self.
+			aNode]
+		ifFalse: [value]!
+
+visitNode: aNode 
+	| value |
+	value := self performSearches: searches on: aNode.
+	^value isNil 
+		ifTrue: 
+			[aNode acceptVisitor: self.
+			aNode]
+		ifFalse: [value]! !
+!SmalltalkParseTreeSearcher categoriesFor: #addArgumentRule:!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #addArgumentRules:!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #addRule:!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #addRules:!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #answer!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #answer:!initialize/release!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #canMatchMethod:!public!testing! !
+!SmalltalkParseTreeSearcher categoriesFor: #context!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #executeMethod:initialAnswer:!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #executeTree:!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #executeTree:initialAnswer:!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #foundMatch!*-unclassified!private! !
+!SmalltalkParseTreeSearcher categoriesFor: #initialize!initialize/release!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #lookForMoreMatchesInContext:!*-unclassified!private! !
+!SmalltalkParseTreeSearcher categoriesFor: #matches:do:!public!searching! !
+!SmalltalkParseTreeSearcher categoriesFor: #matchesAnyArgumentOf:do:!public!searching! !
+!SmalltalkParseTreeSearcher categoriesFor: #matchesAnyMethodOf:do:!public!searching! !
+!SmalltalkParseTreeSearcher categoriesFor: #matchesAnyOf:do:!public!searching! !
+!SmalltalkParseTreeSearcher categoriesFor: #matchesAnyTreeOf:do:!public!searching! !
+!SmalltalkParseTreeSearcher categoriesFor: #matchesArgument:do:!public!searching! !
+!SmalltalkParseTreeSearcher categoriesFor: #matchesArgumentTree:do:!public!searching! !
+!SmalltalkParseTreeSearcher categoriesFor: #matchesMethod:do:!public!searching! !
+!SmalltalkParseTreeSearcher categoriesFor: #matchesTree:do:!public!searching! !
+!SmalltalkParseTreeSearcher categoriesFor: #messages!accessing!public! !
+!SmalltalkParseTreeSearcher categoriesFor: #performSearches:on:!*-unclassified!private! !
+!SmalltalkParseTreeSearcher categoriesFor: #recusivelySearchInContext!*-unclassified!private! !
+!SmalltalkParseTreeSearcher categoriesFor: #visitArgument:!public!visiting! !
+!SmalltalkParseTreeSearcher categoriesFor: #visitNode:!public!visiting! !
+
+!SmalltalkParseTreeSearcher class methodsFor!
+
+buildSelectorString: aSelector 
+	| stream keywords |
+	aSelector numArgs = 0 ifTrue: [^aSelector].
+	stream := WriteStream on: String new.
+	keywords := aSelector keywords.
+	1 to: keywords size
+		do: 
+			[:i | 
+			stream nextPutAll: (keywords at: i);
+				nextPutAll: ' ``@arg';
+				nextPutAll: i printString;
+				nextPut: $ ].
+	^stream contents!
+
+buildSelectorTree: aSelector 
+	aSelector isEmpty ifTrue: [^nil].
+	^SmalltalkParser parseRewriteExpression: '``@receiver ' 
+				, (self buildSelectorString: aSelector)
+		onError: [:err :pos | ^nil]!
+
+buildTree: aString method: aBoolean 
+	^aBoolean 
+		ifTrue: [SmalltalkParser parseRewriteMethod: aString]
+		ifFalse: [SmalltalkParser parseRewriteExpression: aString]!
+
+getterMethod: aVarName 
+	^(self new)
+		matchesMethod: '`method ^' , aVarName do: [:aNode :ans | aNode selector];
+		yourself!
+
+justSendsSuper
+	^(self new)
+		matchesAnyMethodOf: 
+				#('`@method: `@Args ^super `@method: `@Args' 
+				'`@method: `@Args super `@method: `@Args')
+			do: [:aNode :ans | true];
+		yourself!
+
+returnSetterMethod: aVarName 
+	^(self new)
+		matchesMethod: '`method: `Arg ^' , aVarName , ' := `Arg'
+			do: [:aNode :ans | aNode selector];
+		yourself!
+
+setterMethod: aVarName 
+	^(self new)
+		matchesAnyMethodOf: (Array with: '`method: `Arg ' , aVarName , ' := `Arg'
+					with: '`method: `Arg ^' , aVarName , ' := `Arg')
+			do: [:aNode :ans | aNode selector];
+		yourself!
+
+treeMatching: aString in: aParseTree 
+	(self new)
+		matches: aString do: [:aNode :answer | ^aNode];
+		executeTree: aParseTree.
+	^nil!
+
+treeMatchingStatements: aString in: aParseTree 
+	| notifier tree lastIsReturn |
+	notifier := self new.
+	tree := SmalltalkParser parseExpression: aString.
+	lastIsReturn := tree lastIsReturn.
+	notifier matches: (lastIsReturn 
+				ifTrue: ['| `@temps | `@.S1. ' , tree formattedCode]
+				ifFalse: ['| `@temps | `@.S1. ' , tree formattedCode , '. `@.S2'])
+		do: [:aNode :answer | ^tree].
+	notifier executeTree: aParseTree.
+	^nil! !
+!SmalltalkParseTreeSearcher class categoriesFor: #buildSelectorString:!*-unclassified!private! !
+!SmalltalkParseTreeSearcher class categoriesFor: #buildSelectorTree:!*-unclassified!public! !
+!SmalltalkParseTreeSearcher class categoriesFor: #buildTree:method:!*-unclassified!public! !
+!SmalltalkParseTreeSearcher class categoriesFor: #getterMethod:!instance creation!public! !
+!SmalltalkParseTreeSearcher class categoriesFor: #justSendsSuper!instance creation!public! !
+!SmalltalkParseTreeSearcher class categoriesFor: #returnSetterMethod:!instance creation!public! !
+!SmalltalkParseTreeSearcher class categoriesFor: #setterMethod:!instance creation!public! !
+!SmalltalkParseTreeSearcher class categoriesFor: #treeMatching:in:!accessing!public! !
+!SmalltalkParseTreeSearcher class categoriesFor: #treeMatchingStatements:in:!accessing!public! !
+

--- a/FetchVM.ps1
+++ b/FetchVM.ps1
@@ -4,7 +4,7 @@
 
 param 
 (
-    [string]$VMversion="v7.0.42"
+    [string]$VMversion="v7.0.43"
 )
 
 Try 

--- a/PreBoot.st
+++ b/PreBoot.st
@@ -176,3 +176,18 @@ lookup: keyObject
 
 lookup: keyObject
 	^super lookup: keyObject asSymbol! !
+
+!CRTLibrary methodsFor!
+
+_splitpath_s: path drive: drive driveLen: driveInteger dir: dir dirLen: dirInteger fname: fname fnameLen: nameInteger ext: ext extLen: extInteger
+	<cdecl: sdword _splitpath_s char* char* sdword char* sdword char* sdword char* sdword>
+	^self invalidCall!
+
+strcat_s: strDestination bufferSize: anInteger strSource: strSource
+	<cdecl: sdword strcat_s lpstr sdword lpstr>
+	^self invalidCall!
+
+_makepath_s: path bufferSize: sizeInBytes drive: drive dir: dir fname: fname ext: ext
+	<cdecl: sdword _makepath_s char* intptr char* char* char* char*>
+	^self invalidCall! !
+


### PR DESCRIPTION
Replace all the CRT functions that are still in use with secure
equivalents.

The replacements for makepath/splitpath now support arbitrary length paths
and filenames, so modify all the path manipulations in `File class` to take
advantage of this. Improve the associated unit tests.