### PR TITLE
Fix #593 Some HTTP_PROPERTY_FLAGS subclasses doesn't implement #propertyId

### DIFF
--- a/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
@@ -724,6 +724,13 @@ indexOf: target ifAbsent: exceptionHandler
 		ifTrue: [exceptionHandler value]
 		ifFalse: [index]!
 
+indexOf: target startingAt: start
+	"Answer the <integer> index of the first element of the receiver which is 
+	equal to the <Object> argument, target, within the receiver. If the receiver 
+	does not contain any elements equal to target, answer 0."
+
+	^self nextIndexOf: target from: start to: self size!
+
 indexOfAnyOf: aCollection startingAt: anInteger 
 	"Answer the one-based integer index of the first encountered element of the receiver which 
 	is equal to one of the elements of the <Collection> argument, starting from the specified
@@ -1265,6 +1272,7 @@ writeStream
 !SequenceableCollection categoriesFor: #includesKey:!public!testing! !
 !SequenceableCollection categoriesFor: #indexOf:!public!searching! !
 !SequenceableCollection categoriesFor: #indexOf:ifAbsent:!public!searching! !
+!SequenceableCollection categoriesFor: #indexOf:startingAt:!public!searching! !
 !SequenceableCollection categoriesFor: #indexOfAnyOf:startingAt:!public!searching! !
 !SequenceableCollection categoriesFor: #indexOfSubCollection:!public!searching! !
 !SequenceableCollection categoriesFor: #indexOfSubCollection:startingAt:!public!searching! !

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_BINDING_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_BINDING_INFO.cls
@@ -72,7 +72,7 @@ defineFields
 	self byteSize: 8!
 
 propertyId
-	^WinHttpServerConsts.HttpServerBindingProperty! !
+	^HttpServerBindingProperty! !
 !HTTP_BINDING_INFO class categoriesFor: #defineFields!**auto generated**!initializing!public! !
 !HTTP_BINDING_INFO class categoriesFor: #propertyId!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_LISTEN_ENDPOINT_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_LISTEN_ENDPOINT_INFO.cls
@@ -53,6 +53,10 @@ defineFields
 	super defineFields.
 	self
 		defineField: #EnableSharing type: BOOLEANField new offset: 4.
-	self byteSize: 8! !
+	self byteSize: 8!
+
+propertyId
+	^HttpServerListenEndpointProperty! !
 !HTTP_LISTEN_ENDPOINT_INFO class categoriesFor: #defineFields!**auto generated**!initializing!public! !
+!HTTP_LISTEN_ENDPOINT_INFO class categoriesFor: #propertyId!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_LOGGING_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_LOGGING_INFO.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 HTTP_PROPERTY_FLAGS subclass: #HTTP_LOGGING_INFO
-	instanceVariableNames: ''
+	instanceVariableNames: 'directoryName softwareName'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -44,7 +44,9 @@ DirectoryName
 DirectoryName: anUtf16String
 	"Set the receiver's 'DirectoryName' field to the value of the argument, anUtf16String"
 
-	bytes uintPtrAtOffset: ##(self offsetOf: #DirectoryName) put: anUtf16String yourAddress!
+	directoryName := anUtf16String asUtf16String.
+	bytes uintPtrAtOffset: ##(self offsetOf: #DirectoryName) put: directoryName yourAddress.
+	self DirectoryNameLength: directoryName byteSize - 2!
 
 DirectoryNameLength
 	"Answer the <Integer> value of the receiver's 'DirectoryNameLength' field."
@@ -123,8 +125,10 @@ SoftwareName
 
 SoftwareName: anUtf16String
 	"Set the receiver's 'SoftwareName' field to the value of the argument, anUtf16String"
-
-	bytes uintPtrAtOffset: ##(self offsetOf: #SoftwareName) put: anUtf16String yourAddress!
+	
+	softwareName := anUtf16String asUtf16String.
+	bytes uintPtrAtOffset: ##(self offsetOf: #SoftwareName) put: softwareName yourAddress.
+	self SoftwareNameLength: softwareName byteSize - 2!
 
 SoftwareNameLength
 	"Answer the <Integer> value of the receiver's 'SoftwareNameLength' field."
@@ -197,6 +201,10 @@ defineFields
 		defineField: #RolloverType type: SDWORDField new offset: 36;
 		defineField: #RolloverSize type: DWORDField new offset: 40;
 		defineField: #pSecurityDescriptor type: LPVOIDField new offset: 44.
-	self byteSize: 48! !
+	self byteSize: 48!
+
+propertyId
+	^HttpServerLoggingProperty! !
 !HTTP_LOGGING_INFO class categoriesFor: #defineFields!**auto generated**!initializing!public! !
+!HTTP_LOGGING_INFO class categoriesFor: #propertyId!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_PROTECTION_LEVEL_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_PROTECTION_LEVEL_INFO.cls
@@ -53,6 +53,10 @@ defineFields
 	super defineFields.
 	self
 		defineField: #Level type: SDWORDField new offset: 4.
