### PR TITLE
Fix #817: Debugger data tips should not use the compiler for evaluation

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -274,6 +274,7 @@ package methodNames
 	add: #FLOATField -> #newAspect:class:;
 	add: #FramingLayout -> #arrangementAspect;
 	add: #HANDLEField -> #printAccessorExpressionSuffixOn:;
+	add: #Interval -> #debugPrintString;
 	add: #Interval -> #newBatchAccessor;
 	add: #KernelLibrary -> #queryThreadCycleTime:cycleTime:;
 	add: #LargeInteger -> #debugPrintString;
@@ -3774,8 +3775,12 @@ choose
 
 !Interval methodsFor!
 
+debugPrintString
+	^self printString!
+
 newBatchAccessor
 	^IndexedInstVarBatchAccessor subject: self batchSize: self publishedKeyedAspectsBatchSize! !
+!Interval categoriesFor: #debugPrintString!printing!public! !
 !Interval categoriesFor: #newBatchAccessor!public! !
 
 !KernelLibrary methodsFor!

--- a/Core/Object Arts/Dolphin/IDE/Base/MethodWorkspace.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/MethodWorkspace.cls
@@ -339,6 +339,21 @@ resetParseTimer
 		killParseTimer;
 		setParseTimer!
 
+resolveIdentifier: aString ifDefined: aMonadicValuable
+	| methodClass |
+	methodClass := self selectedMethod methodClass.
+	"In the debugger will have an evaluation context which is the receiver."
+	(self evaluationContext isKindOf: methodClass)
+		ifTrue: 
+			[
+			aString = 'self' ifTrue: [^aMonadicValuable value: self evaluationContext].
+			(self contextBindingFor: aString) ifNotNil: [:var | ^aMonadicValuable value: var value].
+			(methodClass indexOfInstVar: aString ifAbsent: [])
+				ifNotNil: [:i | ^aMonadicValuable value: (self evaluationContext instVarAt: i)]].
+	(methodClass fullBindingFor: aString)
+		ifNotNil: [:binding | binding value ifNotNil: [:value | ^aMonadicValuable value: value]].
+	^nil!
+
 selectedErrorRange
 	^self selectedNode sourceInterval!
 
@@ -399,24 +414,8 @@ targetOfMessage: aStMessageNode
 	receiver := aStMessageNode receiver.
 	receiver isVariable
 		ifTrue: 
-			[| methodClass identifier |
-			methodClass := self selectedMethod methodClass.
-			"Semantic analysis may not have been run, but special variables can be identified syntactically."
-			receiver isSpecialVariable ifTrue: [^receiver valueClassIn: methodClass].
-			identifier := receiver name.
-			(self isTempVariable: receiver)
-				ifTrue: 
-					["If hosted in the debugger can make a stab at these"
-					(self contextBindingFor: identifier)
-						ifNotNil: [:binding | binding value ifNotNil: [:value | ^value basicClass]].
-					^nil].
-			((self evaluationContext isKindOf: methodClass)
-				and: [methodClass allInstVarNames includes: identifier])
-					ifTrue: 
-						["In the debugger will have an evaluation context which is the receiver."
-						^(self evaluationContext instVarNamed: identifier) basicClass].
-			(methodClass fullBindingFor: identifier)
-				ifNotNil: [:binding | binding value ifNotNil: [:value | ^value basicClass]]]
+			[receiver isSpecialVariable ifTrue: [^receiver valueClassIn: self selectedMethod methodClass].
+			^self resolveIdentifier: receiver name ifDefined: [:value | value basicClass]]
 		ifFalse: [receiver isLiteralNode ifTrue: [^aStMessageNode receiver value basicClass]].
 	^nil!
 
@@ -488,6 +487,7 @@ widenSourceSelection
 !MethodWorkspace categoriesFor: #reformattedSource!helpers!private! !
 !MethodWorkspace categoriesFor: #repositionAtSourceLine:!operations!public! !
 !MethodWorkspace categoriesFor: #resetParseTimer!helpers!private! !
+!MethodWorkspace categoriesFor: #resolveIdentifier:ifDefined:!helpers!private! !
 !MethodWorkspace categoriesFor: #selectedErrorRange!accessing!private!refactoring! !
 !MethodWorkspace categoriesFor: #selectedMessage!accessing!private! !
 !MethodWorkspace categoriesFor: #selectedMessageNode!accessing!private!refactoring! !

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
@@ -163,15 +163,13 @@ chooseEvaluationPools
 chunkFilerClass
 	^ChunkSourceFiler!
 
