### PR TITLE
Use Windows BCrypt API for SHA1

### DIFF
--- a/Core/Object Arts/Dolphin/DolphinSure/BCryptConstants.st
+++ b/Core/Object Arts/Dolphin/DolphinSure/BCryptConstants.st
@@ -1,0 +1,52 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+Smalltalk at: #BCryptConstants put: (PoolConstantsDictionary named: #BCryptConstants)!
+BCryptConstants at: 'BCRYPT_3DES_112_ALGORITHM' put: '3DES_112'!
+BCryptConstants at: 'BCRYPT_3DES_ALGORITHM' put: '3DES'!
+BCryptConstants at: 'BCRYPT_AES_ALGORITHM' put: 'AES'!
+BCryptConstants at: 'BCRYPT_AES_CMAC_ALGORITHM' put: 'AES-CMAC'!
+BCryptConstants at: 'BCRYPT_AES_GMAC_ALGORITHM' put: 'AES-GMAC'!
+BCryptConstants at: 'BCRYPT_ALGORITHM_NAME' put: 'AlgorithmName'!
+BCryptConstants at: 'BCRYPT_AUTH_TAG_LENGTH' put: 'AuthTagLength'!
+BCryptConstants at: 'BCRYPT_BLOCK_LENGTH' put: 'BlockLength'!
+BCryptConstants at: 'BCRYPT_BLOCK_SIZE_LIST' put: 'BlockSizeList'!
+BCryptConstants at: 'BCRYPT_CHAINING_MODE' put: 'ChainingMode'!
+BCryptConstants at: 'BCRYPT_DES_ALGORITHM' put: 'DES'!
+BCryptConstants at: 'BCRYPT_DESX_ALGORITHM' put: 'DESX'!
+BCryptConstants at: 'BCRYPT_DH_ALGORITHM' put: 'DH'!
+BCryptConstants at: 'BCRYPT_DSA_ALGORITHM' put: 'DSA'!
+BCryptConstants at: 'BCRYPT_ECDH_P256_ALGORITHM' put: 'ECDH_P256'!
+BCryptConstants at: 'BCRYPT_ECDH_P384_ALGORITHM' put: 'ECDH_P384'!
+BCryptConstants at: 'BCRYPT_ECDH_P521_ALGORITHM' put: 'ECDH_P521'!
+BCryptConstants at: 'BCRYPT_ECDSA_P256_ALGORITHM' put: 'ECDSA_P256'!
+BCryptConstants at: 'BCRYPT_ECDSA_P384_ALGORITHM' put: 'ECDSA_P384'!
+BCryptConstants at: 'BCRYPT_ECDSA_P521_ALGORITHM' put: 'ECDSA_P521'!
+BCryptConstants at: 'BCRYPT_EFFECTIVE_KEY_LENGTH' put: 'EffectiveKeyLength'!
+BCryptConstants at: 'BCRYPT_HASH_BLOCK_LENGTH' put: 'HashBlockLength'!
+BCryptConstants at: 'BCRYPT_HASH_LENGTH' put: 'HashDigestLength'!
+BCryptConstants at: 'BCRYPT_HASH_OID_LIST' put: 'HashOIDList'!
+BCryptConstants at: 'BCRYPT_KEY_LENGTH' put: 'KeyLength'!
+BCryptConstants at: 'BCRYPT_KEY_LENGTHS' put: 'KeyLengths'!
+BCryptConstants at: 'BCRYPT_KEY_OBJECT_LENGTH' put: 'KeyObjectLength'!
+BCryptConstants at: 'BCRYPT_KEY_STRENGTH' put: 'KeyStrength'!
+BCryptConstants at: 'BCRYPT_MD2_ALGORITHM' put: 'MD2'!
+BCryptConstants at: 'BCRYPT_MD4_ALGORITHM' put: 'MD4'!
+BCryptConstants at: 'BCRYPT_MD5_ALGORITHM' put: 'MD5'!
+BCryptConstants at: 'BCRYPT_OBJECT_LENGTH' put: 'ObjectLength'!
+BCryptConstants at: 'BCRYPT_PADDING_SCHEMES' put: 'PaddingSchemes'!
+BCryptConstants at: 'BCRYPT_PROVIDER_HANDLE' put: 'ProviderHandle'!
+BCryptConstants at: 'BCRYPT_RC2_ALGORITHM' put: 'RC2'!
+BCryptConstants at: 'BCRYPT_RC4_ALGORITHM' put: 'RC4'!
+BCryptConstants at: 'BCRYPT_RNG_ALGORITHM' put: 'RNG'!
+BCryptConstants at: 'BCRYPT_RNG_DUAL_EC_ALGORITHM' put: 'DUALECRNG'!
+BCryptConstants at: 'BCRYPT_RNG_FIPS186_DSA_ALGORITHM' put: 'FIPS186DSARNG'!
+BCryptConstants at: 'BCRYPT_RSA_ALGORITHM' put: 'RSA'!
+BCryptConstants at: 'BCRYPT_RSA_SIGN_ALGORITHM' put: 'RSA_SIGN'!
+BCryptConstants at: 'BCRYPT_SHA1_ALGORITHM' put: 'SHA1'!
+BCryptConstants at: 'BCRYPT_SHA1_HASH_SIZE' put: 16r14!
+BCryptConstants at: 'BCRYPT_SHA256_ALGORITHM' put: 'SHA256'!
+BCryptConstants at: 'BCRYPT_SHA384_ALGORITHM' put: 'SHA384'!
+BCryptConstants at: 'BCRYPT_SHA512_ALGORITHM' put: 'SHA512'!
+BCryptConstants at: 'BCRYPT_SIGNATURE_LENGTH' put: 'SignatureLength'!
+BCryptConstants at: 'BCRYPT_STATUS_UNSUCCESSFUL' put: 16rC0000001!
+BCryptConstants shrink!

