### PR TITLE
Fix #808: Restore lost conditional guard on shift modifier in IsUserBreakRequested

### DIFF
--- a/Core/DolphinVM/bytecde.cpp
+++ b/Core/DolphinVM/bytecde.cpp
@@ -185,6 +185,7 @@ bool Interpreter::IsUserBreakRequested()
 	int vk = hotkey & 0x1FF;
 	bool interrupt = (::GetAsyncKeyState(vk) & 0x8001) != 0;
 	int modifiers = (hotkey >> 9);
+	if (modifiers & FSHIFT)
 	{
 		interrupt &= (::GetAsyncKeyState(VK_SHIFT) & 0x8001) != 0;
 	}


### PR DESCRIPTION
A line was accidentally deleted from this function some time ago, meaning
that it always checked for the shift key being down regardless of the
actual choice of interrupt key (the default being Ctrl+F12, i.e. no shift)