### PR TITLE
Rewrite assembler lowBit and highBit primitives in C++

### DIFF
--- a/Core/DolphinVM/IntPrim.cpp
+++ b/Core/DolphinVM/IntPrim.cpp
@@ -275,3 +275,26 @@ Oop* __fastcall Interpreter::primitiveMultiply(Oop* const sp, unsigned)
 		return sp - 1;
 	}
 }
+
+Oop* __fastcall Interpreter::primitiveLowBit(Oop* const sp, unsigned)
+{
+	SMALLINTEGER value = *(sp) ^ 1;
+	unsigned long index;
+	_BitScanForward(&index, value);
+	*sp = ObjectMemoryIntegerObjectOf(index);
+	return sp;
+}
+
+Oop* __fastcall Interpreter::primitiveHighBit(Oop* const sp, unsigned)
+{
+	SMALLINTEGER value = *(sp);
+	if (value >= 0)
+	{
+		unsigned long index;
+		_BitScanReverse(&index, value);
+		*sp = ObjectMemoryIntegerObjectOf(index);
+		return sp;
+	}
+	else
+		return nullptr;
+}

--- a/Core/DolphinVM/Interprt.h
+++ b/Core/DolphinVM/Interprt.h
@@ -548,6 +548,7 @@ private:
 	static Oop* __fastcall primitiveLargeIntegerBitOr(Oop* const sp, unsigned argCount);
 	static Oop* __fastcall primitiveLargeIntegerBitXor(Oop* const sp, unsigned argCount);
 	static Oop* __fastcall primitiveLargeIntegerBitShift(Oop* const sp, unsigned argCount);
+	static Oop* __fastcall primitiveLargeIntegerHighBit(Oop* const sp, unsigned argCount);
 
 	// LargeInteger miscellaneous
 	static Oop* __fastcall primitiveLargeIntegerNormalize(Oop* const sp, unsigned argCount);

