### PR TITLE
  Fix #588: `String>>unescapePercents` doesn't work for `Utf16String`s

### DIFF
--- a/Core/DolphinVM/StreamPrim.cpp
+++ b/Core/DolphinVM/StreamPrim.cpp
@@ -509,7 +509,7 @@ Oop* __fastcall Interpreter::primitiveNextPut(Oop* const sp, unsigned)
 					if (ObjectMemoryIsIntegerObject(value))
 					{
 						MWORD intValue = ObjectMemoryIntegerValueOf(value);
-						if (intValue > 255)
+						if (intValue <= 255)
 						{
 							ByteArrayOTE* oteByteArray = reinterpret_cast<ByteArrayOTE*>(oteBuf);
 

--- a/Core/Object Arts/Dolphin/Base/AbstractStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/AbstractStringTest.cls
@@ -477,37 +477,64 @@ testTrimNulls
 	self assert: (self newCollection: trimmed) equals: (self newCollection: 'a')!
 
 testUnescapePercents
-	self assert: (self newCollection: '') unescapePercents equals: (self newCopy: '').
-	self assert: (self newCollection: '+') unescapePercents equals: (self newCopy: ' ').
-	self assert: (self newCollection: 'A') unescapePercents equals: (self newCopy: 'A').
-	self assert: (self newCollection: '+A') unescapePercents equals: (self newCopy: ' A').
-	self assert: (self newCollection: '++A') unescapePercents equals: (self newCopy: '  A').
-	self assert: (self newCollection: 'A+') unescapePercents equals: (self newCopy: 'A ').
-	self assert: (self newCollection: 'A++') unescapePercents equals: (self newCopy: 'A  ').
-	self assert: (self newCollection: 'AB') unescapePercents equals: (self newCopy: 'AB').
-	self assert: (self newCollection: '+A+B+') unescapePercents equals: (self newCopy: ' A B ').
-	self assert: (self newCollection: '++A++B++') unescapePercents equals: (self newCopy: '  A  B  ').
-	self assert: (self newCollection: '%41') unescapePercents equals: (self newCopy: 'A').
-	self assert: (self newCollection: '+%41+') unescapePercents equals: (self newCopy: ' A ').
-	self assert: (self newCollection: '%41B') unescapePercents equals: (self newCopy: 'AB').
-	self assert: (self newCollection: '%41+B') unescapePercents equals: (self newCopy: 'A B').
-	self assert: (self newCollection: '%41++B') unescapePercents equals: (self newCopy: 'A  B').
-	self assert: (self newCollection: '%41BC') unescapePercents equals: (self newCopy: 'ABC').
-	self assert: (self newCollection: '%41%42') unescapePercents equals: (self newCopy: 'AB').
-	self assert: (self newCollection: '%41B%43') unescapePercents equals: (self newCopy: 'ABC').
-	self assert: (self newCollection: '%41BC%44') unescapePercents equals: (self newCopy: 'ABCD').
-	self assert: (self newCollection: 'A%42%43') unescapePercents equals: (self newCopy: 'ABC').
-	self assert: (self newCollection: 'AB%43%44') unescapePercents equals: (self newCopy: 'ABCD').
-	self assert: (self newCollection: 'AB%43D%45') unescapePercents equals: (self newCopy: 'ABCDE').
-	self assert: (self newCollection: 'AB%43DE%46') unescapePercents equals: (self newCopy: 'ABCDEF').
-	self assert: (self newCollection: 'AB%43DE%46G') unescapePercents equals: (self newCopy: 'ABCDEFG').
-	self assert: (self newCollection: 'AB%43DE%46GH') unescapePercents
-		equals: (self newCopy: 'ABCDEFGH').
-	"Invalid (non-ascii) character, therefore assume not an escaped string"
-	self assert: (self newCollection: '%GA') unescapePercents equals: (self newCollection: '%GA').
-	self assert: (self newCollection: '%AG') unescapePercents equals: (self newCollection: '%AG').
-	self assert: (self newCollection: '%[1') unescapePercents equals: (self newCollection: '%[1').
-	self assert: (self newCollection: '%1[') unescapePercents equals: (self newCollection: '%1[')!
+	"Test URI decoding per RFC3986"
+
+	| unreserved misencoded |
+	#(#('' '') #('+' ' ') #('A' 'A') #('+A' ' A') #('++A' '  A') #('A+' 'A ') #('A++' 'A  ') #('AB' 'AB') #('+A+B+' ' A B ') #('++A++B++' '  A  B  ') #('%41' 'A') #('+%41+' ' A ') #('%41B' 'AB') #('%41+B' 'A B') #('%41++B' 'A  B') #('%41BC' 'ABC') #('%41%42' 'AB') #('%41B%43' 'ABC') #('%41BC%44' 'ABCD') #('A%42%43' 'ABC') #('AB%43%44' 'ABCD') #('AB%43D%45' 'ABCDE') #('AB%43DE%46' 'ABCDEF') #('AB%43DE%46G' 'ABCDEFG') #('AB%43DE%46GH' 'ABCDEFGH') #('~25%25' '~25%'))
+		do: 
+			[:each |
+			| subject actual |
+			subject := self collectionClass fromString: each first.
+			actual := subject unescapePercents.
+			self assert: actual equals: each last].
+	"Test case from @fxgallego"
+	self assert: (self collectionClass fromString: 'Ca%C3%B1%C3%B3n') unescapePercents equals: 'Cañón'.
+	"Non-latin 3-byte encoding test case from RFC3986"
+	self assert: (self collectionClass fromString: '%E3%82%A2') unescapePercents
+		equals: $\x30A2 asUtf8String.
+	"And a 4-byte encoding for fun"
+	self assert: (self collectionClass fromString: '%F0%9F%90%AC') unescapePercents equals: '🐬'.
+
+	"All reserved characters in RFC3986, exception '+', should be unaffected by decoding"
+	self assert: (self collectionClass fromString: ':/?#[]@!!$&''()*+,;=') unescapePercents
+		equals: ':/?#[]@!!$&''()* ,;='.
+
+	"Unreserved characters, also untouched"
+	unreserved := (Character byteCharacterSet select: [:each | each isEnglishLetter or: [each isDigit]])
+				, '-._~'.
+	self assert: (self collectionClass fromString: unreserved) unescapePercents equals: unreserved.
+	"But should be coded if found encoded"
+	misencoded := String writeStream.
+	unreserved do: 
+			[:each |
+			misencoded nextPut: $%.
+			each asciiValue
+				printOn: misencoded
+				base: 16
+				showRadix: false].
+	misencoded := misencoded contents.
+	self assert: (self collectionClass fromString: misencoded) unescapePercents equals: unreserved.
+
+	"Invalid cases, therefore assume not an escaped string"
+	#('%GA' '%AG' '%[1' '%1[' '+%A' '%1' '100%' '%+') do: 
+			[:each |
+			| subject actual |
+			subject := self collectionClass fromString: each.
+			actual := subject unescapePercents.
+			self assert: actual equals: (self newCopy: subject)].
+
+	"Special cases of non-ASCII input - these should be detected and not decoded"
+	#('€5+&+change' '£5+') do: 
+			[:each |
+			| subject actual |
+			subject := self collectionClass fromString: each.
+			actual := subject unescapePercents.
+			self assert: actual equals: each].
+	self collectionClass == AnsiString
+		ifFalse: 
+			[| subject |
+			subject := self collectionClass fromString: '%97+🐬'.
+			self assert: subject unescapePercents equals: subject]!
 
 testWithNormalizedLineDelimiters
 	"Empty"

--- a/Core/Object Arts/Dolphin/Base/AnsiString.cls
+++ b/Core/Object Arts/Dolphin/Base/AnsiString.cls
@@ -7,11 +7,11 @@ String variableByteSubclass: #AnsiString
 	classInstanceVariableNames: ''!
 AnsiString guid: (GUID fromString: '{5b59aa2a-fc01-4424-95aa-9ffb62e6af03}')!
 AnsiString isNullTerminated: true!
-AnsiString comment: 'AnsiString is the class of <Strings>s that use a single-byte encoding based on the current ANSI code page (e.g. Windows 1252). "ANSI" is a bit of a misnomer, but is used because it is common parlance in the Windows API documentation for APIs that expect strings encoded with the "ANSI" code page. 
+AnsiString comment: '`AnsiString` is the class of `Strings`s that use a single-byte encoding based on the current ANSI code page (e.g. Windows 1252). "ANSI" is a bit of a misnomer, but is used because it is common parlance in the Windows API documentation for APIs that expect strings encoded with the "ANSI" code page. 
 
 Note that Ansi code pages that require multiple bytes to represent each character are not supported properly in Dolphin.
 
-At present AnsiString is still the default String type, but this will be changing to either Utf8String or Utf16String in future.'!
+The default string type in Dolphin as of 7.1 is `Utf8String` rather than `AnsiString`.'!
 !AnsiString categoriesForClass!Collections-Text! !
 !AnsiString methodsFor!
 
@@ -142,7 +142,38 @@ trimNulls
 	Take advantage of some private knowledge about the implementation of
 	#fromAddress:"
 
-	^self species fromAddress: self yourAddress! !
+	^self species fromAddress: self yourAddress!
+
+unescapePercents
+	"Asuming that receiver is a URI-encoded representation of a UTF-8 encoded original as
+	specified in RFC3986, answer a <Utf8String> which has been unescaped to reveal the original
+	text. If it is detected that the content is not URI-encoded (e.g. it contains %-prefixed
+	character sequences where the next two characters are not hex digits) then the original
+	string is answered."
+
+	| unescaped escaped ch |
+	unescaped := Utf8String writeStream: self size.
+	escaped := self readStream.
+	[(ch := escaped basicNextAvailable) isNil] whileFalse: 
+			[ch == ##($+ asciiValue)
+				ifTrue: [unescaped nextPut: $\x20]
+				ifFalse: 
+					[ch == ##($% asciiValue)
+						ifTrue: 
+							[| digit1 digit2 |
+							"If not followed by two hex digits, then assume it is not really an escaped string and exit"
+							digit1 := escaped nextAvailable ifNil: [-1] ifNotNil: [:ch1 | ch1 asUppercase digitValue].
+							digit1 < 0 | (digit1 > 15) ifTrue: [^self].
+							digit2 := escaped nextAvailable ifNil: [-1] ifNotNil: [:ch2 | ch2 asUppercase digitValue].
+							digit2 < 0 | (digit2 > 15) ifTrue: [^self].
+							unescaped basicNextPut: digit1 * 16 + digit2]
+						ifFalse: 
+							[ch > 16r7F
+								ifTrue: 
+									["Non-ascii character encountered "
+									^self].
+							unescaped basicNextPut: ch]]].
+	^unescaped contents! !
 !AnsiString categoriesFor: #_beginsString:!comparing!double dispatch!private! !
 !AnsiString categoriesFor: #asAnsiString!converting!public! !
 !AnsiString categoriesFor: #asLowercase!converting!public! !
@@ -158,6 +189,7 @@ trimNulls
 !AnsiString categoriesFor: #skipEncodingMarkerFrom:!encode/decode!private! !
 !AnsiString categoriesFor: #strlen!accessing!private! !
 !AnsiString categoriesFor: #trimNulls!copying!public! !
+!AnsiString categoriesFor: #unescapePercents!operations!public! !
 
 !AnsiString class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/ChunkSourceFiler.cls
+++ b/Core/Object Arts/Dolphin/Base/ChunkSourceFiler.cls
@@ -6,7 +6,7 @@ SourceFiler subclass: #ChunkSourceFiler
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ChunkSourceFiler guid: (GUID fromString: '{558b318a-9ff3-4346-a445-76ee18d5458b}')!
-ChunkSourceFiler addClassConstant: 'NormalizeEolsMask' value: 2!
+ChunkSourceFiler addClassConstant: 'NormalizeEolsMask' value: 16r2!
 ChunkSourceFiler comment: ''!
 !ChunkSourceFiler categoriesForClass!Development!System-Support! !
 !ChunkSourceFiler methodsFor!
@@ -84,6 +84,7 @@ emitCommentOfClass: aClass
 		cr!
 
 emitDeclarationForClass: aClass variable: anAssociation
+	| value |
 	stream
 		nextPutAll: aClass name;
 		nextPutAll: (anAssociation isImmutable
@@ -91,7 +92,9 @@ emitDeclarationForClass: aClass variable: anAssociation
 					ifFalse: [' addClassVariable: ']);
 		print: anAssociation key;
 		nextPutAll: ' value: '.
-	self nextChunkPut: anAssociation value storeString.
+	value := anAssociation value.
+	self
+		nextChunkPut: (value isInteger ifTrue: [value printStringRadix: 16] ifFalse: [value storeString]).
 	stream cr!
 
 emitFooterForMethodsOf: aClass 

--- a/Core/Object Arts/Dolphin/Base/ClassTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassTest.cls
@@ -1,0 +1,24 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #ClassTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ClassTest guid: (GUID fromString: '{3c2fe318-ee64-4a1e-8b1a-8bf38c6d1803}')!
+ClassTest comment: ''!
+!ClassTest categoriesForClass!Unclassified! !
+!ClassTest methodsFor!
+
+testClassPoolsWellFormed
+	"https://github.com/dolphinsmalltalk/Dolphin/issues/562"
+
+	| badPools |
+	self skip.	"Pending fix for #562"
+	badPools := Smalltalk allClasses reject: 
+					[:each |
+					each classPool class == PoolDictionary
+						and: [each classPool associations allSatisfy: [:v | v class == VariableBinding]]].
+	self assert: badPools asArray equals: #()! !
+!ClassTest categoriesFor: #testClassPoolsWellFormed!public! !
+

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -23,6 +23,7 @@ package classNames
 	add: #CharacterTest;
 	add: #ClassBuilderTestClasses;
 	add: #ClassBuilderTests;
+	add: #ClassTest;
 	add: #CollectionCombinator;
 	add: #CommandLineTest;
 	add: #CommandLineTestRunner;
@@ -225,6 +226,11 @@ DolphinTest subclass: #CharacterTest
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #ClassBuilderTests
 	instanceVariableNames: 'wasOAD'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+DolphinTest subclass: #ClassTest
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -8,26 +8,26 @@ ArrayedCollection variableByteSubclass: #String
 String guid: (GUID fromString: '{87b4c514-026e-11d3-9fd7-00a0cc3e4a32}')!
 String isNullTerminated: true!
 String isAbstract: true!
-String addClassConstant: 'EncodingAnsi' value: 0!
-String addClassConstant: 'EncodingUtf16' value: 2!
-String addClassConstant: 'EncodingUtf32' value: 3!
-String addClassConstant: 'EncodingUtf8' value: 1!
+String addClassConstant: 'EncodingAnsi' value: 16r0!
+String addClassConstant: 'EncodingUtf16' value: 16r2!
+String addClassConstant: 'EncodingUtf32' value: 16r3!
+String addClassConstant: 'EncodingUtf8' value: 16r1!
 String addClassConstant: 'LineDelimiter' value: '
 '!
-String comment: 'String is the abstract class of <ArrayedCollection>s representing strings of <Character>s. It has subclasses for strings in the most common encodings, e.g. Latin1, UTF-8, and UTF-16. 
+String comment: '`String` is the abstract class of `ArrayedCollection`s representing strings of `Character`s. It has subclasses for strings in the most common encodings, e.g. Latin1, UTF-8, and UTF-16. 
 
-The default and preferred string type is Utf8String, representing UTF-8 encoded strings, however many Windows APIs will expect to be passed (and will return) UTF-16 encoded strings. Utf16String is the concreted subclass to  represent UTF-16 encoded strings.
+The default and preferred string type is `Utf8String`, representing UTF-8 encoded strings, however many Windows APIs will expect to be passed (and will return) UTF-16 encoded strings. `Utf16String` is the concrete subclass to  represent UTF-16 encoded strings.
 
-N.B. Dolphin Strings are, unlike Smalltalk-80 strings, null terminated. Space for the null terminator is implicity included when a String is allocated, but is not reported when the size of the String is requested.
+N.B. Dolphin Strings are, unlike Smalltalk-80 strings, null-terminated. Space for the null terminator is implicity included when a `String` is allocated, but is not reported when the size of the `String` is requested.
 
-String complies with the following ANSI protocols:
-	Object
-	magnitude
-	collection
-	sequencedReadableCollection
-	sequencedCollection
-	readableString
-	String'!
+`String` complies with the following ANSI Smalltalk protocols:
+ Object`
+ magnitude
+ collection
+ sequencedReadableCollection
+ sequencedCollection
+ readableString
+ String'!
 !String categoriesForClass!Collections-Text! !
 !String methodsFor!
 
@@ -1125,39 +1125,17 @@ truncateTo: anInteger
 	^self size <= anInteger ifTrue: [self] ifFalse: [self copyFrom: 1 to: anInteger]!
 
 unescapePercents
-	"Answer a copy of the receiver with each %XY substring replaced by 
-	the character with hex ASCII value XY and $+'s replaced by spaces."
+	"Asuming that receiver is a URI encoded representation from UTF-8 as specified in RFC3986,
+	answer a <Utf8String> representing the unescaped (original) UTF-8 encoded text. If it is
+	detected that the content is not URI-encoded (e.g. it contains %-prefixed character
+	sequences where the next two characters are not hex digits, or it contains non-ASCII
+	characters) then the original text is answered as UTF-8. The detection of non URI-encoded
+	input is not 100% reliable, so it is an application responsibility to avoid double-decoding
+	strings or decoding those that were never encoded in the first place."
 
-	| answer pos oldPos |
-	answer := self species writeStream: self size.
-	oldPos := 1.
-	
-	[pos := self indexOfAnyOf: '+%' startingAt: oldPos.
-	pos > 0] whileTrue: 
-				[| char |
-				answer 
-					next: pos - oldPos
-					putAll: self
-					startingAt: oldPos.
-				char := self at: pos.
-				char == $+ 
-					ifTrue: [answer nextPut: $\x20]
-					ifFalse: 
-						[(char == $% and: [pos + 2 <= self size]) 
-							ifTrue: 
-								[| digit1 digit2 |
-								digit1 := (self at: pos + 1) asUppercase.
-								digit2 := (self at: pos + 2) asUppercase.
-								(digit1 isHexDigit and: [digit2 isHexDigit]) ifFalse: [^self].	"not really an escaped string"
-								answer nextPut: (Character value: digit1 digitValue * 16 + digit2 digitValue).
-								pos := pos + 2]
-							ifFalse: [answer nextPut: char]].
-				oldPos := pos + 1].
-	answer 
-		next: self size - oldPos + 1
-		putAll: self
-		startingAt: oldPos.
-	^answer contents!
+	| ansi |
+	ansi := self asAnsiString.
+	^(ansi equals: self) ifTrue: [ansi unescapePercents] ifFalse: [self]!
 
 withNormalizedLineDelimiters
 	"Answer a copy of the receiver with any line terminator convention converted to the windows (CR/LF) convention."

--- a/Core/Object Arts/Dolphin/Base/Utf8String.cls
+++ b/Core/Object Arts/Dolphin/Base/Utf8String.cls
@@ -8,13 +8,13 @@ UtfEncodedString variableByteSubclass: #Utf8String
 Utf8String guid: (GUID fromString: '{c5ab1b05-241f-4955-8b44-0c80b93bafbb}')!
 Utf8String isNullTerminated: true!
 Utf8String addClassConstant: 'Bom' value: #[239 187 191 ]!
-Utf8String addClassConstant: 'LeadByteMask2' value: 192!
-Utf8String addClassConstant: 'LeadByteMask3' value: 224!
-Utf8String addClassConstant: 'LeadByteMask4' value: 240!
-Utf8String addClassConstant: 'TrailByteMask' value: 128!
-Utf8String comment: 'Utf8String is the class of <Strings>s that use a the multi-byte UTF-8 encoding. UTF-8 is the defacto standard for text interchange, and is now the default representation in Dolphin.
+Utf8String addClassConstant: 'LeadByteMask2' value: 16rC0!
+Utf8String addClassConstant: 'LeadByteMask3' value: 16rE0!
+Utf8String addClassConstant: 'LeadByteMask4' value: 16rF0!
+Utf8String addClassConstant: 'TrailByteMask' value: 16r80!
+Utf8String comment: '`Utf8String` is the class of `Strings`s that use a the multi-byte UTF-8 encoding. UTF-8 is the defacto standard for text interchange, and is now the default representation in Dolphin.
 
-The cautionary notes in the abstract superclass (UtfEncodedString) should be read carefully to understand the compromises made in introducing a variable width encoding into the SequenceableCollection hierarchy.'!
+The cautionary notes in the abstract superclass `UtfEncodedString` should be read carefully to understand the compromises made in introducing a variable width encoding into the `SequenceableCollection` hierarchy.'!
 !Utf8String categoriesForClass!Collections-Text! !
 !Utf8String methodsFor!
 

--- a/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
@@ -366,14 +366,13 @@ testBSTRArg
 	"#1377 - Make sure there is no problem in the VM's automatic conversion of a string to a BSTR.
 	In an unpatched VM this typically crashes the whole system."
 
-	| dom |
-	dom := IXMLDOMDocument new.
+	| method |
+	method := Compiler compile: 'test: aString <stdcall: bstr AnswerDWORD bstr>' in: VMLibrary.
 	1000 timesRepeat: 
-			[| instr |
-			instr := dom createProcessingInstruction: 'ATarget' data: 'Some data'.
-			self assert: instr data equals: 'Some data'.
-			self assert: instr target equals: 'ATarget'.
-			instr free]!
+			[| bstr |
+			bstr := method value: VMLibrary default withArguments: #('Some 🐬 data').
+			self assert: bstr value equals: 'Some 🐬 data'.
+			bstr free]!
 
 testCRTFault
 	"Tests that the VM sends an interrupt when the CRT is passed an invalid parameter and calls

--- a/Core/Object Arts/Dolphin/IDE/PublishedAspectInspectorTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/PublishedAspectInspectorTest.cls
@@ -17,10 +17,13 @@ aspectPresenter
 	^inspector instVarNamed: 'aspectPresenter'!
 
 createInspectorOn: inspectee
-	inspector := PublishedAspectInspector shellOn: inspectee.
-	treePresenter := inspector instVarNamed: 'aspectTreePresenter'.
-	displayPresenter := inspector instVarNamed: 'displayPresenter'.
-	treePresenter selection: (treePresenter model roots first)!
+	inspector isNil
+		ifTrue: 
+			[inspector := PublishedAspectInspector shellOn: inspectee.
+			treePresenter := inspector instVarNamed: 'aspectTreePresenter'.
+			displayPresenter := inspector instVarNamed: 'displayPresenter'.
+			treePresenter selection: treePresenter model roots first]
+		ifFalse: [inspector value: inspectee]!
 
 getAccessorKeyText: anAspectAccessor 
 	^treePresenter view getItemText: (treePresenter view handleFromObject: anAspectAccessor)!
@@ -44,7 +47,7 @@ repaint
 seqCollMoveDownTest: testClass
 	| inspectee collection |
 	inspectee := testClass withAll: (1 to: 5).
-	inspector value: inspectee.
+	self createInspectorOn: inspectee.
 	collection := inspectee.
 	treePresenter selection: treePresenter model roots first.
 	self repaint.
@@ -53,7 +56,7 @@ seqCollMoveDownTest: testClass
 			[:j |
 			| listPresenter |
 			self assert: treePresenter view itemCount identicalTo: collection size + 1 + j.
-			listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
+			listPresenter := self aspectPresenter listPresenter.
 			listPresenter selectionByIndex: 1.
 			2 to: 5
 				do: 
@@ -61,74 +64,60 @@ seqCollMoveDownTest: testClass
 					self aspectPresenter moveDown.
 					self repaint.
 					self assert: treePresenter view itemCount identicalTo: collection size + 1 + j.
-					listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
 					self assert: listPresenter selectionByIndex equals: i.
-					self assert: collection asArray equals: (2 to: i) , (Array with: 1) , (i + 1 to: 5)].
-			collection := Array withAll: (1 to: 5).
-			inspectee := Array with: collection.
+					self assert: collection asArray equals: (2 to: i) , {1} , (i + 1 to: 5)].
+			"Repeat with a nested collection"
+			collection := testClass withAll: (1 to: 5).
+			inspectee := {collection}.
 			inspector value: inspectee.
 			treePresenter selection: (treePresenter model childrenOf: treePresenter model roots first) first.
 			treePresenter view expandAll]!
 
 seqCollMoveFirstTest: testClass
-	| inspectee last |
-	last := 5.
-	inspectee := testClass withAll: (1 to: last).
-	inspector value: inspectee.
-	self assert: treePresenter view itemCount identicalTo: last + 1.
+	| inspectee expected |
+	inspectee := testClass withAll: (1 to: 5).
+	self createInspectorOn: inspectee.
+	self assert: treePresenter view itemCount identicalTo: 5 + 1.
 	self repaint.
+	expected := #(#(1 2 3 4 5) #(2 1 3 4 5) #(3 2 1 4 5) #(4 3 2 1 5) #(5 4 3 2 1)).
 	1 to: inspectee size
 		do: 
 			[:i |
 			| listPresenter |
-			listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
+			listPresenter := self aspectPresenter listPresenter.
 			listPresenter selectionByIndex: i.
 			self aspectPresenter moveFirst.
 			self repaint.
-			self assert: treePresenter view itemCount identicalTo: last + 1.
-			listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
+			self assert: treePresenter view itemCount identicalTo: 5 + 1.
 			self assert: listPresenter selectionByIndex equals: 1.
-			self assert: inspectee asArray equals: (Array with: i) , (1 to: i - 1) , (i + 1 to: last).
-			inspectee
-				replaceFrom: 1
-				to: last
-				with: (1 to: last)
-				startingAt: 1.
-			inspector aspectChanged: #yourself]!
+			self assert: inspectee asArray equals: (expected at: i)]!
 
 seqCollMoveLastTest: testClass
-	| inspectee listPresenter last |
-	last := 5.
-	inspectee := testClass withAll: (1 to: last).
-	inspector value: inspectee.
-	self assert: treePresenter view itemCount identicalTo: last + 1.
+	| inspectee expected |
+	inspectee := testClass withAll: (1 to: 5).
+	self createInspectorOn: inspectee.
+	self assert: treePresenter view itemCount identicalTo: 5 + 1.
 	self repaint.
-	listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
+	expected := #(#(2 3 4 5 1) #(2 4 5 1 3) #(2 4 1 3 5) #(2 4 1 5 3) #(2 4 1 5 3)).
 	1 to: inspectee size
 		do: 
 			[:i |
-			listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
+			| listPresenter |
+			listPresenter := self aspectPresenter listPresenter.
 			listPresenter selectionByIndex: i.
 			self aspectPresenter moveLast.
 			self repaint.
-			self assert: treePresenter view itemCount identicalTo: last + 1.
-			listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
-			self assert: listPresenter selectionByIndex equals: last.
-			self assert: inspectee asArray equals: (1 to: i - 1) , (i + 1 to: last) , (Array with: i).
-			inspectee
-				replaceFrom: 1
-				to: last
-				with: (1 to: last)
-				startingAt: 1.
-			inspector aspectChanged: #yourself]!
+			self assert: treePresenter view itemCount identicalTo: 5 + 1.
+			self assert: listPresenter selectionByIndex equals: 5.
+			self assert: inspectee asArray equals: (expected at: i)]!
 
 seqCollMoveUpTest: testClass
 	| inspectee listPresenter |
 	inspectee := testClass withAll: (1 to: 5).
-	inspector value: inspectee.
+	self createInspectorOn: inspectee.
 	self assert: treePresenter view itemCount identicalTo: 6.
 	self repaint.
-	listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
+	listPresenter := self aspectPresenter listPresenter.
 	listPresenter selectionByIndex: 5.
 	4 to: 1
 		by: -1
@@ -136,9 +125,9 @@ seqCollMoveUpTest: testClass
 			[:i |
 			self aspectPresenter moveUp.
 			self repaint.
-			self assert: inspectee asArray equals: (1 to: i - 1) , (Array with: 5) , (i to: 4).
+			self assert: inspectee asArray equals: (1 to: i - 1) , {5} , (i to: 5 - 1).
 			self assert: listPresenter selectionByIndex equals: i.
-			self assert: treePresenter view itemCount identicalTo: 6]!
+			self assert: treePresenter view itemCount identicalTo: 5 + 1]!
 
 tearDown
 	inspector isNil
@@ -154,7 +143,7 @@ testAddRemoveCollectionElement
 	self createInspectorOn: inspectee.
 	self assert: treePresenter view itemCount identicalTo: 1.
 	self repaint.
-	listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
+	listPresenter := self aspectPresenter listPresenter.
 	self aspectPresenter addItem: 1.
 	"The item always remains expanded"
 	self assert: treePresenter view itemCount identicalTo: 2.
@@ -318,19 +307,15 @@ testCopyAndPasteMenu
 	inspectee2 create.
 	
 	[| menuBar1 accessor menuBar2 |
-	menuBar1 := inspectee1 menuBar.
-	self assertIsNil: menuBar1.
+	menuBar1 := (MenuBar fromStrings: #('&File' 'Open//fileOpen' '-' '&Save/Ctrl+S/fileSave')).
+	self assert: menuBar1 size equals: 3.
+	self assert: menuBar1 items first text equals: 'Open'.
+	inspectee1 menuBar: menuBar1.
 	self createInspectorOn: inspectee1.
 	accessor := self aspectAccessorNamed: #menuBar.
 	treePresenter selection: accessor.
-	self assertIsNil: accessor value.
-	self aspectPresenter
-		value: (MenuBar fromStrings: #('&File' 'Open//fileOpen' '-' '&Save/Ctrl+S/fileSave')).
+	self assert: accessor value identicalTo: menuBar1.
 	self repaint.
-	menuBar1 := inspectee1 menuBar.
-	self denyIsNil: menuBar1.
-	self assert: menuBar1 size equals: 3.
-	self assert: menuBar1 items first text equals: 'Open'.
 	inspector copyAspect.
 	inspector value: inspectee2.
 	self repaint.
@@ -524,7 +509,7 @@ testListViewColumnsEdit
 
 	"Delete the midle one"
 	columnsList := inspectee columnsList.
-	(self aspectPresenter instVarNamed: 'listPresenter') selectionByIndex: 2.
+	self aspectPresenter listPresenter selectionByIndex: 2.
 	"If not looking at a copy, this will fail anyway as the View will think it had two columns all along"
 	self aspectPresenter removeItem.
 	self repaint.
@@ -602,32 +587,16 @@ testListViewColumnsEdit
 			ensure: [inspectee topView destroy]!
 
 testMoveDown
-	self createInspectorOn: nil.
-	(Array 
-		with: Array
-		with: ByteArray
-		with: OrderedCollection) do: [:each | self seqCollMoveDownTest: each]!
+	{Array. ByteArray. OrderedCollection} do: [:each | self seqCollMoveDownTest: each]!
 
 testMoveFirst
-	self createInspectorOn: nil.
-	(Array 
-		with: Array
-		with: ByteArray
-		with: OrderedCollection) do: [:each | self seqCollMoveFirstTest: each]!
+	{Array. ByteArray. OrderedCollection} do: [:each | self seqCollMoveFirstTest: each]!
 
 testMoveLast
-	self createInspectorOn: nil.
-	(Array 
-		with: Array
-		with: ByteArray
-		with: OrderedCollection) do: [:each | self seqCollMoveLastTest: each]!
+	{Array. ByteArray. OrderedCollection} do: [:each | self seqCollMoveLastTest: each]!
 
 testMoveUp
-	self createInspectorOn: nil.
-	(Array 
-		with: Array
-		with: ByteArray
-		with: OrderedCollection) do: [:each | self seqCollMoveUpTest: each]!
+	{Array. ByteArray. OrderedCollection} do: [:each | self seqCollMoveUpTest: each]!
 
 testPublishedAspectsOfInstancesOnClassSide
 	"#2136"
@@ -657,7 +626,7 @@ testRemoveCollectionElements1
 	self assert: treePresenter view itemCount equals: 2.
 	treePresenter view expandAll.
 	self assert: treePresenter view itemCount equals: 5.
-	listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
+	listPresenter := self aspectPresenter listPresenter.
 	listPresenter selectionByIndex: 2.
 	self aspectPresenter removeItem.
 	self repaint.
@@ -688,7 +657,7 @@ testSetToNil
 	self createInspectorOn: inspectee.
 	self assert: treePresenter view itemCount identicalTo: 2.
 	self repaint.
-	listPresenter := self aspectPresenter instVarNamed: 'listPresenter'.
+	listPresenter := self aspectPresenter listPresenter.
 	self assert: treePresenter view itemCount identicalTo: 2.
 	treePresenter view expandAll.
 	self repaint.

--- a/Core/Object Arts/Dolphin/MVP/Base/PositionEvent.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/PositionEvent.cls
@@ -54,6 +54,11 @@ isClientAreaChanged
 
 	^(lpwp flags bitAnd: ##(SWP_NOSIZE | SWP_FRAMECHANGED)) ~= SWP_NOSIZE!
 
+isHideWindow
+	"Answer whether the receiver is describing a hide event."
+
+	^lpwp flags anyMask: SWP_HIDEWINDOW!
+
 isMove
 	"Answer whether the receiver is describing a move event."
 
@@ -135,6 +140,7 @@ y
 !PositionEvent categoriesFor: #height:!accessing!public! !
 !PositionEvent categoriesFor: #isActivate!public!testing! !
 !PositionEvent categoriesFor: #isClientAreaChanged!public!testing! !
+!PositionEvent categoriesFor: #isHideWindow!public!testing! !
 !PositionEvent categoriesFor: #isMove!public!testing! !
 !PositionEvent categoriesFor: #isRectangleChanged!public!testing! !
 !PositionEvent categoriesFor: #isResize!public!testing! !

--- a/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
@@ -6,29 +6,29 @@ ContainerView subclass: #ShellView
 	poolDictionaries: 'ButtonConstants'
 	classInstanceVariableNames: ''!
 ShellView guid: (GUID fromString: '{87b4c71a-026e-11d3-9fd7-00a0cc3e4a32}')!
-ShellView addClassConstant: 'DefaultButtonIndex' value: 20!
-ShellView addClassConstant: 'TransientMask' value: 1!
-ShellView comment: 'ShellView implements the <topView> protocol for top-level windows whose parent is the desktop. ShellView is also a <topPresenter> so that it is able to stand in as a <Shell> when there is no associated presenter.
+ShellView addClassConstant: 'DefaultButtonIndex' value: 16r14!
+ShellView addClassConstant: 'TransientMask' value: 16r1!
+ShellView comment: '`ShellView` implements the `<topView>` protocol for top-level windows whose parent is the desktop. `ShellView` is also a `<topPresenter>` so that it is able to stand in as a `Shell` when there is no associated presenter.
 
 Instance Variables:
-	menuBar			<MenuBar> or nil, that is the menu bar for the window.
-	acceleratorTable	<AcceleratorTable> or nil, that is the local accelerator table.
-	combinedAcceleratorTable	<AcceleratorTable> that is the cached actual accelerator table.
-	lastFocus			<view> or nil, which is the last view within the local hierarchy to have focus.
-	defaultButton		<PushButton> or nil, which is the default button within the window
-	largeIcon			<Icon> or nil, which is a specific large icon to use.
-	smallIcon			<Icon> or nil, which is a specific small icon to use.
-	maxExtent		<Point> or nil, specifying the maximum extent when resizing.
-	minExtent			<Point> or nil, specifying the minimum extent when resizing.
-	flashes			<integer>. Temporary used to count down the number of flashes.
-	svFlags			<integer>. Various flags
+  menuBar					`MenuBar` or `nil`, that is the menu bar for the window.
+  acceleratorTable			`AcceleratorTable` or `nil` that is the local accelerator table.
+  combinedAcceleratorTable	`AcceleratorTable` that is the cached actual accelerator table.
+  lastFocus					`<view>` or `nil`, which is the last view within the local hierarchy to have focus.
+  defaultButton				`PushButton` or `nil`, which is the default button within the window
+  largeIcon				`Icon` or `nil`, which is a specific large icon to use.
+  smallIcon				`Icon` or `nil`, which is a specific small icon to use.
+  maxExtent				`Point` or `nil`, specifying the maximum extent when resizing.
+  minExtent				`Point or `nil`, specifying the minimum extent when resizing.
+  flashes					`<integer>`. Temporary used to count down the number of flashes.
+  svFlags					`<integer>`. Various flags
 
 Class Variables:
-	DialogMessageMap		<LookupTable> of Windows messages to <selector>s
-	TransientMask			<integer>
-	CreateHookBlock		<nil>/<dyadicValuable>
-	DefaultButtonIndex		<integer>
-	DefaultExtentBlock		<BlockClosure>
+	DialogMessageMap		`LookupTable` of Windows messages to `<selector>`s
+	TransientMask			`<integer>` 
+	CreateHookBlock		`nil` or `<dyadicValuable>`
+	DefaultButtonIndex		`<integer>`
+	DefaultExtentBlock		`<BlockClosure>`
 
 
 
@@ -604,11 +604,14 @@ onCloseRequested
 	the close is permisible. Those observers which wish to block the close must set the value of
 	the passed boolean <value> to false."
 
-	self queryClose 
+	self queryClose
 		ifTrue: 
-			[self
-				update;
-				destroy.
+			["Ensure the window is repainted in case we popped up a dialog in queryClose,
+			but don't bother with re-layout as this may be expensive and we are going
+			away anyway."
+			flags := flags bitOr: LayoutValidMask.
+			self update.
+			self destroy.
 			^true].
 	^false!
 
@@ -648,7 +651,7 @@ onIdleEntered
 		self presenter validateUserInterface ].
 	^true!
 
-onPositionChanged: aPositionEvent 
+onPositionChanged: aPositionEvent
 	"Default handler for window position change (move or resize).
 	Implementation Note: The superclass implementation considers that any
 	position change invalidates the layout, but moving a top-level window
@@ -656,8 +659,10 @@ onPositionChanged: aPositionEvent
 	time to revalidate too."
 
 	aPositionEvent isClientAreaChanged ifTrue: [self invalidateLayoutDeeply].
-	"We can't rely on revalidating in paint, as repainting may not be needed when the shell is shrunk"
-	self validateLayout.
+	(aPositionEvent isHideWindow not and: [self isWindowVisible])
+		ifTrue: 
+			["We can't rely on revalidating in paint, as repainting may not be needed when the shell is shrunk"
+			self validateLayout].
 	self presenter trigger: #positionChanged: with: aPositionEvent!
 
 onPostSaveImage
@@ -809,8 +814,10 @@ releaseAccelerators
 releaseMenu
 	"Private - Release the menu."
 
-	self basicMenu: nil.
-	menuBar ifNotNil: [menuBar free]!
+	menuBar
+		ifNotNil: 
+			[self basicMenu: nil.
+			menuBar free]!
 
 resetDefaultButton
 	"Private - No default button has been explicitly specified for the receiver, so attempt
@@ -832,31 +839,29 @@ resolutionScaledBy: scale
 
 !
 
-restorePlacement: aWINDOWPLACEMENT resolution: aPointResolution 
-	"Private - Restore the placement for the receiver to aWINDOWPLACEMENT which was
-	measured at a screen resolution of aPointResolution. If the current resolution is different
-	then the placement rectangle will have to be scaled appropriately. 
-	Subclasses can override this message to compensate for a resolution change
-	in any other ways required."
+restorePlacement: aWINDOWPLACEMENT resolution: aPointResolution
+	"Private - Restore the placement for the receiver to aWINDOWPLACEMENT which was measured at
+	a screen resolution of aPointResolution. If the current resolution is different then the
+	placement rectangle will have to be scaled appropriately. Subclasses can override this
+	message to compensate for a resolution change in any other ways required."
 
-	| rect |
+	| rect desktopResolution |
 	rect := aWINDOWPLACEMENT rcNormalPosition asRectangle.
-	aPointResolution = View desktop resolution 
+	desktopResolution := View desktop resolution.
+	aPointResolution = desktopResolution
 		ifFalse: 
-			["Resolution is now different so recompute the placement"
-			| scale |
-			scale := View desktop resolution / aPointResolution.
+			[| scale |
+			"Resolution is now different so recompute the placement"
+			scale := desktopResolution / aPointResolution.
 			rect := (rect scaleBy: scale) truncated.
 			self resolutionScaledBy: scale].
 
-	"If the receiver wants to use a preferred extent, then use that.
-	Otherwise, choose a default extent."
-	self usePreferredExtent 
+	"If the receiver wants to use a preferred extent, then use that. Otherwise, choose a default
+	extent."
+	self usePreferredExtent
 		ifTrue: 
 			[| extent |
-			extent := self preferredExtent notNil 
-						ifTrue: [self preferredExtent]
-						ifFalse: [self defaultExtentWithin: creationParent].
+			extent := self preferredExtent ifNil: [self defaultExtentWithin: creationParent].
 			rect extent: extent].
 	rect position: (self defaultPositionWithin: creationParent forExtent: rect extent).
 	aWINDOWPLACEMENT rcNormalPosition: rect asParameter.

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Collection/SequenceableCollectionPresenter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Collection/SequenceableCollectionPresenter.cls
@@ -24,7 +24,11 @@ moveDown
 	| index list |
 	index := listPresenter selectionByIndex.
 	list := self listModel.
-	list swap: index with: index + 1.
+	"Although we are only swapping two elements, the collection presenter responds to any event
+	from the list model by refreshing everything (see
+	CollectionPresenter>>createSchematicWiring). We don't want to refresh it twice."
+	list noEventsDo: [list swap: index with: index + 1].
+	list notifyListChanged.
 	listPresenter selectionByIndex: index + 1!
 
 moveFirst
@@ -66,7 +70,8 @@ moveUp
 	| index list |
 	index := listPresenter selectionByIndex.
 	list := self listModel.
-	list swap: index with: index - 1.
+	list noEventsDo: [list swap: index with: index - 1].
+	list notifyListChanged.
 	listPresenter selectionByIndex: index - 1!
 
 onValueChanged


### PR DESCRIPTION
Fixed and added tests for compliance with RFC 3986.
The reimplementation uses a stream and processes the escaped string
character-by-character. Ironically this is faster in general.