--- a/Core/Object Arts/Dolphin/DolphinSure/BCryptLibrary.cls
+++ b/Core/Object Arts/Dolphin/DolphinSure/BCryptLibrary.cls
@@ -1,0 +1,183 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+ExternalLibrary subclass: #BCryptLibrary
+	instanceVariableNames: 'shaAlgorithmHandle'
+	classVariableNames: ''
+	poolDictionaries: 'BCryptConstants'
+	classInstanceVariableNames: ''!
+BCryptLibrary guid: (GUID fromString: '{84b3c6ee-a194-413c-8071-95953a50412e}')!
+BCryptLibrary comment: '"Windows BCrypt (Cryptography Next Generation, CNG) library.
+  Replacement for DolphinSureCryptoLibrary class and DLL."'!
+!BCryptLibrary categoriesForClass!External-Libraries! !
+!BCryptLibrary methodsFor!
+
+closeAlgorithmProvider: aAlgorithmHandle flags: aFlags
+	"The BCryptCloseAlgorithmProvider function closes an algorithm provider.
+
+	NTSTATUS WINAPI BCryptCloseAlgorithmProvider(
+		_Inout_	BCRYPT_ALG_HANDLE	hAlgorithm,
+		_In_		ULONG				dwFlags );"
+
+	<cdecl: dword BCryptCloseAlgorithmProvider handle dword>
+	^ self invalidCall.!
+
+createHash: aAlgorithmHandle hashHandle: aHashHandle hashObject: aHashObject hashObjectSize: aHashObjectSize secret: aSecret secretSize: aSecretSize flags: aFlags
+	"The The BCryptCreateHash function is called to create a hash or Message Authentication Code (MAC) object.
+
+	NTSTATUS WINAPI BCryptCreateHash(
+		_Inout_	BCRYPT_ALG_HANDLE	hAlgorithm,
+		_Out_	BCRYPT_HASH_HANDLE*	phHash,
+		_Out_	PUCHAR				pbHashObject,
+		_In_opt_	ULONG				cbHashObject,
+		_In_opt_	PUCHAR				pbSecret,
+		_In_		ULONG				cbSecret,
+		_In_		ULONG				dwFlags
+);"
+	<cdecl: dword BCryptCreateHash handle handle* byte* dword byte* dword dword>
+	^ self invalidCall.!
+
+destroyHash: aHashHandle
+	"The BCryptDestroyHash function closes an algorithm provider.
+
+	NTSTATUS WINAPI BCryptDestroyHash(
+		_Inout_	BCRYPT_HASH_HANDLE	hHash );"
+
+	<cdecl: dword BCryptDestroyHash handle>
+	^ self invalidCall.!
+
+finishHash: aHashHandle output: aOutput outputSize: aOutputSize flags: aFlags
+	"The BCryptFinishHash function retrieves the hash or Message Authentication Code (MAC) value for the data accumulated from prior calls to BCryptHashData.
+
+	NTSTATUS WINAPI BCryptFinishHash(
+		_Inout_	BCRYPT_HASH_HANDLE	hHash,
+		_Out_	PUCHAR				pbOutput,
+		_In_		ULONG				cbOutput,
+		_In_		ULONG				dwFlags );"
+
+	<cdecl: dword BCryptFinishHash handle byte* dword dword>
+	^ self invalidCall.!
+
+getProperty: aHandle property: aProperty output: aOutput outputSize: aOutputSize resultSize: aResultSize flags: aFlags
+	"The BCryptGetProperty function retrieves the value of a named property for a BCrypt object.
+
+	NTSTATUS WINAPI BCryptGetProperty(
+		_In_		BCRYPT_HANDLE	hObject,
+		_In_		LPCWSTR			pszProperty,
+		_Out_	PUCHAR			pbOutput,
+		_In_		ULONG			cbOutput,
+		_Out_	ULONG			*pcbResult,
+		_In_		ULONG			dwFlags ); "
+
+	<cdecl: dword BCryptOpenAlgorithmProvider handle bstr byte* dword dword* dword>
+	^ self invalidCall.!
+
+hashData: aHashHandle input: aInput inputSize: aInputSize flags: aFlags
+	"The BCryptHashData function performs a one way hash or Message Authentication Code (MAC) on a data buffer.
+
+	NTSTATUS WINAPI BCryptHashData(
+		_Inout_	BCRYPT_HASH_HANDLE	hHash,
+		_In_		PUCHAR				pbInput,
+		_In_		ULONG				cbInput,
+		_In_		ULONG				dwFlags );"
+
+	<cdecl: dword BCryptHashData handle byte* dword dword>
+	^ self invalidCall.!
+
+openAlgorithmProvider: aHandle id: anId implementation: anImplementation flags: aFlags
+	"The BCryptOpenAlgorithmProvider function loads and initializes a BCrypt provider.
+
+	NTSTATUS WINAPI BCryptOpenAlgorithmProvider(
+		_Out_	BCRYPT_ALG_HANDLE*	phAlgorithm,
+		_In_		LPCWSTR				pszAlgId,
+		_In_		LPCWSTR				pszImplementation,
+		_In_		DWORD				dwFlags );"
+
+	<cdecl: dword BCryptOpenAlgorithmProvider handle* bstr bstr dword>
+	^ self invalidCall.!
+
+shaAlgorithmHandle
+	"Answer internal handle. to the SHA1 algorithm.
+	Create it, if it was not allocated yet.
+	This handle is never freed, because re-creating it is expensive."
+
+	| status |
+
+	( shaAlgorithmHandle isNil or: [ shaAlgorithmHandle value = 0 ] ) ifTrue: [
+		shaAlgorithmHandle := ExternalHandle new.
+		status := self openAlgorithmProvider: shaAlgorithmHandle id: BCRYPT_SHA1_ALGORITHM implementation: nil flags: 0.
+		( self statusFailed: status ) ifTrue: [ 
+			self error: 'BCrypt>>openAlgorithmProvider failed: ', ( status printStringRadix: 16 showRadix: false ) ] ].
+
+	^ shaAlgorithmHandle.!
+
+shaCreate
+	"Creates a SHA context. In BCrypt terms, the context is the hash handle."
+
+	| hashHandle status |
+
+	hashHandle := ExternalHandle new.
+	status := self createHash: self shaAlgorithmHandle hashHandle: hashHandle hashObject: nil hashObjectSize: 0 secret: 0 secretSize: 0 flags: 0.
+	( self statusFailed: status ) ifTrue: [ 
+		self error: 'BCrypt>>createHash: failed: ', ( status printStringRadix: 16 showRadix: false ) ].
+
+	^ hashHandle.!
+
+shaDestroy: aHashHandle
+	"Destroys the argument SHA handle (context)."
+
+	| status | 
+
+	status := self destroyHash: aHashHandle.
+	( self statusFailed: status ) ifTrue: [ 
+		self error: 'BCrypt>>destroyHash failed: ', ( status printStringRadix: 16 showRadix: false ) ].
+!
+
+shaGetHash: aHashHandle
+	"Answer the computed hash for the argument SHA handle.
+	 The answer will be a ByteArray of 20 bytes for SHA1"
+
+	| hash status |
+
+	hash := ByteArray new: 20.
+	status := self finishHash: aHashHandle output: hash outputSize: hash size flags: 0.
+	( self statusFailed: status ) ifTrue: [ 
+		self error: 'BCrypt>>finishHash failed: ', ( status printStringRadix: 16 showRadix: false ) ].
+
+	^ hash.!
+
+shaHashBuffer: aHashHandle buffer: buffer
+	"Hash the contents in of ByteArray buffer in the currently open hash context."
+
+	| status | 
+
+	status := self hashData: aHashHandle input: buffer inputSize: buffer size flags: 0.
+	( self statusFailed: status ) ifTrue: [ 
+		self error: 'BCrypt>>hashData failed: ', ( status printStringRadix: 16 showRadix: false ) ].
+!
+
+statusFailed: aStatus
+	"Answer true if the argument NTSTATUS indicates a fail value."
+
+	^ aStatus >= BCRYPT_STATUS_UNSUCCESSFUL.! !
+!BCryptLibrary categoriesFor: #closeAlgorithmProvider:flags:!public!win32 functions-bcrypt library! !
+!BCryptLibrary categoriesFor: #createHash:hashHandle:hashObject:hashObjectSize:secret:secretSize:flags:!public!win32 functions-bcrypt library! !
+!BCryptLibrary categoriesFor: #destroyHash:!public!win32 functions-bcrypt library! !
+!BCryptLibrary categoriesFor: #finishHash:output:outputSize:flags:!public!win32 functions-bcrypt library! !
+!BCryptLibrary categoriesFor: #getProperty:property:output:outputSize:resultSize:flags:!public!win32 functions-bcrypt library! !
+!BCryptLibrary categoriesFor: #hashData:input:inputSize:flags:!public!win32 functions-bcrypt library! !
+!BCryptLibrary categoriesFor: #openAlgorithmProvider:id:implementation:flags:!public!win32 functions-bcrypt library! !
+!BCryptLibrary categoriesFor: #shaAlgorithmHandle!hashing!public! !
+!BCryptLibrary categoriesFor: #shaCreate!hashing!public! !
+!BCryptLibrary categoriesFor: #shaDestroy:!hashing!public! !
+!BCryptLibrary categoriesFor: #shaGetHash:!hashing!public! !
+!BCryptLibrary categoriesFor: #shaHashBuffer:buffer:!hashing!public! !
+!BCryptLibrary categoriesFor: #statusFailed:!error handling!hashing!public! !
+
+!BCryptLibrary class methodsFor!
+
+fileName
+	"Answer the host system file name for the library"
+
+	^ 'BCrypt'! !
+!BCryptLibrary class categoriesFor: #fileName!constants!public! !
+

