### PR TITLE
Remove pool dictionary overrides not required with Symbol/String equality

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
@@ -16,7 +16,6 @@ package classNames
 	add: #ConformantStructureArrayField;
 	add: #ConformantStructureArrayPointerField;
 	add: #MEMORY_BASIC_INFORMATION;
-	add: #MethodContext;
 	add: #OSVERSIONINFO;
 	add: #STBSymbolProxy;
 	add: #SymbolStringSearchPolicy;
@@ -186,11 +185,6 @@ package!
 
 "Class Definitions"!
 
-Object variableSubclass: #MethodContext
-	instanceVariableNames: 'frame method receiver'
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
 ArrayField subclass: #ConformantArrayField
 	instanceVariableNames: ''
 	classVariableNames: ''

--- a/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Legacy Package Support.pax
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Legacy Package Support.pax
@@ -11,6 +11,10 @@ package basicPackageVersion: '6.1.1'.
 package basicScriptAt: #postinstall put: 'Package binaryPacLoader: [:package :stream | package loadLegacyPAC: stream]'.
 package basicScriptAt: #postuninstall put: 'Package binaryPacLoader: nil'.
 
+package classNames
+	add: #MethodContext;
+	yourself.
+
 package methodNames
 	add: #Package -> #basicLoadVersion4:filer:;
 	add: #Package -> #errorUnknownFileVersion:;
@@ -44,6 +48,11 @@ package!
 
 "Class Definitions"!
 
+Object variableSubclass: #MethodContext
+	instanceVariableNames: 'frame method receiver'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
 
 "Global Aliases"!
 

--- a/Core/Object Arts/Dolphin/Base/PoolConstantsDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/PoolConstantsDictionary.cls
@@ -69,17 +69,6 @@ fileOutName
 		path := File replacePath:  path with: package path ].
 	^path!
 
-findKeyOrNil: anObject 
-	"Private - Answer the index of the given key in the receiver, or, if not found,
-	the index of the first empty slot including and after that to which 
-	the key hashes."
-
-	"Implementation Note: By overriding this to convert the key to a string we
-	can avoid the need to override all the key lookup methods such as #at:ifAbsent:,
-	#includesKey:, etc ."
-
-	^super findKeyOrNil: anObject asString!
-
 isChanged
 	"Answer true if the receiver or any of it's contents have been changed since
 	their changed flag was last reset."
@@ -175,7 +164,6 @@ removeIndex: anInteger
 !PoolConstantsDictionary categoriesFor: #displayOn:!displaying!public! !
 !PoolConstantsDictionary categoriesFor: #environment!constants!public! !
 !PoolConstantsDictionary categoriesFor: #fileOutName!development!public!source filing! !
-!PoolConstantsDictionary categoriesFor: #findKeyOrNil:!private!searching! !
 !PoolConstantsDictionary categoriesFor: #isChanged!development!public!source filing!testing! !
 !PoolConstantsDictionary categoriesFor: #isChanged:!development!public!source filing! !
 !PoolConstantsDictionary categoriesFor: #isValidKey:!adding!development!private! !

--- a/Core/Object Arts/Dolphin/Base/PoolDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/PoolDictionary.cls
@@ -10,35 +10,11 @@ PoolDictionary comment: ''!
 !PoolDictionary categoriesForClass!Collections-Unordered!System-Support! !
 !PoolDictionary methodsFor!
 
-add: anAssociation
-	"Add anAssociation to the receiver. Answer anAssociation.
-	Although very similar to at:put:, we store the actual association passed
-	as an argument here in order to maintain its references.
-	The keys of associations stored in pool dictionaries must be strings."
-
-	(anAssociation key isString and: [anAssociation key isSymbol not])
-		ifFalse: [self error: 'Pools are keyed with Strings'].
-	^super add: anAssociation!
-
 associationClass
 	"Private - Answer the class of association to be used for holding
 	key-value pairs in the receiver. Must respond to the Association protocol."
 	
 	^VariableBinding!
-
-at: key ifAbsent: exceptionHandler
-	"Answer the value named by the argument, key.  If key is not found,
-	answer the result of evaluating the niladic valuable, exceptionHandler.
-	The keys of pools are Strings."
-
-	^super at: key asString ifAbsent: exceptionHandler
-!
-
-at: key put: anObject
-	"Store the argument anObject with the external key, aKey,
-	in the receiver. Answer anObject. Ensure the key is a String."
-
-	^super at: key asString put: anObject!
 
 displayOn: aStream
 	"Append, to aStream, a String whose characters are a representation of the receiver as a user
@@ -62,12 +38,6 @@ fileOutName
 	package notNil ifTrue: [
 		path := File replacePath:  path with: package path ].
 	^path!
-
-includesKey: key
-	"Answer whether the receiver has a key equal to the argument, key.
-	Override superclass to permit symbolic/string keys."
-
-	^super includesKey: key asString!
 
 initializerFor: aString 
 	"Answer a chunk reader to read and evaluate an initializer for the receiver's named variable"
