### PR TITLE
Fix for breaks in SSW embedded text edit views caused by Color changes

### DIFF
--- a/Core/Contributions/Solutions Software/EmbeddedMultilineTextEdit.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedMultilineTextEdit.cls
@@ -52,7 +52,7 @@ display: aValue in: aRectangle on: aCanvas forecolor: fColor backcolor: bColor e
 	| color myRect formatRect text displayRect commonFlags horzAlignmentFlag |
 
 	text := self typeconverter convertFromLeftToRight: aValue.
-	color := fColor.
+	color := fColor ifNil: [Color black].
 	(text isEmpty and: [self hasCueBanner]) ifTrue: 
 		[text := self cueBanner.
 		color := Color grayText].

--- a/Core/Contributions/Solutions Software/EmbeddedTextEdit.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedTextEdit.cls
@@ -62,7 +62,7 @@ display: aValue in: aRectangle on: aCanvas forecolor: fColor backcolor: bColor e
 
 	text := self typeconverter convertFromLeftToRight: aValue.
 
-	color := fColor.
+	color := fColor ifNil: [Color black].
 	(text isEmpty and: [self hasCueBanner]) ifTrue: 
 		[text := self cueBanner.
 		color := Color grayText].


### PR DESCRIPTION
It was possible to get away with passing nil to Canvas>>forecolor:
(or Canvas>>backcolor:) in the past, but this is now an error.
Previously the color argument was converted for passing to the underlying
Windows API call by sending it #asParameter, and the effect would have
been to pass RGB 0 (black) as the color. Therefore I've changed the code
to use Color black if nil is passed from higher layers as a foreground
colour.