### PR TITLE
Correcting typos in HelpImagesCreationTest

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/HelpImagesCreationTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/HelpImagesCreationTest.cls
@@ -257,7 +257,7 @@ testSmalltalkTools
 		using: 
 			[:shell | 
 			shell
-				browseExecutableManfiestFile: (FileLocator installRelative 
+				browseExecutableManifestFile: (FileLocator installRelative 
 							localFileSpecFor: 'Help\Hello World.xml');
 				method: (HelloWorld compiledMethodAt: #onPaintRequired:);
 				ensureSourceVisible].
@@ -319,7 +319,7 @@ testSystemFolder
 	"Client only image"
 	folderPresenter resetSelection.
 	(folderPresenter view)
-		lvmSetBkImage: LVBKIMAGE new;
+		lvmSetBkImage: LVBKIMAGEW new;
 		backcolor: (Color 
 					red: 255
 					green: 255


### PR DESCRIPTION
I noticed two typos when trying to load the tests, so I've corrected them as best as I know how.