### PR TITLE
Generalize support for working with Windows theme engine in Views

### DIFF
--- a/Core/Contributions/Solutions Software/EmbeddedCheckButton.cls
+++ b/Core/Contributions/Solutions Software/EmbeddedCheckButton.cls
@@ -260,10 +260,6 @@ textRectIn: aRectangle on: aCanvas iStateId: iStateId
 
 	^aRectangle insetBy: 0@((aRectangle height - formatRect height) // 2)!
 
-themePartName
-
-	^#BUTTON!
-
 totalExtent
 
 	^(self buttonExtent x + self textOffset x + self textExtent x)@(self buttonExtent y max: self textExtent y).
@@ -304,7 +300,6 @@ uStateFor: aValue enabled: aBoolean
 !EmbeddedCheckButton categoriesFor: #textExtent:!accessing!public! !
 !EmbeddedCheckButton categoriesFor: #textOffset!accessing!public! !
 !EmbeddedCheckButton categoriesFor: #textRectIn:on:iStateId:!drawing!private! !
-!EmbeddedCheckButton categoriesFor: #themePartName!accessing!public! !
 !EmbeddedCheckButton categoriesFor: #totalExtent!accessing!public! !
 !EmbeddedCheckButton categoriesFor: #uStateFor:enabled:!drawing!private! !
 

--- a/Core/Contributions/Solutions Software/SSW ListView Extensions.pax
+++ b/Core/Contributions/Solutions Software/SSW ListView Extensions.pax
@@ -28,7 +28,6 @@ package methodNames
 	add: #ListView -> #maxTipWidth:;
 	add: #ListView -> #rowPixelHeight;
 	add: #ListView -> #smallImageExtent;
-	add: #ListView -> #themePartName;
 	add: #ListView -> #vertScrollBy:;
 	add: #ListView -> #vertScrollPos;
 	add: #ListView -> #vertScrollPos:;
@@ -171,10 +170,6 @@ smallImageExtent
 
 	^Icon smallExtent!
 
-themePartName
-
-	^#LISTVIEW!
-
 vertScrollBy: anInteger
 
 	self sendMessage: LVM_SCROLL wParam: 0 lParam: anInteger!
@@ -206,7 +201,6 @@ vertScrollPos: anInteger
 !ListView categoriesFor: #maxTipWidth:!helpers!public! !
 !ListView categoriesFor: #rowPixelHeight!helpers!public! !
 !ListView categoriesFor: #smallImageExtent!accessing!private! !
-!ListView categoriesFor: #themePartName!constants!public! !
 !ListView categoriesFor: #vertScrollBy:!enquiries!public! !
 !ListView categoriesFor: #vertScrollPos!enquiries!public! !
 !ListView categoriesFor: #vertScrollPos:!enquiries!public! !

--- a/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
+++ b/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
@@ -23,12 +23,6 @@ package methodNames
 	add: #ComboBox -> #droppedWidth;
 	add: #ComboBox -> #droppedWidth:;
 	add: #ComboBox -> #hasCueBanner;
-	add: #ControlView -> #freeTheme;
-	add: #ControlView -> #hasTheme;
-	add: #ControlView -> #onViewDestroyed;
-	add: #ControlView -> #openTheme;
-	add: #ControlView -> #theme;
-	add: #ControlView -> #themePartName;
 	add: #Date -> #shortString;
 	add: #GDILibrary -> #getClipRgn:hrgn:;
 	add: #Icon -> #asSmallIcon;
@@ -41,7 +35,6 @@ package methodNames
 	add: #PushButton -> #alignment:;
 	add: #PushButton -> #isRightButton;
 	add: #PushButton -> #isRightButton:;
-	add: #PushButton -> #themePartName;
 	add: #PushButton -> #tipText;
 	add: #PushButton -> #tipText:;
 	add: #PushButton -> #ttnGetDispInfo:;
@@ -188,52 +181,6 @@ hasCueBanner
 !ComboBox categoriesFor: #droppedWidth:!hierarchy!public!sub views! !
 !ComboBox categoriesFor: #hasCueBanner!public!testing! !
 
-!ControlView methodsFor!
-
-freeTheme
-
-	self hasTheme ifTrue:
-		[ThemeLibrary default closeThemeData: self theme.
-		self removePropertyAt: #themeHandle]!
-
-hasTheme
-
-	^(self propertyAt: #themeHandle ifAbsent: [nil]) notNull!
-
-onViewDestroyed
-
-	self hasTheme ifTrue: [self freeTheme].
-
-	super onViewDestroyed!
-
-openTheme
-	^self themePartName
-		ifNotNil: 
-			[:themePartName |
-			self propertyAt: #themeHandle
-				put: (ThemeLibrary default openThemeData: self asParameter pszClassList: themePartName)]!
-
-theme
-
-	| theme |
-
-	theme := self propertyAt: #themeHandle ifAbsent: [nil].
-	^theme isNull 
-		ifTrue: [self openTheme. self propertyAt: #themeHandle ifAbsent: [nil]]
-		ifFalse: [theme]!
-
-themePartName
-
-	"Subclasses should override to enable theme support"
-
-	^nil! !
-!ControlView categoriesFor: #freeTheme!helpers!public! !
-!ControlView categoriesFor: #hasTheme!public!testing! !
-!ControlView categoriesFor: #onViewDestroyed!public!realizing/unrealizing! !
-!ControlView categoriesFor: #openTheme!helpers!public! !
-!ControlView categoriesFor: #theme!accessing!public! !
-!ControlView categoriesFor: #themePartName!constants!public! !
-
 !Date methodsFor!
 
 shortString
@@ -370,10 +317,6 @@ isRightButton: aBoolean
 
 	self baseStyleMask: BS_RIGHTBUTTON set: aBoolean!
 
-themePartName
-
-	^#BUTTON!
-
 tipText
 
 	^self propertyAt: #tipText ifAbsent: [nil]!
@@ -412,7 +355,6 @@ wmNotify: message wParam: wParam lParam: lParam
 !PushButton categoriesFor: #alignment:!accessing-styles!public! !
 !PushButton categoriesFor: #isRightButton!accessing-styles!public! !
 !PushButton categoriesFor: #isRightButton:!accessing-styles!public! !
-!PushButton categoriesFor: #themePartName!constants!public! !
 !PushButton categoriesFor: #tipText!accessing!public! !
 !PushButton categoriesFor: #tipText:!accessing!public! !
 !PushButton categoriesFor: #ttnGetDispInfo:!event handling-win32!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/CheckButton.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/CheckButton.cls
@@ -183,11 +183,15 @@ initialize
 				isImmutable: true;
 				yourself)!
 
+themePartName
+	^'BUTTON'!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realising the receiver."
 
 	^'BUTTON'! !
 !CheckButton class categoriesFor: #defaultModel!models!public! !
 !CheckButton class categoriesFor: #initialize!development!initializing!private! !
+!CheckButton class categoriesFor: #themePartName!accessing!public! !
 !CheckButton class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/CommandButton.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/CommandButton.cls
@@ -134,7 +134,11 @@ initialize
 				at: #ignore put: IDCONTINUE;
 				shrink;
 				isImmutable: true;
-				yourself)! !
+				yourself)!
+
+themePartName
+	^'BUTTON'! !
 !CommandButton class categoriesFor: #icon!constants!public! !
 !CommandButton class categoriesFor: #initialize!development!initializing!private! !
+!CommandButton class categoriesFor: #themePartName!constants!public!theming! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/DesktopView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DesktopView.cls
@@ -117,8 +117,10 @@ ensureSubView: aView rectangleVisible: aRectangle
 	is visible in the receiver if the parent has this level of control."
 !
 
-ensureSubViewVisible: aSubView
-	aSubView zOrderTop!
+ensureSubViewVisible: aShellView
+	"Sending #ensureVisible to a ShellView that is a direct child of the desktop is expected to bring it to the top of the z-order."
+
+	aShellView zOrderTop!
 
 ensureVisible
 	"Ensures that the receiver is visible. 

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -534,7 +534,7 @@ Object subclass: #View
 	instanceVariableNames: 'handle creationParent creationStyle presenter model backcolor preferredExtent flags contextMenu font events interactor'
 	classVariableNames: 'CreateCenteredMask DragSourceMask DropTargetMask LayoutValidMask ManagedMask MessageMap MinimizedMask NextId NoInheritMenuMask StateRestoringMask UIValidMask UsePreferredExtentMask ViewClosedError WndClassAtom'
 	poolDictionaries: 'Win32Constants Win32Errors'
-	classInstanceVariableNames: ''!
+	classInstanceVariableNames: 'theme'!
 Object subclass: #ViewState
 	instanceVariableNames: 'view state placement subViewStates'
 	classVariableNames: ''
@@ -707,7 +707,7 @@ ExternalLibrary subclass: #HTMLHelpLibrary
 	classInstanceVariableNames: ''!
 ExternalLibrary subclass: #ThemeLibrary
 	instanceVariableNames: ''
-	classVariableNames: ''
+	classVariableNames: 'IsAppThemed'
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!
 PermanentLibrary subclass: #GDILibrary

--- a/Core/Object Arts/Dolphin/MVP/Base/GroupBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/GroupBox.cls
@@ -75,6 +75,9 @@ resource_Static_group_box
 
 	^#(#'!!STL' 4 788558 10 ##(Smalltalk.STBViewProxy) ##(Smalltalk.GroupBox) 34 14 nil nil 34 2 8 1140850695 65 416 nil 327686 ##(Smalltalk.Color) #transparent nil 7 nil nil nil 416 nil 8 1903885040 983302 ##(Smalltalk.MessageSequence) 138 144 34 2 721670 ##(Smalltalk.MessageSend) #createAt:extent: 34 2 328198 ##(Smalltalk.Point) 3839 21 642 299 201 416 594 #text: 34 1 8 'Text here' 416 983302 ##(Smalltalk.WINDOWPLACEMENT) 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 127 7 0 0 10 0 0 0 20 8 0 0 110 0 0 0] 8 #() 642 193 193 nil 27 )!
 
+themePartName
+	^'BUTTON'!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realizing the receiver.
 	Why Microsoft chose to make the GroupBox a button is a mystery beyond possible
@@ -84,5 +87,6 @@ winClassName
 !GroupBox class categoriesFor: #icon!constants!public! !
 !GroupBox class categoriesFor: #resource_Default_view!public!resources-views! !
 !GroupBox class categoriesFor: #resource_Static_group_box!public!resources-views! !
+!GroupBox class categoriesFor: #themePartName!constants!public!theming! !
 !GroupBox class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/ThemeConstants.st
+++ b/Core/Object Arts/Dolphin/MVP/Base/ThemeConstants.st
@@ -206,7 +206,12 @@ ThemeConstants at: 'LIS_HOT' put: 16r2!
 ThemeConstants at: 'LIS_NORMAL' put: 16r1!
 ThemeConstants at: 'LIS_SELECTED' put: 16r3!
 ThemeConstants at: 'LIS_SELECTEDNOTFOCUS' put: 16r5!
+ThemeConstants at: 'LVEB_HOVER' put: 16r2!
+ThemeConstants at: 'LVEB_NORMAL' put: 16r1!
+ThemeConstants at: 'LVEB_PUSHED' put: 16r3!
+ThemeConstants at: 'LVP_COLLAPSEBUTTON' put: 16r9!
 ThemeConstants at: 'LVP_EMPTYTEXT' put: 16r5!
+ThemeConstants at: 'LVP_EXPANDBUTTON' put: 16r8!
 ThemeConstants at: 'LVP_LISTDETAIL' put: 16r3!
 ThemeConstants at: 'LVP_LISTGROUP' put: 16r2!
 ThemeConstants at: 'LVP_LISTITEM' put: 16r1!

--- a/Core/Object Arts/Dolphin/MVP/Base/ThemeLibrary.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ThemeLibrary.cls
@@ -2,7 +2,7 @@
 
 ExternalLibrary subclass: #ThemeLibrary
 	instanceVariableNames: ''
-	classVariableNames: ''
+	classVariableNames: 'IsAppThemed'
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!
 ThemeLibrary guid: (GUID fromString: '{fb91df3f-4cb4-48a2-adee-a75b9a4d30a2}')!
@@ -1043,6 +1043,9 @@ fileName
 	^'UXTHEME'
 !
 
+isAppThemed
+	^IsAppThemed!
+
 new
 	^(SystemMetrics current hasThemes 
 		ifTrue: [SystemMetrics current hasEnhancedThemes ifTrue: [VistaThemeLibrary] ifFalse: [self]]
@@ -1051,8 +1054,10 @@ new
 onStartup2
 	"Private - Perform session startup processing for the receiver and its subclasses."
 
-	default := nil! !
+	default := nil.
+	IsAppThemed := self default isThemeActive and: [default isAppThemed]! !
 !ThemeLibrary class categoriesFor: #fileName!**auto generated**!constants!public! !
+!ThemeLibrary class categoriesFor: #isAppThemed!private!testing! !
 !ThemeLibrary class categoriesFor: #new!instance creation!public! !
 !ThemeLibrary class categoriesFor: #onStartup2!event handling!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -4,7 +4,7 @@ Object subclass: #View
 	instanceVariableNames: 'handle creationParent creationStyle presenter model backcolor preferredExtent flags contextMenu font events interactor'
 	classVariableNames: 'CreateCenteredMask DragSourceMask DropTargetMask LayoutValidMask ManagedMask MessageMap MinimizedMask NextId NoInheritMenuMask StateRestoringMask UIValidMask UsePreferredExtentMask ViewClosedError WndClassAtom'
 	poolDictionaries: 'Win32Constants Win32Errors'
-	classInstanceVariableNames: ''!
+	classInstanceVariableNames: 'theme'!
 View guid: (GUID fromString: '{87b4c4cc-026e-11d3-9fd7-00a0cc3e4a32}')!
 View addClassConstant: 'CreateCenteredMask' value: 16r40!
 View addClassConstant: 'DragSourceMask' value: 16r4!
@@ -1104,8 +1104,8 @@ ensureSubViewVisible: aSubView
 	!
 
 ensureVisible
-	"Ensures that the receiver is visible in it's parent if the parent has
-	this level of control"
+	"Ensures that the receiver is visible in it's parent if the parent has this level of control.
+	Note that this is not expected to bring the containing shell window to the top of the z-order."
 
 	self parentView ensureSubViewVisible: self
 
@@ -1362,9 +1362,10 @@ frameWidths
 	^self class frameWidths: self baseStyle!
 
 freeTheme
-	"Private - Override point to free any theme related resources"
-
-	!
+	"Private - Override point to free any theme related resources. Additional action is not generally required but may be needed if the instance:
+		- holds theme handles or resource
+		- caches theme metrics or colours that would be wrong if the Windows theme is changed by the user."
+!
 
 getDC
 	"Answer a device context to enable drawing on the receiver."
@@ -1991,7 +1992,7 @@ isTabStop: aBoolean
 !
 
 isThemed
-	^ThemeLibrary default isThemeActive and: [ThemeLibrary default isAppThemed]!
+	^self theme notNull!
 
 isTopView
 	"Answer whether the receiver is child of the Desktop."
@@ -2643,9 +2644,7 @@ onZOrderChanged
 !
 
 openTheme
-	"Private - Override point to allocate any theme related resources and query theme metrics"
-
-	!
+	"Generally the theme handle is common to the class and is opened lazily on demand. Generally no instance specific action is required."!
 
 parentPresenter
 	"Answer the presenter that can be considered the parent of the receiver.
@@ -3535,6 +3534,9 @@ textLength
 
 	^UserLibrary default getWindowTextLength: handle!
 
+theme
+	^self class theme!
+
 themeSubAppName
 	"Answer the theme class name to use for the view, or nil to use the default."
 
@@ -3732,6 +3734,7 @@ winFinalize
 	nil the handle at this stage because it may be required to complete processing of the
 	destroy message that caused this finalization."
 
+	self freeTheme.
 	self isStateRestoring ifFalse: [self release].
 	SessionManager inputState removeWindowAt: handle!
 
@@ -4333,12 +4336,12 @@ wmSysKeyUp: message wParam: wParam lParam: lParam
 				wParam: wParam
 				lParam: lParam)!
 
-wmThemeChanged: message wParam: wParam lParam: lParam 
+wmThemeChanged: message wParam: wParam lParam: lParam
 	"Private - Default handler for a WM_THEMECHANGED message from Windows."
 
-	self
-		freeTheme;
-		openTheme.
+	self freeTheme.
+	self class freeTheme.
+	self openTheme.
 	"Let the control see the theme change event too, otherwise it will not change style"
 	^nil!
 
@@ -4611,7 +4614,7 @@ zOrderTop
 !View categoriesFor: #forecolorChanged!private!updating! !
 !View categoriesFor: #frameChanged!helpers!private! !
 !View categoriesFor: #frameWidths!accessing!public! !
-!View categoriesFor: #freeTheme!helpers!private! !
+!View categoriesFor: #freeTheme!private!theming! !
 !View categoriesFor: #getDC!accessing!public! !
 !View categoriesFor: #getEvents!events!private! !
 !View categoriesFor: #getFileLocator!accessing!private! !
@@ -4793,7 +4796,7 @@ zOrderTop
 !View categoriesFor: #onXButtonPressed:!event handling!public! !
 !View categoriesFor: #onXButtonReleased:!event handling!public! !
 !View categoriesFor: #onZOrderChanged!event handling!public! !
-!View categoriesFor: #openTheme!helpers!private! !
+!View categoriesFor: #openTheme!private!theming! !
 !View categoriesFor: #parentPresenter!presenter!public! !
 !View categoriesFor: #parentView!hierarchy!public! !
 !View categoriesFor: #parentView:!hierarchy!private! !
@@ -4886,6 +4889,7 @@ zOrderTop
 !View categoriesFor: #text!accessing!public! !
 !View categoriesFor: #text:!accessing!public! !
 !View categoriesFor: #textLength!accessing!private! !
+!View categoriesFor: #theme!public!theming! !
 !View categoriesFor: #themeSubAppName!constants!private! !
 !View categoriesFor: #toolTipWindow!accessing!private! !
 !View categoriesFor: #toolTipWindow:!accessing!not an aspect!private! !
@@ -5227,6 +5231,10 @@ frameWidths: anInteger
 				ifTrue: [SystemMetrics current sizingFrameExtent]
 				ifFalse: [(anInteger allMask: WS_BORDER) ifTrue: [SystemMetrics current borderExtent] ifFalse: [0 @ 0]]]!
 
