### PR TITLE
Simplify reporting of exchaustion of virtual memory

### DIFF
--- a/Core/DolphinVM/ConsoleToGo/ConsoleToGo.rc
+++ b/Core/DolphinVM/ConsoleToGo/ConsoleToGo.rc
@@ -124,6 +124,7 @@ BEGIN
     IDP_ZCTRESERVEFAIL      "Unable to reserve memory for %1!u! ZT entries. %nPlease close some appliations and try again."
     IDP_ZCTCOMMITFAIL       "Out of memory attempting to commit %1!u! ZT entries. %nPlease close some appliations and try again."
     IDP_BADSYSINFO          "Unexpected page size %1!d! or allocation granularity %2!d!. This application is limited to running on Intel machines with a page size of %3!d! and an allocation granularity of %4!d!."
+    IDP_OUTOFVIRTUALMEMORY  "There is insufficient virtual memory to load the application."
     IDP_FAILTOCREATEVMWND   "Failed to create VM message window: %2 (%1!d!)"
     IDP_CORRUPTIMAGE        "Executable is corrupt.%nMismatched checksums %1!u! and %2!u!"
     IDP_IMAGEREADERROR      "Error %1!d! loading executable"

--- a/Core/DolphinVM/InProcToGo/IPToGo.rc
+++ b/Core/DolphinVM/InProcToGo/IPToGo.rc
@@ -175,6 +175,7 @@ BEGIN
     IDP_OTCOMMITFAIL        "Out of memory attempting to commit %1!u! further Object Pointers.%n%2!u! Object Pointers are currently allocated."
     IDP_OTRESERVEFAIL       "Unable to reserve memory for %1!u! objects%nPlease close some appliations and try again."
     IDP_BADSYSINFO          "Unexpected page size %1!d! or allocation granularity %2!d!. This application is limited to running on Intel machines with a page size of %3!d! and an allocation granularity of %4!d!."
+    IDP_OUTOFVIRTUALMEMORY  "There is insufficient virtual memory to load the application."
     IDP_FAILTOCREATEVMWND   "Failed to create VM message window: %2 %1!d!)"
     IDP_CORRUPTIMAGE        "Executable is corrupt.%nMismatched checksums %1!u! and %2!u!"
     IDP_IMAGEREADERROR      "Error %1!d! loading executable"

--- a/Core/DolphinVM/ToGoStub/ToGoStub.rc
+++ b/Core/DolphinVM/ToGoStub/ToGoStub.rc
@@ -195,6 +195,7 @@ BEGIN
     IDP_ZCTRESERVEFAIL      "Unable to reserve memory for %1!u! ZT entries. %nPlease close some appliations and try again."
     IDP_ZCTCOMMITFAIL       "Out of memory attempting to commit %1!u! ZT entries. %nPlease close some appliations and try again."
     IDP_BADSYSINFO          "Unexpected page size %1!d! or allocation granularity %2!d!. This application is limited to running on x86 machines with a page size of %3!d! and an allocation granularity of %4!d!."
+    IDP_OUTOFVIRTUALMEMORY  "There is insufficient virtual memory to load the application."
     IDP_FAILTOCREATEVMWND   "Failed to create VM message window: %2 (%1!d!)"
     IDP_CORRUPTIMAGE        "Executable is corrupt.%nMismatched checksums %1!u! and %2!u!"
     IDP_IMAGEREADERROR      "Error %1!d! loading executable"

--- a/Core/DolphinVM/alloc.cpp
+++ b/Core/DolphinVM/alloc.cpp
@@ -111,6 +111,8 @@ PointersOTE* __fastcall ObjectMemory::shallowCopy(PointersOTE* ote)
 		VirtualOTE* virtualCopy = ObjectMemory::newVirtualObject(classPointer,
 			currentTotalByteSize / sizeof(MWORD),
 			maxByteSize / sizeof(MWORD));
+		if (!virtualCopy)
+			return nullptr;
 
 		pVObj = virtualCopy->m_location;
 		pBase = pVObj->getHeader();