--- a/Core/Object Arts/Dolphin/DolphinSure/BCryptLibrary.cls
+++ b/Core/Object Arts/Dolphin/DolphinSure/BCryptLibrary.cls
@@ -18,7 +18,7 @@ closeAlgorithmProvider: aAlgorithmHandle flags: aFlags
 		_Inout_	BCRYPT_ALG_HANDLE	hAlgorithm,
 		_In_		ULONG				dwFlags );"
 
-	<cdecl: dword BCryptCloseAlgorithmProvider handle dword>
+	<stdcall: dword BCryptCloseAlgorithmProvider handle dword>
 	^ self invalidCall.!
 
 createHash: aAlgorithmHandle hashHandle: aHashHandle hashObject: aHashObject hashObjectSize: aHashObjectSize secret: aSecret secretSize: aSecretSize flags: aFlags
@@ -31,9 +31,9 @@ createHash: aAlgorithmHandle hashHandle: aHashHandle hashObject: aHashObject has
 		_In_opt_	ULONG				cbHashObject,
 		_In_opt_	PUCHAR				pbSecret,
 		_In_		ULONG				cbSecret,
-		_In_		ULONG				dwFlags
-);"
-	<cdecl: dword BCryptCreateHash handle handle* byte* dword byte* dword dword>
+		_In_		ULONG				dwFlags );"
+
+	<stdcall: dword BCryptCreateHash handle handle* byte* dword byte* dword dword>
 	^ self invalidCall.!
 
 destroyHash: aHashHandle
