### PR TITLE
Break unecessary dependence of STLInFiler on STBInFiler

### DIFF
--- a/Core/Object Arts/Dolphin/Base/STBFiler.cls
+++ b/Core/Object Arts/Dolphin/Base/STBFiler.cls
@@ -110,12 +110,6 @@ errorInconsistentSTB: anObject
 				expandMacrosWith: anObject
 				with: self signature)!
 
-errorNotSTB
-	"Private - Signal an STBError indicating that the stream being
-	read is not in Smalltalk Binary (STB) format."
-
-	STBError signal: ('Input stream not in <1s> format' expandMacrosWith: self signature)!
-
 errorUnrecognisedClass: aClass version: version 
 	"Private - Signal an STBError indicating that the STB data contains
 	instances of aClass of version that we don't know how to convert."
@@ -123,14 +117,6 @@ errorUnrecognisedClass: aClass version: version
 	STBError 
 		signal: self signature , ' contains a version ' , version displayString , ' instance of ' 
 				, aClass name , ' and is unable to convert it.'!
-
-errorVersion: anInteger 
-	"Private - Signal an STBError indicating that the stream being
-	read has been written in a different version of STB."
-
-	^STBError 
-		signal: ('Input stream is an incompatible <2s> format (version <1d>)' expandMacrosWith: anInteger
-				with: self signature)!
 
 fixedClasses
 	"Answer a <sequencedReadableCollection> of the classes that are pre-registered in every STB
@@ -183,9 +169,7 @@ version
 	^4
 ! !
 !STBFiler class categoriesFor: #errorInconsistentSTB:!exceptions!private! !
-!STBFiler class categoriesFor: #errorNotSTB!exceptions!private! !
 !STBFiler class categoriesFor: #errorUnrecognisedClass:version:!exceptions!private! !
-!STBFiler class categoriesFor: #errorVersion:!exceptions!private! !
 !STBFiler class categoriesFor: #fixedClasses!constants!public! !
 !STBFiler class categoriesFor: #on:!instance creation!public! !
 !STBFiler class categoriesFor: #signature!constants!private! !

--- a/Core/Object Arts/Dolphin/Base/STBInFiler.cls
+++ b/Core/Object Arts/Dolphin/Base/STBInFiler.cls
@@ -213,7 +213,7 @@ readVersion
 	version := 0.
 	[(char := Character ansiValue: stream next) isDigit]
 		whileTrue: [version := version * 10 + char digitValue].
-	char == $\x20 ifFalse: [self class errorNotSTB]!
+	^char == $\x20!
 
 register: anObject
 	"Private - Add anObject to the readMap."
@@ -232,9 +232,13 @@ reset
 	super reset!
 
 resetAndValidateStream
-	(self class peekForSignatureIn: stream) ifFalse: [self class errorNotSTB].
-	self readVersion.
-	version > self class version ifTrue: [self class errorVersion: version]!
+	((self class peekForSignatureIn: stream) and: [self readVersion])
+		ifFalse: [STBError signal: ('Input stream not in <1s> format' expandMacrosWith: self class signature)].
+	version > self class version
+		ifTrue: 
+			[STBError
+				signal: ('Input stream is an incompatible <2s> format (version <1d>)' expandMacrosWith: version
+						with: self class signature)]!
 
 setRefOffset: anInteger
 	readMap setSize: anInteger!

--- a/Core/Object Arts/Dolphin/System/Filer/STLInFiler.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/STLInFiler.cls
@@ -33,7 +33,8 @@ readLiteralData
 	^newObject!
 
 readVersion
-	version := stream next!
+	version := stream next.
+	^true!
 
 registerPredefinedObjects
 	"Private - Post version 3 the out filer stores everything."
@@ -64,7 +65,7 @@ signature
 	"Private - Answer the signature that identifies the data as
 	being in Smalltalk Literal (STL) format."
 
-	^STLOutFiler signature! !
+	^#'!!STL'! !
 !STLInFiler class categoriesFor: #peekForSignatureIn:!public!testing! !
 !STLInFiler class categoriesFor: #signature!constants!private! !
 


### PR DESCRIPTION
STLInFiler, which is required in all GUI applications, references
STBInFiler, preventing the latter from being stripped on application
deployment, even though it is generally not needed in applications.

Fixes #672