### PR TITLE
EditableListView fixes and enhancements

### DIFF
--- a/Core/Contributions/Solutions Software/EditableListView.cls
+++ b/Core/Contributions/Solutions Software/EditableListView.cls
@@ -16,27 +16,21 @@ activateEditorAt: aPoint cause: aSymbol tabbed: aBoolean
 	if aBoolean is true, act as if tabbed into the field
 	Return the editor activated, or nil if none"
 
-	| itemIndex item column columnRectangle |
+	| itemIndex item column columnRectangle editor |
 
 	self hideToolTipWindow.
 
 	"requestDeactivateEditor should already have been sent and approved"
-	self hasActiveEditor ifTrue: [self deactivateEditor].
-
-	"From hereon, disableRedraw is in effect so any early return must enableRedraw"
+	self hasActiveEditor ifTrue: [self hideActiveEditor].
 
 	itemIndex := aPoint x.
-	(self ensureIndexSelected: itemIndex cause: aSymbol) ifFalse: 
-		["Selection suppressed"
-		self enableRedraw. 
-		^nil].
+	(self ensureIndexSelected: itemIndex cause: aSymbol) ifFalse: ["Selection suppressed" ^nil].
 
 	item := self list at: itemIndex.
 	column := self columnAtIndex: aPoint y.
 
 	(column isEditableWith: item) ifFalse: 
 		[column isEditable ifTrue: [Sound beep: MessageBoxConstants.MB_ICONWARNING]. "Bell if the column is disabled for the current item only"
-		self enableRedraw. 
 		^nil].
 
 	"Ensure the editor is visibile"
@@ -44,25 +38,23 @@ activateEditorAt: aPoint cause: aSymbol tabbed: aBoolean
 	(columnRectangle left < 0 or: [columnRectangle right > self width]) ifTrue: [self horzScrollBy: columnRectangle left].
 
 	self activeEditorCoords: aPoint.
+	self activeColumn setEditorValueFrom: item.
 	
-	[| editor |
 	editor := self activeEditor.
 
 	self activeEditorNeedsHighlight
 		ifTrue: [editor backcolor: self activeEditorHighlightColor]
 		ifFalse: [editor backcolor: Color window].
 
-	self activeColumn setEditorValueFrom: item.
+	editor showIn: self activeEditorCellRect.	
 
 	"If the cause is a mouse click, focus will be set by that. Otherwise set manually"
 	aSymbol = #keyboard ifTrue: 
-		[[aBoolean 
+		[aBoolean 
 			ifTrue: [editor tabFocus] 
-			ifFalse: [editor setFocus]] postToInputQueue].
+			ifFalse: [editor setFocus]].
 
-	editor showIn: self activeEditorCellRect] ensure: [self enableRedraw].
-
-	^self activeEditor!
+	^editor!
 
 activateEditorForColumn: anEditableListViewColumn
 
@@ -202,14 +194,6 @@ columnUnderPoint: aPoint
 	itemStruct := self fullItemFromPoint: aPoint.
 
 	^self allColumns at: (itemStruct iSubItem + 1)!
-
-deactivateEditor
-
-	"Private - Note that redraw is turned off to prevent flickering if the receiver gets focus.
-	Clients of this method should ensure redraw is later reactivated"
-
-	self disableRedraw.
-	self hideActiveEditor!
 
 defaultOffsetForEditor: aColumnEditor
 
@@ -611,27 +595,22 @@ onLeftButtonPressed: aMouseEvent
 
 	self hasActiveEditor ifTrue: 
 		[self requestDeactivateEditor ifFalse: [^0].
-		self deactivateEditor].
+		self hideActiveEditor].
 
 	"Special handling only needed for single select"
-	(self isMultiSelect and: [aMouseEvent isShiftDown or: [aMouseEvent isCtrlDown]]) ifTrue: 
-		[self enableRedraw. 
-		^super onLeftButtonPressed: aMouseEvent].
+	(self isMultiSelect and: [aMouseEvent isShiftDown or: [aMouseEvent isCtrlDown]]) ifTrue: [^super onLeftButtonPressed: aMouseEvent].
 
 	point := aMouseEvent position.
 	itemStruct := self fullItemFromPoint: point.
 
 	"Not interested in clicks not on list items"
