### PR TITLE
Refactor FindDetails to resolve unimplemented message regexpClass

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/MethodSearch.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/MethodSearch.cls
@@ -28,7 +28,7 @@ findDetails: aFindDetails
 	findDetails := aFindDetails!
 
 initialize
-	findDetails := FindDetails new!
+	findDetails := AdvancedFindDetails new!
 
 literal
 	^literal!
@@ -212,7 +212,7 @@ newLiteral: anObject
 		yourself!
 
 newPattern: aString 
-	^self newFindDetails: (FindDetails newPattern: aString)!
+	^self newFindDetails: (AdvancedFindDetails newPattern: aString)!
 
 newSelector: aSymbol 
 	^self newLiteral: aSymbol asSymbol! !

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
@@ -614,23 +614,6 @@ findDetails
 findDetails: aFindDetails 
 	"Sets the findDetails instance variable to the argument."
 
-	"Nasty, but for backwards compatibility - will be removed in a future release"
-
-	(aFindDetails isKindOf: Array) 
-		ifTrue: 
-			[| array sender |
-			sender := Processor activeProcess topFrame sender.
-			Notification 
-				signal: ('Deprecated usage of TextPresenter>>findDetails: from <1p> (Argument is no longer an Array)' 
-						expandMacrosWith: sender method).
-			array := aFindDetails.
-			findDetails := (FindDetails new)
-						findWhat: array first;
-						isForwards: array second;
-						isCaseSensitive: array third;
-						isWholeWord: array fourth;
-						yourself.
-			^self].
 	findDetails := aFindDetails!
 
 firstError

--- a/Core/Object Arts/Dolphin/MVP/Base/FindDetails.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/FindDetails.cls
@@ -18,13 +18,14 @@ action
 action: aSymbol 
 	action := aSymbol!
 
+findIn: aView range: anIntervalOfInteger
+	^aView findMatch: self inRange: anIntervalOfInteger!
+
 findWhat
 	^pattern!
 
 hasValidRegularExpression
-	^
-	[self regularExpression test: ''.
-	true] on: HRESULTError do: [:ex | false]!
+	^false!
 
 initialize
 	pattern := replaceWith := ''.
@@ -55,12 +56,7 @@ isForwards: aBoolean
 isRegularExpression
 	"Answer true if this is a regular expression search."
 
