### PR TITLE
  Fix #662: Dev system should not depend on FileSystemChangeReader

### DIFF
--- a/BootAll.cmd
+++ b/BootAll.cmd
@@ -1,2 +1,0 @@
-CALL BootCore
-CALL BootDPRO

--- a/BootCore.cmd
+++ b/BootCore.cmd
@@ -1,6 +1,0 @@
-@ECHO OFF
-Dolphin7 DBOOT.img7 DolphinCoreProduct
-IF %ERRORLEVEL% NEQ 0 (
-  ECHO Boot failed, Code=%ERRORLEVEL%
-  if "%AppVeyor%"=="" PAUSE
-)

--- a/Core/Object Arts/Dolphin/Base/NTLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/NTLibrary.cls
@@ -20,6 +20,10 @@ ntQueryTimerResolution: pulMinimumResolution maximum: pulMaximumResolution actua
 	<stdcall: sdword NtQueryTimerResolution lpvoid lpvoid lpvoid>
 	^self invalidCall!
 
+rtlNtStatusToDosError: status
+	<stdcall: dword RtlNtStatusToDosError dword>
+	^self invalidCall!
+
 setTimerResolution: anInteger set: aBoolean actualResolution: actualResolution 
 	"NTSYSAPI
 		NTSTATUS
@@ -38,6 +42,7 @@ wineGetVersion
 	<stdcall: lpstr wine_get_version>
 	^nil	"instead of reporting an error"! !
 !NTLibrary categoriesFor: #ntQueryTimerResolution:maximum:actual:!public! !
+!NTLibrary categoriesFor: #rtlNtStatusToDosError:!public!win32 functions-error handling! !
 !NTLibrary categoriesFor: #setTimerResolution:set:actualResolution:!accessing!public! !
 !NTLibrary categoriesFor: #wineGetVersion!public! !
 

--- a/Core/Object Arts/Dolphin/DolphinSure/PC1Cipher.cls
+++ b/Core/Object Arts/Dolphin/DolphinSure/PC1Cipher.cls
@@ -182,11 +182,7 @@ initialize
 	"
 
 	RandPool := 0.
-	10 timesRepeat: [self churnRandPool].
-	SessionManager current 
-		when: #sessionStarted
-		send: #churnRandPool
-		to: self!
+	10 timesRepeat: [self churnRandPool]!
 
 randPool
 	"Private - Answer the 160 bit random pool seed generated from real world events.

--- a/Core/Object Arts/Dolphin/DolphinSure/SecureHashAlgorithm.cls
+++ b/Core/Object Arts/Dolphin/DolphinSure/SecureHashAlgorithm.cls
@@ -13,10 +13,12 @@ This standard is described in FIPS PUB 180-1, "SECURE HASH STANDARD", April 17, 
 
 context
 	"Private - Gets an SHA context"
-	
-	context isNil ifTrue: [ context := self shaLibrary shaCreate ].
-	^context
-!
+
+	context isNil
+		ifTrue: 
+			[VMLibrary default isWindows7OrGreater ifFalse: [self error: 'Not supported on Vista and earlier versions of  Windows'].
+			context := self shaLibrary shaCreate].
+	^context!
 
 finalHash
 	"Private - Answers the final hash from the context and closes it"

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -389,7 +389,6 @@ package methodNames
 	add: 'ExternalInteger class' -> #newInstanceAspect:class:;
 	add: 'ExternalIntegerBytes class' -> #newInstanceAspect:class:;
 	add: 'ExternalMethod class' -> #publishedAspectsOfInstances;
-	add: 'FileSystemChangeReader class' -> #icon;
 	add: 'Float class' -> #newInstanceAspect:class:;
 	add: 'FLOAT class' -> #newInstanceAspect:class:;
 	add: 'FlowLayout class' -> #publishedAspectsOfInstances;
