### PR TITLE
Fix RuntimeSessionManager-deploy: (issue #612)

### DIFF
--- a/Core/Object Arts/Dolphin/Base/SessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SessionManager.cls
@@ -170,6 +170,10 @@ basicTertiaryStartup
 
 	^self subclassResponsibility!
 
+bootInfo
+	"The default behaviour is no boot info."
+	^ nil.!
+
 clearSessionState
 	"Clear any state saved down for a image save which is will not be required until that saved image is
 	rehydrated."
@@ -1105,6 +1109,7 @@ windowsDirectory
 !SessionManager categoriesFor: #basicShutdown!operations-shutdown!private! !
 !SessionManager categoriesFor: #basicStdioStreams!accessing!private! !
 !SessionManager categoriesFor: #basicTertiaryStartup!operations-startup!public! !
+!SessionManager categoriesFor: #bootInfo!patching!public! !
 !SessionManager categoriesFor: #clearSessionState!operations!public! !
 !SessionManager categoriesFor: #closeConsole!operations!public! !
 !SessionManager categoriesFor: #closeConsoleStreams!operations!public! !


### PR DESCRIPTION
Add bootInfo method to SessionMananger that's expected by the deploy: method.