### PR TITLE
Fix deprecated method call

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Base/ColorRef.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ColorRef.cls
@@ -84,7 +84,7 @@ stbReadFrom: anSTBInFiler format: anSTBClassConversion
 			anSTBInFiler stream skip: 4].
 	"Make a placeholder for the Color"
 	ref := anSTBInFiler register: nil.
-	answer := self fromInteger: anSTBInFiler basicNext.
+	answer := self fromCOLORREF: anSTBInFiler basicNext.
 	anSTBInFiler fixup: ref to: answer.
 	^answer! !
 !ColorRef class categoriesFor: #defaultColorRepresentation!constants!private! !


### PR DESCRIPTION
I saw a deprecation warning in the Transcript when running some tests and this change resolved it.