--- a/Core/DolphinVM/PrimitivesTable.cpp
+++ b/Core/DolphinVM/PrimitivesTable.cpp
@@ -52,7 +52,7 @@ Interpreter::PrimitiveFp Interpreter::primitivesTable[256] = {
 	Interpreter::primitiveFloatGreaterOrEqual					, // case 46	Float>>#>= in Smalltalk-80
 	Interpreter::primitiveFloatEqual							, // case 47	Float>>#= in Smalltalk-80
 	Interpreter::primitiveAsyncDLL32CallThunk					, // case 48	Float>>#~= in Smalltalk-80
-	Interpreter::unusedPrimitive								, // case 49	Float>>#* in Smalltalk-80
+	Interpreter::primitiveLargeIntegerHighBit					, // case 49	Float>>#* in Smalltalk-80
 	Interpreter::primitiveCopyFromTo							, // case 50	Float>>#/ in Smalltalk-80
 	Interpreter::primitiveStringCmp								, // case 51	Float>>#truncated
 	Interpreter::primitiveStringNextIndexOfFromTo				, // case 52	Float>>#fractionPart in Smalltalk-80

--- a/Core/DolphinVM/SmallIntPrim.asm
+++ b/Core/DolphinVM/SmallIntPrim.asm
@@ -438,39 +438,4 @@ LocalPrimitiveFailure 1
 
 ENDPRIMITIVE primitiveSmallIntegerAt
 
-
-; Only reason for having a primitive to do this is that there is a single assembler
-; instruction to do the job, and its a short easy routine to write.
-BEGINPRIMITIVE primitiveHighBit
-	mov		ecx, [_SP]
-	test	ecx, ecx
-	js		localPrimitiveFailure0				; If negative then fail it
-	bsr		eax, ecx						; Actually quite handy that shifted left one, as we'll get 1-based index!
-	lea		eax, [eax+eax+1]
-
-	mov		[_SP], eax
-	
-	mov		eax, _SP						; primitiveSuccess(0)
-	ret
-
-localPrimitiveFailure0:
-	xor		eax, eax
-	ret
-
-ENDPRIMITIVE primitiveHighBit
-
-; Ditto
-BEGINPRIMITIVE primitiveLowBit
-	mov		ecx, [_SP]
-	xor		eax, eax						; Must clear in case value is zero
-	xor		ecx, 1							; Remove flag bit (as otherwise would always find that)
-	bsf		eax, ecx						; Actually quite handy that shifted left one, as we'll get 1-based index!
-	lea		eax, [eax+eax+1]
-	mov		[_SP], eax
-
-	mov		eax, _SP						; primitiveSuccess(0)
-	ret
-
-ENDPRIMITIVE primitiveLowBit
-
 END

--- a/Core/DolphinVM/largeintprim.cpp
+++ b/Core/DolphinVM/largeintprim.cpp
@@ -1940,6 +1940,34 @@ Oop* __fastcall Interpreter::primitiveLargeIntegerEqual(Oop* const sp, unsigned)
 ///////////////////////////////////////////////////////////////////////////////
 //	Bit manipulation primitives for LargeIntegers
 
+Oop* __fastcall Interpreter::primitiveLargeIntegerHighBit(Oop* const sp, unsigned argCount)
+{
+	// Note that Integers are always normalized. This means that zero cannot be a LargeInteger, i.e.
+	// the bottom limb can never be zero, and the result of this primitive cannot be zero. 
+	// Also there can be at most one leading zero limb (e.g. for 2**63)
+
+	LargeIntegerOTE* oteReceiver = reinterpret_cast<LargeIntegerOTE*>(*sp);
+	LargeInteger* liReceiver = oteReceiver->m_location;
+	MWORD i = oteReceiver->getWordSize() - 1;
+	uint32_t digit = liReceiver->m_digits[i];
+	if (static_cast<int32_t>(digit) >= 0)
+	{
+		if (digit == 0)
+		{
+			digit = liReceiver->m_digits[--i];
+		}
+		
+		unsigned long index;
+		_BitScanReverse(&index, digit);
+		index = i * 32 + index + 1;
+		*sp = ObjectMemoryIntegerObjectOf(index);
+		return sp;
+	}
+	else
+		// Negative, undefined
+		return nullptr;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // LargeInteger #bitAnd:
 //

--- a/Core/Object Arts/Dolphin/Base/LargeInteger.cls
+++ b/Core/Object Arts/Dolphin/Base/LargeInteger.cls
@@ -303,6 +303,13 @@ hash
 		ifTrue: [(highBits bitShift: -1) bitXor: (shiftDistance - 1) abs]
 		ifFalse: [highBits bitXor: shiftDistance abs]!
 
+highBit
+	"Answer the <integer> index of the most significant non-zero bit of the binary representation of the receiver.
+	N.B. This operation is not defined for negative integers."
+
+	<primitive: 49>
+	^super highBit!
+
 intPtrAtOffset: anInteger put: anObject 
 	"Private - Store anObject as a signed machine-word sized integer at anInteger offset in the receiver. anInteger must 
 	be representable in a machine word. Uses the intPtrAtOffset:put: primitive. This is intended only as a way to initialize
@@ -482,6 +489,7 @@ subtractFromInteger: anInteger
 !LargeInteger categoriesFor: #generality!coercing!private! !
 !LargeInteger categoriesFor: #greaterThanInteger:!double dispatch!private! !
 !LargeInteger categoriesFor: #hash!comparing!public! !
+!LargeInteger categoriesFor: #highBit!bit manipulation!public! !
 !LargeInteger categoriesFor: #intPtrAtOffset:put:!initializing!primitives!private! !
 !LargeInteger categoriesFor: #isZero!public!testing! !
 !LargeInteger categoriesFor: #limbSize!accessing!private! !

--- a/Core/Object Arts/Dolphin/Base/LargeIntegerTest.cls
+++ b/Core/Object Arts/Dolphin/Base/LargeIntegerTest.cls
@@ -1028,6 +1028,11 @@ testLessThan
 			self deny: pair last < pair first].
 	self should: [SmallInteger maximum + 1 < nil] raise: MessageNotUnderstood!
 
+testLowBit
+	#(#(16r40000000 31) #(16r80000000 32) #(16r70000000 29) #(16r10000000000000000 65))
+		do: [:each | self assert: each first lowBit equals: each second.
+	self assert: each first negated lowBit equals: each second]!
+
 testMod
 	| b mod expected result |
 	b := 16r10000000000000000.
@@ -1388,6 +1393,7 @@ testSubtractSmall
 !LargeIntegerTest categoriesFor: #testImmutable!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testLessOrEqual!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testLessThan!public!unit tests! !
+!LargeIntegerTest categoriesFor: #testLowBit!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testMod!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testModulo!public!unit tests! !
 !LargeIntegerTest categoriesFor: #testMulSmall!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/SmallIntegerTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SmallIntegerTest.cls
@@ -127,6 +127,15 @@ testLargeSmallComparisons
 testLcm
 	self assert: (6 lcm: 10) identicalTo: 30!
 
+testLowBit
+	0 to: 30 do: [:each | 
+		| i |
+		i := 1 << each.
+		self assert: i lowBit equals: each+1.
+		self assert: i negated lowBit equals: each + 1].
+	#(#(0 0) #(3 1) #(16r30000000 29) #(-3 1) #(-16r40000000 31))
+		do: [:each | self assert: each first lowBit equals: each second]!
+
 testMaxVal
 	self should: [SmallInteger maximum = ((1 bitShift: VMConstants.IntPtrBits - 2) - 1)]!
 
@@ -302,6 +311,7 @@ testSubtract
 !SmallIntegerTest categoriesFor: #testIntegerDivide!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testLargeSmallComparisons!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testLcm!public!unit tests! !
+!SmallIntegerTest categoriesFor: #testLowBit!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testMaxVal!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testMinMax!public!unit tests! !
 !SmallIntegerTest categoriesFor: #testMinVal!public!unit tests! !


### PR DESCRIPTION
By using the Intel intrinsics, the compiler generated code is virtually the same as the hand-coded assembler.