@@ -615,11 +617,16 @@ Oop* __fastcall Interpreter::primitiveNewVirtual(Oop* const sp, unsigned)
 			if (instSpec.m_indexable && !instSpec.m_nonInstantiable)
 			{
 				unsigned fixedFields = instSpec.m_fixedFields;
-				VirtualOTE* newObject = ObjectMemory::newVirtualObject(receiverClass, initialSize + fixedFields, maxSize + fixedFields);
-				*(sp - 2) = reinterpret_cast<Oop>(newObject);
-				// No point saving down SP before potential Zct reconcile as the init & max args must be SmallIntegers
-				ObjectMemory::AddToZct((OTE*)newObject);
-				return sp - 2;
+				VirtualOTE* newObject = ObjectMemory::newVirtualObject(receiverClass, initialSize + fixedFields, maxSize);
+				if (newObject)
+				{
+					*(sp - 2) = reinterpret_cast<Oop>(newObject);
+					// No point saving down SP before potential Zct reconcile as the init & max args must be SmallIntegers
+					ObjectMemory::AddToZct((OTE*)newObject);
+					return sp - 2;
+				}
+				else
+					return primitiveFailure(4);	// OOM
 			}
 			else
 			{
@@ -647,52 +654,52 @@ MWORD* __stdcall AllocateVirtualSpace(MWORD maxBytes, MWORD initialBytes)
 {
 	unsigned reserveBytes = _ROUND2(maxBytes + dwPageSize, dwAllocationGranularity);
 	ASSERT(reserveBytes % dwAllocationGranularity == 0);
-	VirtualObjectHeader* pLocation;
-	
-	pLocation = static_cast<VirtualObjectHeader*>(::VirtualAlloc(NULL, reserveBytes, MEM_RESERVE, PAGE_NOACCESS));
-	if (!pLocation)
-		// This is continuable
-		::RaiseException(STATUS_NO_MEMORY, 0, 0, NULL);
+	void* pReservation = ::VirtualAlloc(NULL, reserveBytes, MEM_RESERVE, PAGE_NOACCESS);
+	if (pReservation)
+	{
 
-	#ifdef _DEBUG
+#ifdef _DEBUG
 		// Let's see whether we got the rounding correct!
 		MEMORY_BASIC_INFORMATION mbi;
-		VERIFY(::VirtualQuery(pLocation, &mbi, sizeof(mbi)) == sizeof(mbi));
-		ASSERT(mbi.AllocationBase == pLocation);
-		ASSERT(mbi.BaseAddress == pLocation);
-	ASSERT(mbi.AllocationProtect == PAGE_NOACCESS);
-	//	ASSERT(mbi.Protect == PAGE_NOACCESS);
+		VERIFY(::VirtualQuery(pReservation, &mbi, sizeof(mbi)) == sizeof(mbi));
+		ASSERT(mbi.AllocationBase == pReservation);
+		ASSERT(mbi.BaseAddress == pReservation);
+		ASSERT(mbi.AllocationProtect == PAGE_NOACCESS);
+		//	ASSERT(mbi.Protect == PAGE_NOACCESS);
 		ASSERT(mbi.RegionSize == reserveBytes);
 		ASSERT(mbi.State == MEM_RESERVE);
 		ASSERT(mbi.Type == MEM_PRIVATE);
-	#endif
+#endif
 
-	// We expect the initial byte size to be a integral number of pages, and it must also take account
-	// of the virtual allocation overhead (currently 4 bytes)
-	initialBytes = _ROUND2(initialBytes + sizeof(VirtualObjectHeader), dwPageSize);
-	ASSERT(initialBytes % dwPageSize == 0);
+		// We expect the initial byte size to be a integral number of pages, and it must also take account
+		// of the virtual allocation overhead (currently 4 bytes)
+		initialBytes = _ROUND2(initialBytes + sizeof(VirtualObjectHeader), dwPageSize);
+		ASSERT(initialBytes % dwPageSize == 0);
 
-	// Note that VirtualAlloc initializes the committed memory to zeroes.
-	pLocation = static_cast<VirtualObjectHeader*>(::VirtualAlloc(pLocation, initialBytes, MEM_COMMIT, PAGE_READWRITE));
-	if (!pLocation)
-		// This is also continuable
-		::RaiseException(STATUS_NO_MEMORY, 0, 0, NULL);
+		// Note that VirtualAlloc initializes the committed memory to zeroes.
+		VirtualObjectHeader* pLocation = static_cast<VirtualObjectHeader*>(::VirtualAlloc(pReservation, initialBytes, MEM_COMMIT, PAGE_READWRITE));
+		if (pLocation)
+		{
 
-	#ifdef _DEBUG
-		// Let's see whether we got the rounding correct!
-		VERIFY(::VirtualQuery(pLocation, &mbi, sizeof(mbi)) == sizeof(mbi));
-		ASSERT(mbi.AllocationBase == pLocation);
-		ASSERT(mbi.BaseAddress == pLocation);
-		ASSERT(mbi.AllocationProtect == PAGE_NOACCESS);
-		ASSERT(mbi.Protect == PAGE_READWRITE);
-		ASSERT(mbi.RegionSize == initialBytes);
-		ASSERT(mbi.State == MEM_COMMIT);
-		ASSERT(mbi.Type == MEM_PRIVATE);
-	#endif
+#ifdef _DEBUG
+			// Let's see whether we got the rounding correct!
+			VERIFY(::VirtualQuery(pLocation, &mbi, sizeof(mbi)) == sizeof(mbi));
+			ASSERT(mbi.AllocationBase == pLocation);
+			ASSERT(mbi.BaseAddress == pLocation);
+			ASSERT(mbi.AllocationProtect == PAGE_NOACCESS);
+			ASSERT(mbi.Protect == PAGE_READWRITE);
+			ASSERT(mbi.RegionSize == initialBytes);
+			ASSERT(mbi.State == MEM_COMMIT);
+			ASSERT(mbi.Type == MEM_PRIVATE);
+#endif
 
-	// Use first slot to hold the maximum size for the object
-	pLocation->setMaxAllocation(maxBytes);
-	return reinterpret_cast<MWORD*>(pLocation+1);
+			// Use first slot to hold the maximum size for the object
+			pLocation->setMaxAllocation(maxBytes);
+			return reinterpret_cast<MWORD*>(pLocation + 1);
+		}
+	}
+
+	return nullptr;
 }
 
 // N.B. Like the other instantiate methods in ObjectMemory, this method for instantiating
@@ -726,23 +733,27 @@ VirtualOTE* ObjectMemory::newVirtualObject(BehaviorOTE* classPointer, MWORD init
 
 	unsigned byteSize = initialSize*sizeof(MWORD);
 	VariantObject* pLocation = reinterpret_cast<VariantObject*>(AllocateVirtualSpace(maxSize * sizeof(MWORD), byteSize));
+	if (pLocation)
+	{
+		// No need to alter ref. count of process class, as it is sticky
 
-	// No need to alter ref. count of process class, as it is sticky
+		// Fill space with nils for initial values
+		const Oop nil = Oop(Pointers.Nil);
+		const unsigned loopEnd = initialSize;
+		for (unsigned i = 0; i < loopEnd; i++)
+			pLocation->m_fields[i] = nil;
 
-	// Fill space with nils for initial values
-	const Oop nil = Oop(Pointers.Nil);
-	const unsigned loopEnd = initialSize;
-	for (unsigned i = 0; i< loopEnd; i++)
-		pLocation->m_fields[i] = nil;
+		OTE* ote = ObjectMemory::allocateOop(static_cast<POBJECT>(pLocation));
+		ote->setSize(byteSize);
+		ote->m_oteClass = classPointer;
+		classPointer->countUp();
+		ote->m_flags = m_spaceOTEBits[OTEFlags::VirtualSpace];
+		ASSERT(ote->isPointers());
 
-	OTE* ote = ObjectMemory::allocateOop(static_cast<POBJECT>(pLocation));
-	ote->setSize(byteSize);
-	ote->m_oteClass = classPointer;
-	classPointer->countUp();
-	ote->m_flags = m_spaceOTEBits[OTEFlags::VirtualSpace];
-	ASSERT(ote->isPointers());
+		return reinterpret_cast<VirtualOTE*>(ote);
+	}
 
-	return reinterpret_cast<VirtualOTE*>(ote);
+	return nullptr;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/Core/DolphinVM/interprt.cpp
+++ b/Core/DolphinVM/interprt.cpp
@@ -577,11 +577,8 @@ int Interpreter::interpreterExceptionFilter(LPEXCEPTION_POINTERS pExInfo)
 		break;
 
 	case STATUS_NO_MEMORY:
-		if (PleaseTrapGPFs())
-		{
-			sendExceptionInterrupt(VMI_NOMEMORY, pExInfo);
-			action = EXCEPTION_EXECUTE_HANDLER;
-		}
+		sendExceptionInterrupt(VMI_NOMEMORY, pExInfo);
+		action = EXCEPTION_EXECUTE_HANDLER;
 		break;
 
 	case EXCEPTION_INT_DIVIDE_BY_ZERO:

--- a/Core/DolphinVM/ist.h
+++ b/Core/DolphinVM/ist.h
@@ -131,8 +131,9 @@ void __cdecl DebugCrashDump(LPCWSTR szFormat, ...);
 void __cdecl DebugDump(LPCWSTR szFormat, ...);
 HRESULT __cdecl ReportError(int nPrompt, ...);
 HRESULT __cdecl ReportWin32Error(int nPrompt, DWORD errorCode, LPCWSTR arg = NULL);
-void __cdecl RaiseFatalError(int nCode, int nArgs, ...);
+__declspec(noreturn) void __cdecl RaiseFatalError(int nCode, int nArgs, ...);
 __declspec(noreturn) void __stdcall FatalException(const EXCEPTION_RECORD& exRec);
+__declspec(noreturn) void __stdcall DolphinFatalExit(int exitCode, const char* msg);
 void __stdcall DolphinExit(int nExitCode);
 
 BOOL __stdcall GetVersionInfo(VS_FIXEDFILEINFO* lpInfoOut);

--- a/Core/DolphinVM/rc_vm.h
+++ b/Core/DolphinVM/rc_vm.h
@@ -18,6 +18,7 @@
 #define IDP_ZCTRESERVEFAIL              518
 #define IDP_ZCTCOMMITFAIL               519
 #define IDP_BADSYSINFO                  520
+#define IDP_OUTOFVIRTUALMEMORY          521
 #define IDP_FAILTOCREATEVMWND           522
 #define IDP_CORRUPTIMAGE                524
 #define IDP_IMAGEREADERROR              525

--- a/Core/DolphinVM/vm.rc
+++ b/Core/DolphinVM/vm.rc
@@ -153,6 +153,7 @@ BEGIN
     IDP_ZCTRESERVEFAIL      "Unable to reserve memory for %1!u! ZT entries. There is insufficient virtual memory remaining, or it is too fragmented."
     IDP_ZCTCOMMITFAIL       "Out of memory attempting to commit %1!u! ZT entries."
     IDP_BADSYSINFO          "Unexpected page size %1!d! or allocation granularity %2!d!. This application is limited to running on Intel machines with a page size of %3!d! and an allocation granularity of %4!d!."
+    IDP_OUTOFVIRTUALMEMORY  "There is insufficient virtual memory to load the image."
     IDP_FAILTOCREATEVMWND   "Failed to create VM message window: %2 (%1!d!)"
     IDP_CORRUPTIMAGE        "Image is corrupt. %nMismatch between object data size (%1!u!) and checksum (%2!u!)"
     IDP_IMAGEREADERROR      "Error %1!d! reading image"


### PR DESCRIPTION
Raising an exception in the virtual memory allocator that is caught in the main VM handler and translated to an interrupt sent to Smalltalk does work, but is more complicated to debug than the simpler solution of returning null and failing the primitive.