@@ -42,7 +42,7 @@ destroyHash: aHashHandle
 	NTSTATUS WINAPI BCryptDestroyHash(
 		_Inout_	BCRYPT_HASH_HANDLE	hHash );"
 
-	<cdecl: dword BCryptDestroyHash handle>
+	<stdcall: dword BCryptDestroyHash handle>
 	^ self invalidCall.!
 
 finishHash: aHashHandle output: aOutput outputSize: aOutputSize flags: aFlags
@@ -54,7 +54,7 @@ finishHash: aHashHandle output: aOutput outputSize: aOutputSize flags: aFlags
 		_In_		ULONG				cbOutput,
 		_In_		ULONG				dwFlags );"
 
-	<cdecl: dword BCryptFinishHash handle byte* dword dword>
+	<stdcall: dword BCryptFinishHash handle byte* dword dword>
 	^ self invalidCall.!
 
 getProperty: aHandle property: aProperty output: aOutput outputSize: aOutputSize resultSize: aResultSize flags: aFlags
@@ -68,7 +68,7 @@ getProperty: aHandle property: aProperty output: aOutput outputSize: aOutputSize
 		_Out_	ULONG			*pcbResult,
 		_In_		ULONG			dwFlags ); "
 
-	<cdecl: dword BCryptOpenAlgorithmProvider handle bstr byte* dword dword* dword>
+	<stdcall: dword BCryptGetProperty handle lpwstr byte* dword dword* dword>
 	^ self invalidCall.!
 
 hashData: aHashHandle input: aInput inputSize: aInputSize flags: aFlags