-	itemStruct iItem negative ifTrue: 
-		[self enableRedraw.
-		^super onLeftButtonPressed: aMouseEvent].
+	itemStruct iItem negative ifTrue: [^super onLeftButtonPressed: aMouseEvent].
 
 	itemCoords := (itemStruct iItem @ itemStruct iSubItem) + (1@1).
 
 	"If clicked the icon, then select only"
 	((self columnAtIndex: itemCoords y) hasColumnImage and: [(self lvmGetSubItemRect: itemStruct iItem subitem: itemStruct iSubItem bounding: LVIR_ICON) containsPoint: point]) ifTrue: 
-		[self enableRedraw. 
-		^super onLeftButtonPressed: aMouseEvent].
+		[^super onLeftButtonPressed: aMouseEvent].
 
 	self hasFocus ifFalse: [self setFocus].
 
@@ -724,10 +703,10 @@ preTranslateKeyboardInput: aMSG
 
 	key := aMSG wParam.
 
-	aMSG message = WM_KEYDOWN ifTrue:
+	(self activeColumn isNil and: [aMSG message = WM_KEYDOWN]) ifTrue:
 		[(key = VK_RIGHT and: [self itemCount > 0]) ifTrue:
 			[self hasSelection 
-				ifTrue: [(self activeColumn isNil and: [self activateFirstEditor notNil]) ifTrue: [^true]]
+				ifTrue: [self activateFirstEditor notNil ifTrue: [^true]]
 				ifFalse: [self selectionByIndex: 1. ^true]].
 
 		(key =VK_TAB and: [self hasEditableColumn]) ifTrue:
@@ -953,7 +932,6 @@ wmVScroll: message wParam: wParam lParam: lParam
 !EditableListView categoriesFor: #columnNamed:!accessing!public! !
 !EditableListView categoriesFor: #columnNamed:ifNone:!accessing!public! !
 !EditableListView categoriesFor: #columnUnderPoint:!accessing!public! !
-!EditableListView categoriesFor: #deactivateEditor!operations!private! !
 !EditableListView categoriesFor: #defaultOffsetForEditor:!accessing!public! !
 !EditableListView categoriesFor: #disconnectFromModel!operations!private! !
 !EditableListView categoriesFor: #drawHorizontalGridlinesOn:from:to:by:!drawing!private! !

--- a/Core/Contributions/Solutions Software/EditableListViewColumn.cls
+++ b/Core/Contributions/Solutions Software/EditableListViewColumn.cls
@@ -290,15 +290,13 @@ ownerDraw: aContext
 	aContext rc width = 0 ifTrue: [^false].
 
 	"Reset canvas/context to defaults otherwise per-column changes are carried over from previous columns"
-	canvas := aContext canvas.
-	canvas font: self parent actualFont.
 	aContext
 		forecolor: (self displayForecolor ifNil: [Color default]);
 		backcolor: (self displayBackcolor ifNil: [Color default]).
 
+	canvas := aContext canvas.
 	self hasPreDrawBlock ifTrue: 
-		[aContext font: canvas font copy.
-		self preDrawBlock value: aContext.
+		[self preDrawBlock value: aContext.
 		aContext applyFont].
 
 	iSubItem := aContext iSubItem. 
@@ -380,15 +378,17 @@ preDrawBlock: anObject
 
 rectangle
 
-	| zeroIndex itemRectangle |
+	| zeroIndex itemRectangle iconRectangle |
 
-	self isVisible ifFalse: [^##(0@0 corner: 0@0)].
+	(self isVisible and: [self parent itemCount > 0]) ifFalse: [^##(0@0 corner: 0@0)].
 
 	zeroIndex := self index - 1.
 	itemRectangle := self parent lvmGetSubItemRect: 0 subitem: zeroIndex bounding: LVIR_LABEL.
 
-	"In row image mode, the first column excludes the row icon. We want the full box"
-	(zeroIndex = 0 and: [self parent hasRowImage]) ifTrue: [itemRectangle left: (itemRectangle left - parent smallImageExtent x)].
+	"The primary column excludes the row icon (if any) We want the full box"
+	(self == self parent primaryColumn and: [self hasColumnImage]) ifTrue: 
+		[iconRectangle := self parent lvmGetSubItemRect: 0 subitem: zeroIndex bounding: LVIR_ICON.
+		itemRectangle left: iconRectangle left].
 
 	^(itemRectangle left@self parent rectangle top) extent: (itemRectangle width@self parent height)!
 

--- a/Core/Contributions/Solutions Software/SSW EditableListView.pax
+++ b/Core/Contributions/Solutions Software/SSW EditableListView.pax
@@ -36,21 +36,20 @@ package binaryGlobalNames: (Set new
 package globalAliases: (Set new
 	yourself).
 
-package setPrerequisites: (IdentitySet new
-	add: '..\..\Object Arts\Dolphin\Base\Dolphin';
-	add: '..\..\Object Arts\Dolphin\MVP\Base\Dolphin Basic Geometry';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Common Controls\Dolphin Common Controls';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\Date Time\Dolphin Date Time Presenters';
-	add: '..\..\Object Arts\Dolphin\MVP\Models\List\Dolphin List Models';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\Radio\Dolphin Radio Buttons';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters';
-	add: '..\..\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models';
-	add: 'SSW ListView Extensions';
-	add: 'SSW Widget Enhancements';
-	yourself).
+package setPrerequisites: #(
+	'..\..\Object Arts\Dolphin\Base\Dolphin'
+	'..\..\Object Arts\Dolphin\MVP\Base\Dolphin Basic Geometry'
+	'..\..\Object Arts\Dolphin\MVP\Views\Common Controls\Dolphin Common Controls'
+	'..\..\Object Arts\Dolphin\MVP\Presenters\Date Time\Dolphin Date Time Presenters'
+	'..\..\Object Arts\Dolphin\MVP\Models\List\Dolphin List Models'
+	'..\..\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter'
+	'..\..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base'
+	'..\..\Object Arts\Dolphin\MVP\Presenters\Radio\Dolphin Radio Buttons'
+	'..\..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter'
+	'..\..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters'
+	'..\..\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models'
+	'SSW ListView Extensions'
+	'SSW Widget Enhancements').
 
 package setManualPrerequisites: #(
 	'SSW ListView Extensions').

--- a/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
+++ b/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
@@ -77,16 +77,15 @@ package binaryGlobalNames: (Set new
 package globalAliases: (Set new
 	yourself).
 
-package setPrerequisites: (IdentitySet new
-	add: '..\..\Object Arts\Dolphin\Base\Dolphin';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Common Controls\Dolphin Common Controls';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Control Bars\Dolphin Control Bars';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base';
-	add: '..\..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter';
-	add: '..\..\Object Arts\Dolphin\MVP\Views\Tooltips\Dolphin Tooltips';
-	add: '..\..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters';
-	yourself).
+package setPrerequisites: #(
+	'..\..\Object Arts\Dolphin\Base\Dolphin'
+	'..\..\Object Arts\Dolphin\MVP\Views\Common Controls\Dolphin Common Controls'
+	'..\..\Object Arts\Dolphin\MVP\Views\Control Bars\Dolphin Control Bars'
+	'..\..\Object Arts\Dolphin\MVP\Presenters\List\Dolphin List Presenter'
+	'..\..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base'
+	'..\..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter'
+	'..\..\Object Arts\Dolphin\MVP\Views\Tooltips\Dolphin Tooltips'
+	'..\..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters').
 
 package!
 
@@ -127,12 +126,11 @@ TextEdit subclass: #FormattedTextEdit
 
 clipTo: aRectangle during: aBlock
 
-	| oldClipRegion |
+	| oldDC |
 
-	oldClipRegion := Region empty.
-	GDILibrary default getClipRgn: self asParameter hrgn: oldClipRegion asParameter.
+	oldDC := self save.
 	[self intersectClipRectangle: aRectangle.
-	aBlock value] ensure: [self selectClipRegion: oldClipRegion]!
+	aBlock value] ensure: [self restore: oldDC]!
 
 erase: aRectangle
 	"Erase the receiver to the current background colour"


### PR DESCRIPTION
Primary change is to remove disable/enableRedraw around editor moves. This was originally to minimize flickering but actually had minimal visible effect, and by forcing a full invalidate made navigating around large lists rather slow.
Also remove code duplication with recent changes to ListView subitem custom draw, and fix the broken implementation of Canvas>>clipTo:during: