### PR TITLE
Fix #687

### DIFF
--- a/Core/Contributions/IDB/ChunkBrowser.cls
+++ b/Core/Contributions/IDB/ChunkBrowser.cls
@@ -108,6 +108,9 @@ fileOpenPatch
 			self updateChunkList].
 	self caption: ('ChunkBrowser - <1s>' expandMacrosWith: (File splitFilenameFrom: pathname))!
 
+helpFileStem
+	^'idbchunkbrowser'!
+
 idbAbout
 	"Display the about view"
 
@@ -117,7 +120,7 @@ idbAbout
 				expandMacros!
 
 idbHelp
-	self idbHelp: 'idbchunkbrowser'!
+	self idbHelp: self helpFileStem!
 
 onActionPerformed
 	chunkList selections do: [:each | each picked: each picked not].
@@ -158,76 +161,82 @@ printableView
 
 queryCommand: aCommandQuery
 	aCommandQuery commandSymbol == #toggleChunkType:
-		ifTrue:
+		ifTrue: 
 			[| argument |
 			aCommandQuery isEnabled: true.
 			argument := aCommandQuery commandDescription command arguments first.
 			aCommandQuery isChecked: (filter isChunkTypeSelected: argument).
 			^true].
 	aCommandQuery commandSymbol == #toggleComparisonType:
-		ifTrue:
+		ifTrue: 
 			[| argument |
 			aCommandQuery isEnabled: true.
 			argument := aCommandQuery commandDescription command arguments first.
 			aCommandQuery isChecked: (filter isComparisonTypeSelected: argument).
 			^true].
 	aCommandQuery commandSymbol == #restrictionRange
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: chunkList hasSelection.
 			^true].
 	aCommandQuery commandSymbol == #restrictionSave
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: model hasChunks.
 			^true].
 	aCommandQuery commandSymbol == #restrictionClear
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: filter isRestrictingRange.
 			^true].
 	aCommandQuery commandSymbol == #restrictionClass
-		ifTrue:
-			[aCommandQuery
-				isEnabled:
-					filter isRestrictingClass
+		ifTrue: 
+			[aCommandQuery isEnabled: filter isRestrictingClass
 						| (chunkList selections size = 1 and: [chunkList selection chunkClass notNil]).
 			aCommandQuery isChecked: filter isRestrictingClass.
 			^true].
 	aCommandQuery commandSymbol == #toggleRestrictingMostRecent
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: true.
 			aCommandQuery isChecked: filter isRestrictingMostRecent.
 			^true].
 	aCommandQuery commandSymbol == #toggleRestrictingPicked
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: true.
 			aCommandQuery isChecked: filter isRestrictingPicked.
 			^true].
 	aCommandQuery commandSymbol == #showDifferences
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: self canShowDifferences.
 			^true].
 	aCommandQuery commandSymbol == #copyText
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: chunkList selections size = 1.
 			^true].
 	aCommandQuery commandSymbol == #browseChunk
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: self canBrowse.
 			^true].
 	(#(#print #printPreview) identityIncludes: aCommandQuery command)
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: self canPrint.
 			^true].
 	(#(#pickSelection #unpickSelection #restoreSelection) identityIncludes: aCommandQuery command)
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: chunkList hasSelection.
 			^true].
 	aCommandQuery commandSymbol == #restorePicked
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: model hasAnyChunksPicked.
 			^true].
 	aCommandQuery commandSymbol == #clipboardOpen
-		ifTrue:
+		ifTrue: 
 			[aCommandQuery isEnabled: (Clipboard current isFormatIdAvailable: CF_TEXT).
+			^true].
+	#idbHelp == aCommandQuery command
+		ifTrue: 
+			[aCommandQuery
+				isEnabled: (File exists: (File
+								composePath: SessionManager current idbDocumentationFolder
+								stem: self helpFileStem
+								extension: 'html')).
 			^true].
 	^super queryCommand: aCommandQuery!
 