@@ -80,7 +80,7 @@ hashData: aHashHandle input: aInput inputSize: aInputSize flags: aFlags
 		_In_		ULONG				cbInput,
 		_In_		ULONG				dwFlags );"
 
-	<cdecl: dword BCryptHashData handle byte* dword dword>
+	<stdcall: dword BCryptHashData handle byte* dword dword>
 	^ self invalidCall.!
 
 openAlgorithmProvider: aHandle id: anId implementation: anImplementation flags: aFlags
@@ -92,7 +92,7 @@ openAlgorithmProvider: aHandle id: anId implementation: anImplementation flags: 
 		_In_		LPCWSTR				pszImplementation,
 		_In_		DWORD				dwFlags );"
 
-	<cdecl: dword BCryptOpenAlgorithmProvider handle* bstr bstr dword>
+	<stdcall: dword BCryptOpenAlgorithmProvider handle* lpwstr lpwstr dword>
 	^ self invalidCall.!
 
 shaAlgorithmHandle
@@ -104,6 +104,7 @@ shaAlgorithmHandle
 
 	( shaAlgorithmHandle isNil or: [ shaAlgorithmHandle value = 0 ] ) ifTrue: [
 		shaAlgorithmHandle := ExternalHandle new.
+
 		status := self openAlgorithmProvider: shaAlgorithmHandle id: BCRYPT_SHA1_ALGORITHM implementation: nil flags: 0.
 		( self statusFailed: status ) ifTrue: [ 
 			self error: 'BCrypt>>openAlgorithmProvider failed: ', ( status printStringRadix: 16 showRadix: false ) ] ].
@@ -158,7 +159,7 @@ shaHashBuffer: aHashHandle buffer: buffer
 statusFailed: aStatus
 	"Answer true if the argument NTSTATUS indicates a fail value."
 
-	^ aStatus >= BCRYPT_STATUS_UNSUCCESSFUL.! !
+	^ aStatus >= 16r80000000.! !
 !BCryptLibrary categoriesFor: #closeAlgorithmProvider:flags:!public!win32 functions-bcrypt library! !
 !BCryptLibrary categoriesFor: #createHash:hashHandle:hashObject:hashObjectSize:secret:secretSize:flags:!public!win32 functions-bcrypt library! !
 !BCryptLibrary categoriesFor: #destroyHash:!public!win32 functions-bcrypt library! !