-	self byteSize: 8! !
+	self byteSize: 8!
+
+propertyId
+	^HttpServerProtectionLevelProperty! !
 !HTTP_PROTECTION_LEVEL_INFO class categoriesFor: #defineFields!**auto generated**!initializing!public! !
+!HTTP_PROTECTION_LEVEL_INFO class categoriesFor: #propertyId!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVER_AUTHENTICATION_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_SERVER_AUTHENTICATION_INFO.cls
@@ -152,6 +152,10 @@ defineFields
 		defineField: #ExFlags type: BYTEField new offset: 11;
 		defineField: #DigestParams type: (StructureField type: HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS) offset: 12;
 		defineField: #BasicParams type: (StructureField type: HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS) offset: 28.
-	self byteSize: 36! !
+	self byteSize: 36!
+
+propertyId
+	^HttpServerAuthenticationProperty! !
 !HTTP_SERVER_AUTHENTICATION_INFO class categoriesFor: #defineFields!**auto generated**!initializing!public! !
+!HTTP_SERVER_AUTHENTICATION_INFO class categoriesFor: #propertyId!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HTTP_TIMEOUT_LIMIT_INFO.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HTTP_TIMEOUT_LIMIT_INFO.cls
@@ -128,6 +128,10 @@ defineFields
 		defineField: #IdleConnection type: WORDField new offset: 10;
 		defineField: #HeaderWait type: WORDField new offset: 12;
 		defineField: #MinSendRate type: DWORDField new offset: 16.
-	self byteSize: 20! !
+	self byteSize: 20!
+
+propertyId
+	^HttpServerTimeoutsProperty! !
 !HTTP_TIMEOUT_LIMIT_INFO class categoriesFor: #defineFields!**auto generated**!initializing!public! !
+!HTTP_TIMEOUT_LIMIT_INFO class categoriesFor: #propertyId!constants!public! !
 

--- a/Core/Object Arts/Dolphin/System/Win32/HttpApiLibrary.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HttpApiLibrary.cls
@@ -1312,6 +1312,28 @@ example7
 	lib querySession: sessionId property: HttpServerStateProperty]
 			ensure: [lib httpCloseServerSession: sessionId]!
 
+example8
+	"Example of setting/querying HTTP_LOGGING_INFO session properties.
+		self example8
+	"
+
+	| lib sessionId |
+	lib := self default.
+	
+	[sessionId := lib createServerSession.
+	lib setSession: sessionId
+		property: (HTTP_LOGGING_INFO new
+				Present: true;
+				DirectoryName: FileLocator imageRelative basePath;
+				SoftwareName: 'Dolphin';
+				Format: HttpLoggingTypeW3C;
+				RolloverType: HttpLoggingRolloverSize;
+				RolloverSize: 1024 * 1024;
+				Fields: (HTTP_LOG_FIELD_DATE | HTTP_LOG_FIELD_TIME | HTTP_LOG_FIELD_CLIENT_IP | HTTP_LOG_FIELD_METHOD | HTTP_LOG_FIELD_URI);
+				yourself).
+	^lib halt querySession: sessionId property: HttpServerLoggingProperty]
+			ensure: [lib httpCloseServerSession: sessionId]!
+
 fileName
 	"Answer the host system file name for the library."
 
@@ -1412,6 +1434,7 @@ queryUrlAclInfo
 !HttpApiLibrary class categoriesFor: #example4!examples!public! !
 !HttpApiLibrary class categoriesFor: #example6!examples!public! !
 !HttpApiLibrary class categoriesFor: #example7!examples!public! !
+!HttpApiLibrary class categoriesFor: #example8!examples!public! !
 !HttpApiLibrary class categoriesFor: #fileName!**auto generated**!constants!public! !
 !HttpApiLibrary class categoriesFor: #initFlags!constants!public! !
 !HttpApiLibrary class categoriesFor: #querySslCertInfo!examples!public! !

--- a/Core/Object Arts/Dolphin/System/Win32/Windows HTTP Server.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Windows HTTP Server.pax
@@ -320,7 +320,7 @@ HTTP_PROPERTY_FLAGS subclass: #HTTP_LISTEN_ENDPOINT_INFO
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 HTTP_PROPERTY_FLAGS subclass: #HTTP_LOGGING_INFO
-	instanceVariableNames: ''
+	instanceVariableNames: 'directoryName softwareName'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!


### PR DESCRIPTION
Fix #593
Adds several #propertyId definitions
Adds instance variables for HTTP_LOGGING_INFO
Modifies DirectoryName and SoftwareName setters to ensure UTF16 strings are passed and its lengths are correctly set.
Adds a new example, `HttpApiLibrary>>example8` that currently doesn't works.

Fix #589