### PR TITLE
BootDPRO: Hang on "Dolphin Community Edition Tools.pax" Error Handling #546

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@
 *.st linguist-language=Smalltalk
 *.pax linguist-language=Smalltalk
 *.img7 filter=lfs diff=lfs merge=lfs -text
+SciLexer.dll filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.sml
 *.exe
 *.dll
-SciLexer.*
+!SciLexer.dll
 !DBOOT.img7
 !DBOOT.sml
 Repository/

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
@@ -20,35 +20,6 @@ Please Note: The contents of this package must not be redistributed in any form.
 
 package basicPackageVersion: '6.1'.
 
-package basicScriptAt: #postinstall put: '"Download the correct version of wscite zip from Scintilla.org and extract the built binary
-of SciLexer.dll from it into the Dolphin directory."
-
-
-	| scilexer locator currentVer version filename zip dest temp shell scintilla url exists |
-	locator := FileLocator installRelative.
-	version := ScintillaLibrary versionString.
-	scilexer := locator localFileSpecFor: (File path: ScintillaLibrary fileName extension: ''dll'').
-	exists := File exists: scilexer.
-	currentVer := exists ifTrue: [(VersionInfo forPath: scilexer) productVersionString].
-	version = currentVer ifTrue: [^self].
-	filename := ''wscite<1s>.zip'' expandMacrosWith: (version copyWithout: $.).
-	url := ''http://www.scintilla.org/'' , filename.
-	temp := URLMonLibrary default urlDownloadToCacheFile: url.
-	"Extract SciLexer.dll from the wscite zip"
-	shell := IDispatch createObject: ''Shell.Application''.
-	zip := shell invoke: ''NameSpace'' with: temp.
-	scintilla := zip invoke: ''ParseName'' with: ''wscite\SciLexer.dll''.
-	dest := shell invoke: ''Namespace'' with: locator basePath.
-	exists
-		ifTrue: [File rename: scilexer to: (File path: scilexer extension: (currentVer copyWithout: $.))].
-	dest
-		invoke: ''CopyHere''
-		with: scintilla
-		with: 16r14.
-	dest free.
-	scintilla free.
-	zip free.
-	shell free'.
 
 package classNames
 	add: #ClassHierarchyDiagram;

--- a/SciLexer.dll
+++ b/SciLexer.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d34a1099a5f6ae7984c791e798389b642fc96f5da7004016a421dc9b5f38778c
+size 994816


### PR DESCRIPTION
Move SciLexer.dll to Git LFS rather than downloading at boot time