### PR TITLE
Improve diagnostics of intermittently failing ViewComposer tests #413

### DIFF
--- a/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
@@ -12,9 +12,12 @@ package methodNames
 	add: #TestCase -> #=;
 	add: #TestCase -> #assert:isKindOf:;
 	add: #TestCase -> #assert:sameAs:;
+	add: #TestCase -> #assertIsNil:;
 	add: #TestCase -> #debugWithResult;
 	add: #TestCase -> #debugWithResult:;
+	add: #TestCase -> #deny:equals:;
 	add: #TestCase -> #deny:sameAs:;
+	add: #TestCase -> #denyIsNil:;
 	add: #TestCase -> #hash;
 	add: #TestCase -> #should:raise:matching:;
 	add: #TestCase -> #should:trigger:against:;
@@ -80,6 +83,15 @@ assert: actualObject sameAs: expectedObject
 	expectedObject == actualObject
 		ifFalse: [self fail: (self comparingStringBetween: expectedObject and: actualObject)]!
 
+assertIsNil: anObject
+	anObject
+		ifNotNil: 
+			[self fail: (String writeStream
+						nextPutAll: 'Expected nil, not ';
+						print: anObject;
+						nextPutAll: '.';
+						contents)]!
+
 debugWithResult
 	| result |
 	result := TestResult new.
@@ -89,14 +101,28 @@ debugWithResult
 debugWithResult: aResult
 	aResult debugCase: self!
 
+deny: actualObject equals: expectedObject
+	expectedObject ~= actualObject
+		ifFalse: 
+			[self fail: (String writeStream
+						nextPutAll: 'Unexpectedly equal to ';
+						print: expectedObject;
+						nextPutAll: ' Actual: ';
+						print: actualObject;
+						nextPutAll: '.';
+						contents)]!
+
 deny: actualObject sameAs: expectedObject
 	expectedObject ~~ actualObject
 		ifFalse: 
