### PR TITLE
primitiveAllReferences does not work correctly for objects only on stack

### DIFF
--- a/Core/DolphinVM/objmem.cpp
+++ b/Core/DolphinVM/objmem.cpp
@@ -460,11 +460,7 @@ ArrayOTE* __stdcall ObjectMemory::referencesTo(Oop referencedObjectPointer, bool
 {
 	WeaknessMask = includeWeakRefs ? 0 : OTEFlags::WeakMask;
 
-	unsigned size;
-	if (!isIntegerObject(referencedObjectPointer))
-		size = reinterpret_cast<OTE*>(referencedObjectPointer)->m_count;
-	else
-		size = 32;
+	unsigned size = !isIntegerObject(referencedObjectPointer) ? max(reinterpret_cast<OTE*>(referencedObjectPointer)->m_count, 1) : 32;
 
 	ArrayOTE* arrayPointer = Array::New(size);
 	Array* pRefs = arrayPointer->m_location;

--- a/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
@@ -368,6 +368,26 @@ suspendAndTerminate
 
 	"2) Ditto, but resumed and so allowed to complete"!
 
+testAllReferences
+	| object refs weak |
+	object := Array new: 1.
+	refs := object allReferences.
+	self assert: refs equals: {Processor activeProcess}.
+	object at: 1 put: object.
+	refs := object allReferences.
+	self assert: (refs noDifference: {Processor activeProcess. object})!
+
+testAllReferencesWeak
+	| object refs weak |
+	object := Object new.
+	weak := WeakArray with: object.
+	refs := object allReferences.
+	self assert: (refs noDifference: {Processor activeProcess. weak}).
+	refs := object allReferences: false.
+	self assert: (refs noDifference: {Processor activeProcess}).
+
+!
+
 testBSTRArg
 	"#1377 - Make sure there is no problem in the VM's automatic conversion of a string to a BSTR.
 	In an unpatched VM this typically crashes the whole system."
@@ -3165,6 +3185,8 @@ verifyPrimitiveNextPutAllOnUtfStrings: method
 !VMTest categoriesFor: #isFault:raisedIn:receiver:!helpers!private! !
 !VMTest categoriesFor: #isGPF:reading:address:!helpers!private! !
 !VMTest categoriesFor: #suspendAndTerminate!helpers!private! !
+!VMTest categoriesFor: #testAllReferences!public!unit tests! !
+!VMTest categoriesFor: #testAllReferencesWeak!public! !
 !VMTest categoriesFor: #testBSTRArg!public!unit tests! !
 !VMTest categoriesFor: #testCRTFault!public!unit tests! !
 !VMTest categoriesFor: #testDwordAtOffsetPut!public!unit tests! !


### PR DESCRIPTION
primitiveAllReferences fails for newly created objects that are
referenced only from a stack temporary (or other stack slot).