### PR TITLE
Add/fix storeString methods for Dates and Times classes

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Date.cls
+++ b/Core/Object Arts/Dolphin/Base/Date.cls
@@ -270,18 +270,17 @@ setDays: dayCount
 	days := dayCount
 !
 
-storeOn: aStream 
-	"Append to the <puttableStream> argument, target, an expression which when 
-	evaluated will answer a collection similar to the receiver."
-
-	"Use a format which is locale invariant."
+storeOn: aStream
+	"Append to the <puttableStream> argument, target, an expression which when evaluated will answer a <Date> equivalent to the receiver."
 
 	aStream
-		display: self class;
+		nextPut: $(;
+		print: self class;
 		space;
 		display: #fromDays:;
 		space;
-		display: self asDays!
+		print: self asDays;
+		nextPut: $)!
 
 subtractDate: aDate
 	"Answer the difference in days between the receiver and aData, as an Integer"

--- a/Core/Object Arts/Dolphin/Base/DateAndTime.cls
+++ b/Core/Object Arts/Dolphin/Base/DateAndTime.cls
@@ -341,6 +341,22 @@ setRataDie: anInteger seconds: aNumber offset: secondsInteger
 	offset := secondsInteger.
 	^self!
 
+storeOn: aStream
+	"Append to the <puttableStream> argument, target, an expression which when evaluated will answer a <DateAndTime> equivalent to the receiver."
+
+	aStream
+		nextPut: $(;
+		print: self class;
+		nextPutAll: ' year: ';
+		print: self year;
+		nextPutAll: ' day: ';
+		print: self dayOfYear;
+		nextPutAll: ' seconds: ';
+		print: self seconds;
+		nextPutAll: ' offset: ';
+		store: offset seconds;
+		nextPut: $)!
+
 subtractFromDateAndTime: aDateAndTime 
 	"Private - Part of a double dispatch for <DateAndTime> subtraction. 
 	Answers a <Duration> representing the argument subtracted from the receiver."
@@ -424,6 +440,7 @@ year
 !DateAndTime categoriesFor: #second!accessing!public! !
 !DateAndTime categoriesFor: #seconds!accessing!public! !
 !DateAndTime categoriesFor: #setRataDie:seconds:offset:!initializing!private! !
+!DateAndTime categoriesFor: #storeOn:!printing!public! !
 !DateAndTime categoriesFor: #subtractFromDateAndTime:!arithmetic!double dispatch!private! !
 !DateAndTime categoriesFor: #timeZoneAbbreviation!accessing!public! !
 !DateAndTime categoriesFor: #timeZoneName!accessing!public! !
@@ -743,6 +760,26 @@ year: year day: dayOfYear hour: hour minute: minute second: second offsetSeconds
 year: yearInteger day: ordinalDateInteger offset: aDuration
 	^self year: yearInteger day: ordinalDateInteger hour: 0 minute: 0 second: 0 offset: aDuration!
 
+year: yearInteger day: ordinalDateInteger seconds: seconds offset: aDuration
+	| offset |
+	(ordinalDateInteger >= 1 and: [ordinalDateInteger <= 366])
+		ifFalse: 
+			[InvalidArgumentError signal: ordinalDateInteger printString , ' is outside [1, 366]'
+				with: 'dayOfYear'].
+	(seconds >= 0 and: [seconds < Duration.SecondsPerDay])
+		ifFalse: 
+			[InvalidArgumentError signal: ordinalDateInteger printString , ' is outside [1, 366]' with: 'seconds'].
+	offset := aDuration asSeconds.
+	self validateOffset: offset.
+	^self new
+		setRataDie: (self
+				encodeRataDieYear: yearInteger
+				month: 1
+				day: 1) + ordinalDateInteger
+				- 1
+		seconds: seconds asTrueFraction
+		offset: offset!
+
 year: yearInteger month: monthInteger day: dayInteger
 	"Answer a new <DateAndTime> representing midnight local time on the specified day of the specified month of the specified year."
 
@@ -855,7 +892,8 @@ yesterday
 !DateAndTime class categoriesFor: #year:day:hour:minute:second:!instance creation!public! !
 !DateAndTime class categoriesFor: #year:day:hour:minute:second:offset:!instance creation!public! !
 !DateAndTime class categoriesFor: #year:day:hour:minute:second:offsetSeconds:!instance creation!private! !
-!DateAndTime class categoriesFor: #year:day:offset:!accessing!public! !
+!DateAndTime class categoriesFor: #year:day:offset:!instance creation!public! !
+!DateAndTime class categoriesFor: #year:day:seconds:offset:!instance creation!public! !
 !DateAndTime class categoriesFor: #year:month:day:!instance creation!public! !
 !DateAndTime class categoriesFor: #year:month:day:hour:minute:second:!instance creation!public! !
 !DateAndTime class categoriesFor: #year:month:day:hour:minute:second:offset:!instance creation!public! !