@@ -117,11 +87,6 @@ isChanged: aBoolean
 				package isChanged: true]]
 		ifFalse: [self removePropertyAt: #isChanged ifAbsent: []]!
 
-lookup: keyObject
-	"Answer the value named by the <Object> argument, keyObject, or nil if there is no such key in the receiver."
-
-	^super lookup: keyObject asString!
-
 name
 	"Answer the receiver's name."
 
@@ -139,32 +104,18 @@ owningPackage
 owningPackage: aPackage
 	"Set the receiver's <Package> to be the argument. Any current package association is lost."
 
-	aPackage addGlobalNamed: self name!
-
-removeKey: key ifAbsent: exceptionHandler
-	"Remove the key (and its associated value), from the receiver. If key is
-	not in the receiver, answer the result of evaluating the niladic valuable,
-	exceptionHandler. Otherwise, answer the value named by key.
-	Override in order to accept Symbols/Strings."
-
-	^super removeKey: key asString ifAbsent: exceptionHandler! !
-!PoolDictionary categoriesFor: #add:!adding!development!public! !
+	aPackage addGlobalNamed: self name! !
 !PoolDictionary categoriesFor: #associationClass!constants!private! !
-!PoolDictionary categoriesFor: #at:ifAbsent:!accessing!public! !
-!PoolDictionary categoriesFor: #at:put:!accessing!public! !
 !PoolDictionary categoriesFor: #displayOn:!displaying!public! !
 !PoolDictionary categoriesFor: #environment!constants!public! !
 !PoolDictionary categoriesFor: #fileOutName!development!public!source filing! !
-!PoolDictionary categoriesFor: #includesKey:!public!searching! !
 !PoolDictionary categoriesFor: #initializerFor:!development!public!source filing-sif! !
 !PoolDictionary categoriesFor: #isChanged!development!public!source filing!testing! !
 !PoolDictionary categoriesFor: #isChanged:!development!public!source filing! !
-!PoolDictionary categoriesFor: #lookup:!accessing!public! !
 !PoolDictionary categoriesFor: #name!accessing!public! !
 !PoolDictionary categoriesFor: #name:!accessing!private! !
 !PoolDictionary categoriesFor: #owningPackage!development!public!source filing! !
 !PoolDictionary categoriesFor: #owningPackage:!accessing!development!public! !
-!PoolDictionary categoriesFor: #removeKey:ifAbsent:!public!removing! !
 
 !PoolDictionary class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/Symbol.cls
+++ b/Core/Object Arts/Dolphin/Base/Symbol.cls
@@ -33,17 +33,6 @@ argumentCount
 asString
 	"Answer a new <String> containing the characters of the receiver."
 
-	^self asUtf8String!
-
-asSymbol
-	"Answer the <symbol> containing the characters of the receiver
-	(i.e. the receiver, since <symbol>s are unique)."
-
-	^self!
-
-asUtf8String
-	"Answer a <UTF8String> containing the same character as the receiver."
-
 	| len string |
 	len := self size.
 	string := Utf8String new: len.
@@ -53,6 +42,12 @@ asUtf8String
 		to: len
 		startingAt: 1.
 	^string!
+
+asSymbol
+	"Answer the <symbol> containing the characters of the receiver
+	(i.e. the receiver, since <symbol>s are unique)."
+
+	^self!
 
 copyFrom: startInteger to: stopInteger
 	"Answer a new <sequencedReadableCollection> like the receiver containing those elements of
@@ -82,7 +77,7 @@ displayString
 	return self (for better performance), we must override back to a suitable
 	implementation for Symbols which does not include the hash prefix."
 
-	^self asUtf8String!
+	^self asString!
 
 forwardTo: anObject
 	"Send the <Object> argument the receiver as a niladic message,
@@ -120,7 +115,7 @@ keywords
 mutableCopy
 	"Answer a <sequencedReadableCollection> like the receiver, but which is a mutable copy with the same elements."
 
-	^self asUtf8String!
+	^self asString!
 
 numArgs
 	^self argumentCount!
@@ -173,7 +168,6 @@ stbSaveOn: anSTBOutFiler
 !Symbol categoriesFor: #argumentCount!accessing!public! !
 !Symbol categoriesFor: #asString!converting!public! !
 !Symbol categoriesFor: #asSymbol!converting!public! !
-!Symbol categoriesFor: #asUtf8String!converting!public! !
 !Symbol categoriesFor: #copyFrom:to:!copying!public! !
 !Symbol categoriesFor: #deepCopy!copying!public! !
 !Symbol categoriesFor: #displayString!printing!public! !

--- a/Core/Object Arts/Dolphin/Base/SystemDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/SystemDictionary.cls
@@ -57,24 +57,11 @@ allRoots
 	allRoots isNil ifTrue: [allRoots := Class allRoots].
 	^allRoots!
 
-associationAt: key ifAbsent: exceptionHandler
-	"Answer the association named by the argument, key. If key is not found,
-	answer the result of evaluating the niladic valuable, exceptionHandler."
-
-	^(self basicAt: (self findKeyOrNil: key asSymbol)) ifNil: [exceptionHandler value]!
-
 associationClass
 	"Private - Answer the class of association to be used for holding
 	key-value pairs in the receiver. Must respond to the Association protocol."
 	
 	^VariableBinding!
-
-at: key ifAbsent: exceptionHandler
-	"Answer the value named by the argument, key.  If key is not found,
-	answer the result of evaluating the niladic valuable, exceptionHandler.
-	The keys of pools are Strings."
-
-	^super at: key asSymbol ifAbsent: exceptionHandler!
 
 at: key put: anObject
 	"Store the argument anObject with the external key, aKey,
@@ -82,12 +69,6 @@ at: key put: anObject
 
 	key isEmpty ifTrue: [self error: 'Invalid global name'].
 	^super at: key asSymbol put: anObject!
-
-bindingFor: aString 
-	"Answer the association whose key is equal to the argument in
-	the receiver, or nil if the key is not present. Used by the Compiler."
-
-	^super bindingFor: aString asSymbol!
 
 classAdded: class
 	"Private - The new <Class>, class, has been added to the receiver.
@@ -130,12 +111,6 @@ getEvents
 
 	^events!
 
-includesKey: key
-	"Answer whether the receiver has a key equal to the argument, key.
-	Override superclass to permit symbolic/string keys."
-
-	^super includesKey: key asSymbol!
-
 isAtomic
 	"Answer whether or not the receiver is the single unique instance of its class that can
 	represents its value."
@@ -143,11 +118,6 @@ isAtomic
 	"There can only be one ProcessorScheduler instance."
 
 	^true!
-
-lookup: keyObject
-	"Answer the value named by the <Object> argument, keyObject, or nil if there is no such key in the receiver."
-
-	^super lookup: keyObject asSymbol!
 
 postResize: oldMe
 	"Private - This message is sent by the receiver when resizing, after the
@@ -182,17 +152,16 @@ removeKey: key ifAbsent: exceptionHandler
 	removed. Also #unitialize it if it directly implements #uninitialize and
 	is not a class (or alias for a class)."
 
-	| index element globalName |
-	globalName := key asSymbol.
-	index := self findKeyOrNil: globalName.
-	^(element := self basicAt: index) isNil 
+	| index element |
+	index := self findKeyOrNil: key.
+	^(element := self basicAt: index) isNil
 		ifTrue: [exceptionHandler value]
 		ifFalse: 
 			[| global isClass |
 			self removeIndex: index.
 			global := element value.
 			isClass := global class isMeta.
-			(isClass not or: [global name ~~ globalName]) 
+			(isClass not or: [global name ~= key])
 				ifTrue: 
 					[self trigger: #globalRemoved: with: element.
 					"Uninitialize any global which is not a class name alias"
@@ -225,20 +194,15 @@ triggerGlobalRenamed: anAssociation from: oldSymbol
 !SystemDictionary categoriesFor: #allBehaviorsDo:!enumerating!private! !
 !SystemDictionary categoriesFor: #allClasses!accessing!public! !
 !SystemDictionary categoriesFor: #allRoots!accessing!public! !
-!SystemDictionary categoriesFor: #associationAt:ifAbsent:!accessing!public! !
 !SystemDictionary categoriesFor: #associationClass!constants!private! !
-!SystemDictionary categoriesFor: #at:ifAbsent:!accessing!public! !
 !SystemDictionary categoriesFor: #at:put:!accessing!public! !
-!SystemDictionary categoriesFor: #bindingFor:!binding!public! !
 !SystemDictionary categoriesFor: #classAdded:!event handling!private! !
 !SystemDictionary categoriesFor: #classRemoved:!private!removing! !
 !SystemDictionary categoriesFor: #classUpdated:!event handling!private! !
 !SystemDictionary categoriesFor: #clearCachedClasses!accessing!private! !
 !SystemDictionary categoriesFor: #developmentSystem!accessing!public! !
 !SystemDictionary categoriesFor: #getEvents!events!private! !
-!SystemDictionary categoriesFor: #includesKey:!public!searching! !
 !SystemDictionary categoriesFor: #isAtomic!public!testing! !
-!SystemDictionary categoriesFor: #lookup:!accessing!public! !
 !SystemDictionary categoriesFor: #postResize:!adding!private! !
 !SystemDictionary categoriesFor: #removeClass:!class hierarchy-removing!private! !
 !SystemDictionary categoriesFor: #removeGlobalNamed:!operations!public! !


### PR DESCRIPTION
Now that a Symbol and a String (in any encoding) with the same sequence of characters compare as equal, a number of overrides in PoolDictionary, PoolConstantsDictionary and SystemDictionary are no longer required.