-classForIdentifier: aString 
+classForIdentifier: aString
 	aString = 'self' ifTrue: [^self selfClass].
 	aString = 'super' ifTrue: [^self selfClass superclass].
 	aString = 'thisContext' ifTrue: [^Integer].
 	"In the debugger the workspacePool will also contain any temps and args, so we'll get
 	sensible autocompletion on those too"
-	(self workspacePool bindingFor: aString) ifNotNil: [:var | ^var value basicClass].
-	^[(self evaluationContext instVarNamed: aString) basicClass] on: NotFoundError
-		do: [:ex | (self selfClass fullBindingFor: aString) ifNotNil: [:var | var value basicClass]]!
+	^self resolveIdentifier: aString ifDefined: [:value | value basicClass]!
 
 classForToken: anAssociation
 	"Private - Answer the inferred class of the specified token, or nil if not known."
@@ -745,7 +743,7 @@ initialize
 	"Private - Initialize the receiver"
 
 	super initialize.
-	flags := 0.
+	flags := VariableTipsMask.
 	"Set up the pools for evaluations in the receiver"
 	self evaluationPools: {}.
 	self newVariablePool.
@@ -1147,6 +1145,12 @@ replaceSelection: aString
 	
 	^self view replaceSelection: aString!
 
+resolveIdentifier: aString ifDefined: aMonadicValuable
+	(self workspacePool bindingFor: aString) ifNotNil: [:var | ^aMonadicValuable value: var value].
+	^(self evaluationContext class indexOfInstVar: aString ifAbsent: [])
+		ifNil: [(self selfClass fullBindingFor: aString) ifNotNil: [:var | aMonadicValuable value: var value]]
+		ifNotNil: [:i | aMonadicValuable value: (self evaluationContext instVarAt: i)]!
+
 searchEnvironment
 	^searchEnvironment ifNil: [self systemModel systemEnvironment]!
 
@@ -1400,22 +1404,15 @@ showSymbolCompletionListAt: posInteger maxItems: maxInteger
 	self showCompletionList: symbols prefixLength: prefixLength!
 
 showTipForIdentifier: anStIdentifierToken
-	| context name |
-	context := self evaluationContext.
+	| name |
 	name := anStIdentifierToken value.
-	
-	[(context basicClass compilerClass
-		evaluate: name
-		for: context
-		evaluationPools: self allPools)
-			ifNotNil: 
-				[:result |
-				| tip |
-				tip := result debugPrintString.
-				"Don't display the tip if it contains no useful information"
-				tip = name ifFalse: [self view showCallTip: result debugPrintString at: anStIdentifierToken stop]]]
-			on: Compiler notificationClass
-			do: [:ex | ]!
+	self resolveIdentifier: name
+		ifDefined: 
+			[:result |
+			| tip |
+			tip := [result debugPrintString] on: Error do: [:ex | name].
+			"Don't display the tip if it contains no useful information"
+			tip = name ifFalse: [self view showCallTip: tip at: anStIdentifierToken stop]]!
 
 showTipForIndicators: aCollectionOfScintillaIndicators
 	| tip last |
@@ -1637,6 +1634,7 @@ wrapLinesInRange: anInterval indent: anInteger
 !SmalltalkWorkspace categoriesFor: #reformatComment!commands!public! !
 !SmalltalkWorkspace categoriesFor: #reformatSource!commands!public! !
 !SmalltalkWorkspace categoriesFor: #replaceSelection:!operations!public! !
+!SmalltalkWorkspace categoriesFor: #resolveIdentifier:ifDefined:!autocompletion!helpers!private! !
 !SmalltalkWorkspace categoriesFor: #searchEnvironment!commands!public! !
 !SmalltalkWorkspace categoriesFor: #searchEnvironment:!accessing!public! !
 !SmalltalkWorkspace categoriesFor: #selectedWord!helpers!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspaceDocument.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspaceDocument.cls
@@ -534,7 +534,7 @@ initialize
 	self wordWrap: true.
 	self canUseIdeaSpace: true.
 	self defaultExtent: 640 @ 480.
-	self variableTips: false.
+	self variableTips: true.
 	LanguageExtensions := (LookupTable new)
 				at: 'txt' put: #text;
 				at: 'xml' put: #xml;


### PR DESCRIPTION
The variables are now looked up by name in whatever context is available
to the workspace.

Data tips (aka "variable tips") are also enabled by default in all
workspaces. These are less useful in non-debugger workspaces as most
variables do not have static values, but it will show the values of
workspace variables, globals, class variables, and pool variables/
constants.