--- a/Core/Object Arts/Dolphin/Base/DateAndTimeTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DateAndTimeTest.cls
@@ -476,6 +476,13 @@ testStbConvertFrom
 				actual := Object fromLiteralStoreArray: stl.
 				self assert: actual equals: expected]!
 
+testStoreOn
+	| now stored collection |
+	now := DateAndTime now.
+	collection := OrderedCollection with: now with: self canonicalInstance.
+	stored := collection storeString.
+	self assert: (Compiler evaluate: stored) equals: collection!
+
 testToday
 	| today subject |
 	today := Date today.
@@ -633,6 +640,7 @@ testYearMonthDayHourMinuteSecondOffsetErrors
 !DateAndTimeTest categoriesFor: #testRataDie!public!unit tests! !
 !DateAndTimeTest categoriesFor: #testSecond!public!unit tests! !
 !DateAndTimeTest categoriesFor: #testStbConvertFrom!public!unit tests! !
+!DateAndTimeTest categoriesFor: #testStoreOn!public!testing! !
 !DateAndTimeTest categoriesFor: #testToday!public!unit tests! !
 !DateAndTimeTest categoriesFor: #testYearMonthDay!public!unit tests! !
 !DateAndTimeTest categoriesFor: #testYearMonthDayHourMinuteSecondOffset!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/DateTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DateTest.cls
@@ -49,6 +49,17 @@ testFromSeconds
 	self assert: now month equals: dtNow month.
 	self assert: now dayOfMonth equals: dtNow dayOfMonth!
 
+testStoreOn
+	| subject stored collection |
+	subject := Date today.
+	collection := OrderedCollection with: subject
+				with: (Date
+						year: -2000
+						month: 2
+						day: 29).
+	stored := collection storeString.
+	self assert: (Compiler evaluate: stored) equals: collection!
+
 testYyyymmdd
 	| subject |
 	subject := Date newDay: 1 monthIndex: 2 year: 3.
@@ -60,5 +71,6 @@ testYyyymmdd
 	! !
 !DateTest categoriesFor: #testFromDays!public!unit tests! !
 !DateTest categoriesFor: #testFromSeconds!public!unit tests! !
+!DateTest categoriesFor: #testStoreOn!public!testing! !
 !DateTest categoriesFor: #testYyyymmdd!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/Duration.cls
+++ b/Core/Object Arts/Dolphin/Base/Duration.cls
@@ -216,6 +216,14 @@ setSeconds: aNumber
 	seconds := aNumber.
 	^self!
 
+storeOn: aStream
+	"Append to the <puttableStream> argument, target, an expression which when evaluated will answer a <Duration> equivalent to the receiver."
+
+	aStream
+		print: seconds;
+		space;
+		display: #seconds!
+
 subtractFromDateAndTime: aDateAndTime
 	"Private - Part of a double dispatch for <DateAndTime> subtraction. Answers a 
 	<DateAndTime> representing the receiver subtracted from the argument"
@@ -252,6 +260,7 @@ subtractFromDateAndTime: aDateAndTime
 !Duration categoriesFor: #printStringFormat:!printing!public! !
 !Duration categoriesFor: #seconds!accessing!public! !
 !Duration categoriesFor: #setSeconds:!initializing!private! !
+!Duration categoriesFor: #storeOn:!printing!public! !
 !Duration categoriesFor: #subtractFromDateAndTime:!initializing!private! !
 
 Duration methodProtocol: #Duration attributes: #(#ansi #readOnly) selectors: #(#- #* #/ #~~ #~= #+ #< #<= #= #== #> #>= #abs #asSeconds #between:and: #class #copy #days #doesNotUnderstand: #error: #hash #hours #identityHash #isKindOf: #isMemberOf: #isNil #max: #min: #minutes #negated #negative #notNil #perform: #perform:with: #perform:with:with: #perform:with:with:with: #perform:withArguments: #positive #printOn: #printString #respondsTo: #seconds #yourself)!

--- a/Core/Object Arts/Dolphin/Base/DurationTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DurationTest.cls
@@ -300,6 +300,18 @@ testPrintString
 		self assert: nanos nanoseconds printString equals: expected]
 !
 
+testStoreOn
+	| subject stored collection |
+	collection := OrderedCollection new
+				add: 1 nanoseconds;
+				add: 1 microseconds;
+				add: 1 milliseconds;
+				add: 1 seconds;
+				add: 1 days;
+				add: 364 days + 23 hours + 59 minutes + 59.999999999 seconds.
+	stored := collection storeString.
+	self assert: (Compiler evaluate: stored) equals: collection!
+
 testSubtract
 	| subject |
 	subject := 1.5 seconds.
