### PR TITLE
Fix test to run in non-UTC zone

### DIFF
--- a/Core/Object Arts/Dolphin/Base/DateTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DateTest.cls
@@ -43,7 +43,7 @@ testFromSeconds
 	today := Date today.
 	date := Date fromSeconds: today asSeconds.
 	self assert: today equals: date.
-	dtNow := DateAndTime now.
+	dtNow := DateAndTime nowUTC.
 	now := Date fromSeconds: dtNow asSeconds.
 	self assert: now year equals: dtNow year.
 	self assert: now month equals: dtNow month.


### PR DESCRIPTION
Depending on when I run the tests, I often get an error in DateTest>>testFromSeconds. I believe that the difference is that I'm not in the UTC time zone.