### PR TITLE
Virtual Categories for Loose Methods

### DIFF
--- a/Core/Object Arts/Dolphin/Base/ClassDescription.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescription.cls
@@ -517,7 +517,7 @@ methodCategories
 	the receiver's methods are classified."
 
 	^(self realMethodCategories)
-		addAll: self methodCategoryClass pseudoCategories;
+		addAll: (self methodCategoryClass pseudoCategoriesForClass: self);
 		yourself!
 
 methodCategoryClass

--- a/Core/Object Arts/Dolphin/Base/MethodCategory.cls
+++ b/Core/Object Arts/Dolphin/Base/MethodCategory.cls
@@ -1,11 +1,11 @@
-"Filed out from Dolphin Smalltalk X6"!
+"Filed out from Dolphin Smalltalk 7"!
 
 Category subclass: #MethodCategory
 	instanceVariableNames: ''
 	classVariableNames: 'Private Pseuds Public Table'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-MethodCategory guid: (GUID fromString: '{87B4C502-026E-11D3-9FD7-00A0CC3E4A32}')!
+MethodCategory guid: (GUID fromString: '{87b4c502-026e-11d3-9fd7-00a0cc3e4a32}')!
 MethodCategory comment: 'MethodCategory is the class of objects used to classify the methods of classes in taxonomies that are generally unrelated to the class hierarchy.
 
 Instance Variables: (None)
@@ -70,6 +70,13 @@ isPrivacy
 
 	^false!
 
+isPseudoCategoryForClass: aClassDescription
+
+	"Return whether the receiver should be included as part of aClassDescription's set of pseduo method categories.
+	By default, pseudo categories are included for all classes"
+
+	^self isPseud!
+
 methodsInBehavior: aBehavior 
 	"Answer a <sequencedReadableCollection> of <CompiledMethods>s being all the methods in the <Behavior>
 	argument which are members of the receiver."
@@ -120,6 +127,7 @@ removeMethodSilently: method
 !MethodCategory categoriesFor: #contents!enumerating!public! !
 !MethodCategory categoriesFor: #includesMethod:!public!testing! !
 !MethodCategory categoriesFor: #isPrivacy!private!testing! !
+!MethodCategory categoriesFor: #isPseudoCategoryForClass:!public!testing! !
 !MethodCategory categoriesFor: #methodsInBehavior:!enumerating!public! !
 !MethodCategory categoriesFor: #methodsInBehavior:do:!enumerating!public! !
 !MethodCategory categoriesFor: #removeClass:!public!removing! !
@@ -137,6 +145,19 @@ addPseud: category
 	self removeCategory: category.
 	Pseuds add: category.
 	^Table at: category name put: category.!
+
+addPseuds: aCollection
+	"Add the virtual method categories in aCollection to the global list of virtual categories
+	which may be associated with any class. Any samed name standard category
+	is removed from the system.
+	Much more performant than repeatedly sending addPseud: when adding multiple categories"
+
+	self removeCategories: aCollection.
+
+	^aCollection do: 
+		[ :category | 
+		Pseuds add: category.
+		Table at: category name put: category]!
 
 allMethodCategories
 	"Answer the set of all <methodCategory>s current registered in the system."
@@ -201,6 +222,10 @@ pseudoCategories
 
 	^Pseuds!
 
+pseudoCategoriesForClass: aClassDescription
+
+	^self pseudoCategories select: [ :each | each isPseudoCategoryForClass: aClassDescription]!
+
 pseudPrefix
 	"Private - Answer the <readableString> prefix to be prepended to the names of the
 	standard pseudo categories. N.B. The prefix should be short."
@@ -212,6 +237,27 @@ public
 
 	Public isNil ifTrue: [Public := self name: 'public'].
 	^Public!
+
+removeCategories: aCollection
+	"Remove the specified categories from all classes with which they are associated,
+	and also from the table of categories.
+	More performant than repeatedly sending removeCategory: when removing multiple categories"
+
+	| catNames |
+
+	catNames := Set new.
+	aCollection do: [ :each | catNames add: each asString].
+
+	"Make absolutely sure any standard category of the same name has been removed"
+	self environment allBehaviorsDo: [:c | | catalogue dead |
+		catalogue := c methodsCatalogue.
+		dead := OrderedCollection new.
+		catalogue keysDo: [ :e | (catNames includes: e name) ifTrue: [dead add: e]]. 
+		dead	do: [:k | catalogue removeKey: k]].
+
+	catNames do: 
+		[ :catName |
+		Pseuds remove: (Table removeKey: catName ifAbsent: []) ifAbsent: []]!
 
 removeCategory: category
 	"Remove the specified category from all classes with which it is associated,
@@ -256,6 +302,7 @@ uninitialize
 
 	Pseuds := Table := nil! !
 !MethodCategory class categoriesFor: #addPseud:!adding!public! !
