### PR TITLE
Remember interrupted command

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Base/Command.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Command.cls
@@ -103,8 +103,10 @@ value
 	"Executes the receiver and answers the result. Maintain the currently executing
 	command in the class variable, Current."
 
+	| prior |
+	prior := Current.
 	Current := self.
-	^[self commandDescription performAgainst: self receiver] ensure: [Current := nil]! !
+	^[self commandDescription performAgainst: self receiver] ensure: [Current := prior]! !
 !Command categoriesFor: #beBenign!accessing!public! !
 !Command categoriesFor: #canRedo!accessing!public! !
 !Command categoriesFor: #canUndo!accessing!public! !


### PR DESCRIPTION
I found in one of my application's tests a situation where there was an embedded Command (a button on a window triggered a Choice Prompter with an 'Okay' button). Later code expected to find the original Command present. This code restores the original value and is offered for consideration.