--- a/Core/Object Arts/Dolphin/DolphinSure/DolphinSure.pax
+++ b/Core/Object Arts/Dolphin/DolphinSure/DolphinSure.pax
@@ -15,6 +15,7 @@ package basicPackageVersion: '6.1'.
 
 
 package classNames
+	add: #BCryptLibrary;
 	add: #DigitalSignatureAlgorithm;
 	add: #DolphinSureCertificate;
 	add: #DolphinSureCertificateInfo;
@@ -38,6 +39,10 @@ package methodNames
 	add: #SourceManager -> #secureFileIn:;
 	add: #SourceManager -> #secureFileInFrom:;
 	add: #SourceManager -> #secureFileItIn:;
+	yourself.
+
+package globalNames
+	add: #BCryptConstants;
 	yourself.
 
 package binaryGlobalNames: (Set new
@@ -125,6 +130,11 @@ Error subclass: #TrustedDataError
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ExternalLibrary subclass: #BCryptLibrary
+	instanceVariableNames: 'shaAlgorithmHandle'
+	classVariableNames: ''
+	poolDictionaries: 'BCryptConstants'
 	classInstanceVariableNames: ''!
 ExternalLibrary subclass: #DolphinSureCryptoLibrary
 	instanceVariableNames: ''

--- a/Core/Object Arts/Dolphin/DolphinSure/SecureHashAlgorithm.cls
+++ b/Core/Object Arts/Dolphin/DolphinSure/SecureHashAlgorithm.cls
@@ -14,27 +14,28 @@ This standard is described in FIPS PUB 180-1, "SECURE HASH STANDARD", April 17, 
 context
 	"Private - Gets an SHA context"
 	
-	context isNil ifTrue: [ context := self shaLibrary shaCreate].
-	^context!
+	context isNil ifTrue: [ context := self shaLibrary shaCreate ].
+	^context
+!
 
 finalHash
 	"Private - Answers the final hash from the context and closes it"
 
-	| totals hash |
-	totals := DWORDArray new: 5.
-	self shaLibrary shaGetHash: self context lpHashBytes: totals.
+	| hashBytes hashValue |
+
+	hashBytes := self shaLibrary shaGetHash: self context.
 	self resetContext.
-	hash := 0.
-	1 to: 5 do: [:i | hash := hash bitOr: ((totals at: i) bitShift: 32 * (5 - i))].
-	^hash!
+
+	hashValue := 0.
+	1 to: hashBytes size do: [ :i | hashValue := ( hashValue bitShift: 8 ) bitOr: ( hashBytes at: i ) ].
+	^ hashValue.!
 
 hashIn: aByteArray 
 	"Private - Hashes the data in aByteArray using the current SHA context"
 
 	self shaLibrary 
-		shaHashBuffer: self context
-		lpBuffer: aByteArray
-		dwLen: aByteArray size!
+		shaHashBuffer: self context buffer: aByteArray.
+!
 
 hashInInteger: aPositiveInteger 
 	"Hash in the given positive integer. The integer to be hashed should have 512 or fewer bits."
@@ -103,7 +104,7 @@ resetContext
 shaLibrary
 	"Private - Answers the <ExternalLibrary> containing the SHA functions"
 
-	^DolphinSureCryptoLibrary default! !
+	^ BCryptLibrary default! !
 !SecureHashAlgorithm categoriesFor: #context!helpers!private! !
 !SecureHashAlgorithm categoriesFor: #finalHash!helpers!private! !
 !SecureHashAlgorithm categoriesFor: #hashIn:!helpers!private! !


### PR DESCRIPTION
Replaces Dolphin SHA1 use of the DolphinSureCrypto.dll with use of the standard Windows BCrypt API. 
The implementation of the BCrypt API is partial for now, only for Dolphin SHA1 usage. 
The DolphinSureCryptoLib.dll is not removed from the VM yet. That will be a following PR, if all goes well. :)
I tested this with a rebuild of the image and then running the regression tests, that also contain 3 SHA tests.
Discussion about this is in issue #537.