### PR TITLE
Fix #828: Dolphin7.exe fails to start due to ucrtbase.dll error bug

### DIFF
--- a/Core/DolphinVM/GC.cpp
+++ b/Core/DolphinVM/GC.cpp
@@ -187,6 +187,10 @@ void ObjectMemory::reclaimInaccessibleObjects(DWORD gcFlags)
 					else
 						nMaxUnmarked = nMaxUnmarked << 1;
 					pUnmarked = static_cast<OTE**>(realloc(pUnmarked, nMaxUnmarked*sizeof(OTE*)));
+					if (pUnmarked == nullptr)
+					{
+						::RaiseException(E_OUTOFMEMORY, EXCEPTION_NONCONTINUABLE, 0, nullptr);
+					}
 				}
 				pUnmarked[nUnmarked++] = ote;
 

--- a/Core/DolphinVM/IntPrim.cpp
+++ b/Core/DolphinVM/IntPrim.cpp
@@ -672,7 +672,7 @@ Oop* __fastcall Interpreter::primitiveSmallIntegerAt(Oop* const sp, unsigned)
 		SMALLINTEGER value = abs(ObjectMemoryIntegerValueOf(*(sp - 1)));
 		if (index > 0 && index <= 4)
 		{
-			uint8_t byte = value >> (index - 1) * 8;
+			uint8_t byte = (value >> (index - 1) * 8) & 0xff;
 			*(sp - 1) = ObjectMemoryIntegerObjectOf(byte);
 			return sp - 1;
 		}

