### PR TITLE
ExternalLibrary should not be abstract

### DIFF
--- a/Core/Object Arts/Dolphin/Base/ExternalLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalLibrary.cls
@@ -6,7 +6,6 @@ Object subclass: #ExternalLibrary
 	poolDictionaries: 'Win32Constants Win32Errors'
 	classInstanceVariableNames: 'default'!
 ExternalLibrary guid: (GUID fromString: '{87b4c488-026e-11d3-9fd7-00a0cc3e4a32}')!
-ExternalLibrary isAbstract: true!
 ExternalLibrary comment: 'ExternalLibrary is the class of objects which represent shared, external, function libraries (i.e. DLLs). Each DLL is represented by a separate subclass, with the methods of that subclass corresponding to functions exported from the DLL. The functions are a special form of primitive method (actually instances of <ExternalMethod>) containing the additional type information needed to interface to statically typed functions. The functions are invoked by sending Smalltalk messages int the normal way, with these being translated by the VM external call primitive to the actual function invocations. The VM coerces the Smalltalk objects passed as arguments to appropriate native types following certain rules (see below). The external call primitive will fail if a type mismatch occurs, and normally this will result in an InvalidExternalCall exception being raised (assuming the #invalidCall method has not been overridden).
 
 External library classes are typically singletons, with the instances representing an "open" (usable) instance of the DLL. The singleton instances are accessible through the class #default method. The libraries are loaded lazily, on demand (but see <PermanentLibrary>).
@@ -389,7 +388,7 @@ fileName
 	"Answer the host system file name for the external library the 
 	receiver represents."
 
-	^self subclassResponsibility!
+	^self error: 'Cannot open anonymous library'!
 
 fromHandle: aHandle
 	"Answers an instance of ExternalLibrary attached to aHandle."


### PR DESCRIPTION
ExternalLibrary was marked as abstract because it has a class-side `subclassResponsibility` method, but it should not have and it is not really abstract as it can be used for opening anonymous libraries. This also fixes a subclass responsibility bug reported by the Code Mentor that ExternalResourceLibrary does not implement the aforementioned subclass responsibility.