@@ -372,6 +381,7 @@ updateStatus
 !ChunkBrowser categoriesFor: #createSchematicWiring!initializing!public! !
 !ChunkBrowser categoriesFor: #fileOpen!commands!public! !
 !ChunkBrowser categoriesFor: #fileOpenPatch!commands!public! !
+!ChunkBrowser categoriesFor: #helpFileStem!constants!private! !
 !ChunkBrowser categoriesFor: #idbAbout!commands!enquiries!public! !
 !ChunkBrowser categoriesFor: #idbHelp!commands!enquiries!public! !
 !ChunkBrowser categoriesFor: #onActionPerformed!event handling!public! !

--- a/Core/Contributions/IDB/IDB Chunk Browser.pax
+++ b/Core/Contributions/IDB/IDB Chunk Browser.pax
@@ -50,28 +50,28 @@ package binaryGlobalNames: (Set new
 package globalAliases: (Set new
 	yourself).
 
-package setPrerequisites: (IdentitySet new
-	add: '..\..\Object Arts\Dolphin\IDE\Base\Development System';
-	add: '..\..\Object Arts\Dolphin\Base\Dolphin';
-	add: '..\..\Object Arts\Dolphin\MVP\Base\Dolphin Basic Geometry';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Common Controls\Dolphin Common Controls';
-	add: '..\..\Object Arts\Dolphin\MVP\Dialogs\Common\Dolphin Common Dialogs';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Control Bars\Dolphin Control Bars';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\Difference\Dolphin Differences Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Models\List\Dolphin List Models';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Scintilla\Dolphin Scintilla View';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Icons\Dolphin Text Tile Icons';
-	add: '..\..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters';
-	add: '..\..\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models';
-	add: '..\..\Object Arts\Dolphin\MVP\Gdiplus\Gdiplus';
-	add: 'IDB Common';
-	add: 'IDB Method History';
-	add: '..\..\Object Arts\Dolphin\MVP\Icons\Internal Bitmaps and Icons';
-	add: '..\..\Object Arts\Dolphin\System\Compiler\Smalltalk Parser';
-	yourself).
+package setPrerequisites: #(
+	'..\..\Object Arts\Dolphin\IDE\Base\Development System'
+	'..\..\Object Arts\Dolphin\Base\Dolphin'
+	'..\..\Object Arts\Dolphin\MVP\Base\Dolphin Basic Geometry'
+	'..\..\Object Arts\Dolphin\MVP\Views\Common Controls\Dolphin Common Controls'
+	'..\..\Object Arts\Dolphin\MVP\Dialogs\Common\Dolphin Common Dialogs'
+	'..\..\Object Arts\Dolphin\MVP\Views\Control Bars\Dolphin Control Bars'
+	'..\..\Object Arts\Dolphin\MVP\Presenters\Difference\Dolphin Differences Presenter'
+	'..\..\Object Arts\Dolphin\MVP\Models\List\Dolphin List Models'
+	'..\..\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter'
+	'..\..\Object Arts\Dolphin\Base\Dolphin Message Box'
+	'..\..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base'
+	'..\..\Object Arts\Dolphin\MVP\Views\Scintilla\Dolphin Scintilla View'
+	'..\..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter'
+	'..\..\Object Arts\Dolphin\MVP\Icons\Dolphin Text Tile Icons'
+	'..\..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters'
+	'..\..\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models'
+	'..\..\Object Arts\Dolphin\MVP\Gdiplus\Gdiplus'
+	'IDB Common'
+	'IDB Method History'
+	'..\..\Object Arts\Dolphin\MVP\Icons\Internal Bitmaps and Icons'
+	'..\..\Object Arts\Dolphin\System\Compiler\Smalltalk Parser').
 
 package!
 


### PR DESCRIPTION
Doesn't add the missing help file, but disables the Help command if not
found. Should somebody add the help, then the command will work. If not it
will remain disabled, but isn't offering something that doesn't work.