@@ -581,7 +580,6 @@ package setPrerequisites: (IdentitySet new
 	add: '..\..\MVP\Views\Control Bars\Dolphin Control Bars';
 	add: '..\..\MVP\Views\Date Time\Dolphin Date Time Controls';
 	add: '..\..\MVP\Presenters\Date Time\Dolphin Date Time Presenters';
-	add: '..\..\System\Win32\Dolphin File System Watcher';
 	add: '..\..\MVP\Dialogs\Find\Dolphin Find Dialog';
 	add: '..\..\MVP\Presenters\Folder\Dolphin Folder Presenter';
 	add: '..\..\MVP\Presenters\Font\Dolphin Font Presenter';
@@ -2418,12 +2416,6 @@ publishedAspects
 	^aspects! !
 !ExternalStructure categoriesFor: #alternateInspectorClass!constants!development!public! !
 !ExternalStructure categoriesFor: #publishedAspects!accessing!development!public! !
-
-!FileSystemChangeReader class methodsFor!
-
-icon
-	^Icon fromId: 'FileSystemMonitor.ico'! !
-!FileSystemChangeReader class categoriesFor: #icon!initializing!public! !
 
 !Float class methodsFor!
 

--- a/Core/Object Arts/Samples/Utilities/File System Monitor.pax
+++ b/Core/Object Arts/Samples/Utilities/File System Monitor.pax
@@ -14,6 +14,10 @@ package classNames
 	add: #FileSystemMonitorSessionManager;
 	yourself.
 
+package methodNames
+	add: 'FileSystemChangeReader class' -> #icon;
+	yourself.
+
 package binaryGlobalNames: (Set new
 	yourself).
 
@@ -54,6 +58,12 @@ RuntimeSessionManager subclass: #FileSystemMonitorSessionManager
 
 
 "Loose Methods"!
+
+!FileSystemChangeReader class methodsFor!
+
+icon
+	^FileSystemMonitor icon! !
+!FileSystemChangeReader class categoriesFor: #icon!initializing!public! !
 
 "End of package definition"!
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Note: if you are just looking to install Dolphin and get going as quickly as pos
 
 * Load the DolphinVM solution into Visual Studio. Choose the **Release** profile (**Debug** will compile but will run slowly) and then _Build Solution_. A bunch of DLLs and `Dolphin7.exe` will have been copied to the `\Dolphin` root folder.
 
-## Building the Dolphin 7 Product Images
+## Building the Dolphin 7 Product Image
 
-Follow these instructions to create the product images and launch Dolphin Smalltalk for the first time.
+Follow these instructions to create the product image and launch Dolphin Smalltalk for the first time.
 
 * First clone the Dolphin repository (this one) into a suitable working directory on your machine, let's call it `\Dolphin`. Any version of Windows from Vista onwards should be suitable but most validation has been done under Windows 10.
 
@@ -35,9 +35,7 @@ Follow these instructions to create the product images and launch Dolphin Smallt
 
 * Before proceeding you will also need to pull the boot image from github large file storage. To do this execute `git lfs pull`.
 
-* In the root folder of the repo you will find a number of CMD files used boot the images for the various products. Two such products are available, DCORE and DPRO. Normally, you will want to use DPRO only, since this is a superset of DCORE. Sometimes it worthwhile booting both products after a change to make sure that nothing in the boot sequence has been broken. This can be done with the `BootAll` CMD file, but let's assume you just want to boot DPRO. _Note: DPRO stands for Dolphin Professional_.
-
-* Double-click `BootDPRO.cmd` or run it from a console window. When the boot process has completed, you should see a `DPRO.img7` file in your directory. IMG7 is the new image extension for Dolphin 7.
+* In the root folder of the repo you will find the `BootDPRO.cmd` script and a small boot image, `DBOOT.img7`. Double-click `BootDPRO.cmd` or run it from a console window. When the boot process has completed, you should see a `DPRO.img7` file in your directory. IMG7 is the new image extension for Dolphin 7, and DPRO stands for _Dolphin Professional_.
 
 * Should you wish to test your booted image before proceeding with your own changes or work, you may want to run the standard regression test suite. This is recommended, and easy to do. Just run the `TestDPRO.cmd` script in the root folder. This will launch Dolphin, load the tests, and then execute them. As it runs you will see results being reported as console output. When complete a summary will state whether there were any failures. You should expect there to be none, but check the [AppVeyor build](https://ci.appveyor.com/project/dolphinsmalltalk/dolphin-db22v/branch/master) to see the current build status.
 


### PR DESCRIPTION
Also remove the scripts for booting the Core configuration as this is not being routinely maintained. For the moment the configuration itself remains as it is more work to remove the product description and refactor what remains. There might also be some value in having a very minimal "Core" development system, although the current one is hardly minimal.