### PR TITLE
Further fix for #711

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMLVCUSTOMDRAW.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/NMLVCUSTOMDRAW.cls
@@ -15,6 +15,13 @@ NMLVCUSTOMDRAW comment: '`NMLVCUSTOMDRAW` is an `ExternalStructure` class to rep
 !NMLVCUSTOMDRAW categoriesForClass!External-Data-Structured-Win32! !
 !NMLVCUSTOMDRAW methodsFor!
 
+applyFont
+	
+	"If a font has not been set, install the view's font to ensure any font change from a previous column is reset"
+	font isNil ifTrue: [font := self view actualFont].
+
+	^super applyFont!
+
 backcolor
 	"Answer the background <Color>."
 
@@ -62,7 +69,7 @@ font
 	"Answer the character font."
 
 	"We assume the font is being accessed in order to be modified, so use a copy"
-	^font ifNil: [font := self canvas font copy]!
+	^font ifNil: [font := self view actualFont copy]!
 
 forecolor
 	"Answer the foreground text colour."
@@ -89,7 +96,6 @@ itemHandle
 reset
 	"Reset the canvas to default settings."
 
-	self canvas font: self view actualFont.
 	self forecolor: (self view forecolor ifNil: [Color windowText])!
 
 subItem
@@ -97,6 +103,7 @@ subItem
 	item := self item.
 	self column ifNotNil: [:col | col getContentsBlock ifNotNil: [:getblock | ^getblock value: item]].
 	^item! !
+!NMLVCUSTOMDRAW categoriesFor: #applyFont!operations!private! !
 !NMLVCUSTOMDRAW categoriesFor: #backcolor!accessing!public! !
 !NMLVCUSTOMDRAW categoriesFor: #backcolor:!accessing!public! !
 !NMLVCUSTOMDRAW categoriesFor: #clrText!**compiled accessors**!public! !


### PR DESCRIPTION
Ensure CDRF_NEWFONT is returned when resetting the font following a change in a previous column.

Closes #711 