-	^self searchMode == #regularExpression!
-
-isRegularExpression: aBoolean 
-	"Set whether this is a regular expression search."
-
-	self searchMode: (aBoolean ifTrue: [#regularExpression] ifFalse: [#text])!
+	^false!
 
 isWholeWord
 	"Answer true if this is a whole word match operation"
@@ -99,16 +95,7 @@ pattern: aString
 	pattern := aString ?? ''!
 
 regularExpression
-	| regexp |
-	regexp := self class regexpClass 
-				ifNil: [self error: 'Regular expression search not supported']
-				ifNotNil: [:class | class new].
-	regexp pattern: self pattern asString.
-	regexp ignoreCase: self isCaseSensitive not.
-	"	regexp
-		multiline: true;
-		global: true."
-	^regexp!
+	^self error: 'Regular expression search not supported'!
 
 replaceWith
 	^replaceWith!
@@ -123,12 +110,10 @@ searchMode
 
 searchMode: aSymbol 
 	(self class searchModes includes: aSymbol) ifFalse: [self error: 'Invalid search mode: ' , aSymbol].
-	searchMode := aSymbol!
-
-wildcardExpression
-	! !
+	searchMode := aSymbol! !
 !FindDetails categoriesFor: #action!accessing!public! !
 !FindDetails categoriesFor: #action:!accessing!public! !
+!FindDetails categoriesFor: #findIn:range:!public! !
 !FindDetails categoriesFor: #findWhat!accessing!public! !
 !FindDetails categoriesFor: #hasValidRegularExpression!public!testing! !
 !FindDetails categoriesFor: #initialize!initializing!public! !
@@ -137,7 +122,6 @@ wildcardExpression
 !FindDetails categoriesFor: #isForwards!public!testing! !
 !FindDetails categoriesFor: #isForwards:!accessing!public! !
 !FindDetails categoriesFor: #isRegularExpression!public!testing! !
-!FindDetails categoriesFor: #isRegularExpression:!accessing!public! !
 !FindDetails categoriesFor: #isWholeWord!public!testing! !
 !FindDetails categoriesFor: #isWholeWord:!accessing!public! !
 !FindDetails categoriesFor: #isWildcard!public!testing! !
@@ -151,7 +135,6 @@ wildcardExpression
 !FindDetails categoriesFor: #replaceWith:!accessing!public! !
 !FindDetails categoriesFor: #searchMode!accessing!public! !
 !FindDetails categoriesFor: #searchMode:!accessing!public! !
-!FindDetails categoriesFor: #wildcardExpression!accessing!public! !
 
 !FindDetails class methodsFor!
 
@@ -185,15 +168,11 @@ newPattern: aString
 		searchMode: mode;
 		yourself!
 
-regexpClass
-	^Smalltalk lookup: #IRegExp2!
-
 searchModes
-	^#(#text #wildcardExpression #regularExpression)! !
+	^#(#text #wildcardExpression)! !
 !FindDetails class categoriesFor: #icon!constants!public! !
-!FindDetails class categoriesFor: #initialize!initializing!public! !
+!FindDetails class categoriesFor: #initialize!development!initializing!public! !
 !FindDetails class categoriesFor: #new!instance creation!public! !
 !FindDetails class categoriesFor: #newPattern:!instance creation!public! !
-!FindDetails class categoriesFor: #regexpClass!constants!public! !
 !FindDetails class categoriesFor: #searchModes!constants!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/StaticPath.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/StaticPath.cls
@@ -51,7 +51,7 @@ setWindowText: pathString
 !StaticPath categoriesFor: #isSingleLine!private!testing! !
 !StaticPath categoriesFor: #layout:!geometry!private! !
 !StaticPath categoriesFor: #plainText!accessing!public! !
-!StaticPath categoriesFor: #plainText:!accessing!private! !
+!StaticPath categoriesFor: #plainText:!private!updating! !
 !StaticPath categoriesFor: #setWindowText:!accessing!private! !
 
 !StaticPath class methodsFor!

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -1244,6 +1244,45 @@ findItemHandle: anInteger ifAbsent: exceptionHandler
 		ifNotNil: [:hWnd | ^hWnd].
 	^exceptionHandler value!
 
+findMatch: aFindDetails inRange: anInterval
+	"Private - Find the first occurrence of text in the receiver that matches the specified
+	<FindDetails>, within the range, anInterval. Answer the <Interval> of the match (an
+	empty interval if not found)."
+
+	| text matchString matchLen start stop textLen |
+	textLen := self textLength.
+	aFindDetails isForwards
+		ifTrue: 
+			[text := self plainText.
+			matchString := aFindDetails pattern.
+			start := anInterval start.
+			stop := anInterval stop]
+		ifFalse: 
+			[text := self plainText reverse.
+			matchString := aFindDetails pattern reverse.
+			start := textLen - anInterval stop + 1.
+			stop := textLen - anInterval start + 1].
+	aFindDetails isCaseSensitive
+		ifFalse: 
+			[text := text asLowercase.
+			matchString := matchString asLowercase].
+	matchLen := matchString size.
+	start to: stop - matchLen + 1
+		do: 
+			[:pos |
+			matchString = (text midString: matchLen from: pos)
+				ifTrue: 
+					["Possible match - check for whole word if necessary."
+					(aFindDetails isWholeWord not or: 
+							[aFindDetails isWholeWord and: 
+									[(pos > 1 and: [(text at: pos - 1) isAlphaNumeric not])
+										and: [pos + matchLen < textLen and: [(text at: pos + matchLen) isAlphaNumeric not]]]])
+						ifTrue: 
+							[| first |
+							first := aFindDetails isForwards ifTrue: [pos] ifFalse: [textLen - pos + 1 - matchLen + 1].
+							^first to: first + matchLen - 1]]].
+	^0 to: -1!
+
 firstSubView
 	"Answers the first sub view of the receiver or nil if there is none"
 
@@ -2671,6 +2710,20 @@ plainText: aString
 
 	self setWindowText: aString
 !
+
+plainTextFrom: startInteger to: stopInteger
+	"Answer a string containing the plain text contents of the receiver
+	in the specified 1-based, end-inclusive, range. If stopInteger is -1, 
+	then answers text from startInteger up to the end."
+
+	| text |
+	text := self plainText.
+	^stopInteger < 0 
+		ifTrue: [text copyFrom: startInteger]
+		ifFalse: [text copyFrom: startInteger to: stopInteger]!
+
+plainTextRange: anInterval
+	^self plainTextFrom: anInterval start to: anInterval stop!
 
 position
 	"Answers the position of the receiver in the coordinates of its parent."
@@ -4547,6 +4600,7 @@ zOrderTop
 !View categoriesFor: #extent:!geometry!public! !
 !View categoriesFor: #filerProxy!binary filing!private! !
 !View categoriesFor: #findItemHandle:ifAbsent:!hierarchy!private! !
+!View categoriesFor: #findMatch:inRange:!private!searching & replacing! !
 !View categoriesFor: #firstSubView!hierarchy!public!sub views! !
 !View categoriesFor: #flash:!operations!public! !
 !View categoriesFor: #font!accessing!public! !
@@ -4747,7 +4801,9 @@ zOrderTop
 !View categoriesFor: #placement!geometry!public! !
 !View categoriesFor: #placement:!geometry!public! !
 !View categoriesFor: #plainText!accessing!public! !
-!View categoriesFor: #plainText:!accessing!private! !
+!View categoriesFor: #plainText:!private!updating! !
+!View categoriesFor: #plainTextFrom:to:!accessing!public! !
+!View categoriesFor: #plainTextRange:!accessing!public! !
 !View categoriesFor: #position!geometry!public! !
 !View categoriesFor: #position:!geometry!public! !
 !View categoriesFor: #positionForKeyboardContextMenu!enquiries!public! !
@@ -4755,7 +4811,7 @@ zOrderTop
 !View categoriesFor: #preferredExtent!geometry!public! !
 !View categoriesFor: #preferredExtent:!geometry!public! !
 !View categoriesFor: #presenter!accessing!public! !
-!View categoriesFor: #presenter:!accessing!public! !
+!View categoriesFor: #presenter:!initializing!public! !
 !View categoriesFor: #presenterConnectionPoint!accessing!public! !
 !View categoriesFor: #preTranslateKeyboardInput:!dispatching!public! !
 !View categoriesFor: #preTranslateMessage:!dispatching!public! !
@@ -4832,7 +4888,7 @@ zOrderTop
 !View categoriesFor: #textLength!accessing!private! !
 !View categoriesFor: #themeSubAppName!constants!private! !
 !View categoriesFor: #toolTipWindow!accessing!private! !
-!View categoriesFor: #toolTipWindow:!accessing!private! !
+!View categoriesFor: #toolTipWindow:!accessing!not an aspect!private! !
 !View categoriesFor: #topShell!hierarchy!public! !
 !View categoriesFor: #topView!hierarchy!public! !
 !View categoriesFor: #trackContextMenu:!menus!private! !

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FINDREPLACEW.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FINDREPLACEW.cls
@@ -23,7 +23,6 @@ findDetails
 		isForwards: self isForwards;
 		isCaseSensitive: self isCaseSensitive;
 		isWholeWord: self isWholeWord;
-		isRegularExpression: false;
 		action: (self isReplaceAll 
 					ifTrue: [#replaceAll]
 					ifFalse: [self isReplace ifTrue: [#replace] ifFalse: [#findNext]]);

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FindDialog.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FindDialog.cls
@@ -94,6 +94,9 @@ winStructClass
 
 !FindDialog class methodsFor!
 
+defaultModel
+	^FindDetails new!
+
 initialize
 	"Private - Initialize the receiver's class variables.
 		self initialize
@@ -130,6 +133,7 @@ showModeless: aView on: aFindDetails
 				ownerView: aView.
 	"N.B. Doesn't really show as a modal dialog"
 	dialog showModal! !
+!FindDialog class categoriesFor: #defaultModel!public! !
 !FindDialog class categoriesFor: #initialize!initializing!private! !
 !FindDialog class categoriesFor: #ownerView:!instance creation!public! !
 !FindDialog class categoriesFor: #ownerView:findWhat:!instance creation!public! !

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Find/AdvancedFindDetails.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Find/AdvancedFindDetails.cls
@@ -1,0 +1,63 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+FindDetails subclass: #AdvancedFindDetails
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+AdvancedFindDetails guid: (GUID fromString: '{6c4e30d4-924f-4c0a-be20-50f5ec823741}')!
+AdvancedFindDetails comment: ''!
+!AdvancedFindDetails categoriesForClass!Kernel-Objects! !
+!AdvancedFindDetails methodsFor!
+
+findIn: aView range: anIntervalOfInteger
+	^self isRegularExpression
+		ifTrue: 
+			[| regexp text matches range |
+			regexp := self regularExpression.
+			text := aView plainTextRange: anIntervalOfInteger.
+			matches := regexp execute: text.
+			range := matches isEmpty ifTrue: [1 to: 0] ifFalse: [matches first range].
+			range + (anIntervalOfInteger start - 1)]
+		ifFalse: [super findIn: aView range: anIntervalOfInteger]!
+
+hasValidRegularExpression
+	^
+	[self regularExpression test: ''.
+	true] on: HRESULTError do: [:ex | false]!
+
+isRegularExpression
+	"Answer true if this is a regular expression search."
+
+	^self searchMode == #regularExpression!
+
+isRegularExpression: aBoolean 
+	"Set whether this is a regular expression search."
+
+	self searchMode: (aBoolean ifTrue: [#regularExpression] ifFalse: [#text])!
+
+regularExpression
+	| regexp |
+	regexp := self class regexpClass new.
+	regexp pattern: self pattern asString.
+	regexp ignoreCase: self isCaseSensitive not.
+	"	regexp
+		multiline: true;
+		global: true."
+	^regexp! !
+!AdvancedFindDetails categoriesFor: #findIn:range:!public! !
+!AdvancedFindDetails categoriesFor: #hasValidRegularExpression!public!testing! !
+!AdvancedFindDetails categoriesFor: #isRegularExpression!public!testing! !
+!AdvancedFindDetails categoriesFor: #isRegularExpression:!accessing!public! !
+!AdvancedFindDetails categoriesFor: #regularExpression!accessing!public! !
+
+!AdvancedFindDetails class methodsFor!
+
+regexpClass
+	^IRegExp2!
+
+searchModes
+	^super searchModes copyWith: #regularExpression! !
+!AdvancedFindDetails class categoriesFor: #regexpClass!constants!public! !
+!AdvancedFindDetails class categoriesFor: #searchModes!constants!public! !
+

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Find/AdvancedFindDialog.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Find/AdvancedFindDialog.cls
@@ -45,7 +45,7 @@ findNext
 
 initialize
 	super initialize.
-	flags := FindDetails regexpClass isNil ifTrue: [0] ifFalse: [RegExpMask].
+	flags := RegExpMask.
 	validationBlock := [:details | self isValidSearch: details]!
 
 isRegExpEnabled
@@ -191,7 +191,7 @@ defaultModel
 	"Answer a default model to be assigned to the receiver when it
 	is initialized."
 
-	^FindDetails new!
+	^AdvancedFindDetails new!
 
 icon
 	"Answers an Icon that can be used to represent this class"

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Find/Dolphin Find Dialog.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Find/Dolphin Find Dialog.pax
@@ -11,6 +11,7 @@ package basicPackageVersion: '6.1'.
 
 
 package classNames
+	add: #AdvancedFindDetails;
 	add: #AdvancedFindDialog;
 	yourself.
 
@@ -29,12 +30,18 @@ package setPrerequisites: (IdentitySet new
 	add: '..\..\Presenters\Text\Dolphin Text Presenter';
 	add: '..\..\Type Converters\Dolphin Type Converters';
 	add: '..\..\Models\Value\Dolphin Value Models';
+	add: '..\..\..\ActiveX\Components\VBScript\VBScript Regular Expressions';
 	yourself).
 
 package!
 
 "Class Definitions"!
 
+FindDetails subclass: #AdvancedFindDetails
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
 Dialog subclass: #AdvancedFindDialog
 	instanceVariableNames: 'patternPresenter wholeWordPresenter matchCasePresenter modePresenter directionPresenter actionButton closeButton flags validationBlock wrapPresenter'
 	classVariableNames: 'RegExpMask WildCardMask'

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/TextEdit.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/TextEdit.cls
@@ -143,7 +143,7 @@ canPaste
 	"Answer whether the window can paste from the current contents of
 	the clipboard."
 
-	^self isReadOnly not and: [Clipboard current isTextAvailable]!
+	^self isReadOnly not and: [UserLibrary default isClipboardFormatAvailable: CF_TEXT]!
 
 canRedo
 	"Answer whether the window can redo the last undone operation."
@@ -345,44 +345,10 @@ find
 
 find: aFindDetails range: anInterval 
 	"Private - Find the first occurrence of text in the receiver that matches the specified
-	<AdvancedFindDetails>, within the range, anInterval. Answer the <Interval> of the match (an
+	<FindDetails>, within the range, anInterval. Answer the <Interval> of the match (an
 	empty interval if not found)."
 
-	| text matchString matchLen start stop textLen |
-	aFindDetails isRegularExpression 
-		ifTrue: [^self findRegularExpression: aFindDetails inRange: anInterval].
-	textLen := self textLength.
-	aFindDetails isForwards 
-		ifTrue: 
-			[text := self plainText.
-			matchString := aFindDetails pattern.
-			start := anInterval start.
-			stop := anInterval stop]
-		ifFalse: 
-			[text := self plainText reverse.
-			matchString := aFindDetails pattern reverse.
-			start := textLen - anInterval stop + 1.
-			stop := textLen - anInterval start + 1].
-	aFindDetails isCaseSensitive 
-		ifFalse: 
-			[text := text asLowercase.
-			matchString := matchString asLowercase].
-	matchLen := matchString size.
-	start to: stop - matchLen + 1
-		do: 
-			[:pos | 
-			matchString = (text midString: matchLen from: pos) 
-				ifTrue: 
-					["Possible match - check for whole word if necessary."
-					(aFindDetails isWholeWord not or: 
-							[aFindDetails isWholeWord and: 
-									[(pos > 1 and: [(text at: pos - 1) isAlphaNumeric not]) 
-										and: [pos + matchLen < textLen and: [(text at: pos + matchLen) isAlphaNumeric not]]]]) 
-						ifTrue: 
-							[| first |
-							first := aFindDetails isForwards ifTrue: [pos] ifFalse: [textLen - pos + 1 - matchLen + 1].
-							^first to: first + matchLen - 1]]].
-	^0 to: -1!
+	^aFindDetails findIn: self range: anInterval!
 
 findDetails
 	"Private - TextEdit does not store information about the find operation, but its presenter
@@ -440,22 +406,15 @@ findNextWrapped: aFindDetails
 	match isEmpty ifFalse: [self highlightFindMatch: match].
 	^match!
 
-findPrompt: aString 
+findPrompt: aString
 	"Private - Launch the modeless Find dialog.
 	Pre-populate the dialog with aString."
 
-	| details |
-	details := self findDetails ifNil: [FindDetails new].
+	| details dialogClass |
+	dialogClass := self findDialogClass.
+	details := self findDetails ifNil: [dialogClass defaultModel].
 	details pattern: aString.
-	^self findDialogClass showModeless: self on: details!
-
-findRegularExpression: aFindDetails inRange: anInterval 
-	| regexp text matches range |
-	regexp := aFindDetails regularExpression.
-	text := self plainTextRange: anInterval.
-	matches := regexp execute: text.
-	range := matches isEmpty ifTrue: [1 to: 0] ifFalse: [matches first range].
-	^range + (anInterval start - 1)!
+	^dialogClass showModeless: self on: details!
 
 findReplace
 	"Launch the FindReplaceText dialog."
@@ -844,20 +803,6 @@ pastePlainText
 
 plainTextAtLine: anInteger 
 	^self plainTextRange: (self lineRange: anInteger)!
-
-plainTextFrom: startInteger to: stopInteger
-	"Answer a string containing the plain text contents of the receiver
-	in the specified 1-based, end-inclusive, range. If stopInteger is -1, 
-	then answers text from startInteger up to the end."
-
-	| text |
-	text := self plainText.
-	^stopInteger < 0 
-		ifTrue: [text copyFrom: startInteger]
-		ifFalse: [text copyFrom: startInteger to: stopInteger]!
-
-plainTextRange: anInterval
-	^self plainTextFrom: anInterval start to: anInterval stop!
 
 positionAtLine: anInteger 
 	"Answer the index of the first character in the specified line (if 0 then
@@ -1365,7 +1310,6 @@ wmSetFocus: message wParam: wParam lParam: lParam
 !TextEdit categoriesFor: #findNext:!helpers!private!searching & replacing! !
 !TextEdit categoriesFor: #findNextWrapped:!public!searching & replacing! !
 !TextEdit categoriesFor: #findPrompt:!private!searching & replacing! !
-!TextEdit categoriesFor: #findRegularExpression:inRange:!public! !
 !TextEdit categoriesFor: #findReplace!commands!public!searching & replacing! !
 !TextEdit categoriesFor: #findReplacePrompt:!public!searching & replacing! !
 !TextEdit categoriesFor: #format!public!testing! !
@@ -1413,8 +1357,6 @@ wmSetFocus: message wParam: wParam lParam: lParam
 !TextEdit categoriesFor: #pasteClipboard!clipboard operations!commands!public! !
 !TextEdit categoriesFor: #pastePlainText!clipboard operations!commands!public! !
 !TextEdit categoriesFor: #plainTextAtLine:!public! !
-!TextEdit categoriesFor: #plainTextFrom:to:!accessing!public! !
-!TextEdit categoriesFor: #plainTextRange:!accessing!public! !
 !TextEdit categoriesFor: #positionAtLine:!accessing!public! !
 !TextEdit categoriesFor: #positionForKeyboardContextMenu!enquiries!public! !
 !TextEdit categoriesFor: #positionOfChar:!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/TextPresenter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/TextPresenter.cls
@@ -53,23 +53,6 @@ findDetails
 findDetails: aFindDetails 
 	"Sets the findDetails instance variable to the argument."
 
-	"Nasty, but for backwards compatibility - will be removed in a future release"
-
-	(aFindDetails isKindOf: Array) 
-		ifTrue: 
-			[| array sender |
-			sender := Processor activeProcess topFrame sender.
-			Notification 
-				signal: ('Deprecated usage of TextPresenter>>findDetails: from <1p> (Argument is no longer an Array)' 
-						expandMacrosWith: sender method).
-			array := aFindDetails.
-			findDetails := (FindDetails new)
-						findWhat: array first;
-						isForwards: array second;
-						isCaseSensitive: array third;
-						isWholeWord: array fourth;
-						yourself.
-			^self].
 	findDetails := aFindDetails!
 
 hasSelection


### PR DESCRIPTION
Split regexp functionality out of base FindDetails since it is only
supported by the Advanced Find Dialog (which may not be used) and has
a dependency on the VBScript Regular Expressions COM object.

Fixes #677