### PR TITLE
Fix for #643.

### DIFF
--- a/Core/Object Arts/Dolphin/Base/ClassDescription.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescription.cls
@@ -818,7 +818,7 @@ resourceSelectorsDo: aMonadicValuable
 	| prefix |
 	prefix := ResourceIdentifier selectorPrefix.
 	self instanceClass class
-		selectorsDo: [:each | (each beginsWith: prefix) ifTrue: [aMonadicValuable value: each]]!
+		selectors do: [:each | (each beginsWith: prefix) ifTrue: [aMonadicValuable value: each]]!
 
 selectorsInCategory: category
 	"Answer an <Collection> of selector <Symbol>s, of the receiver's methods 


### PR DESCRIPTION
the #selectorsDo: method is in an RB package so doesn't exist during the image stripping process. This is a simple fix. I have no strong opinion if it is right, but it works for me!