### PR TITLE
BCryptLibrary>>shaCreate fails on Windows Vista

### DIFF
--- a/Core/Object Arts/Dolphin/Base/NTLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/NTLibrary.cls
@@ -20,6 +20,10 @@ ntQueryTimerResolution: pulMinimumResolution maximum: pulMaximumResolution actua
 	<stdcall: sdword NtQueryTimerResolution lpvoid lpvoid lpvoid>
 	^self invalidCall!
 
+rtlNtStatusToDosError: status
+	<stdcall: dword RtlNtStatusToDosError dword>
+	^self invalidCall!
+
 setTimerResolution: anInteger set: aBoolean actualResolution: actualResolution 
 	"NTSYSAPI
 		NTSTATUS
@@ -38,6 +42,7 @@ wineGetVersion
 	<stdcall: lpstr wine_get_version>
 	^nil	"instead of reporting an error"! !
 !NTLibrary categoriesFor: #ntQueryTimerResolution:maximum:actual:!public! !
+!NTLibrary categoriesFor: #rtlNtStatusToDosError:!public!win32 functions-error handling! !
 !NTLibrary categoriesFor: #setTimerResolution:set:actualResolution:!accessing!public! !
 !NTLibrary categoriesFor: #wineGetVersion!public! !
 

--- a/Core/Object Arts/Dolphin/DolphinSure/PC1Cipher.cls
+++ b/Core/Object Arts/Dolphin/DolphinSure/PC1Cipher.cls
@@ -182,11 +182,7 @@ initialize
 	"
 
 	RandPool := 0.
-	10 timesRepeat: [self churnRandPool].
-	SessionManager current 
-		when: #sessionStarted
-		send: #churnRandPool
-		to: self!
+	10 timesRepeat: [self churnRandPool]!
 
 randPool
 	"Private - Answer the 160 bit random pool seed generated from real world events.

--- a/Core/Object Arts/Dolphin/DolphinSure/SecureHashAlgorithm.cls
+++ b/Core/Object Arts/Dolphin/DolphinSure/SecureHashAlgorithm.cls
@@ -13,10 +13,12 @@ This standard is described in FIPS PUB 180-1, "SECURE HASH STANDARD", April 17, 
 
 context
 	"Private - Gets an SHA context"
-	
-	context isNil ifTrue: [ context := self shaLibrary shaCreate ].
-	^context
-!
+
+	context isNil
+		ifTrue: 
+			[VMLibrary default isWindows7OrGreater ifFalse: [self error: 'Not supported on Vista and earlier versions of  Windows'].
+			context := self shaLibrary shaCreate].
+	^context!
 
 finalHash
 	"Private - Answers the final hash from the context and closes it"


### PR DESCRIPTION
This is a workaround for the problem of BCryptLibrary>>shaCreate raising
an invalid parameter error on Vista, because the code is taking advantage
of an improvement to the API made in Windows 7. A proper fix is arguably
not worthwhile since it would mean refactoring the code to manage the
lifetime of a buffer, and Windows Vista has now been out of support for
over 18 months.

Resolves #660