+!MethodCategory class categoriesFor: #addPseuds:!adding!public! !
 !MethodCategory class categoriesFor: #allMethodCategories!accessing!public! !
 !MethodCategory class categoriesFor: #deprecatedMethods!instance creation!public! !
 !MethodCategory class categoriesFor: #initialize!initializing!private! !
@@ -264,8 +311,10 @@ uninitialize
 !MethodCategory class categoriesFor: #primitives!instance creation!public! !
 !MethodCategory class categoriesFor: #private!instance creation!public! !
 !MethodCategory class categoriesFor: #pseudoCategories!constants!public! !
+!MethodCategory class categoriesFor: #pseudoCategoriesForClass:!accessing!public! !
 !MethodCategory class categoriesFor: #pseudPrefix!constants!private! !
 !MethodCategory class categoriesFor: #public!instance creation!public! !
+!MethodCategory class categoriesFor: #removeCategories:!public!removing! !
 !MethodCategory class categoriesFor: #removeCategory:!public!removing! !
 !MethodCategory class categoriesFor: #removePseud:!public!removing! !
 !MethodCategory class categoriesFor: #setMethod:categories:!helpers!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/ClassBrowserAbstract.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/ClassBrowserAbstract.cls
@@ -114,7 +114,7 @@ actualClassChainMethods
 	^dict values!
 
 addCategoriesOfMethod: aCompiledMethod
-	(aCompiledMethod realCategories difference: categoriesPresenter model asSet) 
+	(aCompiledMethod categories difference: categoriesPresenter model asSet) 
 		do: [:each | categoriesPresenter model addCategory: each]!
 
 addMethod: method toCategory: target 
