### PR TITLE
Regenerate Windows Http Server API from typelib

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/Automation/AXTypeInfoAnalyzer.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/AXTypeInfoAnalyzer.cls
@@ -330,6 +330,9 @@ realize
 	self setTypeInfo: (typeLib basicTypeInfoAt: index)
 !
 
+realTypeInfo
+	^self!
+
 releaseFuncDesc: aFUNCDESC
 	tlbInterface isNull ifFalse: [tlbInterface ReleaseFuncDesc: aFUNCDESC]!
 
@@ -444,6 +447,7 @@ vt
 !AXTypeInfoAnalyzer categoriesFor: #nameOfID:ifAbsent:!accessing!public! !
 !AXTypeInfoAnalyzer categoriesFor: #nameSansTag!accessing!private! !
 !AXTypeInfoAnalyzer categoriesFor: #realize!private!realizing/unrealizing! !
+!AXTypeInfoAnalyzer categoriesFor: #realTypeInfo!accessing!public! !
 !AXTypeInfoAnalyzer categoriesFor: #releaseFuncDesc:!private!realizing/unrealizing! !
 !AXTypeInfoAnalyzer categoriesFor: #releaseTypeAttr:!private!realizing/unrealizing! !
 !AXTypeInfoAnalyzer categoriesFor: #releaseVarDesc:!private!realizing/unrealizing! !

--- a/Core/Object Arts/Dolphin/ActiveX/Automation/TKindAliasAnalyzer.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/TKindAliasAnalyzer.cls
@@ -23,10 +23,23 @@ classDesc
 
 	^(BaseTypes lookup: self name) ifNil: [self tdesc classDesc] ifNotNil: [:class | class -> 0]!
 
+isAnonymous
+	"Answer whether the receiver describes an anonymous (i.e. unnamed) structure or union."
+
+	^(BaseTypes lookup: self name) isNil and: [self tdesc isAnonymous]!
+
+isStructure
+	"Answer whether the receiver describes a structure."
+
+	^self tdesc isStructure!
+
 isUnion
 	"Answer whether the receiver describes a union."
 
 	^self tdesc isUnion!
+
+realTypeInfo
+	^self tdesc realTypeInfo!
 
 vt
 	"Answer the VARTYPE (one of the VT_XXX constants) used to describe the receiver's 
@@ -35,7 +48,10 @@ vt
 	^self tdesc vartype! !
 !TKindAliasAnalyzer categoriesFor: #baseClass!constants!private! !
 !TKindAliasAnalyzer categoriesFor: #classDesc!accessing!constants!private! !
+!TKindAliasAnalyzer categoriesFor: #isAnonymous!public!testing! !
+!TKindAliasAnalyzer categoriesFor: #isStructure!public!testing! !
 !TKindAliasAnalyzer categoriesFor: #isUnion!public!testing! !
+!TKindAliasAnalyzer categoriesFor: #realTypeInfo!accessing!public! !
 !TKindAliasAnalyzer categoriesFor: #vt!accessing!constants!public! !
 
 !TKindAliasAnalyzer class methodsFor!
@@ -46,7 +62,7 @@ initialize
 	"
 
 	BaseTypes := LookupTable new.
-	#(#UINT_PTR #INT_PTR #LARGE_INTEGER #ULARGE_INTEGER #BOOLEAN)
+	#(#UINT_PTR #INT_PTR #LARGE_INTEGER #ULARGE_INTEGER #BOOLEAN #GUID)
 		do: [:each | BaseTypes at: each asString put: (Smalltalk at: each)].
 	BaseTypes
 		at: 'guid' put: GUID;

--- a/Core/Object Arts/Dolphin/ActiveX/Automation/TYPEDESC.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/TYPEDESC.cls
@@ -92,7 +92,7 @@ isStructure
 isUnion
 	"Answer whether the receiver describes a user-defined union type."
 
-	^self isUserDefined and: [self typeInfo isUnion]!
+	^self isUserDefined and: [self realTypeInfo isUnion]!
 
 isUserDefined
 	"Answer whether the receiver describes a user-defined type, e.g. a struct."
@@ -128,6 +128,11 @@ printOn: aStream
 				print: self typeInfo name]
 		ifFalse: [aStream print: self typeName].
 	aStream nextPut: $)!
+
+realTypeInfo
+	"Answer an <AXTypeInfoAnalyzer> on the underlying type described by the receiver."
+
+	^self typeInfo realTypeInfo!
 
 tdesc
 	"Answer a <TYPEDESC> which is the type of the element described by the receiver.
@@ -208,6 +213,7 @@ vtName
 !TYPEDESC categoriesFor: #lptdesc!**compiled accessors**!public! !
 !TYPEDESC categoriesFor: #owner:!accessing!private! !
 !TYPEDESC categoriesFor: #printOn:!development!printing!public! !
+!TYPEDESC categoriesFor: #realTypeInfo!accessing!public! !
 !TYPEDESC categoriesFor: #tdesc!accessing!public! !
 !TYPEDESC categoriesFor: #tdescArray!accessing!public! !
 !TYPEDESC categoriesFor: #typeDesc!helpers!private! !

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/ActiveX Automation Development.pax
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/ActiveX Automation Development.pax
@@ -1908,7 +1908,7 @@ idlAttributesAndId
 idlCustomAttributes
 	| attrs |
 	attrs := Array writeStream.
