### PR TITLE
Attempting to edit a menu command results in an error

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/PublishedAspectInspectorTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/PublishedAspectInspectorTest.cls
@@ -240,6 +240,11 @@ testAspectChanged
 	self assert: treePresenter view itemCount == 1.
 	self repaint!
 
+testCommandMenuItemEditor
+	"#show reproduces the error and is less complicated to debug/test than #showModal"
+
+	(CommandMenuItemDialog createOn: CommandMenuItem new) show view close!
+
 testContextMenuEdit
 	| inspectee |
 	inspectee := View new.
@@ -702,6 +707,7 @@ testSetToNil
 !PublishedAspectInspectorTest categoriesFor: #tearDown!public!running! !
 !PublishedAspectInspectorTest categoriesFor: #testAddRemoveCollectionElement!public!unit tests! !
 !PublishedAspectInspectorTest categoriesFor: #testAspectChanged!public!unit tests! !
+!PublishedAspectInspectorTest categoriesFor: #testCommandMenuItemEditor!public! !
 !PublishedAspectInspectorTest categoriesFor: #testContextMenuEdit!public!unit tests! !
 !PublishedAspectInspectorTest categoriesFor: #testCopyAndPasteMenu!public!unit tests! !
 !PublishedAspectInspectorTest categoriesFor: #testImmutableAspect!public!unit tests! !

--- a/Core/Object Arts/Dolphin/IDE/PublishedAspectInspectorTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/PublishedAspectInspectorTest.cls
@@ -241,9 +241,13 @@ testAspectChanged
 	self repaint!
 
 testCommandMenuItemEditor
-	"#show reproduces the error and is less complicated to debug/test than #showModal"
+	"Simple kick-the-tyres test that inspector in menu item dialog opens without error."
 
-	(CommandMenuItemDialog createOn: CommandMenuItem new) show view close!
+	| dialog cards |
+	dialog := (CommandMenuItemDialog createOn: CommandMenuItem new) show.
+	cards := dialog view viewNamed: 'cards'.
+	cards tabs selectionByIndex: 3.
+	dialog view exit!
 
 testContextMenuEdit
 	| inspectee |
@@ -707,7 +711,7 @@ testSetToNil
 !PublishedAspectInspectorTest categoriesFor: #tearDown!public!running! !
 !PublishedAspectInspectorTest categoriesFor: #testAddRemoveCollectionElement!public!unit tests! !
 !PublishedAspectInspectorTest categoriesFor: #testAspectChanged!public!unit tests! !
-!PublishedAspectInspectorTest categoriesFor: #testCommandMenuItemEditor!public! !
+!PublishedAspectInspectorTest categoriesFor: #testCommandMenuItemEditor!public!unit tests! !
 !PublishedAspectInspectorTest categoriesFor: #testContextMenuEdit!public!unit tests! !
 !PublishedAspectInspectorTest categoriesFor: #testCopyAndPasteMenu!public!unit tests! !
 !PublishedAspectInspectorTest categoriesFor: #testImmutableAspect!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
@@ -293,6 +293,10 @@ getInfoTipBlock: anObject
 
 	getInfoTipBlock := anObject!
 
+hasGridLines: aBoolean
+	"Exists in ListView but not elsewhere. See
+	PublishedAspectInspectorTest>>testCommandMenuItemEditor"!
+
 hasHotTracking
 	"Answer whether the receiver's selection will track the mouse as it hovers over items in thel list."
 
@@ -738,6 +742,7 @@ wmDestroy: message wParam: wParam lParam: lParam
 !IconicListAbstract categoriesFor: #getImageBlock:!adapters!public! !
 !IconicListAbstract categoriesFor: #getInfoTipBlock!accessing!public! !
 !IconicListAbstract categoriesFor: #getInfoTipBlock:!accessing!public! !
+!IconicListAbstract categoriesFor: #hasGridLines:!public! !
 !IconicListAbstract categoriesFor: #hasHotTracking!accessing-styles!public! !
 !IconicListAbstract categoriesFor: #hasHotTracking:!accessing-styles!public! !
 !IconicListAbstract categoriesFor: #hasIcons!public!testing! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
@@ -293,9 +293,18 @@ getInfoTipBlock: anObject
 
 	getInfoTipBlock := anObject!
 
+hasGridLines
+	"Answer whether the receiver is displaying gridlines."
+
+	^false!
+
 hasGridLines: aBoolean
-	"Exists in ListView but not elsewhere. See
-	PublishedAspectInspectorTest>>testCommandMenuItemEditor"!
+	"If supported, turn on or off the display of grid lines in the receiver depending on the
+	value of the argument, aBoolean"
+
+	"Only supported by some subclasses"
+
+	!
 
 hasHotTracking
 	"Answer whether the receiver's selection will track the mouse as it hovers over items in thel list."
@@ -742,7 +751,8 @@ wmDestroy: message wParam: wParam lParam: lParam
 !IconicListAbstract categoriesFor: #getImageBlock:!adapters!public! !
 !IconicListAbstract categoriesFor: #getInfoTipBlock!accessing!public! !
 !IconicListAbstract categoriesFor: #getInfoTipBlock:!accessing!public! !
-!IconicListAbstract categoriesFor: #hasGridLines:!public! !
+!IconicListAbstract categoriesFor: #hasGridLines!accessing-styles!public! !
+!IconicListAbstract categoriesFor: #hasGridLines:!accessing-styles!public! !
 !IconicListAbstract categoriesFor: #hasHotTracking!accessing-styles!public! !
 !IconicListAbstract categoriesFor: #hasHotTracking:!accessing-styles!public! !
 !IconicListAbstract categoriesFor: #hasIcons!public!testing! !


### PR DESCRIPTION
The error was introduced by 361cecf8d43126f6bae62c61d66914c2ddf53c6f. This commit demonstrates the problem with a test, provides a fix, and confirms that the test passes. I fully expect that there is a better test and fix, but this seemed like a good way to communicate the problem and allows me to get beyond the walkback.