### PR TITLE
Fix #424: Recursive walkback on selecting "Next 200 items" item in Aspect Inspector 

### DIFF
--- a/Core/Object Arts/Dolphin/Base/ClassDescription.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescription.cls
@@ -64,11 +64,12 @@ addSharedPool: aPoolDictionary
 allGetters
 	"Private - Answer a <Set> of the instance variable getter methods in the receiver"
 
-	^self withAllSuperclasses inject: Set new
-		into: 
-			[:getters :each | 
-			getters addAll: each getters.
-			getters]!
+	| getters |
+	getters := IdentitySet new.
+	self withAllSuperclassesDo: 
+			[:eachClass |
+			eachClass methodDictionary do: [:eachMethod | eachMethod isGetter ifTrue: [getters add: eachMethod]]].
+	^getters!
 
 allProtocols
 	"Answer a <collection> of all the <MethodProtocol>s implemented by the receiver's
@@ -417,11 +418,6 @@ displayOn: aStream
 
 	aStream nextPutAll: self name
 !
-
-getters
-	"Private - Answer a <Set> of the instance variable getter methods in the receiver"
-
-	^self methodDictionary values select: [:each | each isGetter]!
 
 includesCategory: category
 	"Answer whether the receiver includes the named category."
@@ -906,7 +902,6 @@ whichNonVirtualCategoriesIncludeSelector: aSelector
 !ClassDescription categoriesFor: #defaultResourceIconName!constants!public! !
 !ClassDescription categoriesFor: #definition!development!public!source filing-class definition! !
 !ClassDescription categoriesFor: #displayOn:!displaying!public! !
-!ClassDescription categoriesFor: #getters!accessing!private! !
 !ClassDescription categoriesFor: #includesCategory:!categories-testing!development!public! !
 !ClassDescription categoriesFor: #includeSelector:inCategory:!categories-testing!development!public! !
 !ClassDescription categoriesFor: #indexOfInstVar:!instance variables!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/AspectInspector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/AspectInspector.cls
@@ -100,22 +100,17 @@ createSchematicWiring
 			send: #onAspectSelected
 			to: self!
 
-expandBatchAccessor: batchAccessor 
+expandBatchAccessor: batchAccessor
 	| newAccessors |
 	newAccessors := batchAccessor getBatchAccessors.
-	newAccessors notEmpty 
+	newAccessors notEmpty
 		ifTrue: 
 			[| variableNamesTree parentAccessor |
 			variableNamesTree := aspectTreePresenter model.
 			parentAccessor := variableNamesTree parentOf: batchAccessor.
-			"We disable events from the model while adding the next batch of accessors as otherwise
-			 the updating of the tree can make things very slow as it gets larger"
-			variableNamesTree noEventsDo: 
-					[variableNamesTree remove: batchAccessor.
-					newAccessors do: [:each | variableNamesTree add: each asChildOf: parentAccessor]].
-			variableNamesTree refreshTree: parentAccessor.
-			aspectTreePresenter selection: newAccessors first].
-	^self!
+			newAccessors do: [:each | variableNamesTree add: each asChildOf: parentAccessor].
+			aspectTreePresenter selection: newAccessors first.
+			variableNamesTree remove: batchAccessor]!
 
 inspecteeSelection
 	"Private - Answer the value associated with the currently selected object"

--- a/Core/Object Arts/Dolphin/MVP/Presenters/ListTree/ListTreeView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/ListTree/ListTreeView.cls
@@ -1344,21 +1344,25 @@ parentsOf: anObject includesAny: aSet
 	(aSet includes: parent) ifTrue: [^ true].
 	^ self parentsOf: parent includesAny: aSet.!
 
-previousDisplayedSiblingOf: anObject in: aCollection
+previousDisplayedSiblingOf: anObject in: aSequenceableCollection
 	"private -- given a collection of siblings of anObject (not all of which are necessarily
 	displayed yet), answer the last sibling in the collection that is displayed, and which comes
 	before anObject.  May be nil if there is no such sibling"
 
-	| sibling comparator |
-
-	sibling := nil.
-	comparator := self searchPolicy.
-	aCollection do:
-		[:each |
-		(comparator compare: each with: anObject) ifTrue: [^ sibling].
-		(self isItemDisplayed: each) ifTrue: [sibling := each]].
-
-	^ sibling.!
+	| index |
+	index := self searchPolicy
+				nextIndexOf: anObject
+				in: aSequenceableCollection
+				from: 1
+				to: aSequenceableCollection size.
+	index - 1 to: 1
+		by: -1
+		do: 
+			[:i |
+			| each |
+			each := aSequenceableCollection at: i.
+			(self isItemDisplayed: each) ifTrue: [^each]].
+	^nil!
 
 refreshContents
 	"our display needs to be refreshed.  Overridden to force state images


### PR DESCRIPTION
I've been unable to identify the change that caused this, but the PAI "next 200 items" expanding item is causing a repeating error from the ListTreeView when clicked due to the control trying to redraw itself while the LTV is still updating its internal state to reflect the addition of new items that was being performed as a batch with events disabled.

The fix is to remove the item without events disabled. I've also removed the noEventsDo: and separate refreshTree:, as this is actually much more expensive in a ListTreeView than adding the items one-by-one. The inspector still gets slower and slower as more items are progressively added, but this appears to be due to a poor choice of algorithm in searching the list for the previous sibling of the item that has just been added. I'll address that separately.

I've made some perf optimisations as well in order to improve the experience when expanding large collections, which was slow to start with, and increasingly slow as more and more items were added.