### PR TITLE
Repeat fix for #550

### DIFF
--- a/Core/Contributions/IDB/DateAndTime.cls
+++ b/Core/Contributions/IDB/DateAndTime.cls
@@ -298,7 +298,7 @@ subtractFromDateAndTime: aDateAndTime
 	that would be needed to comply with ANSI if performed in the order specified 
 	by the selector"
 
-	^Duration seconds: self asSecondsUTC - aDateAndTime asSecondsUTC!
+	^Duration seconds: aDateAndTime asSecondsUTC - self asSecondsUTC!
 
 timeZoneAbbreviation
 	"Answer a <readableString> which is the abbreviated  name of the month of 


### PR DESCRIPTION
Issue #550 has regressed, so reapplying the fix from #551.

Whilst looking at this I ported over the DateAndTime unit tests from Pharo but these currently fail due to missing convenience methods (String>>asDateAndTime, Number>>seconds etc.) and differing tolerances for DateAndTime text formats. Porting these tests as-is would probably require significant rework of the DateAndTime package.