@@ -335,5 +347,6 @@ testSubtract
 !DurationTest categoriesFor: #testNumberSeconds!public!unit tests! !
 !DurationTest categoriesFor: #testPositive!public!unit tests! !
 !DurationTest categoriesFor: #testPrintString!public!unit tests! !
+!DurationTest categoriesFor: #testStoreOn!public!testing! !
 !DurationTest categoriesFor: #testSubtract!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/GUID.cls
+++ b/Core/Object Arts/Dolphin/Base/GUID.cls
@@ -158,15 +158,16 @@ species
 	^GUID!
 
 storeOn: aStream
-	"Append to the <puttableStream> argument, target, an expression which when 
-	evaluated will answer a collection similar to the receiver."
+	"Append to the <puttableStream> argument, target, an expression which when evaluated will answer a <GUID> equivalent to the receiver."
 
 	aStream
+		nextPut: $(;
 		print: self class;
 		space;
 		nextPutAll: #fromString:;
 		space;
-		print: self asString!
+		print: self asString;
+		nextPut: $)!
 
 stringSize
 	"Answer the number of characters in a GUID string."

--- a/Core/Object Arts/Dolphin/Base/GUIDTest.cls
+++ b/Core/Object Arts/Dolphin/Base/GUIDTest.cls
@@ -60,10 +60,11 @@ testOrder
 					self deny: guid1 equals: guid2]]!
 
 testStoreOn
-	| subject stored |
+	| subject stored collection |
 	subject := GUID newUnique.
-	stored := subject storeString.
-	self assert: (Compiler evaluate: stored) equals: subject.
+	collection := OrderedCollection with: subject.
+	stored := collection storeString.
+	self assert: (Compiler evaluate: stored) equals: collection.
 	self assert: (Compiler evaluate: GUID null storeString) equals: GUID null!
 
 testUniqueness

--- a/Core/Object Arts/Dolphin/Base/Stream.cls
+++ b/Core/Object Arts/Dolphin/Base/Stream.cls
@@ -200,6 +200,11 @@ skipTo: anObject
 	[self atEnd] whileFalse: [self next = anObject ifTrue: [^true]].
 	^false!
 
+store: anObject
+	"Ask anObject to append its storeString to the receiver."
+
+	anObject storeOn: self!
+
 upTo: anObject
 	"Answer a collection of elements starting with the next element accessed by the receiver,
 	and up to, not inclusive of, the next element that is equal to anObject. Positions the
@@ -244,6 +249,7 @@ upToEnd
 !Stream categoriesFor: #print:!printing!public! !
 !Stream categoriesFor: #skipThrough:!positioning!public! !
 !Stream categoriesFor: #skipTo:!positioning!public! !
+!Stream categoriesFor: #store:!printing!public! !
 !Stream categoriesFor: #upTo:!accessing!public! !
 !Stream categoriesFor: #upToEnd!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/Base/Time.cls
+++ b/Core/Object Arts/Dolphin/Base/Time.cls
@@ -131,11 +131,15 @@ seconds
 seconds: aNumber
 	seconds := aNumber!
 
-storeOn: aStream 
+storeOn: aStream
+	"Append to the <puttableStream> argument, target, an expression which when evaluated will answer a <Time> equivalent to the receiver."
+
 	aStream
-		display: self class;
+		nextPut: $(;
+		print: self class;
 		nextPutAll: ' fromSeconds: ';
-		print: self asSeconds!
+		print: self asSeconds;
+		nextPut: $)!
 
 subtractTime: aTimeOrDate
 	"Answer a new Time, aTimeOrDate seconds before the receiver."

--- a/Core/Object Arts/Dolphin/Base/TimeTest.cls
+++ b/Core/Object Arts/Dolphin/Base/TimeTest.cls
@@ -257,11 +257,15 @@ testStb
 	self assert: rehydrated equals: subject!
 
 testStoreOn
-	| subject stored array |
+	| subject stored collection |
 	subject := Time now.
-	array := Array with: subject with: (Time hour: 23 minute: 59 second: 58).
-	stored := array storeString.
-	self assert: (Compiler evaluate: stored) equals: array! !
+	collection := OrderedCollection with: subject
+				with: (Time
+						hour: 23
+						minute: 59
+						second: 58).
+	stored := collection storeString.
+	self assert: (Compiler evaluate: stored) equals: collection! !
 !TimeTest categoriesFor: #comparePrintStreamFor:hr24:showSeconds:expected:!comparing!private! !
 !TimeTest categoriesFor: #hoursShould:for:!comparing!private! !
 !TimeTest categoriesFor: #millisecondsShould:for:!comparing!private! !


### PR DESCRIPTION
This is something I realised I'd overlooked in my recent work on DateAndTime when I safe @jgfoster's latest PR