### PR TITLE
  Empty reg key values cause error in RegKeyAbstract>>objectFromValue:etc

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/RegKeyTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/RegKeyTest.cls
@@ -43,6 +43,21 @@ testCreateUnderRoot
 	self assert: key parentKey name equals: '2'.
 	RegKey userRoot removeKey: '1'!
 
+testEmptySz
+	| temp |
+	temp := RegKey userRoot createKey: GUID newUnique asString.
+	
+	[self assert: (AdvApiLibrary default
+				regSetValueEx: temp asParameter
+				lpValueName: 'Empty'
+				reserved: 0
+				dwType: WinRegConstants.REG_SZ
+				lpData: #[]
+				cbData: 0)
+		equals: 0.
+	self assert: (temp valueAt: 'Empty') equals: Utf16String empty]
+			ensure: [RegKey userRoot removeKey: temp name]!
+
 testExpandSz
 	| path |
 	path := KernelLibrary default expandEnvironmentStrings: '%PATH%'.
@@ -124,6 +139,7 @@ testSz
 !RegKeyTest categoriesFor: #setUp!private!unit tests! !
 !RegKeyTest categoriesFor: #tearDown!private!unit tests! !
 !RegKeyTest categoriesFor: #testCreateUnderRoot!public!unit tests! !
+!RegKeyTest categoriesFor: #testEmptySz!public!unit tests! !
 !RegKeyTest categoriesFor: #testExpandSz!public!unit tests! !
 !RegKeyTest categoriesFor: #testIntegerSerialisation!public!unit tests! !
 !RegKeyTest categoriesFor: #testMultiSz!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Registry/RegKeyAbstract.cls
+++ b/Core/Object Arts/Dolphin/Registry/RegKeyAbstract.cls
@@ -225,7 +225,11 @@ objectFromValue: bytes type: type size: size
 	"Private - Instantiate an appropriate object to represent the registry value with the
 	specified type, content, and size."
 
-	type == REG_SZ ifTrue: [^Utf16String fromByteArray: bytes length: (size bitShift: -1) - 1].
+	type == REG_SZ
+		ifTrue: 
+			[^size = 0
+				ifTrue: [Utf16String empty]
+				ifFalse: [Utf16String fromByteArray: bytes length: (size bitShift: -1) - 1]].
 	type == REG_DWORD ifTrue: [^bytes sdwordAtOffset: 0].
 	type == REG_BINARY ifTrue: [^bytes copyFrom: 1 to: size].
 	type == REG_MULTI_SZ


### PR DESCRIPTION
Fixes #666 