### PR TITLE
Fix #805: Vertical workspace toolbar does not adopt button size option

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
@@ -342,8 +342,8 @@ allUnimplementedSelectors
 	^self unimplementedSelectorsIn: self systemEnvironment!
 
 applyOptionsToTool: aSmalltalkToolShell
-	(aSmalltalkToolShell view viewNamed: 'toolbar' ifNone: [])
-		ifNotNil: [:toolbar | toolbar bitmapSize: self toolbarBitmapSize]!
+	aSmalltalkToolShell view managedSubViews
+		do: [:each | (each isKindOf: Toolbar) ifTrue: [each bitmapSize: self toolbarBitmapSize]]!
 
 applyPublishedAspectsLiteralMap: aLookupTable to: aTool 
 	"Private - Applies the literal publishes aspect values held in aLookupTable to aTool"


### PR DESCRIPTION
The Development System option `toolbarBitmapSize` allows one to choose
larger toolbar images than the default 16x16 as a preference for the
toolbars in all the development tools. However this was not applied to the
east/vertical toolbar in workspaces.