+freeTheme
+	theme notNull ifTrue: [ThemeLibrary default closeThemeData: theme].
+	theme := nil!
+
 fromHandle: aHandle 
 	"Answers a <View> that has a handle of aHandle (an Integer or
 	ExternalHandle). This method answers a View whether or not
@@ -5304,6 +5312,7 @@ new
 onExit
 	"Clean up the residue on Dolphin exit."
 
+	self allSubclassesDo: [:c | c freeTheme].
 	ThemeLibrary default onExit.
 	self destroyAll.	"Destroy rather than close as more forcible and avoids save prompts"
 	self unregisterClass!
@@ -5312,7 +5321,9 @@ onStartup
 	"Perform post startup processing to initialize the View system"
 
 	WndClassAtom := nil.
-	self allSubclassesDo: [:c | (c class includesSelector: #onStartup) ifTrue: [c onStartup]].
+	self allSubclassesDo: [:c | 
+		c resetTheme.
+		(c class includesSelector: #onStartup) ifTrue: [c onStartup]].
 
 	"Load the Common Control Library."
 	CommCtrlLibrary openDefault.
@@ -5325,6 +5336,11 @@ onStartup
 		fsModifiers: MOD_CONTROL
 		vk: VK_CANCEL.
 	ThemeLibrary default onStartup!
+
+openTheme
+	^(self themePartName isNil or: [ThemeLibrary isAppThemed not])
+		ifTrue: [##(ExternalHandle new)]
+		ifFalse: [ThemeLibrary default openThemeData: nil pszClassList: self themePartName asUtf16String]!
 
 registerClass
 	"Private - Register the receivers corresponding Win32 class - answer the class atom.
@@ -5365,6 +5381,9 @@ reregisterClass
 		unregisterClass;
 		registerClass
 !
+
+resetTheme
+	theme := nil!
 
 resource_Default_view
 	"Answer the literal data from which the 'Default view' resource can be reconstituted.
@@ -5519,6 +5538,15 @@ stbVersion
 
 	^13!
 
+theme
+	^theme ifNil: [theme := self openTheme]!
+
+themePartName
+	"Answer the <string> name of the Windows theme part that might be used for rendering this view."
+
+	^nil
+	!
+
 topLevelViews
 	"Answer a Collection containing all top level Dolphin Views.
 	Note that this will include Views which are not Shells (e.g. tool tips)."
@@ -5616,6 +5644,7 @@ wndClassName
 !View class categoriesFor: #foreground!accessing!public! !
 !View class categoriesFor: #foregroundHandle!accessing!private! !
 !View class categoriesFor: #frameWidths:!constants!public! !
+!View class categoriesFor: #freeTheme!private!theming! !
 !View class categoriesFor: #fromHandle:!instance creation!public! !
 !View class categoriesFor: #fromPoint:!instance creation!private! !
 !View class categoriesFor: #icon!constants!public! !
@@ -5624,11 +5653,13 @@ wndClassName
 !View class categoriesFor: #new!instance creation!public! !
 !View class categoriesFor: #onExit!event handling!public! !
 !View class categoriesFor: #onStartup!event handling!public! !
+!View class categoriesFor: #openTheme!private!theming! !
 !View class categoriesFor: #registerClass!operations!private! !
 !View class categoriesFor: #registerMessage:!dispatching!public! !
 !View class categoriesFor: #registerMessageMappings:!class initialization!public! !
 !View class categoriesFor: #releaseCapture!operations!public! !
 !View class categoriesFor: #reregisterClass!operations!private! !
+!View class categoriesFor: #resetTheme!private!theming! !
 !View class categoriesFor: #resource_Default_view!public!resources-views! !
 !View class categoriesFor: #selectorForMessage:!dispatching!private! !
 !View class categoriesFor: #show!instance creation!public! !
@@ -5648,6 +5679,8 @@ wndClassName
 !View class categoriesFor: #stbConvertFromVersion9:!binary filing!private! !
 !View class categoriesFor: #stbConvertProxy:!binary filing!public! !
 !View class categoriesFor: #stbVersion!binary filing!public! !
+!View class categoriesFor: #theme!public!theming! !
+!View class categoriesFor: #themePartName!constants!public!theming! !
 !View class categoriesFor: #topLevelViews!accessing!public! !
 !View class categoriesFor: #uninitialize!class hierarchy-removing!private! !
 !View class categoriesFor: #unregisterClass!operations!private! !

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Progress/ProgressBar.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Progress/ProgressBar.cls
@@ -164,6 +164,9 @@ initialize
 
 	ValidRange := 0 to: 65535!
 
+themePartName
+	^'PROGRESS'!
+
 validRange
 	"Private - Answer an Interval delimiting the valid range for the 
 	receiver's win common control."
@@ -178,6 +181,7 @@ winClassName
 !ProgressBar class categoriesFor: #defaultModel!models!public! !
 !ProgressBar class categoriesFor: #icon!constants!public! !
 !ProgressBar class categoriesFor: #initialize!development!initializing!private! !
+!ProgressBar class categoriesFor: #themePartName!constants!private! !
 !ProgressBar class categoriesFor: #validRange!constants!private! !
 !ProgressBar class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ComboBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ComboBox.cls
@@ -386,6 +386,10 @@ initialize
 
 	self addClassConstant: 'Modes' value: #(#simple #dropDown #dropDownList)!
 
+themePartName
+	^#ComboBox
+!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realizing the receiver."
 
@@ -393,5 +397,6 @@ winClassName
 ! !
 !ComboBox class categoriesFor: #icon!constants!public! !
 !ComboBox class categoriesFor: #initialize!development!initializing!private! !
+!ComboBox class categoriesFor: #themePartName!constants!private! !
 !ComboBox class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
@@ -563,6 +563,10 @@ listboxMessageMappings
 selectionModes
 	^SelectionModes!
 
+themePartName
+	^#ListBox
+!
+
 uninitialize
 	self unregisterMessageMappings: {WM_BEGINDRAG}!
 
@@ -574,6 +578,7 @@ winClassName
 !ListBox class categoriesFor: #initialize!development!initializing!private! !
 !ListBox class categoriesFor: #listboxMessageMappings!constants!must not strip!private! !
 !ListBox class categoriesFor: #selectionModes!constants!public! !
+!ListBox class categoriesFor: #themePartName!constants!private! !
 !ListBox class categoriesFor: #uninitialize!class hierarchy-removing!private! !
 !ListBox class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/TextEdit.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/TextEdit.cls
@@ -1464,6 +1464,10 @@ onStartup
 	FindDialogMessage := self registerMessage: 'commdlg_FindReplace'
 !
 
+themePartName
+	^'EDIT'
+!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realizing the receiver."
 
@@ -1472,5 +1476,6 @@ winClassName
 !TextEdit class categoriesFor: #icon!constants!public! !
 !TextEdit class categoriesFor: #initialize!development!initializing!private! !
 !TextEdit class categoriesFor: #onStartup!event handling!public! !
+!TextEdit class categoriesFor: #themePartName!constants!private!theming! !
 !TextEdit class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
@@ -212,7 +212,7 @@ ListControlView subclass: #IconicListAbstract
 	classInstanceVariableNames: ''!
 IconicListAbstract subclass: #ListView
 	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent moreParams'
-	classVariableNames: 'LvModes NoImageIndex RevertSelMessage UnknownItem'
+	classVariableNames: 'LvModes NoImageIndex RevertSelMessage SelectionStateMask UnknownItem'
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!
 IconicListAbstract subclass: #TabView
@@ -226,7 +226,7 @@ IconicListAbstract subclass: #TreeView
 	poolDictionaries: 'TreeViewConstants'
 	classInstanceVariableNames: ''!
 TabView subclass: #TabViewXP
-	instanceVariableNames: 'theme lastSelection _tvxReserved1 _tvxReserved2 _tvxReserved3'
+	instanceVariableNames: '_tvxReserved0 lastSelection _tvxReserved1 _tvxReserved2 _tvxReserved3'
 	classVariableNames: ''
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TabViewXP.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TabViewXP.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 TabView subclass: #TabViewXP
-	instanceVariableNames: 'theme lastSelection _tvxReserved1 _tvxReserved2 _tvxReserved3'
+	instanceVariableNames: '_tvxReserved0 lastSelection _tvxReserved1 _tvxReserved2 _tvxReserved3'
 	classVariableNames: ''
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!
@@ -26,16 +26,8 @@ createVerticalFont
 	lf lfEscapement: (self isInverted ifTrue: [2700] ifFalse: [900]).
 	^Font fromLogFont: lf!
 
-freeTheme
-	theme notNull ifFalse: [^self].
-	ThemeLibrary default closeThemeData: theme.
-	theme := nil!
-
 imageTextGap
 	^6!
-
-isThemed
-	^theme notNull!
 
 onEraseRequired: aColorEvent 
 	"Private - Handler for erase background event - allow the control to take care of this, unless
@@ -130,17 +122,9 @@ onSelectionChanging: aSelectionChangingEvent
 	lastSelection := self getSingleSelection.
 	super onSelectionChanging: aSelectionChangingEvent!
 
-onViewCreated
-	self openTheme.
-	super onViewCreated!
-
 onViewDestroyed
 	super onViewDestroyed.
 	self freeTheme!
-
-openTheme
-	theme := super isThemed
-				ifTrue: [ThemeLibrary default openThemeData: handle pszClassList: 'TAB']!
 
 paintLabel: anInteger on: aCanvas in: aRectangle 
 	| inverted rcItem textExtent labelRect textOffset text tcItem imageIndex |
@@ -213,7 +197,7 @@ paintTabLabelsOn: aCanvas
 paintThemedBackgroundOn: aCanvas in: aRectangle 
 	| bkColor |
 	ThemeLibrary default 
-		drawThemeBackground: theme
+		drawThemeBackground: self theme
 		hdc: aCanvas asParameter
 		iPartId: TABP_PANE
 		iStateId: 0
@@ -226,7 +210,7 @@ paintThemedBackgroundOn: aCanvas in: aRectangle
 			aCanvas fillRectangle: (aCanvas clipBox subtract: aRectangle) color: bkColor]!
 
 paintThemedTabsOn: aCanvas offset: aMonadicValuable
-	| selected hot numItems themeLib dc part rcItem |
+	| selected hot numItems themeLib dc part rcItem hTheme |
 	numItems := self itemCount.
 	numItems <= 0 ifTrue: [^self].
 	"Paint all the tabs except for the selected one (assuming there is one; in very unusual circumstances there may not be)"
@@ -234,10 +218,11 @@ paintThemedTabsOn: aCanvas offset: aMonadicValuable
 	selected := self getSingleSelection.
 	themeLib := ThemeLibrary default.
 	dc := aCanvas asParameter.
+	hTheme := self theme.
 	selected == 1
 		ifFalse: 
 			[themeLib
-				drawThemeBackground: theme
+				drawThemeBackground: hTheme
 				hdc: dc
 				iPartId: TABP_TABITEMLEFTEDGE
 				iStateId: (1 == hot ifTrue: [TIS_HOT] ifFalse: [TIS_NORMAL])
@@ -247,7 +232,7 @@ paintThemedTabsOn: aCanvas offset: aMonadicValuable
 		do: 
 			[:i |
 			themeLib
-				drawThemeBackground: theme
+				drawThemeBackground: hTheme
 				hdc: dc
 				iPartId: TABP_TABITEM
 				iStateId: (i == hot ifTrue: [TIS_HOT] ifFalse: [TIS_NORMAL])
@@ -257,7 +242,7 @@ paintThemedTabsOn: aCanvas offset: aMonadicValuable
 		do: 
 			[:i |
 			themeLib
-				drawThemeBackground: theme
+				drawThemeBackground: hTheme
 				hdc: dc
 				iPartId: TABP_TABITEM
 				iStateId: (i == hot ifTrue: [TIS_HOT] ifFalse: [TIS_NORMAL])
@@ -268,7 +253,7 @@ paintThemedTabsOn: aCanvas offset: aMonadicValuable
 			[| anInteger |
 			anInteger := TABP_TABITEMRIGHTEDGE.
 			themeLib
-				drawThemeBackground: theme
+				drawThemeBackground: hTheme
 				hdc: dc
 				iPartId: anInteger
 				iStateId: (numItems == hot ifTrue: [TIS_HOT] ifFalse: [TIS_NORMAL])
@@ -289,7 +274,7 @@ paintThemedTabsOn: aCanvas offset: aMonadicValuable
 					"selected == numItems ifTrue: [TABP_TABITEMRIGHTEDGE] ifFalse: [TABP_TABITEM]"
 					TABP_TABITEM].
 	themeLib
-		drawThemeBackground: theme
+		drawThemeBackground: hTheme
 		hdc: dc
 		iPartId: part
 		iStateId: TIS_SELECTED
@@ -373,9 +358,6 @@ selExtra
 supportsThemedVertical
 	^true!
 
-themeHandle
-	^theme!
-
 wmPaint: message wParam: wParam lParam: lParam
 	"Private - This window requires painting. By default we use the internal painting
 	 dispatch."
@@ -410,16 +392,12 @@ wmPrintClient: message wParam: wParam lParam: lParam
 						paintStruct: nil)]! !
 !TabViewXP categoriesFor: #calcClientRectangleFromRectangle:!geometry!private! !
 !TabViewXP categoriesFor: #createVerticalFont!event handling!private! !
-!TabViewXP categoriesFor: #freeTheme!helpers!private! !
 !TabViewXP categoriesFor: #imageTextGap!constants!private! !
-!TabViewXP categoriesFor: #isThemed!private!testing! !
 !TabViewXP categoriesFor: #onEraseRequired:!event handling!private! !
 !TabViewXP categoriesFor: #onPaintRequired:!event handling!private! !
 !TabViewXP categoriesFor: #onSelChanged:!event handling!private! !
 !TabViewXP categoriesFor: #onSelectionChanging:!event handling!private! !
-!TabViewXP categoriesFor: #onViewCreated!event handling!private! !
 !TabViewXP categoriesFor: #onViewDestroyed!event handling!private! !
-!TabViewXP categoriesFor: #openTheme!helpers!private! !
 !TabViewXP categoriesFor: #paintLabel:on:in:!painting!private! !
 !TabViewXP categoriesFor: #paintTabLabelsOn:!event handling!private! !
 !TabViewXP categoriesFor: #paintThemedBackgroundOn:in:!painting!private! !
@@ -428,7 +406,12 @@ wmPrintClient: message wParam: wParam lParam: lParam
 !TabViewXP categoriesFor: #paintVerticalTabLabelsOn:!event handling!private! !
 !TabViewXP categoriesFor: #selExtra!constants!private! !
 !TabViewXP categoriesFor: #supportsThemedVertical!constants!private! !
-!TabViewXP categoriesFor: #themeHandle!accessing!private! !
 !TabViewXP categoriesFor: #wmPaint:wParam:lParam:!event handling-win32!private! !
 !TabViewXP categoriesFor: #wmPrintClient:wParam:lParam:!event handling-win32!private! !
+
+!TabViewXP class methodsFor!
+
+themePartName
+	^'TAB'! !
+!TabViewXP class categoriesFor: #themePartName!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TreeView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TreeView.cls
@@ -1370,6 +1370,10 @@ stbConvertFromVersion10: anArray
 	newArray at: size + 1 put: 0.
 	^newArray!
 
+themePartName
+
+	^#TreeView!
+
 updateModes
 	^UpdateModes!
 
@@ -1381,6 +1385,7 @@ winClassName
 !TreeView class categoriesFor: #icon!constants!public! !
 !TreeView class categoriesFor: #initialize!development!initializing!private! !
 !TreeView class categoriesFor: #stbConvertFromVersion10:!binary filing!private! !
+!TreeView class categoriesFor: #themePartName!constants!public! !
 !TreeView class categoriesFor: #updateModes!accessing!private! !
 !TreeView class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBar.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBar.cls
@@ -404,11 +404,16 @@ resource_Status_bar
 
 	^#(#'!!STL' 4 788558 10 ##(Smalltalk.STBViewProxy) ##(Smalltalk.StatusBar) 34 18 nil nil 34 2 8 1409288460 1 416 nil 327686 ##(Smalltalk.Color) #default nil 5 nil 263174 ##(Smalltalk.Font) nil true 459014 ##(Smalltalk.LOGFONT) 8 #[243 255 255 255 0 0 0 0 0 0 0 0 0 0 0 0 144 1 0 0 0 0 0 0 3 2 1 34 65 114 105 97 108 0 159 4 0 134 63 1 0 0 204 53 63 1 2 0 20 59 0 0 0 0 247 0 5 86 111 1] 328198 ##(Smalltalk.Point) 193 193 nil 416 nil 8 1903688272 170 192 8 #() 34 1 853766 ##(Smalltalk.StatusBarItem) 1 -1 416 nil 459270 ##(Smalltalk.Message) #displayString 8 #() 722 #iconImageIndex 8 #() nil 1115142 ##(Smalltalk.StatusBarNullItem) 513 1 416 nil nil 983302 ##(Smalltalk.MessageSequence) 138 144 34 1 721670 ##(Smalltalk.MessageSend) #createAt:extent: 34 2 594 3839 21 594 701 45 416 983302 ##(Smalltalk.WINDOWPLACEMENT) 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 127 7 0 0 10 0 0 0 221 8 0 0 32 0 0 0] 8 #() 594 193 193 nil 27 )!
 
+themePartName
+	^'STATUS'
+!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realizing the receiver."
 
 	^'msctls_statusbar32'! !
 !StatusBar class categoriesFor: #icon!constants!public! !
 !StatusBar class categoriesFor: #resource_Status_bar!public!resources-views! !
+!StatusBar class categoriesFor: #themePartName!constants!private! !
 !StatusBar class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Toolbar.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Toolbar.cls
@@ -1266,6 +1266,10 @@ stbConvertFromVersion12: anArray
 	(anArray at: 6) = Color face3d ifTrue: [anArray at: 6 put: Color default].
 	^super stbConvertFromVersion12: anArray!
 
+themePartName
+	^#Toolbar
+!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realizing the receiver."
 
@@ -1279,5 +1283,6 @@ winClassName
 !Toolbar class categoriesFor: #resource_History_tools!public!resources-views! !
 !Toolbar class categoriesFor: #resource_Tool_bar!public!resources-views! !
 !Toolbar class categoriesFor: #stbConvertFromVersion12:!binary filing!private! !
+!Toolbar class categoriesFor: #themePartName!constants!private! !
 !Toolbar class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Date Time/DateTimePicker.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Date Time/DateTimePicker.cls
@@ -216,10 +216,14 @@ defaultModel
 
 	^Date today asValue!
 
+themePartName
+	^'DATEPICKER'!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realizing the receiver."
 
 	^'SysDateTimePick32'! !
 !DateTimePicker class categoriesFor: #defaultModel!models!public! !
+!DateTimePicker class categoriesFor: #themePartName!constants!private!theming! !
 !DateTimePicker class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/MoenTree/Dolphin MoenTree View.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/MoenTree/Dolphin MoenTree View.pax
@@ -54,7 +54,7 @@ Link subclass: #MoenLink
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 View subclass: #MoenTreeView
-	instanceVariableNames: 'anchorNode getTextBlock getImageBlock mtvFlags leading imageManager calculatedExtent parentSpacing selection linePen iconExtent maxTextExtent dtFlags margin textInset theme _mtvReserved1 _mtvReserved2'
+	instanceVariableNames: 'anchorNode getTextBlock getImageBlock mtvFlags leading imageManager calculatedExtent parentSpacing selection linePen iconExtent maxTextExtent dtFlags margin textInset _mtvReserved0 _mtvReserved1 _mtvReserved2'
 	classVariableNames: 'AutoExpandingMask HasButtonsMask MultilineMask SingleLineMask ViewModes'
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/Views/MoenTree/MoenTreeView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/MoenTree/MoenTreeView.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 View subclass: #MoenTreeView
-	instanceVariableNames: 'anchorNode getTextBlock getImageBlock mtvFlags leading imageManager calculatedExtent parentSpacing selection linePen iconExtent maxTextExtent dtFlags margin textInset theme _mtvReserved1 _mtvReserved2'
+	instanceVariableNames: 'anchorNode getTextBlock getImageBlock mtvFlags leading imageManager calculatedExtent parentSpacing selection linePen iconExtent maxTextExtent dtFlags margin textInset _mtvReserved0 _mtvReserved1 _mtvReserved2'
 	classVariableNames: 'AutoExpandingMask HasButtonsMask MultilineMask SingleLineMask ViewModes'
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!
@@ -468,12 +468,6 @@ fontChanged
 
 	self invalidateGeometry!
 
-freeTheme
-	theme notNull 
-		ifTrue: 
-			[ThemeLibrary default closeThemeData: theme.
-			theme := nil]!
-
 generateAbsolutes
 	"Private - Generate the absolute positions of each tree and the preferred view extent.
 	Also cache clip rectangles which enclose a node and all its sub-nodes."
@@ -726,9 +720,6 @@ isAutoExpanding
 
 isAutoExpanding: aBoolean
 	mtvFlags := mtvFlags mask: AutoExpandingMask set: aBoolean!
-
-isThemed
-	^theme notNull!
 
 itemFromPoint: aPoint 
 	"Private - Answer the node of the receiver under the <Point> argument or nil if none."
@@ -1330,24 +1321,6 @@ onTreeChanged: anObjectOrNil
 	anObjectOrNil isNil ifTrue: [ ^self refreshContents].
 	self onItemUpdated: anObjectOrNil; collapse: anObjectOrNil !
 
-onViewCreated
-	"The receiver has just been fully created. This is a suitable place to perform initialization
-	of the window from the receiver's instance variables. Note that this message is sent via
-	a WM_PARENTNOTIFY Windows message to the Window's parent, and thus will not be 
-	available for views that use the WS_EXNOPARENTNOTIFY extended style, or which are 
-	created as immediate children of the desktop or any other Windows not subclassed by Dolphin."
-
-	self openTheme!
-
-onViewDestroyed
-	"Handler for view final view destruction."
-
-	self freeTheme!
-
-openTheme
-	theme := super isThemed
-				ifTrue: [ThemeLibrary default openThemeData: handle pszClassList: #TreeView]!
-
 paint: aMoenTreeNode on: aCanvas fromPoint: aPoint 
 	"Private - Paint the tree object onto the canvas together with all its children."
 
@@ -1437,7 +1410,7 @@ paintNode: aMoenTreeNode on: aCanvas
 
 paintThemeButton: aRectangle on: aCanvas isExpanded: aBoolean 
 	ThemeLibrary default 
-		drawThemeBackground: theme
+		drawThemeBackground: self theme
 		hdc: aCanvas asParameter
 		iPartId: TVP_GLYPH
 		iStateId: (aBoolean ifTrue: [GLPS_OPENED] ifFalse: [GLPS_CLOSED])
@@ -1843,7 +1816,6 @@ zip: aMoenTreeNode
 !MoenTreeView categoriesFor: #expandSubtree:!operations!private! !
 !MoenTreeView categoriesFor: #findNodeForObject:!private!searching! !
 !MoenTreeView categoriesFor: #fontChanged!private!updating! !
-!MoenTreeView categoriesFor: #freeTheme!helpers!private! !
 !MoenTreeView categoriesFor: #generateAbsolutes!geometry!private! !
 !MoenTreeView categoriesFor: #generateNodeClipRects!private!tree layout! !
 !MoenTreeView categoriesFor: #generatePosition:absolute:!geometry!private! !
@@ -1874,7 +1846,6 @@ zip: aMoenTreeNode
 !MoenTreeView categoriesFor: #invalidateTree:imagesOnly:!painting!private! !
 !MoenTreeView categoriesFor: #isAutoExpanding!accessing-styles!public!testing! !
 !MoenTreeView categoriesFor: #isAutoExpanding:!accessing!public! !
-!MoenTreeView categoriesFor: #isThemed!private!testing! !
 !MoenTreeView categoriesFor: #itemFromPoint:!helpers!private! !
 !MoenTreeView categoriesFor: #join:!private!tree layout! !
 !MoenTreeView categoriesFor: #layoutLeaf:!private!tree layout! !
@@ -1919,9 +1890,6 @@ zip: aMoenTreeNode
 !MoenTreeView categoriesFor: #onSelectionChanged!event handling!public! !
 !MoenTreeView categoriesFor: #onSelectionChanging:!event handling!public! !
 !MoenTreeView categoriesFor: #onTreeChanged:!event handling!public! !
-!MoenTreeView categoriesFor: #onViewCreated!event handling!public! !
-!MoenTreeView categoriesFor: #onViewDestroyed!event handling!public! !
-!MoenTreeView categoriesFor: #openTheme!helpers!private! !
 !MoenTreeView categoriesFor: #paint:on:fromPoint:!painting!private! !
 !MoenTreeView categoriesFor: #paintButton:on:isExpanded:!painting!private! !
 !MoenTreeView categoriesFor: #paintClassicButton:on:isExpanded:!painting!private! !
@@ -2041,6 +2009,9 @@ stbConvertFromVersion9: anArray
 		at: 16 put: AutoExpandingMask;
 		yourself!
 
+themePartName
+	^#TreeView!
+
 value: anObject
 	"Private - Implement this message from the monadic valuable to support the default
 	'get image' functionality for an iconic list.  By default we assume icons can be used
@@ -2060,6 +2031,7 @@ viewModes
 !MoenTreeView class categoriesFor: #stbConvertFromVersion10:!binary filing!private! !
 !MoenTreeView class categoriesFor: #stbConvertFromVersion11:!binary filing!private! !
 !MoenTreeView class categoriesFor: #stbConvertFromVersion9:!binary filing!private! !
+!MoenTreeView class categoriesFor: #themePartName!constants!public!theming! !
 !MoenTreeView class categoriesFor: #value:!evaluating!private! !
 !MoenTreeView class categoriesFor: #viewModes!constants!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Scrollbars/ScrollBar.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scrollbars/ScrollBar.cls
@@ -220,6 +220,9 @@ icon
 
 	^##(self) defaultIcon!
 
+themePartName
+	^#ScrollBar!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realizing the receiver."
 
@@ -229,5 +232,6 @@ winClassName
 !ScrollBar class categoriesFor: #defaultModel!models!public! !
 !ScrollBar class categoriesFor: #defaultWidth!constants!public! !
 !ScrollBar class categoriesFor: #icon!constants!public! !
+!ScrollBar class categoriesFor: #themePartName!constants!private! !
 !ScrollBar class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Slider/Slider.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Slider/Slider.cls
@@ -483,6 +483,9 @@ stbConvertFromVersion9: anArray
 
 	^(super stbConvertFromVersion9: anArray) , #(1 nil nil)!
 
+themePartName
+	^'TRACKBAR'!
+
 winClassName
 	"Answer the name of the Windows window class to use when realizing the receiver."
 
@@ -491,5 +494,6 @@ winClassName
 !Slider class categoriesFor: #icon!constants!public! !
 !Slider class categoriesFor: #initialize!development!initializing!private! !
 !Slider class categoriesFor: #stbConvertFromVersion9:!binary filing!private! !
+!Slider class categoriesFor: #themePartName!constants!private! !
 !Slider class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/Dolphin Slidey-Inney-Outey Thing.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/Dolphin Slidey-Inney-Outey Thing.pax
@@ -42,7 +42,7 @@ ContainerView subclass: #SlideyInneyOuteyThing
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!
 CardContainer subclass: #SlidingCardTray
-	instanceVariableNames: 'theme slider pinSize pinInteractor _sctReserved1 _sctReserved2'
+	instanceVariableNames: '_sctReserved0 slider pinSize pinInteractor _sctReserved1 _sctReserved2'
 	classVariableNames: 'PinImageList'
 	poolDictionaries: 'TabViewConstants ThemeConstants'
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/SlidingCardTray.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/SlidingCardTray.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 CardContainer subclass: #SlidingCardTray
-	instanceVariableNames: 'theme slider pinSize pinInteractor _sctReserved1 _sctReserved2'
+	instanceVariableNames: '_sctReserved0 slider pinSize pinInteractor _sctReserved1 _sctReserved2'
 	classVariableNames: 'PinImageList'
 	poolDictionaries: 'TabViewConstants ThemeConstants'
 	classInstanceVariableNames: ''!
@@ -38,11 +38,6 @@ captionGeometryChanged
 
 edgeExtent
 	^2 @ 2!
-
-freeTheme
-	theme notNull ifFalse: [^self].
-	ThemeLibrary default closeThemeData: theme.
-	theme := nil!
 
 headerBackgroundPart
 	^EBP_HEADERBACKGROUND!
@@ -85,9 +80,6 @@ isPinPressed
 
 isResizable
 	^slider notNil and: [slider isTrayResizable]!
-
-isThemed
-	^theme notNull!
 
 onLeftButtonPressed: aMouseEvent 
 	| hit |
@@ -146,16 +138,6 @@ onResize
 							bottom: rect bottom)].
 	self captionGeometryChanged!
 
-onViewCreated
-	"Private - The receiver has just been fully created. This is a suitable place to perform initialization
-	of the window from the receiver's instance variables. Note that this message is sent via
-	a WM_PARENTNOTIFY Windows message to the Window's parent, and thus will not be 
-	available for views that use the WS_EXNOPARENTNOTIFY extended style, or which are 
-	created as immediate children of the desktop or any other Windows not subclassed by Dolphin."
-
-	super onViewCreated.
-	self openTheme!
-
 onViewDestroyed
 	"Private - Handler for view final view destruction."
 
@@ -163,13 +145,11 @@ onViewDestroyed
 	self freeTheme!
 
 openTheme
-	theme := super isThemed
-				ifTrue: [ThemeLibrary default openThemeData: handle pszClassList: 'EXPLORERBAR'].
 	pinSize := SystemMetrics current smallIconExtent asParameter.
-	theme isNull
-		ifFalse: 
+	self isThemed
+		ifTrue: 
 			[ThemeLibrary default
-				getThemePartSize: theme
+				getThemePartSize: self theme
 				hdc: nil
 				iPartId: EBP_HEADERPIN
 				iStateId: EBHP_NORMAL
@@ -209,7 +189,7 @@ paintEdgesOn: aCanvas
 
 paintThemedBackgroundOn: aCanvas 
 	ThemeLibrary default 
-		drawThemeBackground: theme
+		drawThemeBackground: self theme
 		hdc: aCanvas asParameter
 		iPartId: self headerBackgroundPart
 		iStateId: 0
@@ -219,7 +199,7 @@ paintThemedBackgroundOn: aCanvas
 paintThemedEdgesOn: aCanvas 
 	self isPinned ifTrue: [^nil].
 	ThemeLibrary default 
-		drawThemeBackground: tabs themeHandle
+		drawThemeBackground: tabs theme
 		hdc: aCanvas asParameter
 		iPartId: TABP_PANE
 		iStateId: 0
@@ -232,7 +212,7 @@ paintThemedOn: aCanvas
 
 paintThemedPinOn: aCanvas 
 	ThemeLibrary default 
-		drawThemeBackground: theme
+		drawThemeBackground: self theme
 		hdc: aCanvas asParameter
 		iPartId: EBP_HEADERPIN
 		iStateId: self pinStateId
@@ -280,7 +260,6 @@ pinStateId
 setSlider: aSlideyInneyOuteyThing 
 	slider := aSlideyInneyOuteyThing.
 	tabs := slider tabs.
-	self openTheme.
 	pinInteractor := (ButtonInteractor forPresenter: self)
 				buttonRectangle: self pinRectangle;
 				commandDescription: (CommandDescription command: #togglePin description: 'Pin or Unpin the tray');
@@ -372,7 +351,6 @@ wmPrint: message wParam: wParam lParam: lParam
 !SlidingCardTray categoriesFor: #calculateExtent:!geometry!private! !
 !SlidingCardTray categoriesFor: #captionGeometryChanged!event handling!private! !
 !SlidingCardTray categoriesFor: #edgeExtent!constants!private! !
-!SlidingCardTray categoriesFor: #freeTheme!helpers!private! !
 !SlidingCardTray categoriesFor: #headerBackgroundPart!constants!private! !
 !SlidingCardTray categoriesFor: #headerHeight!constants!private! !
 !SlidingCardTray categoriesFor: #headerRectangle!painting!private! !
@@ -382,13 +360,11 @@ wmPrint: message wParam: wParam lParam: lParam
 !SlidingCardTray categoriesFor: #isPinned!private!testing! !
 !SlidingCardTray categoriesFor: #isPinPressed!private!testing! !
 !SlidingCardTray categoriesFor: #isResizable!private!testing! !
-!SlidingCardTray categoriesFor: #isThemed!private!testing! !
 !SlidingCardTray categoriesFor: #onLeftButtonPressed:!event handling!private! !
 !SlidingCardTray categoriesFor: #onMouseMoved:!event handling!private! !
 !SlidingCardTray categoriesFor: #onPaintRequired:!event handling!private! !
 !SlidingCardTray categoriesFor: #onPositionChanged:!event handling!private! !
 !SlidingCardTray categoriesFor: #onResize!helpers!private! !
-!SlidingCardTray categoriesFor: #onViewCreated!event handling!private! !
 !SlidingCardTray categoriesFor: #onViewDestroyed!event handling!private! !
 !SlidingCardTray categoriesFor: #openTheme!helpers!private! !
 !SlidingCardTray categoriesFor: #paintClassicBackgroundOn:!painting!private! !
@@ -417,6 +393,10 @@ wmPrint: message wParam: wParam lParam: lParam
 !SlidingCardTray class methodsFor!
 
 initialize
-	PinImageList := nil! !
+	PinImageList := nil!
+
+themePartName
+	^'EXPLORERBAR'! !
 !SlidingCardTray class categoriesFor: #initialize!initializing!private! !
+!SlidingCardTray class categoriesFor: #themePartName!constants!public!theming! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/SpinButton/SpinButton.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/SpinButton/SpinButton.cls
@@ -386,6 +386,9 @@ initialize
 				isImmutable: true;
 				yourself)!
 
+themePartName
+	^'SPIN'!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realizing the receiver."
 
@@ -393,5 +396,6 @@ winClassName
 !SpinButton class categoriesFor: #defaultModel!models!public! !
 !SpinButton class categoriesFor: #icon!constants!public! !
 !SpinButton class categoriesFor: #initialize!development!initializing!private! !
+!SpinButton class categoriesFor: #themePartName!constants!private! !
 !SpinButton class categoriesFor: #winClassName!constants!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Tooltips/ToolTip.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Tooltips/ToolTip.cls
@@ -375,11 +375,16 @@ icon
 
 	^##(self) defaultIcon!
 
+themePartName
+	^#Tooltip
+!
+
 winClassName
 	"Private - Answer the name of the Windows window class to use when realizing the receiver."
 
 	^'tooltips_class32'
 ! !
 !Tooltip class categoriesFor: #icon!constants!public! !
+!Tooltip class categoriesFor: #themePartName!constants!private! !
 !Tooltip class categoriesFor: #winClassName!constants!private! !
 


### PR DESCRIPTION
Move theme handle management up to View class, subsuming the SSW extensions
to ControlView to provide access to a theme handle for the part associated
with the class of view.