--- a/Core/DolphinVM/Launcher/dull.cpp
+++ b/Core/DolphinVM/Launcher/dull.cpp
@@ -165,7 +165,10 @@ static HRESULT __stdcall StartDevSys(HINSTANCE hInstance, HINSTANCE hPrevInstanc
 int APIENTRY 
 wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nCmdShow)
 {
-	::CoInitialize(NULL);
+	HRESULT hr = ::CoInitialize(NULL);
+	if (FAILED(hr))
+		return hr;
+
  	int nRet = StartDevSys(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
 	::CoUninitialize();
 	return nRet;

--- a/Core/DolphinVM/PrimitiveFailureCode.h
+++ b/Core/DolphinVM/PrimitiveFailureCode.h
@@ -3,7 +3,7 @@
 #include <ntstatus.h>
 #include <winerror.h>
 
-typedef long NTSTATUS;
+typedef _Return_type_success_(return >= 0) SDWORD NTSTATUS;
 
 // Define a macro that packs an HRESULT. Then use these for the primitive failure codes. There is already image code to unpack
 #define PFC_FROM_HRESULT(hr) ((SMALLINTEGER)(((hr) & 0x7ffffff) << 1 | ((hr) & 0xf0000000) | 1))
@@ -14,7 +14,7 @@ typedef long NTSTATUS;
 // the use of the error out of its domain, but the message is relevant.
 // Some codes are commented out because they are not currently used.
 
-typedef enum _PrimitiveFailureCode : SMALLINTEGER 
+enum class _PrimitiveFailureCode : SMALLINTEGER 
 {
 	NoError = 0,
 	//AccessDenied = PFC_FROM_WIN32(ERROR_ACCESS_DENIED),								// Access is denied.
@@ -86,4 +86,4 @@ typedef enum _PrimitiveFailureCode : SMALLINTEGER
 	WrongNumberOfArgs = PFC_FROM_HRESULT(TYPE_E_OUTOFBOUNDS),						// Invalid number of arguments
 	DebugStep = PFC_FROM_NT(STATUS_SINGLE_STEP),									// A single step or trace operation has just been completed.
 
-} _PrimitiveFailureCode;
+};

--- a/Core/DolphinVM/Res/ist.rc2
+++ b/Core/DolphinVM/Res/ist.rc2
@@ -1,11 +1,11 @@
 //
 // IST.RC2 - resources Microsoft Visual C++ does not edit directly
 //
+#pragma code_page(65001)
 
 #ifdef APSTUDIO_INVOKED
 	#error this file is not editable by Microsoft Visual C++
 #endif //APSTUDIO_INVOKED
-
 
 /////////////////////////////////////////////////////////////////////////////
 // Add manually edited resources here...
@@ -36,7 +36,7 @@ BEGIN
             VALUE "FileDescription", "Dolphin Smalltalk Virtual Machine"
             VALUE "FileVersion", DOLPHIN_ASSEMBLY_VERSION
             VALUE "InternalName", "Dolphin"
-            VALUE "LegalCopyright", "Copyright © Object Arts Ltd 1997-2018."
+            VALUE "LegalCopyright", "Copyright Â© Object Arts Ltd 1997-2018."
             VALUE "OriginalFilename", "DolphinVM7.DLL"
             VALUE "PrivateBuild", "11192015"
             VALUE "ProductName", "Dolphin Smalltalk 7"

--- a/Core/DolphinVM/STString.h
+++ b/Core/DolphinVM/STString.h
@@ -79,13 +79,17 @@ namespace ST
 	public:
 		typedef TChar CU;
 		typedef const TChar * __restrict PCSZ;
-		static const UINT CodePage = CP;
 		static const size_t PointersIndex = I;
 
 		CU m_characters[1];		// Variable length array of data
 
 		typedef ByteStringT<CP, PointersIndex, OTE, TChar> MyType;
 		typedef OTE* POTE;
+
+		static unsigned int CodePage()
+		{
+			return CP == CP_ACP ? Interpreter::m_ansiCodePage : CP;
+		}
 
 		static POTE __fastcall New(size_t cch)
 		{
@@ -118,11 +122,11 @@ namespace ST
 		// Allocate a new String from a Unicode string
 		static POTE __fastcall New(LPCWSTR wsz)
 		{
-			int cch = ::WideCharToMultiByte(CP, 0, wsz, -1, nullptr, 0, nullptr, nullptr);
+			int cch = ::WideCharToMultiByte(CodePage(), 0, wsz, -1, nullptr, 0, nullptr, nullptr);
 			// Length includes null terminator since input is null terminated
 			OTE* stringPointer = reinterpret_cast<OTE*>(ObjectMemory::newUninitializedNullTermObject<MyType>((cch - 1)*sizeof(CU)));
 			CU* psz = stringPointer->m_location->m_characters;
-			int cch2 = ::WideCharToMultiByte(CP, 0, wsz, -1, reinterpret_cast<LPSTR>(psz), cch, nullptr, nullptr);
+			int cch2 = ::WideCharToMultiByte(CodePage(), 0, wsz, -1, reinterpret_cast<LPSTR>(psz), cch, nullptr, nullptr);
 			UNREFERENCED_PARAMETER(cch2);
 			ASSERT(cch2 == cch);
 			ASSERT(stringPointer->isNullTerminated());
@@ -131,12 +135,12 @@ namespace ST
 
 		static POTE __fastcall New(const char16_t* pwch, size_t cwch)
 		{
-			int cch = ::WideCharToMultiByte(CP, 0, (LPCWCH)pwch, cwch, nullptr, 0, nullptr, nullptr);
+			int cch = ::WideCharToMultiByte(CodePage(), 0, (LPCWCH)pwch, cwch, nullptr, 0, nullptr, nullptr);
 			// Length does not include null terminator
 			OTE* stringPointer = reinterpret_cast<OTE*>(ObjectMemory::newUninitializedNullTermObject<MyType>(cch*sizeof(CU)));
 			CU* psz = stringPointer->m_location->m_characters;
 			psz[cch] = '\0';
-			int cch2 = ::WideCharToMultiByte(CP, 0, (LPCWCH)pwch, cwch, reinterpret_cast<LPSTR>(psz), cch, nullptr, nullptr);
+			int cch2 = ::WideCharToMultiByte(CodePage(), 0, (LPCWCH)pwch, cwch, reinterpret_cast<LPSTR>(psz), cch, nullptr, nullptr);
 			UNREFERENCED_PARAMETER(cch2);
 			ASSERT(cch2 == cch);
 			ASSERT(stringPointer->isNullTerminated());

--- a/Core/DolphinVM/decode.cpp
+++ b/Core/DolphinVM/decode.cpp
@@ -549,11 +549,6 @@ void DumpStackEntry(Oop* sp, Process* pProc, wostream& stream)
 	}
 }
 
-// determine number of elements in an array (not bytes)
-#ifndef _countof
-#define _countof(array) (sizeof(array)/sizeof(array[0]))
-#endif
-
 /////////////////////////////////////////////////////////////////////////////
 // Formatted output
 

--- a/Core/DolphinVM/disassembler.h
+++ b/Core/DolphinVM/disassembler.h
@@ -703,7 +703,7 @@ public:
 		stream << L"Push " << std::dec << value;
 		if (byteSize > 0)
 		{
-			stream << L" (" << std::hex << L"0x" << setfill(L'0') << setw(byteSize * 2) << value << L')' << setfill(L' ');
+			stream << L" (" << std::hex << L"0x" << setfill(L'0') << setw(static_cast<streamsize>(byteSize) * 2) << value << L')' << setfill(L' ');
 		}
 	}
 };

