### PR TITLE
Identity hash function must be called in a loop to avoid transient zero

### DIFF
--- a/Core/DolphinVM/ote.h
+++ b/Core/DolphinVM/ote.h
@@ -153,7 +153,12 @@ public:
 
 	__forceinline hash_t identityHash()
 	{
-		return m_idHash != 0 ? m_idHash : m_idHash = ObjectMemory::nextIdentityHash();
+		// This needs to be a loop in case nextIdentityHash ever returns zero
+		while (m_idHash == 0)
+		{
+			m_idHash = ObjectMemory::nextIdentityHash();
+		}
+		return m_idHash;
 	}
 
 public:


### PR DESCRIPTION
The new identity hash function uses 16-bits of a 32-bit hash. Very
infrequently the 16-bit value can be zero, which is the same as the
initial value for an object that has not yet been allocated a hash, causing
a further allocation to occur the next time the identity hash is requested.
This resulted in an occasional failure of IdeaSpaceShellTests
testHistoryRemove, which could go away with code changes.
This bug was introduced by 5634a618