### PR TITLE
#543: Remove some inappropriate uses of #shouldNotImplement

### DIFF
--- a/Core/Object Arts/Dolphin/Base/PositionableStream.cls
+++ b/Core/Object Arts/Dolphin/Base/PositionableStream.cls
@@ -64,7 +64,7 @@ basicUpTo: anObject
 	of the collection. If the receiver is at its end, answer an empty Collection."
 
 	| startIndex endIndex |
-	self isReadable ifFalse: [^self shouldNotImplement].
+	self isReadable ifFalse: [^self errorNotReadable].
 	startIndex := position + 1.
 	"We can perform a fast scan for anObject in the collection. Most streamed over
 	SequenceableCollections have a primitive implementation of #nextIdentityIndexOf:from:to:"

--- a/Core/Object Arts/Dolphin/Base/PositionableStreamTest.cls
+++ b/Core/Object Arts/Dolphin/Base/PositionableStreamTest.cls
@@ -41,7 +41,7 @@ readOperationNotImplemented: aBlock
 	self 
 		should: aBlock
 		raise: Error
-		matching: [:ex | ex description beginsWith: self streamClass name , ' should not implement']!
+		matching: [:ex | ex description = 'The stream is not readable']!
 
 runArrays
 	^{{RunArray new. #()}.

--- a/Core/Object Arts/Dolphin/Base/SortedCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SortedCollection.cls
@@ -235,7 +235,7 @@ resize: anInteger
 	"Implementation Note: SortedCollections can be reduced in size, but not grown - in general we don't know if nils are a valid element that have a sort order
 	relationship recognised by the receiver's sort block."
 
-	anInteger > self size ifTrue: [^self error: 'SortedCollections are not resizable'].
+	anInteger > self size ifTrue: [^self error: 'SortedCollections cannot be grown to include nils'].
 	super resize: anInteger!
 
 reSort

--- a/Core/Object Arts/Dolphin/Base/SortedCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SortedCollection.cls
@@ -235,7 +235,7 @@ resize: anInteger
 	"Implementation Note: SortedCollections can be reduced in size, but not grown - in general we don't know if nils are a valid element that have a sort order
 	relationship recognised by the receiver's sort block."
 
-	anInteger > self size ifTrue: [^self shouldNotImplement].
+	anInteger > self size ifTrue: [^self error: 'SortedCollections are not resizable'].
 	super resize: anInteger!
 
 reSort

--- a/Core/Object Arts/Dolphin/Base/SortedCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SortedCollectionTest.cls
@@ -51,7 +51,7 @@ testResize
 	actual := subject resize: 2.
 	self assert: actual identicalTo: subject.
 	self assert: actual equals: (self newCollection: #($a $b)).
-	self shouldnt: [subject resize: 3] implement: #resize:!
+	self should: [subject resize: 3] raise: Error!
 
 testStrongTalkTests
 !

--- a/Core/Object Arts/Dolphin/Base/StdioFileStream.cls
+++ b/Core/Object Arts/Dolphin/Base/StdioFileStream.cls
@@ -209,9 +209,6 @@ contentsSpecies
 
 	^self subclassResponsibility!
 
-errorNotPositionable
-	^self error: 'The stdio stream is not positionable'!
-
 externalType
 	"Answer a <symbol> which names the external stream type of the receiver."
 
@@ -430,7 +427,6 @@ upTo: anObject
 !StdioFileStream categoriesFor: #close!operations!public! !
 !StdioFileStream categoriesFor: #contents!accessing!public! !
 !StdioFileStream categoriesFor: #contentsSpecies!constants!private! !
-!StdioFileStream categoriesFor: #errorNotPositionable!exceptions!private! !
 !StdioFileStream categoriesFor: #externalType!accessing!public! !
 !StdioFileStream categoriesFor: #fileno!accessing!private! !
 !StdioFileStream categoriesFor: #fileSize!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/Stream.cls
+++ b/Core/Object Arts/Dolphin/Base/Stream.cls
@@ -100,6 +100,14 @@ errorEndOfStream
 
 	^self class endOfStreamSignal signalWith: self!
 
+errorNotPositionable
+	^self error: 'The stream is not positionable'!
+
+errorNotReadable
+	"Private - An attempt was made to read from a write-only stream. Raise an appropriate exception."
+
+	^self error: 'The stream is not readable'!
+
 isReadable
 	"Answer whether the receiver can be read from (i.e. it implements the gettableStream
 	protocol)."
@@ -118,7 +126,7 @@ next
 	"Implementation Note: Must be defined by subclasses which wish to implement the 
 	<gettableStream> protocol."
 
-	^self subclassResponsibility!
+	^self errorNotReadable!
 
 next: anInteger
 	"Answer a <sequencedReadableCollection> containing the next anInteger number of objects
@@ -216,6 +224,8 @@ upToEnd
 !Stream categoriesFor: #display:!printing!public! !
 !Stream categoriesFor: #do:!enumerating!public! !
 !Stream categoriesFor: #errorEndOfStream!exceptions!public! !
+!Stream categoriesFor: #errorNotPositionable!exceptions!private! !
+!Stream categoriesFor: #errorNotReadable!exceptions!private! !
 !Stream categoriesFor: #isReadable!public!testing! !
 !Stream categoriesFor: #isWriteable!public!testing! !
 !Stream categoriesFor: #next!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/WriteStream.cls
+++ b/Core/Object Arts/Dolphin/Base/WriteStream.cls
@@ -129,7 +129,7 @@ next
 	"Answer the next object accessible by the receiver. WriteStreams do not support reading.
 	This effectively stubs out all the read methods inherited from superclasses."
 
-	^self shouldNotImplement!
+	^self errorNotReadable!
 
 next: anInteger put: anObject
 	"Store the argument, anObject, as the next anInteger number of elements accessible by the receiver. 

--- a/Core/Object Arts/Dolphin/Sockets/SocketReadStream.cls
+++ b/Core/Object Arts/Dolphin/Sockets/SocketReadStream.cls
@@ -36,7 +36,7 @@ basicNext: countInteger into: aSequenceableCollection startingAt: startInteger
 contents
 	"We don't maintain past history, so we cannot implement this correctly."
 
-	^self shouldNotImplement!
+	^self errorNotPositionable!
 
 hasInput
 	"Answer true if there is data available on the receiver without blocking"
@@ -101,13 +101,13 @@ readPage
 setToEnd
 	"The receiver is not positionable."
 
-	^self shouldNotImplement!
+	^self errorNotPositionable!
 
 size
 	"We don't know the number of elements in the past sequence values, only the number
 	currently in the buffer, so cannot provide a sensible implementation of this message."
 
-	^self shouldNotImplement!
+	^self errorNotPositionable!
 
 socket
 	"Private - Answers the socket instance variable."

--- a/Core/Object Arts/Dolphin/System/Random/Random.cls
+++ b/Core/Object Arts/Dolphin/System/Random/Random.cls
@@ -48,6 +48,11 @@ isReadable
 
 	^true!
 
+next
+	"Answer the next object accessible by the receiver."
+
+	^self subclassResponsibility!
+
 peek
 	"Answer a pseudo-Random floating point number between 0 and 1 generated
 	from the next seed, but do not advance down the stream (i.e. self peek = self peek)."
@@ -74,6 +79,7 @@ skip: anInteger
 !Random categoriesFor: #atEnd!public!testing! !
 !Random categoriesFor: #chiSquareTest:max:!examples!private! !
 !Random categoriesFor: #isReadable!public!testing! !
+!Random categoriesFor: #next!accessing!public! !
 !Random categoriesFor: #peek!accessing!public! !
 !Random categoriesFor: #seed!accessing!public! !
 !Random categoriesFor: #seed:!accessing!public! !

--- a/Core/Object Arts/Dolphin/System/Trace/DebugTraceStream.cls
+++ b/Core/Object Arts/Dolphin/System/Trace/DebugTraceStream.cls
@@ -78,11 +78,6 @@ isWriteable
 
 	^true!
 
-next
-	"Answer the next object accessible by the receiver."
-
-	^self shouldNotImplement!
-
 next: anInteger put: anObject
 	"Store the argument, anObject, as the next anInteger number of elements accessible by the receiver. 
 	Answer anObject."
@@ -140,7 +135,6 @@ tab: tabCount
 !DebugTraceStream categoriesFor: #initialize!initializing!private! !
 !DebugTraceStream categoriesFor: #isEmpty!public! !
 !DebugTraceStream categoriesFor: #isWriteable!public!testing! !
-!DebugTraceStream categoriesFor: #next!accessing!public! !
 !DebugTraceStream categoriesFor: #next:put:!operations!public! !
 !DebugTraceStream categoriesFor: #next:putAll:startingAt:!accessing!public! !
 !DebugTraceStream categoriesFor: #nextPut:!adding!public! !


### PR DESCRIPTION
Mainly in stream classes where read operations are invoked on write-only
streams.