--- a/Core/DolphinVM/extcall.cpp
+++ b/Core/DolphinVM/extcall.cpp
@@ -9,7 +9,6 @@
 
 ******************************************************************************/
 #include "Ist.h"
-typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 
 #pragma code_seg(FFI_SEG)
 
@@ -153,9 +152,9 @@ AddressOTE* __fastcall NewBSTR(OTE* ote)
 		switch (strClass->Encoding)
 		{
 		case StringEncoding::Ansi:
-			return NewBSTR<AnsiString::CodePage, AnsiString::CU>(reinterpret_cast<AnsiStringOTE*>(ote)->m_location->m_characters, ote->getSize());
+			return NewBSTR<CP_ACP, AnsiString::CU>(reinterpret_cast<AnsiStringOTE*>(ote)->m_location->m_characters, ote->getSize());
 		case StringEncoding::Utf8:
-			return NewBSTR<Utf8String::CodePage, Utf8String::CU>(reinterpret_cast<Utf8StringOTE*>(ote)->m_location->m_characters, ote->getSize());
+			return NewBSTR<CP_UTF8, Utf8String::CU>(reinterpret_cast<Utf8StringOTE*>(ote)->m_location->m_characters, ote->getSize());
 		case StringEncoding::Utf16:
 			return NewBSTR(reinterpret_cast<Utf16StringOTE*>(ote)->m_location->m_characters, ote->getSize() / sizeof(Utf16String::CU));
 		case StringEncoding::Utf32:

--- a/Core/DolphinVM/interfac.cpp
+++ b/Core/DolphinVM/interfac.cpp
@@ -868,6 +868,11 @@ void InitializeVtbl()
 	ASSERT(sizeof(VTblThunk) == 10);
 
 	aVtblThunks = static_cast<VTblThunk*>(::VirtualAlloc(NULL, NUMVTBLENTRIES*sizeof(VTblThunk), MEM_COMMIT, PAGE_READWRITE));
+	if (aVtblThunks == nullptr)
+	{
+		RaiseFatalError(IDP_OUTOFVIRTUALMEMORY, 0);
+		return;
+	}
 
 	for (unsigned i=0;i<NUMVTBLENTRIES;i++)
 	{

--- a/Core/DolphinVM/ist.h
+++ b/Core/DolphinVM/ist.h
@@ -87,7 +87,7 @@ typedef INT_PTR 	SMALLINTEGER;	// Optimized SmallInteger; same size as MWORD
 typedef MWORD		SMALLUNSIGNED;	// Unsigned optimized SmallInteger; same size as MWORD	
 typedef MWORD		Oop;
 
-typedef SDWORD		NTSTATUS;
+typedef _Return_type_success_(return >= 0) SDWORD NTSTATUS;
 
 // Define this is using a 16-bit word
 // as it conditionally compiles in MethodHeaderExtension which
@@ -127,6 +127,7 @@ extern CMonitor traceMonitor;
 
 LPCWSTR __stdcall GetErrorText(DWORD win32ErrorCode);
 LPCWSTR __stdcall GetLastErrorText();
+std::wstring GetResourceString(HMODULE hMod, int resId);
 int __cdecl DolphinMessageBox(int idPrompt, UINT flags, ...);
 void __cdecl trace(const wchar_t* szFormat, ...);
 void __cdecl trace(int nPrompt, ...);
@@ -175,5 +176,10 @@ HMODULE GetModuleContaining(LPCVOID pFunc);
 
 #if defined(_DEBUG)
 #include <crtdbg.h>
+#endif
+
+// determine number of elements in an array (not bytes)
+#ifndef _countof
+#define _countof(array) (sizeof(array)/sizeof(array[0]))
 #endif
 

--- a/Core/DolphinVM/istasm.inc
+++ b/Core/DolphinVM/istasm.inc
@@ -740,11 +740,11 @@ GetIPOffsetUsing MACRO tempRegister
 		mov		tempRegister, (OTE PTR[tempRegister]).m_location	;; Include the object header
 	.ENDIF
 	sub		_IP, tempRegister								;; Convert _IP to offset into object
-	IFDEF _DEBUG
-		.IF (_IP > 8192)
-			int	3											;; Probably a bug - _IP index very large
-		.ENDIF
-	ENDIF
+;	IFDEF _DEBUG
+;		.IF (_IP > 8192)
+;			int	3											;; Probably a bug - _IP index very large
+;		.ENDIF
+;	ENDIF
 ENDM
 
 PrimitiveFailureInvalidParameter1 EQU 0680000EFh

--- a/Core/DolphinVM/objmem.h
+++ b/Core/DolphinVM/objmem.h
@@ -730,16 +730,14 @@ inline Oop ObjectMemory::storePointerWithValue(Oop& oopSlot, OTE* oteValue)
 
 inline void ObjectMemory::nilOutPointer(Oop& objectPointer)
 {
-	Oop oldValue = objectPointer;
-	objectPointer = reinterpret_cast<Oop>(Pointers.Nil);
 	countDown(objectPointer);
+	objectPointer = reinterpret_cast<Oop>(Pointers.Nil);
 }
 
 inline void ObjectMemory::nilOutPointer(OTE*& ote)
 {
-	OTE* oldValue = ote;
-	ote = reinterpret_cast<OTE*>(Pointers.Nil);
 	ote->countDown();
+	ote = reinterpret_cast<OTE*>(Pointers.Nil);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/Core/DolphinVM/strgprim.cpp
+++ b/Core/DolphinVM/strgprim.cpp
@@ -581,7 +581,7 @@ Oop* __fastcall Interpreter::primitiveStringAtPut(Oop* const sp, unsigned)
 							{
 							case StringEncoding::Ansi:
 								// Non-ascii Ansi char into Utf16 string. Will always go.
-								psz[index] = m_ansiToUnicodeCharMap[codeUnit];
+								psz[index] = m_ansiToUnicodeCharMap[codeUnit & 0xFF];
 								*newSp = oopValue;
 								return newSp;
 
@@ -1072,10 +1072,11 @@ Utf16StringOTE* __fastcall Utf16String::New(const WCHAR* value, size_t cwch)
 template <UINT CP, class T> Utf16StringOTE * ST::Utf16String::New(const T* psz, size_t cch)
 {
 	// A UTF16 encoded string can never require more code units than a byte encoding (though it will usually require more bytes)
-	int cwch = ::MultiByteToWideChar(CP, 0, reinterpret_cast<LPCCH>(psz), cch, nullptr, 0);
+	const UINT cp = CP == CP_ACP ? Interpreter::m_ansiCodePage : CP;
+	int cwch = ::MultiByteToWideChar(cp, 0, reinterpret_cast<LPCCH>(psz), cch, nullptr, 0);
 	Utf16StringOTE* stringPointer = New(cwch);
 	Utf16String::CU* pwsz = stringPointer->m_location->m_characters;
-	int cwch2 = ::MultiByteToWideChar(CP, 0, reinterpret_cast<LPCCH>(psz), cch, (LPWSTR)pwsz, cwch);
+	int cwch2 = ::MultiByteToWideChar(cp, 0, reinterpret_cast<LPCCH>(psz), cch, (LPWSTR)pwsz, cwch);
 	pwsz[cwch] = L'\0';
 	return stringPointer;
 }

--- a/Core/DolphinVM/timer.cpp
+++ b/Core/DolphinVM/timer.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+ï»¿/******************************************************************************
 
 	File: Timer.cpp
 
@@ -242,7 +242,7 @@ HRESULT Interpreter::initializeTimer()
 {
 	if (::QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(&m_clockFrequency)) == 0)
 	{
-		// MSDN says this shouldn't happen: "On systems that run Windows XP or later, the function will always succeed and will thus never return zero."
+		// MSDN says this shouldn't happen: "On systems that run Windows XP or later, the function will always succeed and will thus never return zero."
 		return ReportWin32Error(IDP_NOHIRESCLOCK, ::GetLastError());
 	}
 

--- a/Core/DolphinVM/vm.rc
+++ b/Core/DolphinVM/vm.rc
@@ -1,5 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "rc_vm.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -17,7 +19,6 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
-#pragma code_page(1252)
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -40,7 +41,6 @@ END
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEUD)
 LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
-#pragma code_page(1252)
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -51,12 +51,6 @@ HSPLIT                  CURSOR                  "res\\hsplit.cur"
 
 VSPLIT                  CURSOR                  "res\\vsplit.cur"
 
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// Bitmap
-//
-
 #endif    // Neutral (Default) resources
 /////////////////////////////////////////////////////////////////////////////
 
@@ -66,7 +60,6 @@ VSPLIT                  CURSOR                  "res\\vsplit.cur"
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENG)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
-#pragma code_page(1252)
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -170,7 +163,7 @@ STRINGTABLE
 BEGIN
     IDP_FAILTOHOOK          "Unable to hook window creation events (%1!d!).%nPlease wait a few moments and try again."
     IDP_NOHIRESCLOCK        "Unable to establish high-resolution clock frequency (%!1d!: %2)"
-    IDP_UNSUPPORTED_ACP     "Unsupported code page %1!d!"
+    IDP_UNSUPPORTED_ACP     "Unsupported multi-byte ANSI code page %d, using 1252 instead"
 END
 
 STRINGTABLE

--- a/Core/DolphinVM/wingui.cpp
+++ b/Core/DolphinVM/wingui.cpp
@@ -173,11 +173,18 @@ LRESULT CALLBACK Interpreter::DolphinDlgProc(HWND /*hWnd*/, UINT /*uMsg*/, WPARA
 
 int __stdcall DolphinMessage(UINT flags, const wchar_t* msg)
 {
-	wchar_t szCaption[512];
 	HMODULE hExe = GetModuleHandle(NULL);
-	if (!::LoadStringW(hExe, IDS_APP_TITLE, szCaption, sizeof(szCaption)-1))
-		::GetModuleFileNameW(hExe, szCaption, sizeof(szCaption));
-	return  ::MessageBoxW(NULL, msg, szCaption, flags|MB_TASKMODAL);
+	std::wstring appTitle = GetResourceString(hExe, IDS_APP_TITLE);
+	if (!appTitle.empty())
+	{
+		return ::MessageBoxW(NULL, msg, appTitle.c_str(), flags | MB_TASKMODAL);
+	}
+	else
+	{
+		WCHAR filename[_MAX_PATH + 1];
+		GetModuleFileNameW(hExe, filename, _countof(filename));
+		return  ::MessageBoxW(NULL, msg, filename, flags | MB_TASKMODAL);
+	}
 }
 
 #pragma code_seg(INIT_SEG)


### PR DESCRIPTION
This was caused by an error in a trace message format string. It is on a
code path that would only be followed by the system default locale for
non-Unicode programs is associated with a multi-byte code page. Dolphin
does not support multi-byte ANSI code pages because its ANSI Strings are
fundamentally single-byte character strings. UTF8Strings are preferred for
international languages, with AnsiStrings only really existing for legacy
reasons. Ironically the limitation around multi-byte ACPs also applies to
the CP_UTF8 code page that Windows 10 finally supports (although only in
"beta") as a system code page (it has long been supported as a conversion
source/target by the MultibyteToWideChar/WideCharToMultibyte APIs).

The trace message is fixed, and also some places where the system code page
would be used rather than the one that the VM decides on during startup -
usually these are the same, but not if falling back on 1252 because the
system code page is multi-byte.

Also fixed a bunch of code analysis warnings from the in IDE parser of
VS2019.