-	self customAttributes associations asSortedCollection do: 
+	(self customAttributes associations asSortedCollection: [:a :b | a key displayString < b key displayString]) do: 
 			[:each |
 			| attr |
 			attr := String writeStream.
@@ -2092,7 +2092,7 @@ generateWrapper
 
 printAnonymousStruct: aVARDESC offset: anInteger prefix: aString hidden: aBoolean on: aWriteStream
 	| hidden prefix offset structTypeInfo |
-	structTypeInfo := aVARDESC tdesc typeInfo.
+	structTypeInfo := aVARDESC tdesc realTypeInfo.
 	offset := anInteger + aVARDESC oInst.
 	prefix := aString , (aVARDESC isAnonymous ifTrue: [''] ifFalse: [aVARDESC name , '_']).
 	hidden := (aBoolean or: [aVARDESC isHidden]) or: [structTypeInfo isHidden].
@@ -2895,7 +2895,7 @@ printIDLForVariable: aVARDESC on: aPuttableStream indent: anInteger
 	typedesc isAnonymous
 		ifTrue: 
 			[| structure |
-			structure := typedesc typeInfo.
+			structure := typedesc realTypeInfo.
 			aPuttableStream
 				nextPutAll: structure idlKeyword;
 				space;

--- a/Core/Object Arts/Dolphin/Sockets/IN6_ADDR.cls
+++ b/Core/Object Arts/Dolphin/Sockets/IN6_ADDR.cls
@@ -26,16 +26,16 @@ struct tagIN6_ADDR {
 !IN6_ADDR methodsFor!
 
 Bytes
-	"Answer the <ByteArray> value of the receiver's 'Bytes' field."
+	"Answer the <ExternalArray> value of the receiver's 'Bytes' field."
 
-	^ByteArray fromAddress: bytes yourAddress length: 16!
+	^ExternalArray fromAddress: bytes yourAddress length: 16!
 
-Bytes: aByteArray
-	"Set the receiver's 'Bytes' field to the value of the argument, aByteArray"
+Bytes: anExternalArray
+	"Set the receiver's 'Bytes' field to the value of the argument, anExternalArray"
 
 	| size |
-	size := aByteArray byteSize min: ##(16 * ByteArray elementSize).
-	aByteArray
+	size := anExternalArray byteSize min: ##(16 * ExternalArray elementSize).
+	anExternalArray
 		replaceBytesOf: bytes
 		from: 1
 		to: size
@@ -51,9 +51,9 @@ addressFamily
 defineFields
 	"Define the fields of the IN6_ADDR structure.
 
-	IN6_ADDR  compileDefinition
+	IN6_ADDR compileDefinition
 
-		typedef [uuid(BEBF4C25-CE63-4511-B68E-2434810FA9C3)]
+		typedef [uuid(bebf4c25-ce63-4511-b68e-2434810fa9c3)]
 		struct tagIN6_ADDR {
 			union {
 				UCHAR Bytes[16];
@@ -63,7 +63,7 @@ defineFields
 "
 
 	self
-		defineField: #Bytes type: (ArrayField type: ByteArray length: 16) offset: 0;
+		defineField: #Bytes type: (ArrayField type: ExternalArray length: 16) offset: 0;
 		defineField: #Words type: (ArrayField type: WORDArray length: 8) beFiller offset: 0.
 	self byteSize: 16! !
 !IN6_ADDR class categoriesFor: #addressFamily!constants!public! !

--- a/Core/Object Arts/Dolphin/Sockets/IN_ADDR.cls
+++ b/Core/Object Arts/Dolphin/Sockets/IN_ADDR.cls
@@ -72,9 +72,9 @@ addressFamily
 defineFields
 	"Define the fields of the IN_ADDR structure.
 
-	IN_ADDR  compileDefinition
+	IN_ADDR compileDefinition
 
-		typedef [uuid(87B4C5F6-026E-11D3-9FD7-00A0CC3E4A32), helpstring('IPv4 Internet address. This is an 'on-wire' format structure.')]
+		typedef [uuid(87b4c5f6-026e-11d3-9fd7-00a0cc3e4a32), helpstring('IPv4 Internet address. This is an 'on-wire' format structure.')]
 		struct tagIN_ADDR {
 			union {
 				[hidden] struct {

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_BANDWIDTH_LIMIT_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_BANDWIDTH_LIMIT_INFO.cls
@@ -6,7 +6,7 @@ HttpQosSetting subclass: #HTTP_BANDWIDTH_LIMIT_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_BANDWIDTH_LIMIT_INFO guid: (GUID fromString: '{197b6874-68bb-4a22-b2fa-9e02210f4cd9}')!
-HTTP_BANDWIDTH_LIMIT_INFO comment: '<HTTP_BANDWIDTH_LIMIT_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_BANDWIDTH_LIMIT_INFO'' from type information in the ''Win32 API'' library.
+HTTP_BANDWIDTH_LIMIT_INFO comment: '<HTTP_BANDWIDTH_LIMIT_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_BANDWIDTH_LIMIT_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Used to set or query the bandwidth throttling limit.This structure must be used when setting or querying the HttpServerBandwidthProperty on a URL Group or server session."
@@ -21,7 +21,7 @@ struct tagHTTP_BANDWIDTH_LIMIT_INFO {
 	[helpstring("The maximum allowed bandwidth rate in bytesper second. Setting the value to HTTP_LIMIT_INFINITE allows unlimited bandwidth rate. The value cannot be smaller than HTTP_MIN_ALLOWED_BANDWIDTH_THROTTLING_RATE.")] ULONG MaxBandwidth;
 } HTTP_BANDWIDTH_LIMIT_INFO;
 '!
-!HTTP_BANDWIDTH_LIMIT_INFO categoriesForClass!Win32-Structs! !
+!HTTP_BANDWIDTH_LIMIT_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_BANDWIDTH_LIMIT_INFO methodsFor!
 
 MaxBandwidth

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_BINDING_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_BINDING_INFO.cls
@@ -6,7 +6,7 @@ HTTP_PROPERTY_FLAGS subclass: #HTTP_BINDING_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_BINDING_INFO guid: (GUID fromString: '{b253697c-f239-4fb6-b474-b35db2c4848f}')!
-HTTP_BINDING_INFO comment: '<HTTP_BINDING_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_BINDING_INFO'' from type information in the ''Win32 API'' library.
+HTTP_BINDING_INFO comment: '<HTTP_BINDING_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_BINDING_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"The HTTP_BINDING_INFO structure is used to associate a URL Group with a request queue. This structure must be used when setting or querying the HttpServerBindingProperty on a URL Group."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_BYTE_RANGE.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_BYTE_RANGE.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_BYTE_RANGE
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_BYTE_RANGE guid: (GUID fromString: '{3426318c-022f-4dd9-9e4e-a04febf70a10}')!
-HTTP_BYTE_RANGE comment: '<HTTP_BYTE_RANGE> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_BYTE_RANGE'' from type information in the ''Win32 API'' library.
+HTTP_BYTE_RANGE comment: '<HTTP_BYTE_RANGE> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_BYTE_RANGE'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"This structure defines a file byte range. If the Length field is HTTP_BYTE_RANGE_TO_EOF then the remainder of the file (everything after StartingOffset) is sent."
@@ -21,7 +21,7 @@ struct tagHTTP_BYTE_RANGE {
 	[helpstring("Size, in bytes, of the range. If this member is HTTP_BYTE_RANGE_TO_EOF, the range extends from the starting offset to the end of the file or data block.")] ULARGE_INTEGER Length;
 } HTTP_BYTE_RANGE;
 '!
-!HTTP_BYTE_RANGE categoriesForClass!Win32-Structs! !
+!HTTP_BYTE_RANGE categoriesForClass!WinHttpServer-Structs! !
 !HTTP_BYTE_RANGE methodsFor!
 
 Length

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_CACHE_POLICY.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_CACHE_POLICY.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_CACHE_POLICY
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_CACHE_POLICY guid: (GUID fromString: '{02064551-c601-4e48-85ac-6d19fe34f58b}')!
-HTTP_CACHE_POLICY comment: '<HTTP_CACHE_POLICY> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_CACHE_POLICY'' from type information in the ''Win32 API'' library.
+HTTP_CACHE_POLICY comment: '<HTTP_CACHE_POLICY> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_CACHE_POLICY'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	" Only cache unauthorized GETs + HEADs."
@@ -21,7 +21,7 @@ struct tagHTTP_CACHE_POLICY {
 	ULONG SecondsToLive;
 } HTTP_CACHE_POLICY;
 '!
-!HTTP_CACHE_POLICY categoriesForClass!Win32-Structs! !
+!HTTP_CACHE_POLICY categoriesForClass!WinHttpServer-Structs! !
 !HTTP_CACHE_POLICY methodsFor!
 
 policy

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_CHANNEL_BIND_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_CHANNEL_BIND_INFO.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_CHANNEL_BIND_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_CHANNEL_BIND_INFO guid: (GUID fromString: '{84ea1900-0bc6-4ac8-9025-7f74436d5dc9}')!
-HTTP_CHANNEL_BIND_INFO comment: '<HTTP_CHANNEL_BIND_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_CHANNEL_BIND_INFO'' from type information in the ''Win32 API'' library.
+HTTP_CHANNEL_BIND_INFO comment: '<HTTP_CHANNEL_BIND_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_CHANNEL_BIND_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"The HTTP_CHANNEL_BIND_INFO structure is used to set or query channel bind authentication."
@@ -18,23 +18,23 @@ IDL definition follows:
 typedef [uuid(84ea1900-0bc6-4ac8-9025-7f74436d5dc9), helpstring("The HTTP_CHANNEL_BIND_INFO structure is used to set or query channel bind authentication.")]
 struct tagHTTP_CHANNEL_BIND_INFO {
 	[helpstring(" HTTP_AUTHENTICATION_HARDENING_LEVELS value indicating the hardening level levels to be set or queried per server session or URL group.")] HTTP_AUTHENTICATION_HARDENING_LEVELS Hardening;
-	[helpstring("Flags from the HTTP_CHANNEL_BIND_* enumeration that determine the behaviour of authentication.")] ULONG flags;
+	[helpstring("Flags from the HTTP_CHANNEL_BIND_* enumeration that determine the behaviour of authentication.")] ULONG Flags;
 	[helpstring("Pointer to a buffer holding an array of 1 or more service names. Each service name is represented by either an HTTP_SERVICE_BINDING_A structure or an HTTP_SERVICE_BINDING_W structure, dependent upon whether the name is ASCII or Unicode."), size_is("NumberOfServiceNames")] HTTP_SERVICE_BINDING_BASE* ServiceNames;
 	[nonbrowsable, helpstring("The number of names in ServiceNames.")] ULONG NumberOfServiceNames;
 } HTTP_CHANNEL_BIND_INFO;
 '!
-!HTTP_CHANNEL_BIND_INFO categoriesForClass!Win32-Structs! !
+!HTTP_CHANNEL_BIND_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_CHANNEL_BIND_INFO methodsFor!
 
-flags
-	"Answer the <Integer> value of the receiver's 'flags' field."
+Flags
+	"Answer the <Integer> value of the receiver's 'Flags' field."
 
-	^bytes dwordAtOffset: ##(self offsetOf: #flags)!
+	^bytes dwordAtOffset: ##(self offsetOf: #Flags)!
 
-flags: anInteger
-	"Set the receiver's 'flags' field to the value of the argument, anInteger"
+Flags: anInteger
+	"Set the receiver's 'Flags' field to the value of the argument, anInteger"
 
-	bytes dwordAtOffset: ##(self offsetOf: #flags) put: anInteger!
+	bytes dwordAtOffset: ##(self offsetOf: #Flags) put: anInteger!
 
 Hardening
 	"Answer the <Integer> value of the receiver's 'Hardening' field."
@@ -69,8 +69,8 @@ ServiceNames: aStructureArray
 
 	bytes uintPtrAtOffset: ##(self offsetOf: #ServiceNames) put: aStructureArray yourAddress.
 	self NumberOfServiceNames: aStructureArray size! !
-!HTTP_CHANNEL_BIND_INFO categoriesFor: #flags!**compiled accessors**!public! !
-!HTTP_CHANNEL_BIND_INFO categoriesFor: #flags:!**compiled accessors**!public! !
+!HTTP_CHANNEL_BIND_INFO categoriesFor: #Flags!**compiled accessors**!public! !
+!HTTP_CHANNEL_BIND_INFO categoriesFor: #Flags:!**compiled accessors**!public! !
 !HTTP_CHANNEL_BIND_INFO categoriesFor: #Hardening!**compiled accessors**!public! !
 !HTTP_CHANNEL_BIND_INFO categoriesFor: #Hardening:!**compiled accessors**!public! !
 !HTTP_CHANNEL_BIND_INFO categoriesFor: #NumberOfServiceNames!**compiled accessors**!private! !
@@ -88,7 +88,7 @@ defineFields
 		typedef [uuid(84ea1900-0bc6-4ac8-9025-7f74436d5dc9), helpstring('The HTTP_CHANNEL_BIND_INFO structure is used to set or query channel bind authentication.')]
 		struct tagHTTP_CHANNEL_BIND_INFO {
 			[helpstring(' HTTP_AUTHENTICATION_HARDENING_LEVELS value indicating the hardening level levels to be set or queried per server session or URL group.')] HTTP_AUTHENTICATION_HARDENING_LEVELS Hardening;
-			[helpstring('Flags from the HTTP_CHANNEL_BIND_* enumeration that determine the behaviour of authentication.')] ULONG flags;
+			[helpstring('Flags from the HTTP_CHANNEL_BIND_* enumeration that determine the behaviour of authentication.')] ULONG Flags;
 			[helpstring('Pointer to a buffer holding an array of 1 or more service names. Each service name is represented by either an HTTP_SERVICE_BINDING_A structure or an HTTP_SERVICE_BINDING_W structure, dependent upon whether the name is ASCII or Unicode.'), size_is('NumberOfServiceNames')] HTTP_SERVICE_BINDING_BASE* ServiceNames;
 			[nonbrowsable, helpstring('The number of names in ServiceNames.')] ULONG NumberOfServiceNames;
 		} HTTP_CHANNEL_BIND_INFO;
@@ -96,7 +96,7 @@ defineFields
 
 	self
 		defineField: #Hardening type: SDWORDField new offset: 0;
-		defineField: #flags type: DWORDField new offset: 4;
+		defineField: #Flags type: DWORDField new offset: 4;
 		defineField: #ServiceNames type: (StructureArrayPointerField type: HTTP_SERVICE_BINDING_BASE lengthField: #NumberOfServiceNames) offset: 8;
 		defineField: #NumberOfServiceNames type: DWORDField new beNonBrowsable offset: 12.
 	self byteSize: 16! !

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_CONNECTION_LIMIT_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_CONNECTION_LIMIT_INFO.cls
@@ -6,7 +6,7 @@ HttpQosSetting subclass: #HTTP_CONNECTION_LIMIT_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_CONNECTION_LIMIT_INFO guid: (GUID fromString: '{6fca5840-1e00-4065-ad55-203bd079a117}')!
-HTTP_CONNECTION_LIMIT_INFO comment: '<HTTP_CONNECTION_LIMIT_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_CONNECTION_LIMIT_INFO'' from type information in the ''Win32 API'' library.
+HTTP_CONNECTION_LIMIT_INFO comment: '<HTTP_CONNECTION_LIMIT_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_CONNECTION_LIMIT_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Used to set or query the limit on the maximum number of outstanding connections for a URL Group."
@@ -21,7 +21,7 @@ struct tagHTTP_CONNECTION_LIMIT_INFO {
 	ULONG MaxConnections;
 } HTTP_CONNECTION_LIMIT_INFO;
 '!
-!HTTP_CONNECTION_LIMIT_INFO categoriesForClass!Win32-Structs! !
+!HTTP_CONNECTION_LIMIT_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_CONNECTION_LIMIT_INFO methodsFor!
 
 MaxConnections

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_COOKED_URL.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_COOKED_URL.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_COOKED_URL
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_COOKED_URL guid: (GUID fromString: '{24928162-1798-46a3-b2c1-3c6ee66c08be}')!
-HTTP_COOKED_URL comment: '<HTTP_COOKED_URL> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_COOKED_URL'' from type information in the ''Win32 API'' library.
+HTTP_COOKED_URL comment: '<HTTP_COOKED_URL> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_COOKED_URL'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"The HTTP_COOKED_URL structure contains a validated, canonical, UTF-16 Unicode-encoded URL request string together with pointers into it and element lengths."
@@ -27,7 +27,7 @@ struct tagHTTP_COOKED_URL {
 	[readonly, helpstring("Pointer to the first question mark (?) in the string, or NULL if there is none."), size_is("QueryStringLength>>1"), string] LPCWSTR pQueryString;
 } HTTP_COOKED_URL;
 '!
-!HTTP_COOKED_URL categoriesForClass!Win32-Structs! !
+!HTTP_COOKED_URL categoriesForClass!WinHttpServer-Structs! !
 !HTTP_COOKED_URL methodsFor!
 
 AbsPathLength

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_DATA_CHUNK.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_DATA_CHUNK.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_DATA_CHUNK
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_DATA_CHUNK guid: (GUID fromString: '{831e8135-6bb5-45e2-b278-10b1c489883a}')!
-HTTP_DATA_CHUNK comment: '<HTTP_DATA_CHUNK> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_DATA_CHUNK'' from type information in the ''Win32 API'' library.
+HTTP_DATA_CHUNK comment: '<HTTP_DATA_CHUNK> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_DATA_CHUNK'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"This structure describes an individual data chunk."
@@ -28,17 +28,17 @@ struct tagHTTP_DATA_CHUNK {
 			HANDLE FileHandle;
 		} FromFileHandle;
 		[helpstring("From-fragment cache data chunk.")] struct {
-			USHORT FragmentNameLength;
+			[helpstring("Size in bytes of FragmentName not including terminating null")] USHORT FragmentNameLength;
 			LPCWSTR pFragmentName;
 		} FromFragmentCache;
 		[helpstring("From-fragment cache data chunk that specifies a byte range.")] struct {
 			HTTP_BYTE_RANGE ByteRange;
-			LPCWSTR pFragmentName;
+			[helpstring("Null-terminated string")] LPCWSTR pFragmentName;
 		} FromFragmentCacheEx;
 	};
 } HTTP_DATA_CHUNK;
 '!
-!HTTP_DATA_CHUNK categoriesForClass!Win32-Structs! !
+!HTTP_DATA_CHUNK categoriesForClass!WinHttpServer-Structs! !
 !HTTP_DATA_CHUNK methodsFor!
 
 data: aByteObject
@@ -200,12 +200,12 @@ defineFields
 					HANDLE FileHandle;
 				} FromFileHandle;
 				[helpstring('From-fragment cache data chunk.')] struct {
-					USHORT FragmentNameLength;
+					[helpstring('Size in bytes of FragmentName not including terminating null')] USHORT FragmentNameLength;
 					LPCWSTR pFragmentName;
 				} FromFragmentCache;
 				[helpstring('From-fragment cache data chunk that specifies a byte range.')] struct {
 					HTTP_BYTE_RANGE ByteRange;
-					LPCWSTR pFragmentName;
+					[helpstring('Null-terminated string')] LPCWSTR pFragmentName;
 				} FromFragmentCacheEx;
 			};
 		} HTTP_DATA_CHUNK;

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_FLOWRATE_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_FLOWRATE_INFO.cls
@@ -6,7 +6,7 @@ HttpQosSetting subclass: #HTTP_FLOWRATE_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_FLOWRATE_INFO guid: (GUID fromString: '{c2fad8f6-f179-4bbb-a5f2-073c416f6704}')!
-HTTP_FLOWRATE_INFO comment: '<HTTP_FLOWRATE_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_FLOWRATE_INFO'' from type information in the ''Win32 API'' library.
+HTTP_FLOWRATE_INFO comment: '<HTTP_FLOWRATE_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_FLOWRATE_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"The transfer rate of a response."
@@ -23,7 +23,7 @@ struct tagHTTP_FLOWRATE_INFO {
 	[helpstring("The size of the content, in bytes, to be delivered at MaxPeakBandwidth. Once this content has been delivered, the response is throttled at MaxBandwidth.")] ULONG BurstSize;
 } HTTP_FLOWRATE_INFO;
 '!
-!HTTP_FLOWRATE_INFO categoriesForClass!Win32-Structs! !
+!HTTP_FLOWRATE_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_FLOWRATE_INFO methodsFor!
 
 BurstSize

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_HEADERS.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_HEADERS.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_HEADERS
 	poolDictionaries: 'WinHttpServerConsts'
 	classInstanceVariableNames: ''!
 HTTP_HEADERS guid: (GUID fromString: '{739d04bb-0a15-47ea-8a7d-20b4fd31cc96}')!
-HTTP_HEADERS comment: '<HTTP_HEADERS> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_HEADERS'' from type information in the ''Win32 API'' library.
+HTTP_HEADERS comment: '<HTTP_HEADERS> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_HEADERS'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Fields common to HTTP_REQUEST_HEADERS and HTTP_RESPONSE_HEADERS"
@@ -19,11 +19,11 @@ typedef [uuid(739d04bb-0a15-47ea-8a7d-20b4fd31cc96), helpstring("Fields common t
 struct tagHTTP_HEADERS {
 	[nonbrowsable, helpstring("The number of entries in the UnknownHeaders array.")] USHORT UnknownHeaderCount;
 	[helpstring("The array of unknown HTTP headers."), size_is("UnknownHeaderCount")] PHTTP_UNKNOWN_HEADER pUnknownHeaders;
-	[hidden, nonbrowsable] USHORT TrailerCount;
-	[hidden, helpstring("Trailers - we don''t use these currently, reserved for a future release"), size_is("TrailerCount")] PHTTP_UNKNOWN_HEADER pTrailers;
+	[hidden, nonbrowsable, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] USHORT TrailerCount;
+	[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0), size_is("TrailerCount")] PHTTP_UNKNOWN_HEADER pTrailers;
 } HTTP_HEADERS;
 '!
-!HTTP_HEADERS categoriesForClass!Win32-Structs! !
+!HTTP_HEADERS categoriesForClass!WinHttpServer-Structs! !
 !HTTP_HEADERS methodsFor!
 
 knownHeaderName: anInteger
@@ -160,8 +160,8 @@ defineFields
 		struct tagHTTP_HEADERS {
 			[nonbrowsable, helpstring('The number of entries in the UnknownHeaders array.')] USHORT UnknownHeaderCount;
 			[helpstring('The array of unknown HTTP headers.'), size_is('UnknownHeaderCount')] PHTTP_UNKNOWN_HEADER pUnknownHeaders;
-			[hidden, nonbrowsable] USHORT TrailerCount;
-			[hidden, helpstring('Trailers - we don't use these currently, reserved for a future release'), size_is('TrailerCount')] PHTTP_UNKNOWN_HEADER pTrailers;
+			[hidden, nonbrowsable, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] USHORT TrailerCount;
+			[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0), size_is('TrailerCount')] PHTTP_UNKNOWN_HEADER pTrailers;
 		} HTTP_HEADERS;
 "
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_KNOWN_HEADER.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_KNOWN_HEADER.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_KNOWN_HEADER
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_KNOWN_HEADER guid: (GUID fromString: '{787c501e-95b2-4a23-9f7c-2dd856b8d51d}')!
-HTTP_KNOWN_HEADER comment: '<HTTP_KNOWN_HEADER> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_KNOWN_HEADER'' from type information in the ''Win32 API'' library.
+HTTP_KNOWN_HEADER comment: '<HTTP_KNOWN_HEADER> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_KNOWN_HEADER'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Structure defining format of a known HTTP header. Name is from HTTP_HEADER_ID."
@@ -17,11 +17,11 @@ IDL definition follows:
 
 typedef [uuid(787c501e-95b2-4a23-9f7c-2dd856b8d51d), helpstring("Structure defining format of a known HTTP header. Name is from HTTP_HEADER_ID.")]
 struct tagHTTP_KNOWN_HEADER {
-	[nonbrowsable] USHORT RawValueLength;
+	[nonbrowsable, helpstring("Size in bytes of RawValue not including terminating null")] USHORT RawValueLength;
 	[size_is("RawValueLength"), string] LPCSTR pRawValue;
 } HTTP_KNOWN_HEADER;
 '!
-!HTTP_KNOWN_HEADER categoriesForClass!Win32-Structs! !
+!HTTP_KNOWN_HEADER categoriesForClass!WinHttpServer-Structs! !
 !HTTP_KNOWN_HEADER methodsFor!
 
 pRawValue
@@ -59,7 +59,7 @@ defineFields
 
 		typedef [uuid(787c501e-95b2-4a23-9f7c-2dd856b8d51d), helpstring('Structure defining format of a known HTTP header. Name is from HTTP_HEADER_ID.')]
 		struct tagHTTP_KNOWN_HEADER {
-			[nonbrowsable] USHORT RawValueLength;
+			[nonbrowsable, helpstring('Size in bytes of RawValue not including terminating null')] USHORT RawValueLength;
 			[size_is('RawValueLength'), string] LPCSTR pRawValue;
 		} HTTP_KNOWN_HEADER;
 "

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_LISTEN_ENDPOINT_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_LISTEN_ENDPOINT_INFO.cls
@@ -6,7 +6,7 @@ HTTP_PROPERTY_FLAGS subclass: #HTTP_LISTEN_ENDPOINT_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_LISTEN_ENDPOINT_INFO guid: (GUID fromString: '{c96f66fd-b678-4046-9100-ed4b4bc7c9fe}')!
-HTTP_LISTEN_ENDPOINT_INFO comment: '<HTTP_LISTEN_ENDPOINT_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_LISTEN_ENDPOINT_INFO'' from type information in the ''Win32 API'' library.
+HTTP_LISTEN_ENDPOINT_INFO comment: '<HTTP_LISTEN_ENDPOINT_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_LISTEN_ENDPOINT_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Controls whether IP-based URLs should listen on the specific IP or wildcard."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_LOGGING_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_LOGGING_INFO.cls
@@ -6,7 +6,7 @@ HTTP_PROPERTY_FLAGS subclass: #HTTP_LOGGING_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_LOGGING_INFO guid: (GUID fromString: '{41c67887-c529-4196-9c0f-5bb698324d32}')!
-HTTP_LOGGING_INFO comment: '<HTTP_LOGGING_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_LOGGING_INFO'' from type information in the ''Win32 API'' library.
+HTTP_LOGGING_INFO comment: '<HTTP_LOGGING_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_LOGGING_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Configuration structure used for setting the logging property."
@@ -25,9 +25,9 @@ struct tagHTTP_LOGGING_INFO {
 	[helpstring("Log file directory must be a fully qualified path.")] LPCWSTR DirectoryName;
 	[helpstring("Specifies the format for the log files.")] HTTP_LOGGING_TYPE Format;
 	[helpstring("Bitmask value indicates which fields to be logged if the log format is set to W3C.This must be the ''bitwise or'' of the HTTP_LOG_FIELD_... values.")] ULONG Fields;
-	[helpstring("Reserved must be NULL.")] void* pExtFields;
-	[helpstring("Reserved must be zero.")] USHORT NumOfExtFields;
-	[helpstring("Reserved must be zero.")] USHORT MaxRecordSize;
+	[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] void* pExtFields;
+	[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] USHORT NumOfExtFields;
+	[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] USHORT MaxRecordSize;
 	[helpstring("Defines the rollover type for the log files.")] HTTP_LOGGING_ROLLOVER_TYPE RolloverType;
 	[helpstring("Indicates the maximum size (in bytes) after which the log files should be rolled over.A value of HTTP_LIMIT_INFINITE (-1) indicates an unlimited size. This value is discarded if rollover type is not set to HttpLoggingRolloverSize.")] ULONG RolloverSize;
 	[helpstring("Specifies the security descriptor to be applied to the log files and the sub - directories. If null we will inherit the system default. This security descriptor must be self-relative.")] void* pSecurityDescriptor;
@@ -85,36 +85,6 @@ LoggingFlags: anInteger
 	"Set the receiver's 'LoggingFlags' field to the value of the argument, anInteger"
 
 	bytes dwordAtOffset: ##(self offsetOf: #LoggingFlags) put: anInteger!
-
-MaxRecordSize
-	"Answer the <Integer> value of the receiver's 'MaxRecordSize' field."
-
-	^bytes wordAtOffset: ##(self offsetOf: #MaxRecordSize)!
-
-MaxRecordSize: anInteger
-	"Set the receiver's 'MaxRecordSize' field to the value of the argument, anInteger"
-
-	bytes wordAtOffset: ##(self offsetOf: #MaxRecordSize) put: anInteger!
-
-NumOfExtFields
-	"Answer the <Integer> value of the receiver's 'NumOfExtFields' field."
-
-	^bytes wordAtOffset: ##(self offsetOf: #NumOfExtFields)!
-
-NumOfExtFields: anInteger
-	"Set the receiver's 'NumOfExtFields' field to the value of the argument, anInteger"
-
-	bytes wordAtOffset: ##(self offsetOf: #NumOfExtFields) put: anInteger!
-
-pExtFields
-	"Answer the <ExternalAddress> value of the receiver's 'pExtFields' field."
-
-	^(bytes uintPtrAtOffset: ##(self offsetOf: #pExtFields)) asExternalAddress!
-
-pExtFields: anExternalAddress
-	"Set the receiver's 'pExtFields' field to the value of the argument, anExternalAddress"
-
-	bytes uintPtrAtOffset: ##(self offsetOf: #pExtFields) put: anExternalAddress!
 
 pSecurityDescriptor
 	"Answer the <ExternalAddress> value of the receiver's 'pSecurityDescriptor' field."
@@ -175,12 +145,6 @@ SoftwareNameLength: anInteger
 !HTTP_LOGGING_INFO categoriesFor: #Format:!**compiled accessors**!public! !
 !HTTP_LOGGING_INFO categoriesFor: #LoggingFlags!**compiled accessors**!public! !
 !HTTP_LOGGING_INFO categoriesFor: #LoggingFlags:!**compiled accessors**!public! !
-!HTTP_LOGGING_INFO categoriesFor: #MaxRecordSize!**compiled accessors**!public! !
-!HTTP_LOGGING_INFO categoriesFor: #MaxRecordSize:!**compiled accessors**!public! !
-!HTTP_LOGGING_INFO categoriesFor: #NumOfExtFields!**compiled accessors**!public! !
-!HTTP_LOGGING_INFO categoriesFor: #NumOfExtFields:!**compiled accessors**!public! !
-!HTTP_LOGGING_INFO categoriesFor: #pExtFields!**compiled accessors**!public! !
-!HTTP_LOGGING_INFO categoriesFor: #pExtFields:!**compiled accessors**!public! !
 !HTTP_LOGGING_INFO categoriesFor: #pSecurityDescriptor!**compiled accessors**!public! !
 !HTTP_LOGGING_INFO categoriesFor: #pSecurityDescriptor:!**compiled accessors**!public! !
 !HTTP_LOGGING_INFO categoriesFor: #RolloverSize!**compiled accessors**!public! !
@@ -209,9 +173,9 @@ defineFields
 			[helpstring('Log file directory must be a fully qualified path.')] LPCWSTR DirectoryName;
 			[helpstring('Specifies the format for the log files.')] HTTP_LOGGING_TYPE Format;
 			[helpstring('Bitmask value indicates which fields to be logged if the log format is set to W3C.This must be the 'bitwise or' of the HTTP_LOG_FIELD_... values.')] ULONG Fields;
-			[helpstring('Reserved must be NULL.')] void* pExtFields;
-			[helpstring('Reserved must be zero.')] USHORT NumOfExtFields;
-			[helpstring('Reserved must be zero.')] USHORT MaxRecordSize;
+			[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] void* pExtFields;
+			[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] USHORT NumOfExtFields;
+			[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] USHORT MaxRecordSize;
 			[helpstring('Defines the rollover type for the log files.')] HTTP_LOGGING_ROLLOVER_TYPE RolloverType;
 			[helpstring('Indicates the maximum size (in bytes) after which the log files should be rolled over.A value of HTTP_LIMIT_INFINITE (-1) indicates an unlimited size. This value is discarded if rollover type is not set to HttpLoggingRolloverSize.')] ULONG RolloverSize;
 			[helpstring('Specifies the security descriptor to be applied to the log files and the sub - directories. If null we will inherit the system default. This security descriptor must be self-relative.')] void* pSecurityDescriptor;
@@ -227,9 +191,9 @@ defineFields
 		defineField: #DirectoryName type: (PointerField type: UnicodeString) offset: 16;
 		defineField: #Format type: SDWORDField new offset: 20;
 		defineField: #Fields type: DWORDField new offset: 24;
-		defineField: #pExtFields type: LPVOIDField new offset: 28;
-		defineField: #NumOfExtFields type: WORDField new offset: 32;
-		defineField: #MaxRecordSize type: WORDField new offset: 34;
+		defineField: #pExtFields type: LPVOIDField new beFiller offset: 28;
+		defineField: #NumOfExtFields type: WORDField new beFiller offset: 32;
+		defineField: #MaxRecordSize type: WORDField new beFiller offset: 34;
 		defineField: #RolloverType type: SDWORDField new offset: 36;
 		defineField: #RolloverSize type: DWORDField new offset: 40;
 		defineField: #pSecurityDescriptor type: LPVOIDField new offset: 44.

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_LOG_FIELDS_DATA.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_LOG_FIELDS_DATA.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_LOG_FIELDS_DATA
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_LOG_FIELDS_DATA guid: (GUID fromString: '{35c62b99-abf3-46f3-b967-7b54dc2641cc}')!
-HTTP_LOG_FIELDS_DATA comment: '<HTTP_LOG_FIELDS_DATA> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_LOG_FIELDS_DATA'' from type information in the ''Win32 API'' library.
+HTTP_LOG_FIELDS_DATA comment: '<HTTP_LOG_FIELDS_DATA> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_LOG_FIELDS_DATA'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Current log fields data structure for of type HttpLogDataTypeFields."
@@ -49,7 +49,7 @@ struct tagHTTP_LOG_FIELDS_DATA {
 	USHORT SubStatus;
 } HTTP_LOG_FIELDS_DATA;
 '!
-!HTTP_LOG_FIELDS_DATA categoriesForClass!Win32-Structs! !
+!HTTP_LOG_FIELDS_DATA categoriesForClass!WinHttpServer-Structs! !
 !HTTP_LOG_FIELDS_DATA methodsFor!
 
 ClientIp

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_MULTIPLE_KNOWN_HEADERS.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_MULTIPLE_KNOWN_HEADERS.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_MULTIPLE_KNOWN_HEADERS
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_MULTIPLE_KNOWN_HEADERS guid: (GUID fromString: '{a12486b1-fdf5-4d31-a4b7-af9848ffe5c6}')!
-HTTP_MULTIPLE_KNOWN_HEADERS comment: '<HTTP_MULTIPLE_KNOWN_HEADERS> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_MULTIPLE_KNOWN_HEADERS'' from type information in the ''Win32 API'' library.
+HTTP_MULTIPLE_KNOWN_HEADERS comment: '<HTTP_MULTIPLE_KNOWN_HEADERS> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_MULTIPLE_KNOWN_HEADERS'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"This structure allows the provision of providing multiple known headers."
@@ -18,23 +18,23 @@ IDL definition follows:
 typedef [uuid(a12486b1-fdf5-4d31-a4b7-af9848ffe5c6), helpstring("This structure allows the provision of providing multiple known headers.")]
 struct tagHTTP_MULTIPLE_KNOWN_HEADERS {
 	[helpstring("Known header id.")] HTTP_HEADER_ID HeaderId;
-	[helpstring("The flags corresponding to the response header in the HeaderId member. This member is used only when the WWW-Authenticate header is present.")] ULONG flags;
+	[helpstring("The flags corresponding to the response header in the HeaderId member. This member is used only when the WWW-Authenticate header is present.")] ULONG Flags;
 	[helpstring("The number of elements in the array specified in the KnownHeaders member.")] USHORT KnownHeaderCount;
 	[helpstring("A pointer to the first element in the array of HTTP_KNOWN_HEADER structures."), size_is("KnownHeaderCount")] PHTTP_KNOWN_HEADER KnownHeaders;
 } HTTP_MULTIPLE_KNOWN_HEADERS;
 '!
-!HTTP_MULTIPLE_KNOWN_HEADERS categoriesForClass!Win32-Structs! !
+!HTTP_MULTIPLE_KNOWN_HEADERS categoriesForClass!WinHttpServer-Structs! !
 !HTTP_MULTIPLE_KNOWN_HEADERS methodsFor!
 
-flags
-	"Answer the <Integer> value of the receiver's 'flags' field."
+Flags
+	"Answer the <Integer> value of the receiver's 'Flags' field."
 
-	^bytes dwordAtOffset: ##(self offsetOf: #flags)!
+	^bytes dwordAtOffset: ##(self offsetOf: #Flags)!
 
-flags: anInteger
-	"Set the receiver's 'flags' field to the value of the argument, anInteger"
+Flags: anInteger
+	"Set the receiver's 'Flags' field to the value of the argument, anInteger"
 
-	bytes dwordAtOffset: ##(self offsetOf: #flags) put: anInteger!
+	bytes dwordAtOffset: ##(self offsetOf: #Flags) put: anInteger!
 
 HeaderId
 	"Answer the <Integer> value of the receiver's 'HeaderId' field."
@@ -69,8 +69,8 @@ KnownHeaders: aStructureArray
 
 	bytes uintPtrAtOffset: ##(self offsetOf: #KnownHeaders) put: aStructureArray yourAddress.
 	self KnownHeaderCount: aStructureArray size! !
-!HTTP_MULTIPLE_KNOWN_HEADERS categoriesFor: #flags!**compiled accessors**!public! !
-!HTTP_MULTIPLE_KNOWN_HEADERS categoriesFor: #flags:!**compiled accessors**!public! !
+!HTTP_MULTIPLE_KNOWN_HEADERS categoriesFor: #Flags!**compiled accessors**!public! !
+!HTTP_MULTIPLE_KNOWN_HEADERS categoriesFor: #Flags:!**compiled accessors**!public! !
 !HTTP_MULTIPLE_KNOWN_HEADERS categoriesFor: #HeaderId!**compiled accessors**!public! !
 !HTTP_MULTIPLE_KNOWN_HEADERS categoriesFor: #HeaderId:!**compiled accessors**!public! !
 !HTTP_MULTIPLE_KNOWN_HEADERS categoriesFor: #KnownHeaderCount!**compiled accessors**!public! !
@@ -88,7 +88,7 @@ defineFields
 		typedef [uuid(a12486b1-fdf5-4d31-a4b7-af9848ffe5c6), helpstring('This structure allows the provision of providing multiple known headers.')]
 		struct tagHTTP_MULTIPLE_KNOWN_HEADERS {
 			[helpstring('Known header id.')] HTTP_HEADER_ID HeaderId;
-			[helpstring('The flags corresponding to the response header in the HeaderId member. This member is used only when the WWW-Authenticate header is present.')] ULONG flags;
+			[helpstring('The flags corresponding to the response header in the HeaderId member. This member is used only when the WWW-Authenticate header is present.')] ULONG Flags;
 			[helpstring('The number of elements in the array specified in the KnownHeaders member.')] USHORT KnownHeaderCount;
 			[helpstring('A pointer to the first element in the array of HTTP_KNOWN_HEADER structures.'), size_is('KnownHeaderCount')] PHTTP_KNOWN_HEADER KnownHeaders;
 		} HTTP_MULTIPLE_KNOWN_HEADERS;
@@ -96,7 +96,7 @@ defineFields
 
 	self
 		defineField: #HeaderId type: SDWORDField new offset: 0;
-		defineField: #flags type: DWORDField new offset: 4;
+		defineField: #Flags type: DWORDField new offset: 4;
 		defineField: #KnownHeaderCount type: WORDField new offset: 8;
 		defineField: #KnownHeaders type: (StructureArrayPointerField type: HTTP_KNOWN_HEADER lengthField: #KnownHeaderCount) offset: 12.
 	self byteSize: 16! !

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_PROPERTY_FLAGS.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_PROPERTY_FLAGS.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_PROPERTY_FLAGS
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_PROPERTY_FLAGS guid: (GUID fromString: '{6ba76c16-b60f-4235-9179-145a93b3f5cb}')!
-HTTP_PROPERTY_FLAGS comment: '<HTTP_PROPERTY_FLAGS> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_PROPERTY_FLAGS'' from type information in the ''Win32 API'' library.
+HTTP_PROPERTY_FLAGS comment: '<HTTP_PROPERTY_FLAGS> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_PROPERTY_FLAGS'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Generic property flags. Each structure defining a property info typically contain an element of this type."
@@ -20,7 +20,7 @@ struct tagHTTP_PROPERTY_FLAGS {
 	[nonbrowsable] BOOL Present;
 } HTTP_PROPERTY_FLAGS;
 '!
-!HTTP_PROPERTY_FLAGS categoriesForClass!Win32-Structs! !
+!HTTP_PROPERTY_FLAGS categoriesForClass!WinHttpServer-Structs! !
 !HTTP_PROPERTY_FLAGS methodsFor!
 
 Present

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_PROTECTION_LEVEL_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_PROTECTION_LEVEL_INFO.cls
@@ -6,7 +6,7 @@ HTTP_PROPERTY_FLAGS subclass: #HTTP_PROTECTION_LEVEL_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_PROTECTION_LEVEL_INFO guid: (GUID fromString: '{e1881388-d03e-4ea0-8e39-8f1439753299}')!
-HTTP_PROTECTION_LEVEL_INFO comment: '<HTTP_PROTECTION_LEVEL_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_PROTECTION_LEVEL_INFO'' from type information in the ''Win32 API'' library.
+HTTP_PROTECTION_LEVEL_INFO comment: '<HTTP_PROTECTION_LEVEL_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_PROTECTION_LEVEL_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Controls whether the associated UrlGroup Namespace should receive edge traversed traffic. By default this parameter is unspecified."
@@ -18,23 +18,23 @@ IDL definition follows:
 typedef [uuid(e1881388-d03e-4ea0-8e39-8f1439753299), helpstring("Controls whether the associated UrlGroup Namespace should receive edge traversed traffic. By default this parameter is unspecified.")]
 struct tagHTTP_PROTECTION_LEVEL_INFO {
 	HTTP_PROPERTY_FLAGS;
-	HTTP_PROTECTION_LEVEL_TYPE level;
+	HTTP_PROTECTION_LEVEL_TYPE Level;
 } HTTP_PROTECTION_LEVEL_INFO;
 '!
 !HTTP_PROTECTION_LEVEL_INFO categoriesForClass!Win32-Structs! !
 !HTTP_PROTECTION_LEVEL_INFO methodsFor!
 
-level
-	"Answer the <Integer> value of the receiver's 'level' field."
+Level
+	"Answer the <Integer> value of the receiver's 'Level' field."
 
-	^bytes sdwordAtOffset: ##(self offsetOf: #level)!
+	^bytes sdwordAtOffset: ##(self offsetOf: #Level)!
 
-level: anInteger
-	"Set the receiver's 'level' field to the value of the argument, anInteger"
+Level: anInteger
+	"Set the receiver's 'Level' field to the value of the argument, anInteger"
 
-	bytes sdwordAtOffset: ##(self offsetOf: #level) put: anInteger! !
-!HTTP_PROTECTION_LEVEL_INFO categoriesFor: #level!**compiled accessors**!public! !
-!HTTP_PROTECTION_LEVEL_INFO categoriesFor: #level:!**compiled accessors**!public! !
+	bytes sdwordAtOffset: ##(self offsetOf: #Level) put: anInteger! !
+!HTTP_PROTECTION_LEVEL_INFO categoriesFor: #Level!**compiled accessors**!public! !
+!HTTP_PROTECTION_LEVEL_INFO categoriesFor: #Level:!**compiled accessors**!public! !
 
 !HTTP_PROTECTION_LEVEL_INFO class methodsFor!
 
@@ -46,13 +46,13 @@ defineFields
 		typedef [uuid(e1881388-d03e-4ea0-8e39-8f1439753299), helpstring('Controls whether the associated UrlGroup Namespace should receive edge traversed traffic. By default this parameter is unspecified.')]
 		struct tagHTTP_PROTECTION_LEVEL_INFO {
 			HTTP_PROPERTY_FLAGS;
-			HTTP_PROTECTION_LEVEL_TYPE level;
+			HTTP_PROTECTION_LEVEL_TYPE Level;
 		} HTTP_PROTECTION_LEVEL_INFO;
 "
 
 	super defineFields.
 	self
-		defineField: #level type: SDWORDField new offset: 4.
+		defineField: #Level type: SDWORDField new offset: 4.
 	self byteSize: 8! !
 !HTTP_PROTECTION_LEVEL_INFO class categoriesFor: #defineFields!**auto generated**!initializing!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_QOS_SETTING_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_QOS_SETTING_INFO.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_QOS_SETTING_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_QOS_SETTING_INFO guid: (GUID fromString: '{a0bcefe3-d299-4e8a-9c7a-6e753a441ad6}')!
-HTTP_QOS_SETTING_INFO comment: '<HTTP_QOS_SETTING_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_QOS_SETTING_INFO'' from type information in the ''Win32 API'' library.
+HTTP_QOS_SETTING_INFO comment: '<HTTP_QOS_SETTING_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_QOS_SETTING_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Contains information about a QOS setting."
@@ -21,7 +21,7 @@ struct tagHTTP_QOS_SETTING_INFO {
 	void* QosSetting;
 } HTTP_QOS_SETTING_INFO;
 '!
-!HTTP_QOS_SETTING_INFO categoriesForClass!Win32-Structs! !
+!HTTP_QOS_SETTING_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_QOS_SETTING_INFO methodsFor!
 
 printFields: aCollection on: aStream limit: anInteger

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_AUTH_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_AUTH_INFO.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_REQUEST_AUTH_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_REQUEST_AUTH_INFO guid: (GUID fromString: '{e0696c2e-1353-45e2-bdcc-a52b6142b827}')!
-HTTP_REQUEST_AUTH_INFO comment: '<HTTP_REQUEST_AUTH_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_REQUEST_AUTH_INFO'' from type information in the ''Win32 API'' library.
+HTTP_REQUEST_AUTH_INFO comment: '<HTTP_REQUEST_AUTH_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_REQUEST_AUTH_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Authentication request info structure"
@@ -19,7 +19,7 @@ typedef [uuid(e0696c2e-1353-45e2-bdcc-a52b6142b827), helpstring("Authentication 
 struct tagHTTP_REQUEST_AUTH_INFO {
 	[helpstring("A member of the HTTP_AUTH_STATUS enumeration that indicates the final authentication status of the request.")] HTTP_AUTH_STATUS AuthStatus;
 	[helpstring("A SECURITY_STATUS value that indicates the security failure status when the AuthStatus member is HttpAuthStatusFailure.")] long SecStatus;
-	[helpstring("Flags from the HTTP_REQUEST_AUTH_FLAG_ enumeration.")] ULONG flags;
+	[helpstring("Flags from the HTTP_REQUEST_AUTH_FLAG_ enumeration.")] ULONG Flags;
 	[helpstring("A member of the HTTP_REQUEST_AUTH_TYPE enumeration that indicates the authentication scheme attempted or established for the request.")] HTTP_REQUEST_AUTH_TYPE AuthType;
 	[helpstring("A handle to the client token that the receiving process can use to impersonate the authenticated client. The handle to the token should be closed by calling CloseHandle when it is no longer required.")] HANDLE AccessToken;
 	[helpstring("The client context attributes for the access token.")] ULONG ContextAttributes;
@@ -32,7 +32,7 @@ struct tagHTTP_REQUEST_AUTH_INFO {
 	[size_is("PackageNameLength>>1"), string] LPWSTR pPackageName;
 } HTTP_REQUEST_AUTH_INFO;
 '!
-!HTTP_REQUEST_AUTH_INFO categoriesForClass!Win32-Structs! !
+!HTTP_REQUEST_AUTH_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_REQUEST_AUTH_INFO methodsFor!
 
 AccessToken
@@ -75,15 +75,15 @@ ContextAttributes: anInteger
 
 	bytes dwordAtOffset: ##(self offsetOf: #ContextAttributes) put: anInteger!
 
-flags
-	"Answer the <Integer> value of the receiver's 'flags' field."
+Flags
+	"Answer the <Integer> value of the receiver's 'Flags' field."
 
-	^bytes dwordAtOffset: ##(self offsetOf: #flags)!
+	^bytes dwordAtOffset: ##(self offsetOf: #Flags)!
 
-flags: anInteger
-	"Set the receiver's 'flags' field to the value of the argument, anInteger"
+Flags: anInteger
+	"Set the receiver's 'Flags' field to the value of the argument, anInteger"
 
-	bytes dwordAtOffset: ##(self offsetOf: #flags) put: anInteger!
+	bytes dwordAtOffset: ##(self offsetOf: #Flags) put: anInteger!
 
 MutualAuthDataLength
 	"Private - Answer the <Integer> value of the receiver's 'MutualAuthDataLength' field."
@@ -178,8 +178,8 @@ SecStatus: anInteger
 !HTTP_REQUEST_AUTH_INFO categoriesFor: #AuthType:!**compiled accessors**!public! !
 !HTTP_REQUEST_AUTH_INFO categoriesFor: #ContextAttributes!**compiled accessors**!public! !
 !HTTP_REQUEST_AUTH_INFO categoriesFor: #ContextAttributes:!**compiled accessors**!public! !
-!HTTP_REQUEST_AUTH_INFO categoriesFor: #flags!**compiled accessors**!public! !
-!HTTP_REQUEST_AUTH_INFO categoriesFor: #flags:!**compiled accessors**!public! !
+!HTTP_REQUEST_AUTH_INFO categoriesFor: #Flags!**compiled accessors**!public! !
+!HTTP_REQUEST_AUTH_INFO categoriesFor: #Flags:!**compiled accessors**!public! !
 !HTTP_REQUEST_AUTH_INFO categoriesFor: #MutualAuthDataLength!**compiled accessors**!private! !
 !HTTP_REQUEST_AUTH_INFO categoriesFor: #MutualAuthDataLength:!**compiled accessors**!private! !
 !HTTP_REQUEST_AUTH_INFO categoriesFor: #PackageNameLength!**compiled accessors**!private! !
@@ -208,7 +208,7 @@ defineFields
 		struct tagHTTP_REQUEST_AUTH_INFO {
 			[helpstring('A member of the HTTP_AUTH_STATUS enumeration that indicates the final authentication status of the request.')] HTTP_AUTH_STATUS AuthStatus;
 			[helpstring('A SECURITY_STATUS value that indicates the security failure status when the AuthStatus member is HttpAuthStatusFailure.')] long SecStatus;
-			[helpstring('Flags from the HTTP_REQUEST_AUTH_FLAG_ enumeration.')] ULONG flags;
+			[helpstring('Flags from the HTTP_REQUEST_AUTH_FLAG_ enumeration.')] ULONG Flags;
 			[helpstring('A member of the HTTP_REQUEST_AUTH_TYPE enumeration that indicates the authentication scheme attempted or established for the request.')] HTTP_REQUEST_AUTH_TYPE AuthType;
 			[helpstring('A handle to the client token that the receiving process can use to impersonate the authenticated client. The handle to the token should be closed by calling CloseHandle when it is no longer required.')] HANDLE AccessToken;
 			[helpstring('The client context attributes for the access token.')] ULONG ContextAttributes;
@@ -225,7 +225,7 @@ defineFields
 	self
 		defineField: #AuthStatus type: SDWORDField new offset: 0;
 		defineField: #SecStatus type: SDWORDField new offset: 4;
-		defineField: #flags type: DWORDField new offset: 8;
+		defineField: #Flags type: DWORDField new offset: 8;
 		defineField: #AuthType type: SDWORDField new offset: 12;
 		defineField: #AccessToken type: HANDLEField new offset: 16;
 		defineField: #ContextAttributes type: DWORDField new offset: 20;

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_CHANNEL_BIND_STATUS.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_CHANNEL_BIND_STATUS.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_REQUEST_CHANNEL_BIND_STATUS
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_REQUEST_CHANNEL_BIND_STATUS guid: (GUID fromString: '{2fc21c2a-e0c8-4c4c-a68f-e8270f8fbd2a}')!
-HTTP_REQUEST_CHANNEL_BIND_STATUS comment: '<HTTP_REQUEST_CHANNEL_BIND_STATUS> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_REQUEST_CHANNEL_BIND_STATUS'' from type information in the ''Win32 API'' library.
+HTTP_REQUEST_CHANNEL_BIND_STATUS comment: '<HTTP_REQUEST_CHANNEL_BIND_STATUS> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_REQUEST_CHANNEL_BIND_STATUS'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains no documentation for this struct
 
@@ -19,10 +19,10 @@ struct tagHTTP_REQUEST_CHANNEL_BIND_STATUS {
 	[helpstring("The service name from the client. This is populated if the request''s Channel Binding Token (CBT) is not configured to retrieve service names.")] HTTP_SERVICE_BINDING_BASE* ServiceName;
 	[helpstring("A pointer to a buffer that contains the secure channel endpoint binding."), size_is("ChannelTokenSize")] UCHAR* ChannelToken;
 	[nonbrowsable, helpstring("The length of the ChannelToken buffer in bytes.")] ULONG ChannelTokenSize;
-	[hidden, helpstring("Reserved.")] ULONG flags;
+	[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] ULONG Flags;
 } HTTP_REQUEST_CHANNEL_BIND_STATUS;
 '!
-!HTTP_REQUEST_CHANNEL_BIND_STATUS categoriesForClass!Win32-Structs! !
+!HTTP_REQUEST_CHANNEL_BIND_STATUS categoriesForClass!WinHttpServer-Structs! !
 !HTTP_REQUEST_CHANNEL_BIND_STATUS methodsFor!
 
 ChannelToken
@@ -75,7 +75,7 @@ defineFields
 			[helpstring('The service name from the client. This is populated if the request's Channel Binding Token (CBT) is not configured to retrieve service names.')] HTTP_SERVICE_BINDING_BASE* ServiceName;
 			[helpstring('A pointer to a buffer that contains the secure channel endpoint binding.'), size_is('ChannelTokenSize')] UCHAR* ChannelToken;
 			[nonbrowsable, helpstring('The length of the ChannelToken buffer in bytes.')] ULONG ChannelTokenSize;
-			[hidden, helpstring('Reserved.')] ULONG flags;
+			[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] ULONG Flags;
 		} HTTP_REQUEST_CHANNEL_BIND_STATUS;
 "
 
@@ -83,7 +83,7 @@ defineFields
 		defineField: #ServiceName type: (PointerField type: HTTP_SERVICE_BINDING_BASE) offset: 0;
 		defineField: #ChannelToken type: (ArrayPointerField type: ExternalArray lengthField: #ChannelTokenSize) offset: 4;
 		defineField: #ChannelTokenSize type: DWORDField new beNonBrowsable offset: 8;
-		defineField: #flags type: DWORDField new beFiller offset: 12.
+		defineField: #Flags type: DWORDField new beFiller offset: 12.
 	self byteSize: 16! !
 !HTTP_REQUEST_CHANNEL_BIND_STATUS class categoriesFor: #defineFields!**auto generated**!initializing!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_HEADERS.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_HEADERS.cls
@@ -6,7 +6,7 @@ HTTP_HEADERS subclass: #HTTP_REQUEST_HEADERS
 	poolDictionaries: 'WinHttpServerConsts'
 	classInstanceVariableNames: ''!
 HTTP_REQUEST_HEADERS guid: (GUID fromString: '{f762b6ac-f56f-4aeb-aca3-d6b628473c2c}')!
-HTTP_REQUEST_HEADERS comment: '<HTTP_REQUEST_HEADERS> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_REQUEST_HEADERS'' from type information in the ''Win32 API'' library.
+HTTP_REQUEST_HEADERS comment: '<HTTP_REQUEST_HEADERS> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_REQUEST_HEADERS'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Structure defining format of request headers."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_INFO.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_REQUEST_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_REQUEST_INFO guid: (GUID fromString: '{8c37d370-da00-4186-b515-ebe6b57d8cc6}')!
-HTTP_REQUEST_INFO comment: '<HTTP_REQUEST_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_REQUEST_INFO'' from type information in the ''Win32 API'' library.
+HTTP_REQUEST_INFO comment: '<HTTP_REQUEST_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_REQUEST_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains no documentation for this struct
 
@@ -21,7 +21,7 @@ struct tagHTTP_REQUEST_INFO {
 	[nonbrowsable, helpstring("The request info data"), size_is("InfoLength")] void* pInfo;
 } HTTP_REQUEST_INFO;
 '!
-!HTTP_REQUEST_INFO categoriesForClass!Win32-Structs! !
+!HTTP_REQUEST_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_REQUEST_INFO methodsFor!
 
 info

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_TOKEN_BINDING_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_TOKEN_BINDING_INFO.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_REQUEST_TOKEN_BINDING_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_REQUEST_TOKEN_BINDING_INFO guid: (GUID fromString: '{9a86eb3d-22ee-4cc3-980d-f3427eecdb0c}')!
-HTTP_REQUEST_TOKEN_BINDING_INFO comment: '<HTTP_REQUEST_TOKEN_BINDING_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_REQUEST_TOKEN_BINDING_INFO'' from type information in the ''Win32 API'' library.
+HTTP_REQUEST_TOKEN_BINDING_INFO comment: '<HTTP_REQUEST_TOKEN_BINDING_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_REQUEST_TOKEN_BINDING_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains no documentation for this struct
 
@@ -23,7 +23,7 @@ struct tagHTTP_REQUEST_TOKEN_BINDING_INFO {
 	LPWSTR KeyType;
 } HTTP_REQUEST_TOKEN_BINDING_INFO;
 '!
-!HTTP_REQUEST_TOKEN_BINDING_INFO categoriesForClass!Win32-Structs! !
+!HTTP_REQUEST_TOKEN_BINDING_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_REQUEST_TOKEN_BINDING_INFO methodsFor!
 
 KeyType

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_V1.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_V1.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_REQUEST_V1
 	poolDictionaries: 'WinHttpServerConsts'
 	classInstanceVariableNames: ''!
 HTTP_REQUEST_V1 guid: (GUID fromString: '{7927a79c-8c4e-423a-bf24-f1b36b4df5c4}')!
-HTTP_REQUEST_V1 comment: '<HTTP_REQUEST_V1> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_REQUEST_V1'' from type information in the ''Win32 API'' library.
+HTTP_REQUEST_V1 comment: '<HTTP_REQUEST_V1> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_REQUEST_V1'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Represents an incoming HTTP request (N.B. this is the V1, pre-Vista, structure)"
@@ -17,7 +17,7 @@ IDL definition follows:
 
 typedef [uuid(7927a79c-8c4e-423a-bf24-f1b36b4df5c4), helpstring("Represents an incoming HTTP request (N.B. this is the V1, pre-Vista, structure)")]
 struct tagHTTP_REQUEST_V1 {
-	[helpstring("Request flags (see HTTP_REQUEST_FLAG_* definitions below).")] ULONG flags;
+	[helpstring("Request flags (see HTTP_REQUEST_FLAG_* definitions below).")] ULONG Flags;
 	[helpstring("An opaque request identifier. These values are used by the driver to correlate outgoing responses with incoming requests.")] unsigned __int64 ConnectionId;
 	unsigned __int64 RequestId;
 	[helpstring("The context associated with the URL prefix.")] HTTP_URL_CONTEXT UrlContext;
@@ -37,7 +37,7 @@ struct tagHTTP_REQUEST_V1 {
 	[helpstring("A pointer to an HTTP_SSL_INFO structure that contains Secure Sockets Layer (SSL) information about the connection on which the request was received.")] HTTP_SSL_INFO* pSslInfo;
 } HTTP_REQUEST_V1;
 '!
-!HTTP_REQUEST_V1 categoriesForClass!Win32-Structs! !
+!HTTP_REQUEST_V1 categoriesForClass!WinHttpServer-Structs! !
 !HTTP_REQUEST_V1 methodsFor!
 
 Address
@@ -103,13 +103,13 @@ EntityChunkCount: anInteger
 
 	bytes wordAtOffset: ##(self offsetOf: #EntityChunkCount) put: anInteger!
 
-flags
-	"Answer the <Integer> value of the receiver's 'flags' field."
+Flags
+	"Answer the <Integer> value of the receiver's 'Flags' field."
 
 	^bytes dwordAtOffset: 0!
 
-flags: anInteger
-	"Set the receiver's 'flags' field to the value of the argument, anInteger"
+Flags: anInteger
+	"Set the receiver's 'Flags' field to the value of the argument, anInteger"
 
 	bytes dwordAtOffset: 0 put: anInteger!
 
@@ -307,8 +307,8 @@ Version: aHTTP_VERSION
 !HTTP_REQUEST_V1 categoriesFor: #CookedUrl:!**compiled accessors**!public! !
 !HTTP_REQUEST_V1 categoriesFor: #EntityChunkCount!**compiled accessors**!private! !
 !HTTP_REQUEST_V1 categoriesFor: #EntityChunkCount:!**compiled accessors**!private! !
-!HTTP_REQUEST_V1 categoriesFor: #flags!**compiled accessors**!public! !
-!HTTP_REQUEST_V1 categoriesFor: #flags:!**compiled accessors**!public! !
+!HTTP_REQUEST_V1 categoriesFor: #Flags!**compiled accessors**!public! !
+!HTTP_REQUEST_V1 categoriesFor: #Flags:!**compiled accessors**!public! !
 !HTTP_REQUEST_V1 categoriesFor: #Headers!**compiled accessors**!public! !
 !HTTP_REQUEST_V1 categoriesFor: #Headers:!**compiled accessors**!public! !
 !HTTP_REQUEST_V1 categoriesFor: #maxPrint!constants!private! !
@@ -348,7 +348,7 @@ defineFields
 
 		typedef [uuid(7927a79c-8c4e-423a-bf24-f1b36b4df5c4), helpstring('Represents an incoming HTTP request (N.B. this is the V1, pre-Vista, structure)')]
 		struct tagHTTP_REQUEST_V1 {
-			[helpstring('Request flags (see HTTP_REQUEST_FLAG_* definitions below).')] ULONG flags;
+			[helpstring('Request flags (see HTTP_REQUEST_FLAG_* definitions below).')] ULONG Flags;
 			[helpstring('An opaque request identifier. These values are used by the driver to correlate outgoing responses with incoming requests.')] unsigned __int64 ConnectionId;
 			unsigned __int64 RequestId;
 			[helpstring('The context associated with the URL prefix.')] HTTP_URL_CONTEXT UrlContext;
@@ -370,7 +370,7 @@ defineFields
 "
 
 	self
-		defineField: #flags type: DWORDField new offset: 0;
+		defineField: #Flags type: DWORDField new offset: 0;
 		defineField: #ConnectionId type: QWORDField new offset: 8;
 		defineField: #RequestId type: QWORDField new offset: 16;
 		defineField: #UrlContext type: QWORDField new offset: 24;

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_V2.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_REQUEST_V2.cls
@@ -6,7 +6,7 @@ HTTP_REQUEST_V1 subclass: #HTTP_REQUEST_V2
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_REQUEST_V2 guid: (GUID fromString: '{5f3f936f-b824-47af-a69e-62dc4730010c}')!
-HTTP_REQUEST_V2 comment: '<HTTP_REQUEST_V2> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_REQUEST_V2'' from type information in the ''Win32 API'' library.
+HTTP_REQUEST_V2 comment: '<HTTP_REQUEST_V2> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_REQUEST_V2'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Represents an incoming HTTP request (N.B. this is the V2, Vista and later, structure)"

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_RESPONSE_HEADERS.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_RESPONSE_HEADERS.cls
@@ -6,7 +6,7 @@ HTTP_HEADERS subclass: #HTTP_RESPONSE_HEADERS
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_RESPONSE_HEADERS guid: (GUID fromString: '{487fd2e3-1549-4dcf-8703-d45a2cbbcd85}')!
-HTTP_RESPONSE_HEADERS comment: '<HTTP_RESPONSE_HEADERS> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_RESPONSE_HEADERS'' from type information in the ''Win32 API'' library.
+HTTP_RESPONSE_HEADERS comment: '<HTTP_RESPONSE_HEADERS> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_RESPONSE_HEADERS'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Structure defining format of response headers."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_RESPONSE_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_RESPONSE_INFO.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_RESPONSE_INFO
 	poolDictionaries: 'WinHttpServerConsts'
 	classInstanceVariableNames: ''!
 HTTP_RESPONSE_INFO guid: (GUID fromString: '{cdf58c2c-140f-4611-b847-12837ce3155f}')!
-HTTP_RESPONSE_INFO comment: '<HTTP_RESPONSE_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_RESPONSE_INFO'' from type information in the ''Win32 API'' library.
+HTTP_RESPONSE_INFO comment: '<HTTP_RESPONSE_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_RESPONSE_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains no documentation for this struct
 
@@ -21,7 +21,7 @@ struct tagHTTP_RESPONSE_INFO {
 	[nonbrowsable, helpstring("Response information data"), size_is("Length")] void* pInfo;
 } HTTP_RESPONSE_INFO;
 '!
-!HTTP_RESPONSE_INFO categoriesForClass!Win32-Structs! !
+!HTTP_RESPONSE_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_RESPONSE_INFO methodsFor!
 
 info

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_RESPONSE_V1.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_RESPONSE_V1.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_RESPONSE_V1
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_RESPONSE_V1 guid: (GUID fromString: '{c23ac8a9-b97f-4aec-8096-91648573c429}')!
-HTTP_RESPONSE_V1 comment: '<HTTP_RESPONSE_V1> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_RESPONSE_V1'' from type information in the ''Win32 API'' library.
+HTTP_RESPONSE_V1 comment: '<HTTP_RESPONSE_V1> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_RESPONSE_V1'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"This structure describes an HTTP response (V1)."
@@ -17,7 +17,7 @@ IDL definition follows:
 
 typedef [uuid(c23ac8a9-b97f-4aec-8096-91648573c429), helpstring("This structure describes an HTTP response (V1).")]
 struct tagHTTP_RESPONSE_V1 {
-	[helpstring("Response flags from the HTTP_RESPONSE_FLAGS_* constants.")] ULONG flags;
+	[helpstring("Response flags from the HTTP_RESPONSE_FLAGS_* constants.")] ULONG Flags;
 	[helpstring("The raw HTTP protocol version number.")] HTTP_VERSION Version;
 	[helpstring("The HTTP status code (e.g., 200).")] USHORT StatusCode;
 	[nonbrowsable] USHORT ReasonLength;
@@ -27,7 +27,7 @@ struct tagHTTP_RESPONSE_V1 {
 	[helpstring("pEntityChunks points to an array of EntityChunkCount HTTP_DATA_CHUNKs."), size_is("EntityChunkCount")] HTTP_DATA_CHUNK* pEntityChunks;
 } HTTP_RESPONSE_V1;
 '!
-!HTTP_RESPONSE_V1 categoriesForClass!Win32-Structs! !
+!HTTP_RESPONSE_V1 categoriesForClass!WinHttpServer-Structs! !
 !HTTP_RESPONSE_V1 methodsFor!
 
 content: aByteObject
@@ -49,13 +49,13 @@ EntityChunkCount: anInteger
 
 	bytes wordAtOffset: ##(self offsetOf: #EntityChunkCount) put: anInteger!
 
-flags
-	"Answer the <Integer> value of the receiver's 'flags' field."
+Flags
+	"Answer the <Integer> value of the receiver's 'Flags' field."
 
 	^bytes dwordAtOffset: 0!
 
-flags: anInteger
-	"Set the receiver's 'flags' field to the value of the argument, anInteger"
+Flags: anInteger
+	"Set the receiver's 'Flags' field to the value of the argument, anInteger"
 
 	bytes dwordAtOffset: 0 put: anInteger!
 
@@ -138,8 +138,8 @@ Version: aHTTP_VERSION
 !HTTP_RESPONSE_V1 categoriesFor: #contentType:!accessing!public! !
 !HTTP_RESPONSE_V1 categoriesFor: #EntityChunkCount!**compiled accessors**!private! !
 !HTTP_RESPONSE_V1 categoriesFor: #EntityChunkCount:!**compiled accessors**!private! !
-!HTTP_RESPONSE_V1 categoriesFor: #flags!**compiled accessors**!public! !
-!HTTP_RESPONSE_V1 categoriesFor: #flags:!**compiled accessors**!public! !
+!HTTP_RESPONSE_V1 categoriesFor: #Flags!**compiled accessors**!public! !
+!HTTP_RESPONSE_V1 categoriesFor: #Flags:!**compiled accessors**!public! !
 !HTTP_RESPONSE_V1 categoriesFor: #Headers!**compiled accessors**!public! !
 !HTTP_RESPONSE_V1 categoriesFor: #Headers:!**compiled accessors**!public! !
 !HTTP_RESPONSE_V1 categoriesFor: #initialize!initializing!private! !
@@ -163,7 +163,7 @@ defineFields
 
 		typedef [uuid(c23ac8a9-b97f-4aec-8096-91648573c429), helpstring('This structure describes an HTTP response (V1).')]
 		struct tagHTTP_RESPONSE_V1 {
-			[helpstring('Response flags from the HTTP_RESPONSE_FLAGS_* constants.')] ULONG flags;
+			[helpstring('Response flags from the HTTP_RESPONSE_FLAGS_* constants.')] ULONG Flags;
 			[helpstring('The raw HTTP protocol version number.')] HTTP_VERSION Version;
 			[helpstring('The HTTP status code (e.g., 200).')] USHORT StatusCode;
 			[nonbrowsable] USHORT ReasonLength;
@@ -175,7 +175,7 @@ defineFields
 "
 
 	self
-		defineField: #flags type: DWORDField new offset: 0;
+		defineField: #Flags type: DWORDField new offset: 0;
 		defineField: #Version type: (StructureField type: HTTP_VERSION) offset: 4;
 		defineField: #StatusCode type: WORDField new offset: 8;
 		defineField: #ReasonLength type: WORDField new beNonBrowsable offset: 10;

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_RESPONSE_V2.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_RESPONSE_V2.cls
@@ -6,7 +6,7 @@ HTTP_RESPONSE_V1 subclass: #HTTP_RESPONSE_V2
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_RESPONSE_V2 guid: (GUID fromString: '{5e3a97da-7345-49a7-a5a9-1ddea2366eb2}')!
-HTTP_RESPONSE_V2 comment: '<HTTP_RESPONSE_V2> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_RESPONSE_V2'' from type information in the ''Win32 API'' library.
+HTTP_RESPONSE_V2 comment: '<HTTP_RESPONSE_V2> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_RESPONSE_V2'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"This structure describes an HTTP response (V2)."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS guid: (GUID fromString: '{813ff062-e4ed-4b4c-8eef-9d94a1fb65c4}')!
-HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS comment: '<HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS'' from type information in the ''Win32 API'' library.
+HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS comment: '<HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains no documentation for this struct
 
@@ -20,7 +20,7 @@ struct tagHTTP_SERVER_AUTHENTICATION_BASIC_PARAMS {
 	LPWSTR Realm;
 } HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS;
 '!
-!HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS categoriesForClass!Win32-Structs! !
+!HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS methodsFor!
 
 Realm

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS guid: (GUID fromString: '{eed513f2-c404-408c-9ddb-f5d39020d426}')!
-HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS comment: '<HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS'' from type information in the ''Win32 API'' library.
+HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS comment: '<HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains no documentation for this struct
 
@@ -22,7 +22,7 @@ struct tagHTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS {
 	LPWSTR Realm;
 } HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS;
 '!
-!HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS categoriesForClass!Win32-Structs! !
+!HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS methodsFor!
 
 DomainName

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVER_AUTHENTICATION_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVER_AUTHENTICATION_INFO.cls
@@ -6,7 +6,7 @@ HTTP_PROPERTY_FLAGS subclass: #HTTP_SERVER_AUTHENTICATION_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVER_AUTHENTICATION_INFO guid: (GUID fromString: '{7f4599b6-bdfd-4a19-8a4a-a7fd55a9e207}')!
-HTTP_SERVER_AUTHENTICATION_INFO comment: '<HTTP_SERVER_AUTHENTICATION_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVER_AUTHENTICATION_INFO'' from type information in the ''Win32 API'' library.
+HTTP_SERVER_AUTHENTICATION_INFO comment: '<HTTP_SERVER_AUTHENTICATION_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVER_AUTHENTICATION_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains no documentation for this struct
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_BINDING_A.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_BINDING_A.cls
@@ -6,7 +6,7 @@ HTTP_SERVICE_BINDING_BASE subclass: #HTTP_SERVICE_BINDING_A
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_BINDING_A guid: (GUID fromString: '{88ca7833-a66a-4e2f-98bc-cd2313254b15}')!
-HTTP_SERVICE_BINDING_A comment: '<HTTP_SERVICE_BINDING_A> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_BINDING_A'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_BINDING_A comment: '<HTTP_SERVICE_BINDING_A> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_BINDING_A'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Provides Service Principle Name (SPN) in ASCII."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_BINDING_BASE.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_BINDING_BASE.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_BINDING_BASE
 	poolDictionaries: 'WinHttpServerConsts'
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_BINDING_BASE guid: (GUID fromString: '{80f84f87-9667-42d4-ace4-1004dfe14475}')!
-HTTP_SERVICE_BINDING_BASE comment: '<HTTP_SERVICE_BINDING_BASE> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_BINDING_BASE'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_BINDING_BASE comment: '<HTTP_SERVICE_BINDING_BASE> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_BINDING_BASE'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Common base for the HTTP_SERVICE_BINDING_A structure and the HTTP_SERVICE_BINDING_W structure."
@@ -20,7 +20,7 @@ struct tagHTTP_SERVICE_BINDING_BASE {
 	[helpstring("Indicates whether the data is in ASCII or Unicode.")] HTTP_SERVICE_BINDING_TYPE Type;
 } HTTP_SERVICE_BINDING_BASE;
 '!
-!HTTP_SERVICE_BINDING_BASE categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_BINDING_BASE categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_BINDING_BASE methodsFor!
 
 Type

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_BINDING_W.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_BINDING_W.cls
@@ -6,7 +6,7 @@ HTTP_SERVICE_BINDING_BASE subclass: #HTTP_SERVICE_BINDING_W
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_BINDING_W guid: (GUID fromString: '{9cd42842-29b3-4e02-b9dc-306b51f0166d}')!
-HTTP_SERVICE_BINDING_W comment: '<HTTP_SERVICE_BINDING_W> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_BINDING_W'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_BINDING_W comment: '<HTTP_SERVICE_BINDING_W> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_BINDING_W'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Provides Service Principle Name (SPN) in Unicode."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_CACHE_SET.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_CACHE_SET.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_CACHE_SET
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_CACHE_SET guid: (GUID fromString: '{7d7f269d-ce99-4ee1-979d-387f6f2147be}')!
-HTTP_SERVICE_CONFIG_CACHE_SET comment: '<HTTP_SERVICE_CONFIG_CACHE_SET> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_CACHE_SET'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_CACHE_SET comment: '<HTTP_SERVICE_CONFIG_CACHE_SET> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_CACHE_SET'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"To set a cache parameter value use the set structure. To query use the key directly.When you query a parameter value the output buffer must be exactly the sizeof param."
@@ -18,10 +18,10 @@ IDL definition follows:
 typedef [uuid(7d7f269d-ce99-4ee1-979d-387f6f2147be), helpstring("To set a cache parameter value use the set structure. To query use the key directly.When you query a parameter value the output buffer must be exactly the sizeof param.")]
 struct tagHTTP_SERVICE_CONFIG_CACHE_SET {
 	HTTP_SERVICE_CONFIG_CACHE_KEY KeyDesc;
-	ULONG paramdesc;
+	ULONG ParamDesc;
 } HTTP_SERVICE_CONFIG_CACHE_SET;
 '!
-!HTTP_SERVICE_CONFIG_CACHE_SET categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_CACHE_SET categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_CACHE_SET methodsFor!
 
 KeyDesc
@@ -34,19 +34,19 @@ KeyDesc: anInteger
 
 	bytes sdwordAtOffset: 0 put: anInteger!
 
-paramdesc
-	"Answer the <Integer> value of the receiver's 'paramdesc' field."
+ParamDesc
+	"Answer the <Integer> value of the receiver's 'ParamDesc' field."
 
-	^bytes dwordAtOffset: ##(self offsetOf: #paramdesc)!
+	^bytes dwordAtOffset: ##(self offsetOf: #ParamDesc)!
 
-paramdesc: anInteger
-	"Set the receiver's 'paramdesc' field to the value of the argument, anInteger"
+ParamDesc: anInteger
+	"Set the receiver's 'ParamDesc' field to the value of the argument, anInteger"
 
-	bytes dwordAtOffset: ##(self offsetOf: #paramdesc) put: anInteger! !
+	bytes dwordAtOffset: ##(self offsetOf: #ParamDesc) put: anInteger! !
 !HTTP_SERVICE_CONFIG_CACHE_SET categoriesFor: #KeyDesc!**compiled accessors**!public! !
 !HTTP_SERVICE_CONFIG_CACHE_SET categoriesFor: #KeyDesc:!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_CACHE_SET categoriesFor: #paramdesc!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_CACHE_SET categoriesFor: #paramdesc:!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_CACHE_SET categoriesFor: #ParamDesc!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_CACHE_SET categoriesFor: #ParamDesc:!**compiled accessors**!public! !
 
 !HTTP_SERVICE_CONFIG_CACHE_SET class methodsFor!
 
@@ -58,13 +58,13 @@ defineFields
 		typedef [uuid(7d7f269d-ce99-4ee1-979d-387f6f2147be), helpstring('To set a cache parameter value use the set structure. To query use the key directly.When you query a parameter value the output buffer must be exactly the sizeof param.')]
 		struct tagHTTP_SERVICE_CONFIG_CACHE_SET {
 			HTTP_SERVICE_CONFIG_CACHE_KEY KeyDesc;
-			ULONG paramdesc;
+			ULONG ParamDesc;
 		} HTTP_SERVICE_CONFIG_CACHE_SET;
 "
 
 	self
 		defineField: #KeyDesc type: SDWORDField new offset: 0;
-		defineField: #paramdesc type: DWORDField new offset: 4.
+		defineField: #ParamDesc type: DWORDField new offset: 4.
 	self byteSize: 8! !
 !HTTP_SERVICE_CONFIG_CACHE_SET class categoriesFor: #defineFields!**auto generated**!initializing!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM guid: (GUID fromString: '{00a93e39-c011-4a5b-af4d-13f2df7a38d4}')!
-HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM comment: '<HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM comment: '<HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Set/Delete IP Listen-Only List record. Used as a parameter to both HttpSetServiceConfiguration() and HttpDeleteServiceConfiguration() functions."
@@ -21,7 +21,7 @@ struct tagHTTP_SERVICE_CONFIG_IP_LISTEN_PARAM {
 	[helpstring("A pointer to an Internet Protocol (IP) address to be added to or deleted from the listen list.")] SOCKADDR* pAddress;
 } HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM;
 '!
-!HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM methodsFor!
 
 address

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY guid: (GUID fromString: '{3eebcb9d-9dc3-4701-a044-c16df022085b}')!
-HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY comment: '<HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY comment: '<HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Query IP Listen-Only List record. Parameter to HttpQueryServiceConfiguration() for the config ID HttpServiceConfigIPListenList."
@@ -21,7 +21,7 @@ struct tagHTTP_SERVICE_CONFIG_IP_LISTEN_QUERY {
 	[helpstring("An array of SOCKADDR_STORAGE structures that contains IP addresses in either IPv4 or IPv6 form. To determine what form an address in the list has, cast it to a SOCKADDR and examine the sa_family element."), size_is("AddrCount")] SOCKADDR_STORAGE AddrList[1];
 } HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY;
 '!
-!HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY methodsFor!
 
 AddrCount

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_CCS_QUERY.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_CCS_QUERY.cls
@@ -6,7 +6,7 @@ HttpServiceConfigQuery subclass: #HTTP_SERVICE_CONFIG_SSL_CCS_QUERY
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_SSL_CCS_QUERY guid: (GUID fromString: '{d6a678d5-678e-4bf6-ab65-77c8e6a641a9}')!
-HTTP_SERVICE_CONFIG_SSL_CCS_QUERY comment: '<HTTP_SERVICE_CONFIG_SSL_CCS_QUERY> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_SSL_CCS_QUERY'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_SSL_CCS_QUERY comment: '<HTTP_SERVICE_CONFIG_SSL_CCS_QUERY> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_SSL_CCS_QUERY'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Used with HttpQueryServiceConfiguration() to query a HttpServiceConfigSslCcsCertInfo record from the SSL store."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_CCS_SET.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_CCS_SET.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_SSL_CCS_SET
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_SSL_CCS_SET guid: (GUID fromString: '{078985f7-29b2-4403-8acf-074217e6e9f4}')!
-HTTP_SERVICE_CONFIG_SSL_CCS_SET comment: '<HTTP_SERVICE_CONFIG_SSL_CCS_SET> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_SSL_CCS_SET'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_SSL_CCS_SET comment: '<HTTP_SERVICE_CONFIG_SSL_CCS_SET> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_SSL_CCS_SET'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Used by HttpSetServiceConfiguration() to add a new HttpServiceConfigSslCcsCertInfo record to the SSL bindings list"
@@ -18,10 +18,10 @@ IDL definition follows:
 typedef [uuid(078985f7-29b2-4403-8acf-074217e6e9f4), helpstring("Used by HttpSetServiceConfiguration() to add a new HttpServiceConfigSslCcsCertInfo record to the SSL bindings list")]
 struct tagHTTP_SERVICE_CONFIG_SSL_CCS_SET {
 	HTTP_SERVICE_CONFIG_SSL_CCS_KEY KeyDesc;
-	HTTP_SERVICE_CONFIG_SSL_PARAM paramdesc;
+	HTTP_SERVICE_CONFIG_SSL_PARAM ParamDesc;
 } HTTP_SERVICE_CONFIG_SSL_CCS_SET;
 '!
-!HTTP_SERVICE_CONFIG_SSL_CCS_SET categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_SSL_CCS_SET categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_SSL_CCS_SET methodsFor!
 
 KeyDesc
@@ -38,23 +38,23 @@ KeyDesc: aSOCKADDR_STORAGE
 		to: ##(SOCKADDR_STORAGE basicByteSize)
 		startingAt: 1!
 
-paramdesc
-	"Answer the <HTTP_SERVICE_CONFIG_SSL_PARAM> value of the receiver's 'paramdesc' field."
+ParamDesc
+	"Answer the <HTTP_SERVICE_CONFIG_SSL_PARAM> value of the receiver's 'ParamDesc' field."
 
-	^HTTP_SERVICE_CONFIG_SSL_PARAM fromAddress: bytes yourAddress + ##(self offsetOf: #paramdesc)!
+	^HTTP_SERVICE_CONFIG_SSL_PARAM fromAddress: bytes yourAddress + ##(self offsetOf: #ParamDesc)!
 
-paramdesc: aHTTP_SERVICE_CONFIG_SSL_PARAM
-	"Set the receiver's 'paramdesc' field to the value of the argument, aHTTP_SERVICE_CONFIG_SSL_PARAM"
+ParamDesc: aHTTP_SERVICE_CONFIG_SSL_PARAM
+	"Set the receiver's 'ParamDesc' field to the value of the argument, aHTTP_SERVICE_CONFIG_SSL_PARAM"
 
 	aHTTP_SERVICE_CONFIG_SSL_PARAM
 		replaceBytesOf: bytes
-		from: ##((self offsetOf: #paramdesc) + 1)
-		to: ##((self offsetOf: #paramdesc) + HTTP_SERVICE_CONFIG_SSL_PARAM basicByteSize)
+		from: ##((self offsetOf: #ParamDesc) + 1)
+		to: ##((self offsetOf: #ParamDesc) + HTTP_SERVICE_CONFIG_SSL_PARAM basicByteSize)
 		startingAt: 1! !
 !HTTP_SERVICE_CONFIG_SSL_CCS_SET categoriesFor: #KeyDesc!**compiled accessors**!public! !
 !HTTP_SERVICE_CONFIG_SSL_CCS_SET categoriesFor: #KeyDesc:!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_SSL_CCS_SET categoriesFor: #paramdesc!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_SSL_CCS_SET categoriesFor: #paramdesc:!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_SSL_CCS_SET categoriesFor: #ParamDesc!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_SSL_CCS_SET categoriesFor: #ParamDesc:!**compiled accessors**!public! !
 
 !HTTP_SERVICE_CONFIG_SSL_CCS_SET class methodsFor!
 
@@ -66,13 +66,13 @@ defineFields
 		typedef [uuid(078985f7-29b2-4403-8acf-074217e6e9f4), helpstring('Used by HttpSetServiceConfiguration() to add a new HttpServiceConfigSslCcsCertInfo record to the SSL bindings list')]
 		struct tagHTTP_SERVICE_CONFIG_SSL_CCS_SET {
 			HTTP_SERVICE_CONFIG_SSL_CCS_KEY KeyDesc;
-			HTTP_SERVICE_CONFIG_SSL_PARAM paramdesc;
+			HTTP_SERVICE_CONFIG_SSL_PARAM ParamDesc;
 		} HTTP_SERVICE_CONFIG_SSL_CCS_SET;
 "
 
 	self
 		defineField: #KeyDesc type: (StructureField type: SOCKADDR_STORAGE) offset: 0;
-		defineField: #paramdesc type: (StructureField type: HTTP_SERVICE_CONFIG_SSL_PARAM) offset: 128.
+		defineField: #ParamDesc type: (StructureField type: HTTP_SERVICE_CONFIG_SSL_PARAM) offset: 128.
 	self byteSize: 184! !
 !HTTP_SERVICE_CONFIG_SSL_CCS_SET class categoriesFor: #defineFields!**auto generated**!initializing!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_PARAM.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_PARAM.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_SSL_PARAM
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_SSL_PARAM guid: (GUID fromString: '{7fe46aef-bb33-40ac-a388-846c53efde1d}')!
-HTTP_SERVICE_CONFIG_SSL_PARAM comment: '<HTTP_SERVICE_CONFIG_SSL_PARAM> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_SSL_PARAM'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_SSL_PARAM comment: '<HTTP_SERVICE_CONFIG_SSL_PARAM> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_SSL_PARAM'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"This defines a record for the SSL config store."
@@ -19,9 +19,9 @@ typedef [uuid(7fe46aef-bb33-40ac-a388-846c53efde1d), helpstring("This defines a 
 struct tagHTTP_SERVICE_CONFIG_SSL_PARAM {
 	[nonbrowsable, helpstring("The size, in bytes, of the SSL hash.")] ULONG SslHashLength;
 	[helpstring("A pointer to the SSL certificate hash."), size_is("SslHashLength")] void* pSslHash;
-	[helpstring("A unique identifier of the application setting this record.")] guid AppId;
+	[helpstring("A unique identifier of the application setting this record.")] GUID AppId;
 	[helpstring("A pointer to a wide-character string that contains the name of the store from which the server certificate is to be read. If set to NULL, "MY" is assumed as the default name.")] LPWSTR pSslCertStoreName;
-	[helpstring("Determines how client certificates are checked.")] DWORD DefaultCertCheckMode;
+	[helpstring("Flags determining how client certificates are checked.")] DWORD DefaultCertCheckMode;
 	[helpstring("DefaultRevocationFreshnessTime (seconds) - How often to check for an updated Certificate revocation list (CRL). If this value is 0 then the new CRL is updated only if the previous one expires")] DWORD DefaultRevocationFreshnessTime;
 	[helpstring("DefaultRevocationUrlRetrievalTimeout (milliseconds) - Timeout on attempt to retrieve certificate revocation list from the remote URL.")] DWORD DefaultRevocationUrlRetrievalTimeout;
 	[helpstring("pDefaultSslCtlIdentifier - Restrict the certificate issuers that you want to trust. Can be a subset of the certificate issuers that are trusted by the machine.")] LPWSTR pDefaultSslCtlIdentifier;
@@ -29,7 +29,7 @@ struct tagHTTP_SERVICE_CONFIG_SSL_PARAM {
 	[helpstring("Default Flags - see HTTP_SERVICE_CONFIG_SSL_FLAG* below.")] DWORD DefaultFlags;
 } HTTP_SERVICE_CONFIG_SSL_PARAM;
 '!
-!HTTP_SERVICE_CONFIG_SSL_PARAM categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_SSL_PARAM categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_SSL_PARAM methodsFor!
 
 AppId
@@ -169,9 +169,9 @@ defineFields
 		struct tagHTTP_SERVICE_CONFIG_SSL_PARAM {
 			[nonbrowsable, helpstring('The size, in bytes, of the SSL hash.')] ULONG SslHashLength;
 			[helpstring('A pointer to the SSL certificate hash.'), size_is('SslHashLength')] void* pSslHash;
-			[helpstring('A unique identifier of the application setting this record.')] guid AppId;
+			[helpstring('A unique identifier of the application setting this record.')] GUID AppId;
 			[helpstring('A pointer to a wide-character string that contains the name of the store from which the server certificate is to be read. If set to NULL, 'MY' is assumed as the default name.')] LPWSTR pSslCertStoreName;
-			[helpstring('Determines how client certificates are checked.')] DWORD DefaultCertCheckMode;
+			[helpstring('Flags determining how client certificates are checked.')] DWORD DefaultCertCheckMode;
 			[helpstring('DefaultRevocationFreshnessTime (seconds) - How often to check for an updated Certificate revocation list (CRL). If this value is 0 then the new CRL is updated only if the previous one expires')] DWORD DefaultRevocationFreshnessTime;
 			[helpstring('DefaultRevocationUrlRetrievalTimeout (milliseconds) - Timeout on attempt to retrieve certificate revocation list from the remote URL.')] DWORD DefaultRevocationUrlRetrievalTimeout;
 			[helpstring('pDefaultSslCtlIdentifier - Restrict the certificate issuers that you want to trust. Can be a subset of the certificate issuers that are trusted by the machine.')] LPWSTR pDefaultSslCtlIdentifier;

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_QUERY.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_QUERY.cls
@@ -6,7 +6,7 @@ HttpServiceConfigQuery subclass: #HTTP_SERVICE_CONFIG_SSL_QUERY
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_SSL_QUERY guid: (GUID fromString: '{d0a38bb4-ba56-4dc6-9079-ac7694ef98ac}')!
-HTTP_SERVICE_CONFIG_SSL_QUERY comment: '<HTTP_SERVICE_CONFIG_SSL_QUERY> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_SSL_QUERY'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_SSL_QUERY comment: '<HTTP_SERVICE_CONFIG_SSL_QUERY> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_SSL_QUERY'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Used with HttpQueryServiceConfiguration() to query a HttpServiceConfigSSLCertInfo record from the SSL store."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_SET.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_SET.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_SSL_SET
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_SSL_SET guid: (GUID fromString: '{f2c9434b-739e-4905-bcf3-d552724f69ff}')!
-HTTP_SERVICE_CONFIG_SSL_SET comment: '<HTTP_SERVICE_CONFIG_SSL_SET> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_SSL_SET'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_SSL_SET comment: '<HTTP_SERVICE_CONFIG_SSL_SET> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_SSL_SET'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Used by HttpSetServiceConfiguration() to add a new HttpServiceConfigSSLCertInfo record to the SSL bindings list"
@@ -18,10 +18,10 @@ IDL definition follows:
 typedef [uuid(f2c9434b-739e-4905-bcf3-d552724f69ff), helpstring("Used by HttpSetServiceConfiguration() to add a new HttpServiceConfigSSLCertInfo record to the SSL bindings list")]
 struct tagHTTP_SERVICE_CONFIG_SSL_SET {
 	HTTP_SERVICE_CONFIG_SSL_KEY KeyDesc;
-	HTTP_SERVICE_CONFIG_SSL_PARAM paramdesc;
+	HTTP_SERVICE_CONFIG_SSL_PARAM ParamDesc;
 } HTTP_SERVICE_CONFIG_SSL_SET;
 '!
-!HTTP_SERVICE_CONFIG_SSL_SET categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_SSL_SET categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_SSL_SET methodsFor!
 
 KeyDesc
@@ -34,23 +34,23 @@ KeyDesc: aSOCKADDR
 
 	bytes uintPtrAtOffset: 0 put: aSOCKADDR yourAddress!
 
-paramdesc
-	"Answer the <HTTP_SERVICE_CONFIG_SSL_PARAM> value of the receiver's 'paramdesc' field."
+ParamDesc
+	"Answer the <HTTP_SERVICE_CONFIG_SSL_PARAM> value of the receiver's 'ParamDesc' field."
 
-	^HTTP_SERVICE_CONFIG_SSL_PARAM fromAddress: bytes yourAddress + ##(self offsetOf: #paramdesc)!
+	^HTTP_SERVICE_CONFIG_SSL_PARAM fromAddress: bytes yourAddress + ##(self offsetOf: #ParamDesc)!
 
-paramdesc: aHTTP_SERVICE_CONFIG_SSL_PARAM
-	"Set the receiver's 'paramdesc' field to the value of the argument, aHTTP_SERVICE_CONFIG_SSL_PARAM"
+ParamDesc: aHTTP_SERVICE_CONFIG_SSL_PARAM
+	"Set the receiver's 'ParamDesc' field to the value of the argument, aHTTP_SERVICE_CONFIG_SSL_PARAM"
 
 	aHTTP_SERVICE_CONFIG_SSL_PARAM
 		replaceBytesOf: bytes
-		from: ##((self offsetOf: #paramdesc) + 1)
-		to: ##((self offsetOf: #paramdesc) + HTTP_SERVICE_CONFIG_SSL_PARAM basicByteSize)
+		from: ##((self offsetOf: #ParamDesc) + 1)
+		to: ##((self offsetOf: #ParamDesc) + HTTP_SERVICE_CONFIG_SSL_PARAM basicByteSize)
 		startingAt: 1! !
 !HTTP_SERVICE_CONFIG_SSL_SET categoriesFor: #KeyDesc!**compiled accessors**!public! !
 !HTTP_SERVICE_CONFIG_SSL_SET categoriesFor: #KeyDesc:!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_SSL_SET categoriesFor: #paramdesc!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_SSL_SET categoriesFor: #paramdesc:!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_SSL_SET categoriesFor: #ParamDesc!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_SSL_SET categoriesFor: #ParamDesc:!**compiled accessors**!public! !
 
 !HTTP_SERVICE_CONFIG_SSL_SET class methodsFor!
 
@@ -62,13 +62,13 @@ defineFields
 		typedef [uuid(f2c9434b-739e-4905-bcf3-d552724f69ff), helpstring('Used by HttpSetServiceConfiguration() to add a new HttpServiceConfigSSLCertInfo record to the SSL bindings list')]
 		struct tagHTTP_SERVICE_CONFIG_SSL_SET {
 			HTTP_SERVICE_CONFIG_SSL_KEY KeyDesc;
-			HTTP_SERVICE_CONFIG_SSL_PARAM paramdesc;
+			HTTP_SERVICE_CONFIG_SSL_PARAM ParamDesc;
 		} HTTP_SERVICE_CONFIG_SSL_SET;
 "
 
 	self
 		defineField: #KeyDesc type: (PointerField type: SOCKADDR) offset: 0;
-		defineField: #paramdesc type: (StructureField type: HTTP_SERVICE_CONFIG_SSL_PARAM) offset: 4.
+		defineField: #ParamDesc type: (StructureField type: HTTP_SERVICE_CONFIG_SSL_PARAM) offset: 4.
 	self byteSize: 56! !
 !HTTP_SERVICE_CONFIG_SSL_SET class categoriesFor: #defineFields!**auto generated**!initializing!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_SNI_KEY.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_SNI_KEY.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_SSL_SNI_KEY
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_SSL_SNI_KEY guid: (GUID fromString: '{32358de8-2f95-48e9-8b5e-72900a0e6f36}')!
-HTTP_SERVICE_CONFIG_SSL_SNI_KEY comment: '<HTTP_SERVICE_CONFIG_SSL_SNI_KEY> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_SSL_SNI_KEY'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_SSL_SNI_KEY comment: '<HTTP_SERVICE_CONFIG_SSL_SNI_KEY> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_SSL_SNI_KEY'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains no documentation for this struct
 
@@ -20,7 +20,7 @@ struct tagHTTP_SERVICE_CONFIG_SSL_SNI_KEY {
 	LPWSTR Host;
 } HTTP_SERVICE_CONFIG_SSL_SNI_KEY;
 '!
-!HTTP_SERVICE_CONFIG_SSL_SNI_KEY categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_SSL_SNI_KEY categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_SSL_SNI_KEY methodsFor!
 
 Host

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_SNI_QUERY.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_SNI_QUERY.cls
@@ -6,7 +6,7 @@ HttpServiceConfigQuery subclass: #HTTP_SERVICE_CONFIG_SSL_SNI_QUERY
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_SSL_SNI_QUERY guid: (GUID fromString: '{4d8cbfdf-8766-4e01-a7f0-c775406dd04c}')!
-HTTP_SERVICE_CONFIG_SSL_SNI_QUERY comment: '<HTTP_SERVICE_CONFIG_SSL_SNI_QUERY> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_SSL_SNI_QUERY'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_SSL_SNI_QUERY comment: '<HTTP_SERVICE_CONFIG_SSL_SNI_QUERY> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_SSL_SNI_QUERY'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Used with HttpQueryServiceConfiguration() to query a HttpServiceConfigSSLSniCertInfo record from the SSL store."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_SNI_SET.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_SSL_SNI_SET.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_SSL_SNI_SET
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_SSL_SNI_SET guid: (GUID fromString: '{4c2fb659-18f1-4258-beb7-2283ed27e94b}')!
-HTTP_SERVICE_CONFIG_SSL_SNI_SET comment: '<HTTP_SERVICE_CONFIG_SSL_SNI_SET> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_SSL_SNI_SET'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_SSL_SNI_SET comment: '<HTTP_SERVICE_CONFIG_SSL_SNI_SET> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_SSL_SNI_SET'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Used by HttpSetServiceConfiguration() to add a new HttpServiceConfigSslSniCertInfo record to the SSL bindings list"
@@ -18,10 +18,10 @@ IDL definition follows:
 typedef [uuid(4c2fb659-18f1-4258-beb7-2283ed27e94b), helpstring("Used by HttpSetServiceConfiguration() to add a new HttpServiceConfigSslSniCertInfo record to the SSL bindings list")]
 struct tagHTTP_SERVICE_CONFIG_SSL_SNI_SET {
 	HTTP_SERVICE_CONFIG_SSL_SNI_KEY KeyDesc;
-	HTTP_SERVICE_CONFIG_SSL_PARAM paramdesc;
+	HTTP_SERVICE_CONFIG_SSL_PARAM ParamDesc;
 } HTTP_SERVICE_CONFIG_SSL_SNI_SET;
 '!
-!HTTP_SERVICE_CONFIG_SSL_SNI_SET categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_SSL_SNI_SET categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_SSL_SNI_SET methodsFor!
 
 KeyDesc
@@ -38,23 +38,23 @@ KeyDesc: aHTTP_SERVICE_CONFIG_SSL_SNI_KEY
 		to: ##(HTTP_SERVICE_CONFIG_SSL_SNI_KEY basicByteSize)
 		startingAt: 1!
 
-paramdesc
-	"Answer the <HTTP_SERVICE_CONFIG_SSL_PARAM> value of the receiver's 'paramdesc' field."
+ParamDesc
+	"Answer the <HTTP_SERVICE_CONFIG_SSL_PARAM> value of the receiver's 'ParamDesc' field."
 
-	^HTTP_SERVICE_CONFIG_SSL_PARAM fromAddress: bytes yourAddress + ##(self offsetOf: #paramdesc)!
+	^HTTP_SERVICE_CONFIG_SSL_PARAM fromAddress: bytes yourAddress + ##(self offsetOf: #ParamDesc)!
 
-paramdesc: aHTTP_SERVICE_CONFIG_SSL_PARAM
-	"Set the receiver's 'paramdesc' field to the value of the argument, aHTTP_SERVICE_CONFIG_SSL_PARAM"
+ParamDesc: aHTTP_SERVICE_CONFIG_SSL_PARAM
+	"Set the receiver's 'ParamDesc' field to the value of the argument, aHTTP_SERVICE_CONFIG_SSL_PARAM"
 
 	aHTTP_SERVICE_CONFIG_SSL_PARAM
 		replaceBytesOf: bytes
-		from: ##((self offsetOf: #paramdesc) + 1)
-		to: ##((self offsetOf: #paramdesc) + HTTP_SERVICE_CONFIG_SSL_PARAM basicByteSize)
+		from: ##((self offsetOf: #ParamDesc) + 1)
+		to: ##((self offsetOf: #ParamDesc) + HTTP_SERVICE_CONFIG_SSL_PARAM basicByteSize)
 		startingAt: 1! !
 !HTTP_SERVICE_CONFIG_SSL_SNI_SET categoriesFor: #KeyDesc!**compiled accessors**!public! !
 !HTTP_SERVICE_CONFIG_SSL_SNI_SET categoriesFor: #KeyDesc:!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_SSL_SNI_SET categoriesFor: #paramdesc!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_SSL_SNI_SET categoriesFor: #paramdesc:!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_SSL_SNI_SET categoriesFor: #ParamDesc!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_SSL_SNI_SET categoriesFor: #ParamDesc:!**compiled accessors**!public! !
 
 !HTTP_SERVICE_CONFIG_SSL_SNI_SET class methodsFor!
 
@@ -66,13 +66,13 @@ defineFields
 		typedef [uuid(4c2fb659-18f1-4258-beb7-2283ed27e94b), helpstring('Used by HttpSetServiceConfiguration() to add a new HttpServiceConfigSslSniCertInfo record to the SSL bindings list')]
 		struct tagHTTP_SERVICE_CONFIG_SSL_SNI_SET {
 			HTTP_SERVICE_CONFIG_SSL_SNI_KEY KeyDesc;
-			HTTP_SERVICE_CONFIG_SSL_PARAM paramdesc;
+			HTTP_SERVICE_CONFIG_SSL_PARAM ParamDesc;
 		} HTTP_SERVICE_CONFIG_SSL_SNI_SET;
 "
 
 	self
 		defineField: #KeyDesc type: (StructureField type: HTTP_SERVICE_CONFIG_SSL_SNI_KEY) offset: 0;
-		defineField: #paramdesc type: (StructureField type: HTTP_SERVICE_CONFIG_SSL_PARAM) offset: 136.
+		defineField: #ParamDesc type: (StructureField type: HTTP_SERVICE_CONFIG_SSL_PARAM) offset: 136.
 	self byteSize: 192! !
 !HTTP_SERVICE_CONFIG_SSL_SNI_SET class categoriesFor: #defineFields!**auto generated**!initializing!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_TIMEOUT_SET.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_TIMEOUT_SET.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_TIMEOUT_SET
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_TIMEOUT_SET guid: (GUID fromString: '{6f4abcfc-2a59-4996-a958-5de93dc64213}')!
-HTTP_SERVICE_CONFIG_TIMEOUT_SET comment: '<HTTP_SERVICE_CONFIG_TIMEOUT_SET> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_TIMEOUT_SET'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_TIMEOUT_SET comment: '<HTTP_SERVICE_CONFIG_TIMEOUT_SET> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_TIMEOUT_SET'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"To set a timeout value use the set structure. To query/delete use the key directly. When you query a timeout value the output buffer must be exactly the sizeof param."
@@ -18,10 +18,10 @@ IDL definition follows:
 typedef [uuid(6f4abcfc-2a59-4996-a958-5de93dc64213), helpstring("To set a timeout value use the set structure. To query/delete use the key directly. When you query a timeout value the output buffer must be exactly the sizeof param.")]
 struct tagHTTP_SERVICE_CONFIG_TIMEOUT_SET {
 	HTTP_SERVICE_CONFIG_TIMEOUT_KEY KeyDesc;
-	USHORT paramdesc;
+	USHORT ParamDesc;
 } HTTP_SERVICE_CONFIG_TIMEOUT_SET;
 '!
-!HTTP_SERVICE_CONFIG_TIMEOUT_SET categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_TIMEOUT_SET categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_TIMEOUT_SET methodsFor!
 
 KeyDesc
@@ -34,19 +34,19 @@ KeyDesc: anInteger
 
 	bytes sdwordAtOffset: 0 put: anInteger!
 
-paramdesc
-	"Answer the <Integer> value of the receiver's 'paramdesc' field."
+ParamDesc
+	"Answer the <Integer> value of the receiver's 'ParamDesc' field."
 
-	^bytes wordAtOffset: ##(self offsetOf: #paramdesc)!
+	^bytes wordAtOffset: ##(self offsetOf: #ParamDesc)!
 
-paramdesc: anInteger
-	"Set the receiver's 'paramdesc' field to the value of the argument, anInteger"
+ParamDesc: anInteger
+	"Set the receiver's 'ParamDesc' field to the value of the argument, anInteger"
 
-	bytes wordAtOffset: ##(self offsetOf: #paramdesc) put: anInteger! !
+	bytes wordAtOffset: ##(self offsetOf: #ParamDesc) put: anInteger! !
 !HTTP_SERVICE_CONFIG_TIMEOUT_SET categoriesFor: #KeyDesc!**compiled accessors**!public! !
 !HTTP_SERVICE_CONFIG_TIMEOUT_SET categoriesFor: #KeyDesc:!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_TIMEOUT_SET categoriesFor: #paramdesc!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_TIMEOUT_SET categoriesFor: #paramdesc:!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_TIMEOUT_SET categoriesFor: #ParamDesc!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_TIMEOUT_SET categoriesFor: #ParamDesc:!**compiled accessors**!public! !
 
 !HTTP_SERVICE_CONFIG_TIMEOUT_SET class methodsFor!
 
@@ -58,13 +58,13 @@ defineFields
 		typedef [uuid(6f4abcfc-2a59-4996-a958-5de93dc64213), helpstring('To set a timeout value use the set structure. To query/delete use the key directly. When you query a timeout value the output buffer must be exactly the sizeof param.')]
 		struct tagHTTP_SERVICE_CONFIG_TIMEOUT_SET {
 			HTTP_SERVICE_CONFIG_TIMEOUT_KEY KeyDesc;
-			USHORT paramdesc;
+			USHORT ParamDesc;
 		} HTTP_SERVICE_CONFIG_TIMEOUT_SET;
 "
 
 	self
 		defineField: #KeyDesc type: SDWORDField new offset: 0;
-		defineField: #paramdesc type: WORDField new offset: 4.
+		defineField: #ParamDesc type: WORDField new offset: 4.
 	self byteSize: 8! !
 !HTTP_SERVICE_CONFIG_TIMEOUT_SET class categoriesFor: #defineFields!**auto generated**!initializing!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_URLACL_QUERY.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_URLACL_QUERY.cls
@@ -6,7 +6,7 @@ HttpServiceConfigQuery subclass: #HTTP_SERVICE_CONFIG_URLACL_QUERY
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_URLACL_QUERY guid: (GUID fromString: '{fbe6f060-f472-445e-b48c-9caa8faedc7e}')!
-HTTP_SERVICE_CONFIG_URLACL_QUERY comment: '<HTTP_SERVICE_CONFIG_URLACL_QUERY> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_URLACL_QUERY'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_URLACL_QUERY comment: '<HTTP_SERVICE_CONFIG_URLACL_QUERY> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_URLACL_QUERY'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"This data structure is used by HttpQueryServiceConfiguration() for the	config ID HttpServiceConfigUrlAclInfo to query records from the URL ACL store."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_URLACL_SET.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVICE_CONFIG_URLACL_SET.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SERVICE_CONFIG_URLACL_SET
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SERVICE_CONFIG_URLACL_SET guid: (GUID fromString: '{8144c4ca-dfd3-4ed0-a83b-ad096bd611a4}')!
-HTTP_SERVICE_CONFIG_URLACL_SET comment: '<HTTP_SERVICE_CONFIG_URLACL_SET> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SERVICE_CONFIG_URLACL_SET'' from type information in the ''Win32 API'' library.
+HTTP_SERVICE_CONFIG_URLACL_SET comment: '<HTTP_SERVICE_CONFIG_URLACL_SET> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SERVICE_CONFIG_URLACL_SET'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"This data structure is used by HttpSetServiceConfiguration for the config ID HttpServiceConfigUrlAclInfo.It is used to add a new record to the URL ACL store."
@@ -18,10 +18,10 @@ IDL definition follows:
 typedef [uuid(8144c4ca-dfd3-4ed0-a83b-ad096bd611a4), helpstring("This data structure is used by HttpSetServiceConfiguration for the config ID HttpServiceConfigUrlAclInfo.It is used to add a new record to the URL ACL store.")]
 struct tagHTTP_SERVICE_CONFIG_URLACL_SET {
 	HTTP_SERVICE_CONFIG_URLACL_KEY KeyDesc;
-	HTTP_SERVICE_CONFIG_URLACL_PARAM paramdesc;
+	HTTP_SERVICE_CONFIG_URLACL_PARAM ParamDesc;
 } HTTP_SERVICE_CONFIG_URLACL_SET;
 '!
-!HTTP_SERVICE_CONFIG_URLACL_SET categoriesForClass!Win32-Structs! !
+!HTTP_SERVICE_CONFIG_URLACL_SET categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SERVICE_CONFIG_URLACL_SET methodsFor!
 
 KeyDesc
@@ -34,19 +34,19 @@ KeyDesc: anUnicodeString
 
 	bytes uintPtrAtOffset: 0 put: anUnicodeString yourAddress!
 
-paramdesc
-	"Answer the <UnicodeString> value of the receiver's 'paramdesc' field."
+ParamDesc
+	"Answer the <UnicodeString> value of the receiver's 'ParamDesc' field."
 
-	^UnicodeString fromAddress: (bytes intPtrAtOffset: ##(self offsetOf: #paramdesc))!
+	^UnicodeString fromAddress: (bytes intPtrAtOffset: ##(self offsetOf: #ParamDesc))!
 
-paramdesc: anUnicodeString
-	"Set the receiver's 'paramdesc' field to the value of the argument, anUnicodeString"
+ParamDesc: anUnicodeString
+	"Set the receiver's 'ParamDesc' field to the value of the argument, anUnicodeString"
 
-	bytes uintPtrAtOffset: ##(self offsetOf: #paramdesc) put: anUnicodeString yourAddress! !
+	bytes uintPtrAtOffset: ##(self offsetOf: #ParamDesc) put: anUnicodeString yourAddress! !
 !HTTP_SERVICE_CONFIG_URLACL_SET categoriesFor: #KeyDesc!**compiled accessors**!public! !
 !HTTP_SERVICE_CONFIG_URLACL_SET categoriesFor: #KeyDesc:!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_URLACL_SET categoriesFor: #paramdesc!**compiled accessors**!public! !
-!HTTP_SERVICE_CONFIG_URLACL_SET categoriesFor: #paramdesc:!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_URLACL_SET categoriesFor: #ParamDesc!**compiled accessors**!public! !
+!HTTP_SERVICE_CONFIG_URLACL_SET categoriesFor: #ParamDesc:!**compiled accessors**!public! !
 
 !HTTP_SERVICE_CONFIG_URLACL_SET class methodsFor!
 
@@ -58,13 +58,13 @@ defineFields
 		typedef [uuid(8144c4ca-dfd3-4ed0-a83b-ad096bd611a4), helpstring('This data structure is used by HttpSetServiceConfiguration for the config ID HttpServiceConfigUrlAclInfo.It is used to add a new record to the URL ACL store.')]
 		struct tagHTTP_SERVICE_CONFIG_URLACL_SET {
 			HTTP_SERVICE_CONFIG_URLACL_KEY KeyDesc;
-			HTTP_SERVICE_CONFIG_URLACL_PARAM paramdesc;
+			HTTP_SERVICE_CONFIG_URLACL_PARAM ParamDesc;
 		} HTTP_SERVICE_CONFIG_URLACL_SET;
 "
 
 	self
 		defineField: #KeyDesc type: (PointerField type: UnicodeString) offset: 0;
-		defineField: #paramdesc type: (PointerField type: UnicodeString) offset: 4.
+		defineField: #ParamDesc type: (PointerField type: UnicodeString) offset: 4.
 	self byteSize: 8! !
 !HTTP_SERVICE_CONFIG_URLACL_SET class categoriesFor: #defineFields!**auto generated**!initializing!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SSL_CLIENT_CERT_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SSL_CLIENT_CERT_INFO.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SSL_CLIENT_CERT_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SSL_CLIENT_CERT_INFO guid: (GUID fromString: '{2ea1d77c-9411-49f7-af99-3554a22fe89e}')!
-HTTP_SSL_CLIENT_CERT_INFO comment: '<HTTP_SSL_CLIENT_CERT_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SSL_CLIENT_CERT_INFO'' from type information in the ''Win32 API'' library.
+HTTP_SSL_CLIENT_CERT_INFO comment: '<HTTP_SSL_CLIENT_CERT_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SSL_CLIENT_CERT_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"SSL Client certificate information."
@@ -21,10 +21,10 @@ struct tagHTTP_SSL_CLIENT_CERT_INFO {
 	[nonbrowsable, helpstring("The size, in bytes, of the certificate")] ULONG CertEncodedSize;
 	[helpstring("A pointer to the actual certificate."), size_is("CertEncodedSize")] UCHAR* pCertEncoded;
 	[helpstring("A handle to an access token.")] HANDLE Token;
-	[hidden, helpstring("Reserved.")] BOOLEAN CertDeniedByMapper;
+	[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] BOOLEAN CertDeniedByMapper;
 } HTTP_SSL_CLIENT_CERT_INFO;
 '!
-!HTTP_SSL_CLIENT_CERT_INFO categoriesForClass!Win32-Structs! !
+!HTTP_SSL_CLIENT_CERT_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SSL_CLIENT_CERT_INFO methodsFor!
 
 CertEncodedSize
@@ -90,7 +90,7 @@ defineFields
 			[nonbrowsable, helpstring('The size, in bytes, of the certificate')] ULONG CertEncodedSize;
 			[helpstring('A pointer to the actual certificate.'), size_is('CertEncodedSize')] UCHAR* pCertEncoded;
 			[helpstring('A handle to an access token.')] HANDLE Token;
-			[hidden, helpstring('Reserved.')] BOOLEAN CertDeniedByMapper;
+			[hidden, custom(9d8468d2-88ea-4452-b32c-992c9937e29c, 0)] BOOLEAN CertDeniedByMapper;
 		} HTTP_SSL_CLIENT_CERT_INFO;
 "
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SSL_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SSL_INFO.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SSL_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SSL_INFO guid: (GUID fromString: '{fd0d6f69-8afe-4748-a88b-9fb70593dfc8}')!
-HTTP_SSL_INFO comment: '<HTTP_SSL_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SSL_INFO'' from type information in the ''Win32 API'' library.
+HTTP_SSL_INFO comment: '<HTTP_SSL_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SSL_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Data computed during SSL handshake."
@@ -27,7 +27,7 @@ struct tagHTTP_SSL_INFO {
 	[helpstring("If non-zero, indicates that the client certificate is already present locally.")] ULONG SslClientCertNegotiated;
 } HTTP_SSL_INFO;
 '!
-!HTTP_SSL_INFO categoriesForClass!Win32-Structs! !
+!HTTP_SSL_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SSL_INFO methodsFor!
 
 ConnectionKeySize

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SSL_PROTOCOL_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SSL_PROTOCOL_INFO.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_SSL_PROTOCOL_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_SSL_PROTOCOL_INFO guid: (GUID fromString: '{73784afd-f4e5-464e-b716-46ebb0c8c6d1}')!
-HTTP_SSL_PROTOCOL_INFO comment: '<HTTP_SSL_PROTOCOL_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_SSL_PROTOCOL_INFO'' from type information in the ''Win32 API'' library.
+HTTP_SSL_PROTOCOL_INFO comment: '<HTTP_SSL_PROTOCOL_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_SSL_PROTOCOL_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"HttpRequestInfoTypeSslProtocol payload. Contains basic information about the SSL/TLS protocol and cipher. See SecPkgContext_ConnectionInfo documentation for details."
@@ -17,7 +17,7 @@ IDL definition follows:
 
 typedef [uuid(73784afd-f4e5-464e-b716-46ebb0c8c6d1), helpstring("HttpRequestInfoTypeSslProtocol payload. Contains basic information about the SSL/TLS protocol and cipher. See SecPkgContext_ConnectionInfo documentation for details.")]
 struct tagHTTP_SSL_PROTOCOL_INFO {
-	[readonly] ULONG protocol;
+	[readonly] ULONG Protocol;
 	[readonly] ULONG CipherType;
 	[readonly] ULONG CipherStrength;
 	[readonly] ULONG HashType;
@@ -26,7 +26,7 @@ struct tagHTTP_SSL_PROTOCOL_INFO {
 	[readonly] ULONG KeyExchangeStrength;
 } HTTP_SSL_PROTOCOL_INFO;
 '!
-!HTTP_SSL_PROTOCOL_INFO categoriesForClass!Win32-Structs! !
+!HTTP_SSL_PROTOCOL_INFO categoriesForClass!WinHttpServer-Structs! !
 !HTTP_SSL_PROTOCOL_INFO methodsFor!
 
 CipherStrength
@@ -59,8 +59,8 @@ KeyExchangeType
 
 	^bytes dwordAtOffset: ##(self offsetOf: #KeyExchangeType)!
 
-protocol
-	"Answer the <Integer> value of the receiver's 'protocol' field."
+Protocol
+	"Answer the <Integer> value of the receiver's 'Protocol' field."
 
 	^bytes dwordAtOffset: 0! !
 !HTTP_SSL_PROTOCOL_INFO categoriesFor: #CipherStrength!**compiled accessors**!public! !
@@ -69,7 +69,7 @@ protocol
 !HTTP_SSL_PROTOCOL_INFO categoriesFor: #HashType!**compiled accessors**!public! !
 !HTTP_SSL_PROTOCOL_INFO categoriesFor: #KeyExchangeStrength!**compiled accessors**!public! !
 !HTTP_SSL_PROTOCOL_INFO categoriesFor: #KeyExchangeType!**compiled accessors**!public! !
-!HTTP_SSL_PROTOCOL_INFO categoriesFor: #protocol!**compiled accessors**!public! !
+!HTTP_SSL_PROTOCOL_INFO categoriesFor: #Protocol!**compiled accessors**!public! !
 
 !HTTP_SSL_PROTOCOL_INFO class methodsFor!
 
@@ -80,7 +80,7 @@ defineFields
 
 		typedef [uuid(73784afd-f4e5-464e-b716-46ebb0c8c6d1), helpstring('HttpRequestInfoTypeSslProtocol payload. Contains basic information about the SSL/TLS protocol and cipher. See SecPkgContext_ConnectionInfo documentation for details.')]
 		struct tagHTTP_SSL_PROTOCOL_INFO {
-			[readonly] ULONG protocol;
+			[readonly] ULONG Protocol;
 			[readonly] ULONG CipherType;
 			[readonly] ULONG CipherStrength;
 			[readonly] ULONG HashType;
@@ -91,7 +91,7 @@ defineFields
 "
 
 	self
-		defineField: #protocol type: DWORDField new beReadOnly offset: 0;
+		defineField: #Protocol type: DWORDField new beReadOnly offset: 0;
 		defineField: #CipherType type: DWORDField new beReadOnly offset: 4;
 		defineField: #CipherStrength type: DWORDField new beReadOnly offset: 8;
 		defineField: #HashType type: DWORDField new beReadOnly offset: 12;

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_STATE_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_STATE_INFO.cls
@@ -6,7 +6,7 @@ HTTP_PROPERTY_FLAGS subclass: #HTTP_STATE_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_STATE_INFO guid: (GUID fromString: '{5dc84435-3eb8-42fe-94bf-25f253e612fd}')!
-HTTP_STATE_INFO comment: '<HTTP_STATE_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_STATE_INFO'' from type information in the ''Win32 API'' library.
+HTTP_STATE_INFO comment: '<HTTP_STATE_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_STATE_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"The HTTP_STATE_INFO structure is used to enable or disable a Server Session or URL Group."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_TIMEOUT_LIMIT_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_TIMEOUT_LIMIT_INFO.cls
@@ -6,7 +6,7 @@ HTTP_PROPERTY_FLAGS subclass: #HTTP_TIMEOUT_LIMIT_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_TIMEOUT_LIMIT_INFO guid: (GUID fromString: '{7dae0007-41d0-4925-b425-a14d837d56d0}')!
-HTTP_TIMEOUT_LIMIT_INFO comment: '<HTTP_TIMEOUT_LIMIT_INFO> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_TIMEOUT_LIMIT_INFO'' from type information in the ''Win32 API'' library.
+HTTP_TIMEOUT_LIMIT_INFO comment: '<HTTP_TIMEOUT_LIMIT_INFO> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_TIMEOUT_LIMIT_INFO'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"For manipulating application specific timeout settings. These timers run when there''s a request being processed on a connection and HTTPAPI has already associated the request with an application."

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_UNKNOWN_HEADER.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_UNKNOWN_HEADER.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_UNKNOWN_HEADER
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_UNKNOWN_HEADER guid: (GUID fromString: '{98a27339-73e3-4d54-baf2-915b818916b1}')!
-HTTP_UNKNOWN_HEADER comment: '<HTTP_UNKNOWN_HEADER> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_UNKNOWN_HEADER'' from type information in the ''Win32 API'' library.
+HTTP_UNKNOWN_HEADER comment: '<HTTP_UNKNOWN_HEADER> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_UNKNOWN_HEADER'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"Structure defining format of an unknown header."
@@ -17,13 +17,13 @@ IDL definition follows:
 
 typedef [uuid(98a27339-73e3-4d54-baf2-915b818916b1), helpstring("Structure defining format of an unknown header.")]
 struct tagHTTP_UNKNOWN_HEADER {
-	[nonbrowsable] USHORT NameLength;
-	[nonbrowsable] USHORT RawValueLength;
+	[nonbrowsable, helpstring("Size in bytes of Name not including terminating null")] USHORT NameLength;
+	[nonbrowsable, helpstring("Size in bytes of RawValue not including terminating null")] USHORT RawValueLength;
 	[helpstring("The header name (minus the '':'' character)"), size_is("NameLength"), string] LPCSTR pName;
 	[helpstring("The header value."), size_is("RawValueLength"), string] LPCSTR pRawValue;
 } HTTP_UNKNOWN_HEADER;
 '!
-!HTTP_UNKNOWN_HEADER categoriesForClass!Win32-Structs! !
+!HTTP_UNKNOWN_HEADER categoriesForClass!WinHttpServer-Structs! !
 !HTTP_UNKNOWN_HEADER methodsFor!
 
 NameLength
@@ -86,8 +86,8 @@ defineFields
 
 		typedef [uuid(98a27339-73e3-4d54-baf2-915b818916b1), helpstring('Structure defining format of an unknown header.')]
 		struct tagHTTP_UNKNOWN_HEADER {
-			[nonbrowsable] USHORT NameLength;
-			[nonbrowsable] USHORT RawValueLength;
+			[nonbrowsable, helpstring('Size in bytes of Name not including terminating null')] USHORT NameLength;
+			[nonbrowsable, helpstring('Size in bytes of RawValue not including terminating null')] USHORT RawValueLength;
 			[helpstring('The header name (minus the ':' character)'), size_is('NameLength'), string] LPCSTR pName;
 			[helpstring('The header value.'), size_is('RawValueLength'), string] LPCSTR pRawValue;
 		} HTTP_UNKNOWN_HEADER;

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_VERSION.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_VERSION.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HTTP_VERSION
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_VERSION guid: (GUID fromString: '{f6a0c406-b01a-4701-aa8c-d4c1a0d2b1a5}')!
-HTTP_VERSION comment: '<HTTP_VERSION> is an <ExternalStructure> class to wrap the struct ''Win32.HTTP_VERSION'' from type information in the ''Win32 API'' library.
+HTTP_VERSION comment: '<HTTP_VERSION> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HTTP_VERSION'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains the following helpstring for this struct
 	"defines a version of the HTTP protocol that a request requires or a response provides."
@@ -21,7 +21,7 @@ struct tagHTTP_VERSION {
 	[readonly, helpstring("Minor version of the HTTP protocol.")] USHORT MinorVersion;
 } HTTP_VERSION;
 '!
-!HTTP_VERSION categoriesForClass!Win32-Structs! !
+!HTTP_VERSION categoriesForClass!WinHttpServer-Structs! !
 !HTTP_VERSION methodsFor!
 
 MajorVersion

--- a/Core/Object Arts/Dolphin/System/Win32/HttpApiLibrary.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HttpApiLibrary.cls
@@ -343,7 +343,7 @@ httpAddFragmentToCache: requestQueueHandle urlPrefix: urlPrefix dataChunk: dataC
 	"Invoke the HttpAddFragmentToCache() function of the module wrapped by the receiver.
 	Helpstring:  caches a data fragment with a specified name by which it can be retrieved, or updates data cached under a specified name. Such cached data fragments can be used repeatedly to construct dynamic responses without going to disk.
 
-		unsigned long __stdcall HttpAddFragmentToCache(
+		ULONG __stdcall HttpAddFragmentToCache(
 			[in]HANDLE RequestQueueHandle,
 			[in]LPCWSTR UrlPrefix,
 			[in]HTTP_DATA_CHUNK* DataChunk,
@@ -357,11 +357,11 @@ httpAddUrlToUrlGroup: urlGroupId pFullyQualifiedUrl: pFullyQualifiedUrl urlConte
 	"Invoke the HttpAddUrlToUrlGroup() function of the module wrapped by the receiver.
 	Helpstring: Adds the specified URL to the URL Group identified by the URL Group ID.
 
-		unsigned long __stdcall HttpAddUrlToUrlGroup(
+		ULONG __stdcall HttpAddUrlToUrlGroup(
 			[in]unsigned __int64 UrlGroupId,
 			[in]LPCWSTR pFullyQualifiedUrl,
 			[in]HTTP_URL_CONTEXT UrlContext,
-			[in]unsigned long Reserved);"
+			[in]ULONG Reserved);"
 
 	<stdcall: dword HttpAddUrlToUrlGroup qword lpwstr qword dword>
 	^self invalidCall!
@@ -370,7 +370,7 @@ httpCancelHttpRequest: requestQueueHandle requestId: requestId overlapped: overl
 	"Invoke the HttpCancelHttpRequest() function of the module wrapped by the receiver.
 	Helpstring: Cancels a specified reqest.
 
-		unsigned long __stdcall HttpCancelHttpRequest(
+		ULONG __stdcall HttpCancelHttpRequest(
 			[in]HANDLE RequestQueueHandle,
 			[in]unsigned __int64 RequestId,
 			[in]LPOVERLAPPED OVERLAPPED);"
@@ -382,7 +382,7 @@ httpCloseRequestQueue: requestQueueHandle
 	"Invoke the HttpCloseRequestQueue() function of the module wrapped by the receiver.
 	Helpstring: Close a request queue when it is no longer required.
 
-		unsigned long __stdcall HttpCloseRequestQueue(
+		ULONG __stdcall HttpCloseRequestQueue(
 			[in]HANDLE RequestQueueHandle);"
 
 	<stdcall: dword HttpCloseRequestQueue handle>
@@ -392,7 +392,7 @@ httpCloseServerSession: serverSessionId
 	"Invoke the HttpCloseServerSession() function of the module wrapped by the receiver.
 	Helpstring: Deletes the server session identified by the server session ID. All remaining URL Groups associated with the server session will also be closed.
 
-		unsigned long __stdcall HttpCloseServerSession(
+		ULONG __stdcall HttpCloseServerSession(
 			[in]unsigned __int64 ServerSessionId);"
 
 	<stdcall: dword HttpCloseServerSession qword>
@@ -402,7 +402,7 @@ httpCloseUrlGroup: urlGroupId
 	"Invoke the HttpCloseUrlGroup() function of the module wrapped by the receiver.
 	Helpstring: Closes the URL Group identified by the URL Group ID. This call also removes all of the URLs that are associated with the URL Group
 
-		unsigned long __stdcall HttpCloseUrlGroup(
+		ULONG __stdcall HttpCloseUrlGroup(
 			[in]unsigned __int64 UrlGroupId);"
 
 	<stdcall: dword HttpCloseUrlGroup qword>
@@ -412,11 +412,11 @@ httpCreateRequestQueue: version name: name securityAttributes: securityAttribute
 	"Invoke the HttpCreateRequestQueue() function of the module wrapped by the receiver.
 	Helpstring: Creates a new request queue or opens an existing request queue.
 
-		unsigned long __stdcall HttpCreateRequestQueue(
+		ULONG __stdcall HttpCreateRequestQueue(
 			[in]HTTPAPI_VERSION Version,
-			[in]LPCWSTR name,
-			[in]SECURITY_ATTRIBUTES* securityAttributes,
-			[in]unsigned long flags,
+			[in]LPCWSTR Name,
+			[in]SECURITY_ATTRIBUTES* SecurityAttributes,
+			[in]ULONG Flags,
 			[out]HANDLE* RequestQueueHandle);"
 
 	<stdcall: dword HttpCreateRequestQueue dword lpwstr SECURITY_ATTRIBUTES* dword handle*>
@@ -426,10 +426,10 @@ httpCreateServerSession: version serverSessionId: serverSessionId reserved: rese
 	"Invoke the HttpCreateServerSession() function of the module wrapped by the receiver.
 	Helpstring: Create a server session for the specified version.
 
-		unsigned long __stdcall HttpCreateServerSession(
+		ULONG __stdcall HttpCreateServerSession(
 			[in]HTTPAPI_VERSION Version,
 			[out]unsigned __int64* ServerSessionId,
-			[in]unsigned long Reserved);"
+			[in]ULONG Reserved);"
 
 	<stdcall: dword HttpCreateServerSession dword qword* dword>
 	^self invalidCall!
@@ -438,10 +438,10 @@ httpCreateUrlGroup: serverSessionId pUrlGroupId: pUrlGroupId reserved: reserved
 	"Invoke the HttpCreateUrlGroup() function of the module wrapped by the receiver.
 	Helpstring: Creates a URL Group under the specified server session.
 
-		unsigned long __stdcall HttpCreateUrlGroup(
+		ULONG __stdcall HttpCreateUrlGroup(
 			[in]unsigned __int64 ServerSessionId,
 			[out]unsigned __int64* pUrlGroupId,
-			[in]unsigned long Reserved);"
+			[in]ULONG Reserved);"
 
 	<stdcall: dword HttpCreateUrlGroup qword qword* dword>
 	^self invalidCall!
@@ -450,13 +450,13 @@ httpDeclarePush: requestQueueHandle requestId: requestId verb: verb path: path q
 	"Invoke the HttpDeclarePush() function of the module wrapped by the receiver.
 	Helpstring: Declares a resource-to-subresource relationship to use for an HTTP server push. HTTP.sys then performs an HTTP 2.0 server push for the given resource, if the underlying protocol, connection, client, and policies allow the push operation.
 
-		unsigned long __stdcall HttpDeclarePush(
-			HANDLE RequestQueueHandle,
-			unsigned __int64 RequestId,
-			HTTP_VERB Verb,
-			LPCWSTR Path,
-			LPCSTR Query,
-			PHTTP_REQUEST_HEADERS Headers);"
+		ULONG __stdcall HttpDeclarePush(
+			[in]HANDLE RequestQueueHandle,
+			[in]unsigned __int64 RequestId,
+			[in]HTTP_VERB Verb,
+			[in]LPCWSTR Path,
+			[in]LPCSTR Query,
+			[in]HTTP_REQUEST_HEADERS* Headers);"
 
 	<stdcall: dword HttpDeclarePush handle qword sdword lpwstr lpstr HTTP_REQUEST_HEADERS*>
 	^self invalidCall!
@@ -465,11 +465,11 @@ httpDeleteServiceConfiguration: serviceHandle configId: configId pConfigInformat
 	"Invoke the HttpDeleteServiceConfiguration() function of the module wrapped by the receiver.
 	Helpstring: Deletes specified data, such as IP addresses or SSL Certificates, from the HTTP Server API configuration store, one record at a time.
 
-		unsigned long __stdcall HttpDeleteServiceConfiguration(
+		ULONG __stdcall HttpDeleteServiceConfiguration(
 			[in]HANDLE ServiceHandle,
 			[in]HTTP_SERVICE_CONFIG_ID ConfigId,
 			[in]void* pConfigInformation,
-			[in]unsigned long ConfigInformationLength,
+			[in]ULONG ConfigInformationLength,
 			[in]LPOVERLAPPED pOverlapped);"
 
 	<stdcall: dword HttpDeleteServiceConfiguration handle sdword void* dword OVERLAPPED*>
@@ -479,10 +479,10 @@ httpFlushResponseCache: requestQueueHandle urlPrefix: urlPrefix flags: flags ove
 	"Invoke the HttpFlushResponseCache() function of the module wrapped by the receiver.
 	Helpstring: Remove from the HTTP Server API cache associated with a given request queue all response fragments that have a name whose site portion matches a specified UrlPrefix.
 
-		unsigned long __stdcall HttpFlushResponseCache(
+		ULONG __stdcall HttpFlushResponseCache(
 			[in]HANDLE RequestQueueHandle,
 			[in]LPCWSTR UrlPrefix,
-			[in]unsigned long flags,
+			[in]ULONG Flags,
 			[in]LPOVERLAPPED OVERLAPPED);"
 
 	<stdcall: dword HttpFlushResponseCache handle lpwstr dword OVERLAPPED*>
@@ -492,10 +492,10 @@ httpInitialize: version flags: flags pReserved: pReserved
 	"Invoke the HttpInitialize() function of the module wrapped by the receiver.
 	Helpstring: The HttpInitialize function initializes the HTTP Server API driver, starts it, if it has not already been started, and allocates data structures for the calling application to support response-queue creation and other operations.
 
-		unsigned long __stdcall HttpInitialize(
+		ULONG __stdcall HttpInitialize(
 			[in]HTTPAPI_VERSION Version,
-			[in]unsigned long flags,
-			[in, out]void* pReserved);"
+			[in]ULONG Flags,
+			[in, out]PVOID pReserved);"
 
 	<stdcall: dword HttpInitialize dword dword void*>
 	^self invalidCall!
@@ -504,11 +504,11 @@ httpPrepareUrl: reserved flags: flags url: url preparedUrl: preparedUrl
 	"Invoke the HttpPrepareUrl() function of the module wrapped by the receiver.
 	Helpstring: Parses, analyzes, and normalizes a non-normalized Unicode or punycode URL so it is safe and valid to use in other HTTP functions (Win8+).
 
-		unsigned long __stdcall HttpPrepareUrl(
-			void* Reserved,
-			unsigned long flags,
-			LPCWSTR Url,
-			LPWSTR* PreparedUrl);"
+		ULONG __stdcall HttpPrepareUrl(
+			PVOID Reserved,
+			ULONG Flags,
+			[in]LPCWSTR Url,
+			[out]LPWSTR* PreparedUrl);"
 
 	<stdcall: dword HttpPrepareUrl void* dword lpwstr lpwstr*>
 	^self invalidCall!
@@ -517,14 +517,14 @@ httpQueryRequestQueueProperty: requestQueueProperty property: property propertyI
 	"Invoke the HttpQueryRequestQueueProperty() function of the module wrapped by the receiver.
 	Helpstring: Query a property of the request queue identified by the specified handle
 
-		unsigned long __stdcall HttpQueryRequestQueueProperty(
+		ULONG __stdcall HttpQueryRequestQueueProperty(
 			[in]HANDLE RequestQueueProperty,
 			[in]HTTP_SERVER_PROPERTY Property,
-			void* PropertyInformation,
-			[in]unsigned long PropertyInformationLength,
-			[in]unsigned long Reserved1,
-			unsigned long* ReturnLength,
-			[in]void* Reserved2);"
+			[out]void* PropertyInformation,
+			[in]ULONG PropertyInformationLength,
+			[in]ULONG Reserved1,
+			[out]ULONG* ReturnLength,
+			[in]PVOID Reserved2);"
 
 	<stdcall: dword HttpQueryRequestQueueProperty handle sdword void* dword dword dword* void*>
 	^self invalidCall!
@@ -533,12 +533,12 @@ httpQueryServerSessionProperty: serverSessionId property: property propertyInfor
 	"Invoke the HttpQueryServerSessionProperty() function of the module wrapped by the receiver.
 	Helpstring: Queries a server property on the specified server session.
 
-		unsigned long __stdcall HttpQueryServerSessionProperty(
+		ULONG __stdcall HttpQueryServerSessionProperty(
 			[in]unsigned __int64 ServerSessionId,
 			[in]HTTP_SERVER_PROPERTY Property,
-			void* PropertyInformation,
-			[in]unsigned long PropertyInformationLength,
-			unsigned long* ReturnLength);"
+			[out]void* PropertyInformation,
+			[in]ULONG PropertyInformationLength,
+			[out]ULONG* ReturnLength);"
 
 	<stdcall: dword HttpQueryServerSessionProperty qword sdword void* dword dword*>
 	^self invalidCall!
@@ -547,14 +547,14 @@ httpQueryServiceConfiguration: serviceHandle configId: configId pInput: pInput i
 	"Invoke the HttpQueryServiceConfiguration() function of the module wrapped by the receiver.
 	Helpstring: Retrieves one or more HTTP Server API configuration records.
 
-		unsigned long __stdcall HttpQueryServiceConfiguration(
+		ULONG __stdcall HttpQueryServiceConfiguration(
 			[in]HANDLE ServiceHandle,
 			[in]HTTP_SERVICE_CONFIG_ID ConfigId,
 			[in]void* pInput,
-			[in]unsigned long InputLength,
+			[in]ULONG InputLength,
 			[out]void* pOutput,
-			[in]unsigned long OutputLength,
-			[out]unsigned long* pReturnLength,
+			[in]ULONG OutputLength,
+			[out]ULONG* pReturnLength,
 			[in]LPOVERLAPPED pOverlapped);"
 
 	<stdcall: dword HttpQueryServiceConfiguration handle sdword void* dword void* dword dword* OVERLAPPED*>
@@ -564,12 +564,12 @@ httpQueryUrlGroupProperty: urlGroupId property: property propertyInformation: pr
 	"Invoke the HttpQueryUrlGroupProperty() function of the module wrapped by the receiver.
 	Helpstring: Query a property on the specified URL Group.
 
-		unsigned long __stdcall HttpQueryUrlGroupProperty(
+		ULONG __stdcall HttpQueryUrlGroupProperty(
 			[in]unsigned __int64 UrlGroupId,
 			[in]HTTP_SERVER_PROPERTY Property,
-			void* PropertyInformation,
-			[in]unsigned long PropertyInformationLength,
-			unsigned long* ReturnLength);"
+			[out]void* PropertyInformation,
+			[in]ULONG PropertyInformationLength,
+			[out]ULONG* ReturnLength);"
 
 	<stdcall: dword HttpQueryUrlGroupProperty qword sdword void* dword dword*>
 	^self invalidCall!
@@ -577,13 +577,13 @@ httpQueryUrlGroupProperty: urlGroupId property: property propertyInformation: pr
 httpReadFragmentFromCache: requestQueueHandle urlPrefix: urlPrefix byteRange: byteRange buffer: buffer bufferLength: bufferLength bytesRead: bytesRead overlapped: overlapped
 	"Invoke the HttpReadFragmentFromCache() function of the module wrapped by the receiver.
 
-		unsigned long __stdcall HttpReadFragmentFromCache(
+		ULONG __stdcall HttpReadFragmentFromCache(
 			[in]HANDLE RequestQueueHandle,
 			[in]LPCWSTR UrlPrefix,
 			[in]PHTTP_BYTE_RANGE ByteRange,
-			void* Buffer,
-			[in]unsigned long BufferLength,
-			unsigned long* BytesRead,
+			[out]void* Buffer,
+			[in]ULONG BufferLength,
+			[out]ULONG* BytesRead,
 			[in]LPOVERLAPPED OVERLAPPED);"
 
 	<stdcall: dword HttpReadFragmentFromCache handle lpwstr HTTP_BYTE_RANGE* void* dword dword* OVERLAPPED*>
@@ -592,13 +592,13 @@ httpReadFragmentFromCache: requestQueueHandle urlPrefix: urlPrefix byteRange: by
 httpReceiveClientCertificate: requestQueueHandle connectionId: connectionId flags: flags sslClientCertInfo: sslClientCertInfo sslClientCertInfoSize: sslClientCertInfoSize bytesReceived: bytesReceived overlapped: overlapped
 	"Invoke the HttpReceiveClientCertificate() function of the module wrapped by the receiver.
 
-		unsigned long __stdcall HttpReceiveClientCertificate(
+		ULONG __stdcall HttpReceiveClientCertificate(
 			[in]HANDLE RequestQueueHandle,
 			[in]unsigned __int64 ConnectionId,
-			[in]unsigned long flags,
-			PHTTP_SSL_CLIENT_CERT_INFO SslClientCertInfo,
-			[in]unsigned long SslClientCertInfoSize,
-			unsigned long* BytesReceived,
+			[in]ULONG Flags,
+			[out]PHTTP_SSL_CLIENT_CERT_INFO SslClientCertInfo,
+			[in]ULONG SslClientCertInfoSize,
+			[out]ULONG* BytesReceived,
 			[in]LPOVERLAPPED OVERLAPPED);"
 
 	<stdcall: dword HttpReceiveClientCertificate handle qword dword HTTP_SSL_CLIENT_CERT_INFO* dword dword* OVERLAPPED*>
@@ -608,28 +608,28 @@ httpReceiveHttpRequest: requestQueueHandle requestId: requestId flags: flags req
 	"Invoke the HttpReceiveHttpRequest() function of the module wrapped by the receiver.
 	Helpstring: Retrieve the next available HTTP request from the specified request queue either synchronously or asynchronously.
 
-		unsigned long __stdcall HttpReceiveHttpRequest(
+		ULONG __stdcall HttpReceiveHttpRequest(
 			[in]HANDLE RequestQueueHandle,
 			[in]unsigned __int64 RequestId,
-			[in]unsigned long flags,
-			PHTTP_REQUEST RequestBuffer,
-			[in]unsigned long RequestBufferLength,
-			unsigned long* BytesReturned,
+			[in]ULONG Flags,
+			[out]HTTP_REQUEST* RequestBuffer,
+			[in]ULONG RequestBufferLength,
+			[out]ULONG* BytesReturned,
 			[in]LPOVERLAPPED OVERLAPPED);"
 
-	<stdcall: dword HttpReceiveHttpRequest handle qword dword HTTP_REQUEST* dword dword* OVERLAPPED*>
+	<stdcall: dword HttpReceiveHttpRequest handle qword dword HTTP_REQUEST_V2* dword dword* OVERLAPPED*>
 	^self invalidCall!
 
 httpReceiveRequestEntityBody: requestQueueHandle requestId: requestId flags: flags entityBuffer: entityBuffer entityBufferLength: entityBufferLength bytesReturned: bytesReturned overlapped: overlapped
 	"Invoke the HttpReceiveRequestEntityBody() function of the module wrapped by the receiver.
 
-		unsigned long __stdcall HttpReceiveRequestEntityBody(
+		ULONG __stdcall HttpReceiveRequestEntityBody(
 			[in]HANDLE RequestQueueHandle,
 			[in]unsigned __int64 RequestId,
-			[in]unsigned long flags,
-			void* EntityBuffer,
-			[in]unsigned long EntityBufferLength,
-			unsigned long* BytesReturned,
+			[in]ULONG Flags,
+			[out]void* EntityBuffer,
+			[in]ULONG EntityBufferLength,
+			[out]ULONG* BytesReturned,
 			[in]LPOVERLAPPED OVERLAPPED);"
 
 	<stdcall: dword HttpReceiveRequestEntityBody handle qword dword void* dword dword* OVERLAPPED*>
@@ -639,10 +639,10 @@ httpRemoveUrlFromUrlGroup: urlGroupId pFullyQualifiedUrl: pFullyQualifiedUrl fla
 	"Invoke the HttpRemoveUrlFromUrlGroup() function of the module wrapped by the receiver.
 	Helpstring: The HttpRemoveUrlFromUrlGroup function removes the specified URL from the group identified by the URL Group ID. This function removes one, or all, of the URLs from the group. 
 
-		unsigned long __stdcall HttpRemoveUrlFromUrlGroup(
+		ULONG __stdcall HttpRemoveUrlFromUrlGroup(
 			[in]unsigned __int64 UrlGroupId,
 			[in]LPCWSTR pFullyQualifiedUrl,
-			[in]unsigned long flags);"
+			[in]ULONG Flags);"
 
 	<stdcall: dword HttpRemoveUrlFromUrlGroup qword lpwstr dword>
 	^self invalidCall!
@@ -651,34 +651,34 @@ httpSendHttpResponse: requestQueueHandle requestId: requestId flags: flags httpR
 	"Invoke the HttpSendHttpResponse() function of the module wrapped by the receiver.
 	Helpstring: Sends an HTTP response to the specified HTTP request.
 
-		unsigned long __stdcall HttpSendHttpResponse(
+		ULONG __stdcall HttpSendHttpResponse(
 			[in]HANDLE RequestQueueHandle,
 			[in]unsigned __int64 RequestId,
-			[in]unsigned long flags,
+			[in]ULONG Flags,
 			[in]PHTTP_RESPONSE HttpResponse,
 			[in]PHTTP_CACHE_POLICY CachePolicy,
-			[out]unsigned long* BytesSent,
-			void* Reserved2,
-			unsigned long reserved3,
+			[out]ULONG* BytesSent,
+			PVOID Reserved2,
+			ULONG Reserved3,
 			[in]LPOVERLAPPED OVERLAPPED,
 			[in]PHTTP_LOG_DATA LogData);"
 
-	<stdcall: dword HttpSendHttpResponse handle qword dword HTTP_RESPONSE* HTTP_CACHE_POLICY* dword* void* dword OVERLAPPED* HTTP_LOG_FIELDS_DATA*>
+	<stdcall: dword HttpSendHttpResponse handle qword dword HTTP_RESPONSE_V2* HTTP_CACHE_POLICY* dword* void* dword OVERLAPPED* HTTP_LOG_FIELDS_DATA*>
 	^self invalidCall!
 
 httpSendResponseEntityBody: requestQueueHandle requestId: requestId flags: flags entityChunkCount: entityChunkCount entityChunks: entityChunks bytesSent: bytesSent reserved1: reserved1 reserved2: reserved2 overlapped: overlapped logData: logData
 	"Invoke the HttpSendResponseEntityBody() function of the module wrapped by the receiver.
 	Helpstring: Sends entity-body data associated with an HTTP response.
 
-		unsigned long __stdcall HttpSendResponseEntityBody(
+		ULONG __stdcall HttpSendResponseEntityBody(
 			[in]HANDLE RequestQueueHandle,
 			[in]unsigned __int64 RequestId,
-			[in]unsigned long flags,
-			[in]unsigned short EntityChunkCount,
-			HTTP_DATA_CHUNK* EntityChunks,
-			[out]unsigned long* BytesSent,
-			void* Reserved1,
-			unsigned long Reserved2,
+			[in]ULONG Flags,
+			[in]USHORT EntityChunkCount,
+			[in]HTTP_DATA_CHUNK* EntityChunks,
+			[out]ULONG* BytesSent,
+			PVOID Reserved1,
+			ULONG Reserved2,
 			[in]LPOVERLAPPED OVERLAPPED,
 			[in]PHTTP_LOG_DATA LogData);"
 
@@ -689,13 +689,13 @@ httpSetRequestQueueProperty: requestQueueHandle property: property propertyInfor
 	"Invoke the HttpSetRequestQueueProperty() function of the module wrapped by the receiver.
 	Helpstring: Set a new property or modifies an existing property on the request queue identified by the specified handle.
 
-		unsigned long __stdcall HttpSetRequestQueueProperty(
+		ULONG __stdcall HttpSetRequestQueueProperty(
 			[in]HANDLE RequestQueueHandle,
 			[in]HTTP_SERVER_PROPERTY Property,
-			void* PropertyInformation,
-			[in]unsigned long PropertyInformationLength,
-			[in]unsigned long Reserved1,
-			[in]void* Reserved2);"
+			[in]void* PropertyInformation,
+			[in]ULONG PropertyInformationLength,
+			[in]ULONG Reserved1,
+			[in]PVOID Reserved2);"
 
 	<stdcall: dword HttpSetRequestQueueProperty handle sdword void* dword dword void*>
 	^self invalidCall!
@@ -704,11 +704,11 @@ httpSetServerSessionProperty: serverSessionId property: property propertyInforma
 	"Invoke the HttpSetServerSessionProperty() function of the module wrapped by the receiver.
 	Helpstring: Sets a new server session property or modifies an existing property on the specified server session.
 
-		unsigned long __stdcall HttpSetServerSessionProperty(
+		ULONG __stdcall HttpSetServerSessionProperty(
 			[in]unsigned __int64 ServerSessionId,
 			[in]HTTP_SERVER_PROPERTY Property,
-			void* PropertyInformation,
-			[in]unsigned long PropertyInformationLength);"
+			[in]void* PropertyInformation,
+			[in]ULONG PropertyInformationLength);"
 
 	<stdcall: dword HttpSetServerSessionProperty qword sdword void* dword>
 	^self invalidCall!
@@ -717,11 +717,11 @@ httpSetServiceConfiguration: serviceHandle configId: configId pConfigInformation
 	"Invoke the HttpSetServiceConfiguration() function of the module wrapped by the receiver.
 	Helpstring: creates and sets a configuration record for the HTTP Server API configuration store. The call fails if the specified record already exists.
 
-		unsigned long __stdcall HttpSetServiceConfiguration(
+		ULONG __stdcall HttpSetServiceConfiguration(
 			[in]HANDLE ServiceHandle,
 			[in]HTTP_SERVICE_CONFIG_ID ConfigId,
 			[in]void* pConfigInformation,
-			[in]unsigned long ConfigInformationLength,
+			[in]ULONG ConfigInformationLength,
 			[in]LPOVERLAPPED pOverlapped);"
 
 	<stdcall: dword HttpSetServiceConfiguration handle sdword void* dword OVERLAPPED*>
@@ -731,11 +731,11 @@ httpSetUrlGroupProperty: urlGroupId property: property propertyInformation: prop
 	"Invoke the HttpSetUrlGroupProperty() function of the module wrapped by the receiver.
 	Helpstring: Sets a new property or modifies an existing property on the specified URL Group.
 
-		unsigned long __stdcall HttpSetUrlGroupProperty(
+		ULONG __stdcall HttpSetUrlGroupProperty(
 			[in]unsigned __int64 UrlGroupId,
 			[in]HTTP_SERVER_PROPERTY Property,
-			void* PropertyInformation,
-			[in]unsigned long PropertyInformationLength);"
+			[in]void* PropertyInformation,
+			[in]ULONG PropertyInformationLength);"
 
 	<stdcall: dword HttpSetUrlGroupProperty qword sdword void* dword>
 	^self invalidCall!
@@ -744,7 +744,7 @@ httpShutdownRequestQueue: requestQueueHandle
 	"Invoke the HttpShutdownRequestQueue() function of the module wrapped by the receiver.
 	Helpstring: Stop queuing requests for the specified request queue process.
 
-		unsigned long __stdcall HttpShutdownRequestQueue(
+		ULONG __stdcall HttpShutdownRequestQueue(
 			[in]HANDLE RequestQueueHandle);"
 
 	<stdcall: dword HttpShutdownRequestQueue handle>
@@ -754,9 +754,9 @@ httpTerminate: flags pReserved: pReserved
 	"Invoke the HttpTerminate() function of the module wrapped by the receiver.
 	Helpstring: Cleans up resources used by the HTTP Server API to process calls by an application. An application should call HttpTerminate once for every time it called HttpInitialize, with matching flag settings.
 
-		unsigned long __stdcall HttpTerminate(
-			[in]unsigned long flags,
-			[in, out]void* pReserved);"
+		ULONG __stdcall HttpTerminate(
+			[in]ULONG Flags,
+			[in, out]PVOID pReserved);"
 
 	<stdcall: dword HttpTerminate dword void*>
 	^self invalidCall!
@@ -765,7 +765,7 @@ httpWaitForDemandStart: requestQueueHandle overlapped: overlapped
 	"Invoke the HttpWaitForDemandStart() function of the module wrapped by the receiver.
 	Helpstring: Wait for the arrival of a new request that can be served by a new request queue process.
 
-		unsigned long __stdcall HttpWaitForDemandStart(
+		ULONG __stdcall HttpWaitForDemandStart(
 			[in]HANDLE RequestQueueHandle,
 			[in]LPOVERLAPPED OVERLAPPED);"
 
@@ -776,7 +776,7 @@ httpWaitForDisconnect: requestQueueHandle connectionId: connectionId overlapped:
 	"Invoke the HttpWaitForDisconnect() function of the module wrapped by the receiver.
 	Helpstring: Notifies the application when the connection to an HTTP client is broken for any reason.
 
-		unsigned long __stdcall HttpWaitForDisconnect(
+		ULONG __stdcall HttpWaitForDisconnect(
 			[in]HANDLE RequestQueueHandle,
 			[in]unsigned __int64 ConnectionId,
 			[in]LPOVERLAPPED OVERLAPPED);"
@@ -788,10 +788,10 @@ httpWaitForDisconnectEx: requestQueueHandle connectionId: connectionId reserved:
 	"Invoke the HttpWaitForDisconnectEx() function of the module wrapped by the receiver.
 	Helpstring: This function is an extension to HttpWaitForDisconnect.
 
-		unsigned long __stdcall HttpWaitForDisconnectEx(
+		ULONG __stdcall HttpWaitForDisconnectEx(
 			[in]HANDLE RequestQueueHandle,
 			[in]unsigned __int64 ConnectionId,
-			[in]unsigned long Reserved,
+			[in]ULONG Reserved,
 			[in]LPOVERLAPPED OVERLAPPED);"
 
 	<stdcall: dword HttpWaitForDisconnectEx handle qword dword OVERLAPPED*>
@@ -963,8 +963,8 @@ setUrlGroup: anIntegerGroupId property: aWinHttpPropertyInfo
 				propertyInformation: aWinHttpPropertyInfo
 				propertyInformationLength: aWinHttpPropertyInfo byteSize)! !
 !HttpApiLibrary categoriesFor: #addUrl:toUrlGroup:!operations!public! !
-!HttpApiLibrary categoriesFor: #asyncReceiveHttpRequest:requestId:flags:requestBuffer:requestBufferLength:bytesReturned:overlapped:!public! !
-!HttpApiLibrary categoriesFor: #asyncSendHttpResponse:requestId:flags:httpResponse:cachePolicy:bytesSent:reserved2:reserved3:overlapped:logData:!**auto generated**!public! !
+!HttpApiLibrary categoriesFor: #asyncReceiveHttpRequest:requestId:flags:requestBuffer:requestBufferLength:bytesReturned:overlapped:!operations!public! !
+!HttpApiLibrary categoriesFor: #asyncSendHttpResponse:requestId:flags:httpResponse:cachePolicy:bytesSent:reserved2:reserved3:overlapped:logData:!operations!public! !
 !HttpApiLibrary categoriesFor: #bindQueue:toUrlGroup:!operations!public! !
 !HttpApiLibrary categoriesFor: #checkReturnCode:!helpers!private! !
 !HttpApiLibrary categoriesFor: #close!public!realizing/unrealizing! !
@@ -1044,7 +1044,7 @@ example1
 	"
 
 	| lib sessionId queue groupId urlPrefix iveConfiguredSsl |
-	iveConfiguredSsl := true.
+	iveConfiguredSsl := false.
 	urlPrefix := iveConfiguredSsl
 				ifTrue: [
 					"Change this to the URL you've added your SSL cert to."
@@ -1161,7 +1161,7 @@ example3
 
 	| param bufSize lib ret sizeRequired buf |
 	lib := self default.
-	"Add IPv6 localhost to the list list"
+	"Add IPv6 localhost to the listen list - needs admin rights"
 	param := HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM new.
 	param address: (SOCKADDR fromString: '::1').
 	ret := lib

--- a/Core/Object Arts/Dolphin/System/Win32/HttpServiceConfigQuery.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HttpServiceConfigQuery.cls
@@ -6,7 +6,7 @@ HttpServerStructure subclass: #HttpServiceConfigQuery
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HttpServiceConfigQuery guid: (GUID fromString: '{38f6548e-ee39-4262-9f31-96ce0e8c6cb7}')!
-HttpServiceConfigQuery comment: '<HttpServiceConfigQuery> is an <ExternalStructure> class to wrap the struct ''Win32.HttpServiceConfigQuery'' from type information in the ''Win32 API'' library.
+HttpServiceConfigQuery comment: '<HttpServiceConfigQuery> is an <ExternalStructure> class to wrap the struct ''WinHttpServer.HttpServiceConfigQuery'' from type information in the ''Windows Http Server API'' library.
 
 The type library contains no documentation for this struct
 
@@ -19,7 +19,7 @@ struct tagHttpServiceConfigQuery {
 	HTTP_SERVICE_CONFIG_QUERY_TYPE QueryDesc;
 } HttpServiceConfigQuery;
 '!
-!HttpServiceConfigQuery categoriesForClass!Win32-Structs! !
+!HttpServiceConfigQuery categoriesForClass!WinHttpServer-Structs! !
 !HttpServiceConfigQuery methodsFor!
 
 QueryDesc

--- a/Core/Object Arts/Dolphin/System/Win32/WinHttpServerConsts.st
+++ b/Core/Object Arts/Dolphin/System/Win32/WinHttpServerConsts.st
@@ -21,7 +21,7 @@ WinHttpServerConsts at: 'HTTP_CREATE_REQUEST_QUEUE_FLAG_OPEN_EXISTING' put: 16r1
 WinHttpServerConsts at: 'HTTP_FLUSH_RESPONSE_FLAG_RECURSIVE' put: 16r1!
 WinHttpServerConsts at: 'HTTP_INITIALIZE_CONFIG' put: 16r2!
 WinHttpServerConsts at: 'HTTP_INITIALIZE_SERVER' put: 16r1!
-WinHttpServerConsts at: 'HTTP_LIMIT_INFINITE' put: 16rFFFFFFFF!
+WinHttpServerConsts at: 'HTTP_LIMIT_INFINITE' put: -16r1!
 WinHttpServerConsts at: 'HTTP_LOG_FIELD_BYTES_RECV' put: 16r2000!
 WinHttpServerConsts at: 'HTTP_LOG_FIELD_BYTES_SENT' put: 16r1000!
 WinHttpServerConsts at: 'HTTP_LOG_FIELD_CLIENT_IP' put: 16r4!


### PR DESCRIPTION
The typelib project for the Win Http Server API has been published at [blairmcg/WinHttpServerTlb](https://github.com/blairmcg/WinHttpServerTlb). There is no build currently, but it can be built easily with VS2017 Community. 
This PR includes a couple of small fixes to the typelib generation code, and a regen of the basic API wrapper for the Win Http Server package from the typelib.