-			[self fail: ((String writeStream: 100)
+			[self fail: (String writeStream
 						nextPutAll: 'Did not expect ';
 						print: actualObject;
 						nextPutAll: '.';
 						contents)]!
+
+denyIsNil: anObject
+	anObject ifNil: [self fail: 'Expected non-nil result']!
 
 hash
 	"Answer the <SmallInteger> hash value for the receiver. We use only the selector at the moment."
@@ -236,9 +262,12 @@ shouldnt: aZeroArgBlock triggerAnyOf: aCollectionOfSymbols against: anObject
 !TestCase categoriesFor: #=!comparing!public! !
 !TestCase categoriesFor: #assert:isKindOf:!asserting!public! !
 !TestCase categoriesFor: #assert:sameAs:!asserting!public! !
+!TestCase categoriesFor: #assertIsNil:!asserting!public! !
 !TestCase categoriesFor: #debugWithResult!public!running! !
 !TestCase categoriesFor: #debugWithResult:!private!running! !
+!TestCase categoriesFor: #deny:equals:!asserting!public! !
 !TestCase categoriesFor: #deny:sameAs:!public! !
+!TestCase categoriesFor: #denyIsNil:!asserting!public! !
 !TestCase categoriesFor: #hash!comparing!public! !
 !TestCase categoriesFor: #should:raise:matching:!asserting!public! !
 !TestCase categoriesFor: #should:trigger:against:!asserting!public! !

--- a/Core/Contributions/Refactory/Refactoring Browser/SmallLint/TransformationRule.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/SmallLint/TransformationRule.cls
@@ -365,13 +365,21 @@ superSends
 		superSends;
 		yourself!
 
-testCaseAssertEquals
-	"TestCase>>assert:equals: provides a better diagnostic on failure."
+testCaseAsserts
+	"Replace TestCase>>assert: with more specific assertions that provide better diagnostics on failure."
 
 	^self
-		rewrite: #(#('self assert: ``@expr = ``@expected' 'self assert: ``@expr equals: ``@expected'))
+		rewrite: #(
+			#('self assert: ``@expr = ``@expected' "->" 'self assert: ``@expr equals: ``@expected')
+			#('self assert: ``@expr ~= ``@expected' "->" 'self deny:``@expr equals: ``@expected')
+			#('self assert: ``@expr == ``@expected' "->" 'self assert: ``@expr sameAs:``@expected')
+			#('self assert: ``@expr ~~ ``@expected' "->" 'self deny: ``@expr sameAs:``@expected')
+			#('self assert: (``@expr isKindOf: ``@expected)' "->" 'self assert: ``@expr isKindOf: ``@expected')
+			#('self assert: ``@expr isNil' "->" 'self assertIsNil: ``@expr')
+			#('self assert: ``@expr notNil' "->" 'self denyIsNil: ``@expr')
+		)
 		methods: false
-		name: 'Use TestCase>>assert:equals: instead of TestCase>>assert: with #='!
+		name: 'Use more intention-revealing TestCase assert methods'!
 
 unwindBlocks
 	#rbFix.	"Remove #valueNowOrOnUnwindDo: and #valueOnUnwindDo: rewrite rules"
@@ -404,6 +412,6 @@ unwindBlocks
 !TransformationRule class categoriesFor: #showWhileBlocks!public!transformations! !
 !TransformationRule class categoriesFor: #streamLiterals!public!transformations! !
 !TransformationRule class categoriesFor: #superSends!public!transformations! !
-!TransformationRule class categoriesFor: #testCaseAssertEquals!public!transformations! !
+!TransformationRule class categoriesFor: #testCaseAsserts!public!transformations! !
 !TransformationRule class categoriesFor: #unwindBlocks!public!transformations! !
 

--- a/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
@@ -116,8 +116,8 @@ testCutCopyPaste
 testDragResourceOverEmptyArena
 	| session |
 	vc onDragOverArena: (session := self dragResourceFor: Shell).
-	self assert: session operation == #copy.
-	self assert: session suggestedTarget == vc arena!
+	self assert: session operation sameAs: #copy.
+	self assert: session suggestedTarget sameAs: vc arena!
 
 testDropResourceLinkOverShell
 	"Drop a Checkbox link onto a shell"
@@ -125,15 +125,15 @@ testDropResourceLinkOverShell
 	| ddSession |
 	vc newShellView.
 	ddSession := self doArenaDropOf: TextPresenter operation: #link.
-	self assert: (vc primarySelection isKindOf: ReferenceView).
-	self assert: vc primarySelection resourceIdentifier = (ResourceIdentifier class: TextPresenter).
+	self assert: vc primarySelection isKindOf: ReferenceView.
+	self assert: vc primarySelection resourceIdentifier equals: (ResourceIdentifier class: TextPresenter).
 	ddSession!
 
 testDropResourceOverEmptyArena
 	"Drop a shell onto an empty arena"
 
 	self doArenaDropOf: Shell operation: #copy.
-	self assert: (vc composingView isKindOf: ShellView)!
+	self assert: vc composingView isKindOf: ShellView!
 
 testDropResourceOverHierarchy
 	"Drop a Checkbox onto a shell"

--- a/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
@@ -51,67 +51,67 @@ tearDown
 
 testBasicEdit
 	| sampleResourceIdentifier |
-	self assert: vc caption = 'View Composer'.
+	self assert: vc caption equals: 'View Composer'.
 	"Test open something reasonably complex"
 	vc openOn: (ResourceIdentifier class: MethodBrowserShell).
-	self assert: vc composingView class == ShellView.
-	self assert: vc primarySelection = vc composingView.
+	self assert: vc composingView class sameAs: ShellView.
+	self assert: vc primarySelection equals: vc composingView.
 	"Test saving"
 	sampleResourceIdentifier := ResourceIdentifier class: testClass.
 	vc resourceIdentifier: sampleResourceIdentifier.
 	vc viewSave.
 	self assert: (testClass class includesSelector: #resource_Default_view).
 	vc viewCloseNoPrompt.
-	self assert: vc composingView isNil.
+	self assertIsNil: vc composingView.
 	self assert: vc hasComposingView not.
-	self assert: vc caption = 'View Composer'.
+	self assert: vc caption equals: 'View Composer'.
 	self assert: vc viewHierarchyPresenter model isEmpty.
 
 	"Test we can reload what we saved"
 	vc openOn: sampleResourceIdentifier.
-	self assert: vc composingView class == ShellView.
-	self assert: vc primarySelection = vc composingView.
+	self assert: vc composingView class sameAs: ShellView.
+	self assert: vc primarySelection equals: vc composingView.
 	vc viewCloseNoPrompt!
 
 testCutCopyPaste
 	| shell container button |
 	vc newShellView.
 	shell := vc composingView.
-	container := vc 
+	container := vc
 				pasteResource: self getContainerResource
 				context: shell
 				position: 0 @ 0.
-	self assert: container class = ContainerView.
+	self assert: container class equals: ContainerView.
 	container name: 'container'.
-	button := vc 
+	button := vc
 				pasteResource: self getButtonResource
 				context: container
 				position: 0 @ 0.
-	self assert: button class = PushButton.
+	self assert: button class equals: PushButton.
 	button name: 'button'.
 	vc selection: button.
 	vc copySelection.
 	vc selection: shell.
 	vc pasteClipboard.
 	"Check new button exists in shell"
-	self assert: vc primarySelection class == PushButton.
-	self assert: vc primarySelection parentView == shell.
-	self assert: vc primarySelection ~~ button.
+	self assert: vc primarySelection class sameAs: PushButton.
+	self assert: vc primarySelection parentView sameAs: shell.
+	self deny: vc primarySelection sameAs: button.
 	"Check old button still exists"
 	self assert: button isOpen.
-	self assert: button parentView == container.
+	self assert: button parentView sameAs: container.
 	"Now try cut"
 	vc selection: button.
 	vc cutSelection.
 	vc selection: shell.
 	vc pasteClipboard.
 	"Check new button exists in shell"
-	self assert: vc primarySelection class == PushButton.
-	self assert: vc primarySelection parentView == shell.
-	self assert: vc primarySelection ~~ button.
+	self assert: vc primarySelection class sameAs: PushButton.
+	self assert: vc primarySelection parentView sameAs: shell.
+	self deny: vc primarySelection sameAs: button.
 	"Check old button has gone"
 	self assert: button isOpen not.
-	self assert: button parentView ~~ container!
+	self deny: button parentView sameAs: container!
 
 testDragResourceOverEmptyArena
 	| session |
@@ -145,13 +145,13 @@ testDropResourceOverHierarchy
 		operation: #copy;
 		suggestedTarget: vc viewHierarchyPresenter model roots first.
 	vc onDropOverHierarchy: session.
-	self assert: (vc primarySelection isKindOf: TextEdit)!
+	self assert: vc primarySelection isKindOf: TextEdit!
 
 testDropResourceOverShell
 	"Drop a Checkbox onto a shell"
 
 	self doArenaDropOf: TextPresenter operation: #copy.
-	self assert: (vc primarySelection isKindOf: TextEdit)!
+	self assert: vc primarySelection isKindOf: TextEdit!
 
 testIgnoreShellPreferredExtent
 	"Check to make sure that the VC doesn't allow the choice of shell extents
@@ -161,21 +161,20 @@ testIgnoreShellPreferredExtent
 	self assert: vc composingView usePreferredExtent.
 	"If this test fails check to see that ShellView>>resourcce_Default_view does indeed have an
 	extent of 600@400 when saved by the VC"
-	self assert: vc composingView extent = (600 @ 400)!
+	self assert: vc composingView extent equals: 600 @ 400!
 
 testNoDragResourceOverInUseArena
 	| session toolbox |
 	vc newShellView.
 	toolbox := vc instVarNamed: 'toolboxPresenter'.
-	session := InternalDragDropSession dragSource: toolbox view
-				item: (ResourceIdentifier class: Shell).
+	session := InternalDragDropSession dragSource: toolbox view item: (ResourceIdentifier class: Shell).
 	toolbox resourcesPresenter onDragResource: session.
 	session
 		startTrackingAt: 20 @ 20;
 		operation: #copy.
 	vc onDragOverArena: session.
-	self assert: session operation isNil.
-	self assert: session suggestedTarget isNil!
+	self assertIsNil: session operation.
+	self assertIsNil: session suggestedTarget!
 
 testPasteToArena
 	"Get a ShellView to paste"
@@ -184,25 +183,25 @@ testPasteToArena
 	vc newShellView.
 	shell := vc composingView.
 	vc copySelection.
-	vc viewCloseNoPrompt .
+	vc viewCloseNoPrompt.
 	"Paste to empty view composer"
 	self assert: vc canPaste.
 	vc pasteClipboard.
 	shell := vc primarySelection.
-	self assert: shell class = ShellView.
+	self assert: shell class equals: ShellView.
 	"Get a PushButton to paste"
-	button := vc 
+	button := vc
 				pasteResource: self getButtonResource
 				context: shell
 				position: 0 @ 0.
 	vc selection: button.
 	vc copySelection.
-	vc viewCloseNoPrompt .
+	vc viewCloseNoPrompt.
 	"Paste to empty view composer"
 	vc pasteClipboard.
 	"Check new button exists"
-	self assert: vc primarySelection class == PushButton.
-	self assert: vc primarySelection parentView == View desktop.
+	self assert: vc primarySelection class sameAs: PushButton.
+	self assert: vc primarySelection parentView sameAs: View desktop.
 	vc viewCloseNoPrompt!
 
 testWidenSelection
@@ -211,15 +210,15 @@ testWidenSelection
 	chb := vc composingView.
 	classTree := chb viewNamed: 'classes'.
 	vc selection: classTree.
-	self assert: vc primarySelection == classTree.
+	self assert: vc primarySelection sameAs: classTree.
 	vc widenSelection.
-	self assert: vc primarySelection == classTree parentView.
+	self assert: vc primarySelection sameAs: classTree parentView.
 	vc widenSelection.
-	self assert: vc primarySelection == classTree parentView parentView.
+	self assert: vc primarySelection sameAs: classTree parentView parentView.
 	vc widenSelection.
-	self assert: vc primarySelection == chb.
+	self assert: vc primarySelection sameAs: chb.
 	vc widenSelection.
-	self assert: vc primarySelection == chb!
+	self assert: vc primarySelection sameAs: chb!
 
 testZOrderPreservedByMutate
 	| shell |
@@ -227,17 +226,17 @@ testZOrderPreservedByMutate
 	shell := vc pasteContext.
 	1 to: 3
 		do: 
-			[:i | 
+			[:i |
 			| view |
-			view := vc 
+			view := vc
 						pasteResource: (ResourceIdentifier class: TextPresenter name: 'Default view') resource
 						context: shell
 						position: (20 * i) @ (10 * i).
 			view name: i printString].
-	self assert: (shell subViews collect: [:each | each name]) asArray = #('1' '2' '3').
+	self assert: (shell subViews collect: [:each | each name]) asArray equals: #('1' '2' '3').
 	vc selection: shell.
 	vc mutateTo: ContainerView.
-	self assert: (shell subViews collect: [:each | each name]) asArray = #('1' '2' '3')! !
+	self assert: (shell subViews collect: [:each | each name]) asArray equals: #('1' '2' '3')! !
 !ViewComposerTest categoriesFor: #doArenaDropOf:operation:!private!unit tests! !
 !ViewComposerTest categoriesFor: #dragResourceFor:!private!unit tests! !
 !ViewComposerTest categoriesFor: #getButtonResource!private!unit tests! !

--- a/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
@@ -15,7 +15,11 @@ doArenaDropOf: subPresenterType operation: aSymbol
 	ddSession := self dragResourceFor: subPresenterType.
 	aSymbol ifNotNil: [ddSession defaultOperation: aSymbol].
 	overShell := vc arena mapPoint: 50 @ 50 to: View desktop.
+	"We need to send two drag events as the VC waits for a drag-move after drag-enter before setting up for the drop."
 	ddSession continueTrackingAt: overShell from: ddSession dragPoint.
+	ddSession continueTrackingAt: overShell + 1 from: ddSession dragPoint.
+	self assert: ddSession operation equals: aSymbol.
+	self assert: ddSession suggestedTarget equals: vc composingView ?? vc arena.
 	ddSession endTrackingAt: overShell.
 	^ddSession!
 


### PR DESCRIPTION
The three tests are still failing occassionally, but the diagnostic info
in the test run log that is uploaded to AppVeyor (now) provides no
particularly useful clue as to the problem as it all three tests are just
reporting "Assertion Failed" because they use the basic assert method.