@@ -1577,7 +1577,7 @@ onTipTextRequired: tool
 		ifTrue: 
 			[| cat |
 			cat := self category.
-			^cat == self allCategory 
+			^(cat == self allCategory or: [cat acceptsAdditions not])
 				ifTrue: ['New unclassified method']
 				ifFalse: ['New method in <1p>' expandMacrosWith: cat name]].
 	(cmd == #historyBack and: [history hasPast]) 

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -60,6 +60,7 @@ package classNames
 	add: #KeyedAspect;
 	add: #KeyedAspectBatch;
 	add: #KeyedAspectBatchAccessor;
+	add: #LooseMethodCategory;
 	add: #MenuBarComposer;
 	add: #MenuBarPainter;
 	add: #MenuComposer;
@@ -241,6 +242,7 @@ package methodNames
 	add: #Package -> #defaultAbout;
 	add: #Package -> #defaultAboutBitmap;
 	add: #Package -> #icon;
+	add: #Package -> #includesLooseMethodsFor:;
 	add: #Package -> #publishedAspects;
 	add: #Package -> #searchForInTool:;
 	add: #PackageManager -> #getVersionInfoFor:;
@@ -718,6 +720,11 @@ VirtualMethodCategory subclass: #ChangedMethodsCategory
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
+VirtualMethodCategory subclass: #LooseMethodCategory
+	instanceVariableNames: 'package'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: 'instances'!
 VirtualMethodCategory subclass: #MethodPrivacyCategory
 	instanceVariableNames: 'privacy'
 	classVariableNames: ''
@@ -3293,6 +3300,10 @@ icon
 	self isBaseImagePackage ifTrue: [^self class dolphinPackageIcon].
 	^super icon!
 
+includesLooseMethodsFor: aBehavior
+
+	^self methodNames anySatisfy: [ :each | (self behaviorFromName: each key ifAbsent: []) = aBehavior]!
+
 publishedAspects
 	"Answer a <LookupTable> of the <Aspect>s published by instances of the receiver."
 
@@ -3310,6 +3321,7 @@ searchForInTool: aSmalltalkToolShell
 !Package categoriesFor: #defaultAbout!development!public! !
 !Package categoriesFor: #defaultAboutBitmap!constants!public! !
 !Package categoriesFor: #icon!public! !
+!Package categoriesFor: #includesLooseMethodsFor:!public!testing! !
 !Package categoriesFor: #publishedAspects!accessing!development!public! !
 !Package categoriesFor: #searchForInTool:!development!public! !
 

--- a/Core/Object Arts/Dolphin/IDE/Base/LooseMethodCategory.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/LooseMethodCategory.cls
@@ -1,0 +1,84 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+VirtualMethodCategory subclass: #LooseMethodCategory
+	instanceVariableNames: 'package'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: 'instances'!
+LooseMethodCategory guid: (GUID fromString: '{ceb19912-445e-4035-92cd-2e35a063441f}')!
+LooseMethodCategory comment: ''!
+!LooseMethodCategory categoriesForClass!Development! !
+!LooseMethodCategory methodsFor!
+
+includesMethod: aCompiledMethod
+
+	^package includesMethod: aCompiledMethod!
+
+isPseudoCategoryForClass: aClassDescription
+
+	^package includesLooseMethodsFor: aClassDescription!
+
+package: aPackage
+
+	package := aPackage! !
+!LooseMethodCategory categoriesFor: #includesMethod:!public!testing! !
+!LooseMethodCategory categoriesFor: #isPseudoCategoryForClass:!public!testing! !
+!LooseMethodCategory categoriesFor: #package:!accessing!public! !
+
+!LooseMethodCategory class methodsFor!
+
+forPackage: aPackage
+
+	^instances at: aPackage name ifAbsent: []!
+
+initialize
+	"Private - Initialize the receiver.
+		self initialize.
+	"
+
+	instances := LookupTable new.
+	self rebuildInstances.
+	Package manager when: #loadedChanged send: #onLoadedPackagesChanged to: self!
+
+looseMethodsPrefix
+
+	^'loose methods-'!
+
+newForPackage: aPackage
+
+	^(self newNamed: (self pseudPrefix, self looseMethodsPrefix, aPackage name))
+		package: aPackage;
+		yourself!
+
+onLoadedPackagesChanged
+
+	self rebuildInstances!
+
+rebuildInstances
+
+	| oldNames departures arrivals |
+
+	oldNames := instances keys.
+
+	departures := oldNames difference: PackageManager current packageNames.
+	arrivals := Package manager packageNames difference: oldNames.
+
+	departures isEmpty ifFalse: [self removeCategories: (departures collect: [ :each | instances removeKey: each])].
+	arrivals isEmpty ifFalse: [self addPseuds: (arrivals collect: [ :each | instances at: each put: (self newForPackage: (Package manager packageNamed: each))])]!
+
+uninitialize
+	"Private - Uninitialize the receiver as it is about to be removed from the system."
+
+	instances isNil ifTrue: [^self].
+
+	PackageManager current removeEventsTriggeredFor: self.
+	self removeCategories: instances.
+	instances := nil! !
+!LooseMethodCategory class categoriesFor: #forPackage:!accessing!public! !
+!LooseMethodCategory class categoriesFor: #initialize!initializing!private! !
+!LooseMethodCategory class categoriesFor: #looseMethodsPrefix!constants!public! !
+!LooseMethodCategory class categoriesFor: #newForPackage:!instance creation!private! !
+!LooseMethodCategory class categoriesFor: #onLoadedPackagesChanged!event handling!public! !
+!LooseMethodCategory class categoriesFor: #rebuildInstances!helpers!private! !
+!LooseMethodCategory class categoriesFor: #uninitialize!class hierarchy-removing!private! !
+

--- a/Core/Object Arts/Dolphin/IDE/Professional/SystemBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/SystemBrowserShell.cls
@@ -135,7 +135,22 @@ selectionEnvironment
 		ifFalse: [classEnvironment]!
 
 slideyPinNames
-	^super slideyPinNames , #('packagesSlidey')! !
+	^super slideyPinNames , #('packagesSlidey')!
+
+updateCategories
+	"Overridden to select the appropriate loose category when viewing a non-owned class"
+
+	| class package |
+
+	class := self actualClass.
+	self hasPackageSelected ifTrue: [package := self packages anyOne].
+	(class notNil and: [package notNil and: [package includesLooseMethodsFor: class]]) ifFalse: [^super updateCategories].
+
+	categoriesPresenter model list: self actualClassChainCategories asOrderedCollection.
+	categoriesPresenter expand: self allCategory.
+	(LooseMethodCategory forPackage: package) 
+		ifNil: [super updateCategories]
+		ifNotNil: [ :cat | categoriesPresenter selection: cat ifAbsent: [super updateCategories]]! !
 !SystemBrowserShell categoriesFor: #canSaveMethod!commands!private! !
 !SystemBrowserShell categoriesFor: #createComponents!initializing!public! !
 !SystemBrowserShell categoriesFor: #createSchematicWiring!initializing!public! !
@@ -151,6 +166,7 @@ slideyPinNames
 !SystemBrowserShell categoriesFor: #searchForPackage:!operations!public! !
 !SystemBrowserShell categoriesFor: #selectionEnvironment!accessing!public! !
 !SystemBrowserShell categoriesFor: #slideyPinNames!accessing!private! !
+!SystemBrowserShell categoriesFor: #updateCategories!private!updating! !
 
 !SystemBrowserShell class methodsFor!
 


### PR DESCRIPTION
When working with extended classes (classes with loose methods) it can be difficult to identify the methods defined by a particular class. This change adds a virtual method category for each package in the image, which group together loose methods defined by individual packages. This allows the methods defined by a particular package to be quickly identified in the browsers.