### PR TITLE
Fix #852: CodeMentor reports undeclared variables for all pool constants

### DIFF
--- a/Core/DolphinVM/Compiler/compiler.cpp
+++ b/Core/DolphinVM/Compiler/compiler.cpp
@@ -641,10 +641,18 @@ void Compiler::GenPushStaticConstant(POTE oteStatic, const TEXTRANGE& range)
 {
 	STVariableBinding& var = *(STVariableBinding*)GetObj(oteStatic);
 	Oop literal = var.value;
-	if (!GenPushImmediate(literal, range))
+	if (GenPushImmediate(literal, range))
 	{
-		// If it doesn't have an immediate form, may as well push the variable binding as this is better for ref searches in the IDE
-		// and means we don't need to recompile if the value changes.
+		// We still want the variable added to the literal frame so that it can be used to accurately
+		// identify references to the constant.
+		AddToFrame(reinterpret_cast<Oop>(oteStatic), range);
+	}
+	else
+	{
+		// If it doesn't have an immediate form, may as well push just the variable binding:
+		// - there is little perf difference in the indirection 
+		// - we need the variable for accurate reference searches, so storing just it saves the space required to 
+		// store references to both variable and value
 		GenStatic(oteStatic, range);
 	}
 }

--- a/Core/DolphinVM/Interprt.h
+++ b/Core/DolphinVM/Interprt.h
@@ -15,6 +15,7 @@
 #include "STExternal.h"
 #include "STBehavior.h"
 #include "STClassDesc.h"
+#include "STBlockClosure.h"
 #include "InterpRegisters.h"
 
 #include "DolphinX.h"

--- a/Core/DolphinVM/Interprt.inl
+++ b/Core/DolphinVM/Interprt.inl
@@ -13,7 +13,6 @@
 	#error You'll need to include interprt.h
 #endif
 
-#include "STString.h"
 #include "STExternal.h"
 #include "STFloat.h"
 #include "STInteger.h"

--- a/Core/DolphinVM/STBlockClosure.h
+++ b/Core/DolphinVM/STBlockClosure.h
@@ -18,6 +18,12 @@
 
 namespace ST
 {
+	class BlockClosure;
+};
+typedef TOTE<ST::BlockClosure> BlockOTE;
+
+namespace ST
+{
 	#include "STBlockInfo.h"
 
 	class BlockClosure : public Object

--- a/Core/DolphinVM/STCharacter.h
+++ b/Core/DolphinVM/STCharacter.h
@@ -14,7 +14,6 @@
 #pragma once
 
 #include "STMagnitude.h"
-#include "STString.h"
 
 namespace ST { class Character; }
 typedef TOTE<ST::Character> CharOTE;

--- a/Core/DolphinVM/STMethod.h
+++ b/Core/DolphinVM/STMethod.h
@@ -14,7 +14,14 @@
 #pragma once
 
 #include "STObject.h"
+#include "STBehavior.h"
 #include "DolphinSmalltalk_i.h"
+
+#ifdef VM
+#include "STString.h"
+#else
+typedef OTE SymbolOTE;
+#endif
 
 // Turn off warning about zero length arrays
 #pragma warning ( disable : 4200)

--- a/Core/DolphinVM/STObject.h
+++ b/Core/DolphinVM/STObject.h
@@ -55,6 +55,14 @@ namespace ST
 	public:
 		Oop				m_fields[];
 	};
+
+	enum class StringEncoding
+	{
+		Ansi,
+		Utf8,
+		Utf16,
+		Utf32
+	};
 }
 
 typedef ST::Object* POBJECT;

--- a/Core/DolphinVM/STString.h
+++ b/Core/DolphinVM/STString.h
@@ -55,14 +55,6 @@ public:
 
 namespace ST
 {
-	enum class StringEncoding
-	{
-		Ansi,
-		Utf8,
-		Utf16,
-		Utf32
-	};
-
 	class String : public ArrayedCollection
 	{
 	public:

--- a/Core/DolphinVM/dolphin.targets
+++ b/Core/DolphinVM/dolphin.targets
@@ -48,10 +48,6 @@
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir);$(SolutionDir);$(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
-    <Midl>
-      <TargetEnvironment>Win32</TargetEnvironment>
-      <GenerateStublessProxies>true</GenerateStublessProxies>
-    </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
       <StringPooling>true</StringPooling>

--- a/Core/DolphinVM/objmem.h
+++ b/Core/DolphinVM/objmem.h
@@ -13,7 +13,6 @@
 #include "Ist.h"
 #include "STObject.h"
 #include "STVirtualObject.h"
-#include "STString.h"
 #include "STBehavior.h"
 #include "STMemoryManager.h"
 #include "ImageHeader.h"

--- a/Core/Object Arts/Dolphin/Base/Behavior.cls
+++ b/Core/Object Arts/Dolphin/Base/Behavior.cls
@@ -767,15 +767,15 @@ recompileAll
 			each class compileAll.
 			each compileAll]!
 
-recompileReferencesToVarNamed: aString
-	"Private - Recompile any of the receiver's methods which appear to reference the named variable."
+recompileReferencesToLiteral: aVariableBinding
+	"Private - Recompile any of the receiver's methods that reference the specified object from their literal frame."
 
 	self methodDictionary do: 
-			[:m |
-			(m containsSource: aString)
+			[:each |
+			(each refersToLiteral: aVariableBinding)
 				ifTrue: 
-					[Notification signal: 'Recompiling ' , m printString.
-					m recompile]]!
+					[Notification signal: 'Recompiling ' , each printString.
+					each recompile]]!
 
 referenceFilterFor: anObject
 	"Private - Answer a <monadicValuable> that when evaluated for a <CompiledMethod> answers
@@ -786,21 +786,7 @@ referenceFilterFor: anObject
 			[| index |
 			index := VMLibrary default indexOfSpecialSelector: anObject ifAbsent: [].
 			index notNil
-				ifTrue: [^[:each | (each refersToLiteral: anObject) or: [each sendsSpecialSelector: index]]]]
-		ifFalse: 
-			[(anObject isKindOf: VariableBinding)
-				ifTrue: 
-					[| value |
-					value := anObject value.
-					"In the case of constant bindings the value may be inlined in the byte codes if there is a representation."
-					(anObject isImmutable and: [VMLibrary hasBytecodeRepresentation: value])
-						ifTrue: 
-							[| constName |
-							constName := anObject key asString.
-							^[:each | (each refersToLiteral: anObject) or: [each containsSource: constName]]]
-						ifFalse: 
-							["For normal const/var bindings, search for both the binding and the current value of the binding"
-							^[:each | (each refersToLiteral: anObject) or: [each refersToLiteral: value]]]]].
+				ifTrue: [^[:each | (each refersToLiteral: anObject) or: [each sendsSpecialSelector: index]]]].
 	^[:each | each refersToLiteral: anObject]!
 
 removeFromSuper
@@ -1179,7 +1165,7 @@ withAllSuperclassesDo: aMonadicValuable
 !Behavior categoriesFor: #primAllSubinstances!instances!private! !
 !Behavior categoriesFor: #recompile:!compiling!development!public! !
 !Behavior categoriesFor: #recompileAll!compiling!development!public! !
-!Behavior categoriesFor: #recompileReferencesToVarNamed:!development!private! !
+!Behavior categoriesFor: #recompileReferencesToLiteral:!development!private! !
 !Behavior categoriesFor: #referenceFilterFor:!development!methods-testing!private! !
 !Behavior categoriesFor: #removeFromSuper!class hierarchy-removing!private! !
 !Behavior categoriesFor: #removeFromSystem!class hierarchy-removing!private! !

--- a/Core/Object Arts/Dolphin/Base/Class.cls
+++ b/Core/Object Arts/Dolphin/Base/Class.cls
@@ -41,14 +41,14 @@ addClassConstant: aString value: anObject
 							["Wasn't constant, recompile if it can be inlined"
 							VMLibrary hasBytecodeRepresentation: anObject]
 						ifTrue: 
-							["Was constant, recompile if changed and was inlined, or can be inlined"
-							| oldValue |
+							[| oldValue |
+							"Was constant, recompile if changed and was inlined, or can be inlined"
 							oldValue := binding value.
 							oldValue ~~ anObject and: 
 									[(VMLibrary hasBytecodeRepresentation: oldValue) or: [VMLibrary hasBytecodeRepresentation: anObject]]]].
 	binding isImmutable: false.
 	[binding value: anObject] ensure: [binding isImmutable: true].
-	requiresRecompile ifTrue: [self recompileAllReferencesToVarNamed: aString].
+	requiresRecompile ifTrue: [self recompileAllReferencesToLiteral: binding].
 	^binding!
 
 addClassVariable: aString value: anObject

--- a/Core/Object Arts/Dolphin/Base/ClassCategory.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassCategory.cls
@@ -78,8 +78,7 @@ initialize
 	Unclassified := self newNamed: self unclassifiedName.
 	Table 
 		at: self unclassifiedName put: Unclassified;
-		removeKey: 'No category' ifAbsent: [].
-	Table haveStrongKeys; haveWeakValues!
+		removeKey: 'No category' ifAbsent: []!
 
 name: cat
 	"Answer a new or existing class category with the specified name."

--- a/Core/Object Arts/Dolphin/Base/ClassDescription.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescription.cls
@@ -552,14 +552,13 @@ realMethodCategories
 		add: 'private' asMethodCategory;
 		yourself!
 
-recompileAllReferencesToVarNamed: aString
-	"Private - Recompile any methods in the receiver's hierarchy which appear to reference the
-	named variable."
+recompileAllReferencesToLiteral: anObject
+	"Private - Recompile any methods in the receiver's hierarchy that reference the specified object from their literal frame."
 
 	self instanceClass withAllSubclassesDo: 
 			[:each |
-			each recompileReferencesToVarNamed: aString.
-			each class recompileReferencesToVarNamed: aString]!
+			each recompileReferencesToLiteral: anObject.
+			each class recompileReferencesToLiteral: anObject]!
 
 removeCategory: category
 	"Remove the Category from the receiver. N.B. All the methods belonging to the
@@ -866,7 +865,7 @@ whichNonVirtualCategoriesIncludeSelector: aSelector
 !ClassDescription categoriesFor: #protocols!private!protocols! !
 !ClassDescription categoriesFor: #protocols:!private!protocols! !
 !ClassDescription categoriesFor: #realMethodCategories!categories-accessing!public! !
-!ClassDescription categoriesFor: #recompileAllReferencesToVarNamed:!development!private! !
+!ClassDescription categoriesFor: #recompileAllReferencesToLiteral:!development!private! !
 !ClassDescription categoriesFor: #removeCategory:!categories-removing!public! !
 !ClassDescription categoriesFor: #removeInstVarName:!class hierarchy-mutating!instance variables!public! !
 !ClassDescription categoriesFor: #removeMethodFromNonVirtualCategories:!development!helpers!private! !

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -720,11 +720,6 @@ LookupTable variableSubclass: #PluggableLookupTable
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-LookupTable variableSubclass: #PoolConstantsDictionary
-	instanceVariableNames: 'name'
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
 LookupTable variableSubclass: #SharedLookupTable
 	instanceVariableNames: 'mutex'
 	classVariableNames: ''
@@ -762,6 +757,11 @@ EventsCollection variableSubclass: #NullEventsCollection
 	classInstanceVariableNames: ''!
 WeakLookupTable variableSubclass: #WeakIdentityDictionary
 	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+PoolDictionary variableSubclass: #PoolConstantsDictionary
+	instanceVariableNames: 'name'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Base/MethodCategory.cls
+++ b/Core/Object Arts/Dolphin/Base/MethodCategory.cls
@@ -167,8 +167,7 @@ initialize
 	to be correctly categorized. However during the booting of the system weakness is not operative so we must
 	repair the table by cleaning out the dead wood."
 
-	Table removeAllKeys: (Table keys select: [:k | k isKindOf: DeadObject]).
-	Table haveStrongKeys; haveWeakValues!
+	Table removeAllKeys: (Table keys select: [:k | k isKindOf: DeadObject])!
 
 name: categoryName
 	"Answer the subinstance of the receiver with the <readableString> name, categoryName."

--- a/Core/Object Arts/Dolphin/Base/PoolConstantsDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/PoolConstantsDictionary.cls
@@ -1,6 +1,6 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-LookupTable variableSubclass: #PoolConstantsDictionary
+PoolDictionary variableSubclass: #PoolConstantsDictionary
 	instanceVariableNames: 'name'
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -10,11 +10,12 @@ PoolConstantsDictionary comment: ''!
 !PoolConstantsDictionary categoriesForClass!Collections-Unordered!System-Support! !
 !PoolConstantsDictionary methodsFor!
 
-associationClass
-	"Private - Answer the class of association to be used for holding
-	key-value pairs in the receiver. Must respond to the Association protocol."
-	
-	^VariableBinding!
+add: anAssociation
+	"Add the key/value pair provided in the <Association> argument to the receiver.
+	The actual <Association> is not added as there are many constraints so it is safe to add a newly formed constant VariableBinding."
+
+	self at: anAssociation key put: anAssociation value.
+	^anAssociation!
 
 at: key ifAbsentPut: operation 
 	"Answer the value of the receiver keyed by the <Object> argument, key.
@@ -46,61 +47,12 @@ at: key put: anObject
 classesReferencing
 	^self environment allClasses select: [:c | c allSharedPools includes: self]!
 
-displayOn: aStream
-	"Append, to aStream, a String whose characters are a representation of the receiver as a user
-	would want to see it."
-
-	self name displayOn: aStream
-!
-
-environment
-	"Answer the receiver's controlling name space."
-
-	^Smalltalk
-!
-
-fileOutName
-	"Answer the receiver's default file name for file outs (<name>.st)."
-
-	| path package |
-	path := File composeStem: self name extension: Package sourceGlobalExtension.
-	package := Package manager packageOfGlobalNamed: self name asSymbol.
-	package notNil ifTrue: [
-		path := File replacePath:  path with: package path ].
-	^path!
-
-isChanged
-	"Answer true if the receiver or any of it's contents have been changed since
-	their changed flag was last reset."
-
-	^self propertyAt: #isChanged ifAbsent: [false]!
-
-isChanged: aBoolean
-	"Flag the receiver as changed or not changed, according to the value 
-	of the <Boolean> argument. If the receiver is marked as changed, then
-	its owning package (if any) is also so marked."
-
-	"Note that we don't test the existing value of the change flag here, because
-	 we want to inform the package regardless (in case it isn't currently changed
-	 for some reason)"
-	aBoolean 
-		ifTrue: [ | package |
-			self propertyAt: #isChanged put: true.
-			(package := self owningPackage) notNil ifTrue: [
-				package isChanged: true]]
-		ifFalse: [self removePropertyAt: #isChanged ifAbsent: []]!
-
-isValidKey: aString 
-	| initial |
-	initial := true.
+isValidKey: aString
 	^aString notEmpty and: 
-			[aString allSatisfy: 
-					[:each | 
-					initial 
-						ifTrue: 
-							[initial := false.
-							each == $_ or: [each isLetter]]
-						ifFalse: [each == $_ or: [each isAlphaNumeric]]]]!
+			[| initial |
+			initial := aString first.
+			(initial == $_ or: [initial isLetter])
+				and: [aString allSatisfy: [:each | each == $_ or: [each isAlphaNumeric]]]]!
 
 keyString: anObject
 	| answer |
@@ -121,17 +73,6 @@ newAssociation: keyObject value: valueObject
 		isImmutable: true;
 		yourself!
 
-owningPackage
-	"Answers the package that owns the receiver or nil if it is not yet owned
-	by any package"
-
-	^Package manager packageOfGlobalNamed: self name!
-
-owningPackage: aPackage
-	"Set the receiver's <Package> to be the argument. Any current package association is lost."
-
-	aPackage addGlobalNamed: self name!
-
 preResize: newMe 
 	"Private - This message is sent by the receiver when resizing, before the
 	receiver's elements are added to newMe. We must assign across the
@@ -143,13 +84,14 @@ recompileReferencesToVarNamed: keyString
 	"Private - Recompile any methods which references the named key, assumed to
 	be a variable name from the receiver."
 
+	| var |
 	Notification
 		signal: ('Recompiling references to <1p> in <2s>' expandMacrosWith: keyString with: self name).
-	(self environment allClasses select: [:c | c allSharedPools includes: self]) do: 
+	var := self associationAt: keyString.
+	self classesReferencing do: 
 			[:c |
-			c recompileReferencesToVarNamed: keyString.
-			c class recompileReferencesToVarNamed: keyString.
-			self]!
+			c recompileReferencesToLiteral: var.
+			c class recompileReferencesToLiteral: var]!
 
 removeIndex: anInteger
 	"Private - Remove the element at index, anInteger, in the receiver. Does not
@@ -157,22 +99,15 @@ removeIndex: anInteger
 
 	super removeIndex: anInteger.
 	self isChanged: true! !
-!PoolConstantsDictionary categoriesFor: #associationClass!constants!private! !
+!PoolConstantsDictionary categoriesFor: #add:!adding!public! !
 !PoolConstantsDictionary categoriesFor: #at:ifAbsentPut:!accessing!development!public! !
 !PoolConstantsDictionary categoriesFor: #at:put:!adding!development!public! !
 !PoolConstantsDictionary categoriesFor: #classesReferencing!development!private! !
-!PoolConstantsDictionary categoriesFor: #displayOn:!displaying!public! !
-!PoolConstantsDictionary categoriesFor: #environment!constants!public! !
-!PoolConstantsDictionary categoriesFor: #fileOutName!development!public!source filing! !
-!PoolConstantsDictionary categoriesFor: #isChanged!development!public!source filing!testing! !
-!PoolConstantsDictionary categoriesFor: #isChanged:!development!public!source filing! !
 !PoolConstantsDictionary categoriesFor: #isValidKey:!adding!development!private! !
 !PoolConstantsDictionary categoriesFor: #keyString:!adding!development!private! !
 !PoolConstantsDictionary categoriesFor: #name!accessing!public! !
 !PoolConstantsDictionary categoriesFor: #name:!accessing!private! !
 !PoolConstantsDictionary categoriesFor: #newAssociation:value:!helpers!private! !
-!PoolConstantsDictionary categoriesFor: #owningPackage!development!public!source filing! !
-!PoolConstantsDictionary categoriesFor: #owningPackage:!accessing!development!public! !
 !PoolConstantsDictionary categoriesFor: #preResize:!adding!private! !
 !PoolConstantsDictionary categoriesFor: #recompileReferencesToVarNamed:!development!private! !
 !PoolConstantsDictionary categoriesFor: #removeIndex:!development!private!removing! !

--- a/Core/Object Arts/Dolphin/Base/PoolConstantsDictionaryTest.cls
+++ b/Core/Object Arts/Dolphin/Base/PoolConstantsDictionaryTest.cls
@@ -19,10 +19,27 @@ key3Value
 makeKey: anObject
 	^'_' , anObject displayString!
 
+testAddExisting
+	| dictionary |
+	dictionary := self newDictionary.
+	dictionary add: #a -> 1.
+	[dictionary add: #a -> 2] on: ConfirmationRequiredWarning do: [:ex | ex confirm].
+	self assert: (dictionary at: #a) equals: 2!
+
 testAtIfAbsentString
 	| dictionary |
 	dictionary := self newDictionary.
 	self assert: (dictionary at: 'key' ifAbsent: [2]) identicalTo: 1!
+
+testAtPutExisting
+	| dictionary |
+	dictionary := self newDictionary.
+	dictionary at: #a put: 1.
+	[dictionary at: #a put: 2] on: ConfirmationRequiredWarning do: [:ex | ex confirm].
+	self assert: (dictionary at: #a) equals: 2!
+
+testChangeConstant
+	!
 
 testIncludesKey
 	| dictionary |
@@ -41,7 +58,10 @@ testRemoveKeyString
 !PoolConstantsDictionaryTest categoriesFor: #collectionClass!helpers!private! !
 !PoolConstantsDictionaryTest categoriesFor: #key3Value!private! !
 !PoolConstantsDictionaryTest categoriesFor: #makeKey:!helpers!private! !
+!PoolConstantsDictionaryTest categoriesFor: #testAddExisting!public!unit tests! !
 !PoolConstantsDictionaryTest categoriesFor: #testAtIfAbsentString!public!unit tests! !
+!PoolConstantsDictionaryTest categoriesFor: #testAtPutExisting!public!unit tests! !
+!PoolConstantsDictionaryTest categoriesFor: #testChangeConstant!public!unit tests! !
 !PoolConstantsDictionaryTest categoriesFor: #testIncludesKey!public!unit tests! !
 !PoolConstantsDictionaryTest categoriesFor: #testRemoveKeyString!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/VariableBinding.cls
+++ b/Core/Object Arts/Dolphin/Base/VariableBinding.cls
@@ -16,7 +16,11 @@ displayOn: aStream
 	aStream display: key!
 
 displayString
-	^key! !
+	^key!
+
+refersToLiteral: anObject
+	^self == anObject! !
 !VariableBinding categoriesFor: #displayOn:!printing!public! !
 !VariableBinding categoriesFor: #displayString!displaying!public! !
+!VariableBinding categoriesFor: #refersToLiteral:!private!testing! !
 

--- a/Core/Object Arts/Dolphin/Base/Win32Constants.st
+++ b/Core/Object Arts/Dolphin/Base/Win32Constants.st
@@ -4,8 +4,6 @@ Smalltalk at: #Win32Constants put: (PoolConstantsDictionary named: #Win32Constan
 Win32Constants at: 'ABOVE_NORMAL_PRIORITY_CLASS' put: 16r8000!
 Win32Constants at: 'AC_SRC_ALPHA' put: 16r1!
 Win32Constants at: 'AC_SRC_OVER' put: 16r0!
-Win32Constants at: 'ANSI_FIXED_FONT' put: 16rB!
-Win32Constants at: 'ANSI_VAR_FONT' put: 16rC!
 Win32Constants at: 'ASPECTX' put: 16r28!
 Win32Constants at: 'ASPECTXY' put: 16r2C!
 Win32Constants at: 'ASPECTY' put: 16r2A!

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -323,7 +323,6 @@ package methodNames
 	add: #PackageManager -> #sourceControl;
 	add: #PointerField -> #printAccessorExpression:on:;
 	add: #PointerField -> #printMutatorBody:on:;
-	add: #PoolConstantsDictionary -> #aspectDisplayOn:;
 	add: #PoolConstantsDictionary -> #browse;
 	add: #PoolConstantsDictionary -> #errorModify:value:;
 	add: #PoolConstantsDictionary -> #referencesTo:;
@@ -4702,15 +4701,6 @@ printMutatorBody: aSymbol on: aWriteStream
 
 !PoolConstantsDictionary methodsFor!
 
-aspectDisplayOn: aStream
-	"Private - Append a single-line textual representatin of the receiver to the <puttableStream>
-  	argument in a form that a user viewing the receiver as the value of a published aspect would 
-  	like to see it. Typically we use #displayOn: but some classes of object can use alternate display 
-  	formats. In this case we override back to the Object implementation.
-  	N.B. This is a development time only method that supports the PublishedAspectInspector."
-  
-  	self displayOn: aStream!
-
 browse
     	"Open a browser on the receiver"
     
@@ -4719,29 +4709,31 @@ browse
 errorModify: key value: value
 	"Private - An attempt was made to modify the value of the constant named, key."
 
-	| recompile |
+	| recompile var |
 	recompile := ConfirmationRequiredWarning
 				signal: ('Would you like to recompile references to <1p><n>to reflect the new value <2d> (currently <3d>)'
 						expandMacrosWith: key
 						with: value
 						with: (self at: key)).
 	recompile isNil ifTrue: [^self].
-	super at: key put: value.
+	var := self associationAt: key.
+	var whileMutableDo: [var value: value].
 	self isChanged: true.
-	recompile ifTrue: [self recompileReferencesToVarNamed: key]!
+	recompile ifTrue: [self recompileReferencesToVarNamed: key]
 
-referencesTo: keyString 
+!
+
+referencesTo: keyString
 	"Answer the collection of any methods which references the named key, assumed to
 	be a variable name from the receiver."
 
-	| refs |
-	refs := OrderedCollection new.
-	self classesReferencing do: 
-			[:c | 
-			c methodDictionary do: [:m | (m containsSource: keyString) ifTrue: [refs add: m]].
-			c class methodDictionary do: [:m | (m containsSource: keyString) ifTrue: [refs add: m]]].
-	^refs! !
-!PoolConstantsDictionary categoriesFor: #aspectDisplayOn:!private! !
+	| env var classes |
+	var := self associationAt: keyString.
+	classes := self classesReferencing.
+	env := BrowserEnvironment new forClasses: classes , (classes collect: [:each | each class]).
+	^(env referencesTo: var)
+		label: ('Methods referencing <1d>.<2s>' expandMacrosWith: self with: keyString);
+		yourself! !
 !PoolConstantsDictionary categoriesFor: #browse!operations-browsing!public! !
 !PoolConstantsDictionary categoriesFor: #errorModify:value:!exceptions!private! !
 !PoolConstantsDictionary categoriesFor: #referencesTo:!private! !

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/PoolDictionariesShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/PoolDictionariesShell.cls
@@ -43,9 +43,7 @@ addPool
 	self selectionOrNil: newPool!
 
 browseEntryReferences
-	| methods |
-	methods := self methodsReferencingSelectedEntry.
-	self systemModel browseMethodsIn: (self systemModel systemEnvironment forMethods: methods)!
+	self systemModel browseMethodsIn: self methodsReferencingSelectedEntry!
 
 classesReferencingSelectedPool
 	^self selectionOrNil classesReferencing!
@@ -96,7 +94,7 @@ queryCommand: aCommandQuery
 
 removeEntry
 	| refs key confirmationMsg ok |
-	refs := self methodsReferencingSelectedEntry.
+	refs := self methodsReferencingSelectedEntry allMethods.
 	key := self selectedItemKey.
 	confirmationMsg := refs notEmpty 
 				ifTrue: ['''' , key , ''' has references.

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -6,7 +6,7 @@ IconicListAbstract subclass: #ListView
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!
 ListView guid: (GUID fromString: '{87b4c730-026e-11d3-9fd7-00a0cc3e4a32}')!
-ListView addClassConstant: 'NoImageIndex' value: -16r1!
+ListView addClassConstant: 'NoImageIndex' value: 16r0!
 ListView comment: 'ListView is the <listView> implementing the Windows "SysListView32" common control. It is for single selection use and, therefore, implements the <selectableItems> protocol for use with any <listModel>.
 
 A ListView is capable of displaying it items in one of four modes (#smallIcons, #largeIcons, #list, #report) which can be set using the #viewMode aspect. In the first three of these modes the list effectively has only one column being displayed; this is the primary column. Columns are described using instances of ListViewColumn. See the comment for this class for details on how to set up a column to display the appropriate information for a list item.

--- a/DBOOT.img7
+++ b/DBOOT.img7
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7420fb7db05ed92bff274caefcd06935d9e98fc0bf35ff04a4280e9d2b54c39f
-size 1450668
+oid sha256:eb61259993ba5ce1db3ed55c7b9cfa2acb03a50be3b134ca3a687028458cea2e
+size 1485595

--- a/DBOOT.sml
+++ b/DBOOT.sml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d8c7133ab87489e6ce979af7c71d4d4a22dc7241142bd2fa96ba9d48e304286
-size 2454444
+oid sha256:2c152e0a98c824f09ba8d9b5bc7f0fb7fcf19a11a98368a00e5ac9cabd961802
+size 2456291


### PR DESCRIPTION
Remove the old optimisation of PoolConstantsDictionary being a LookupTable
and not actually storing unique VariableBindings. Also ensure that method
literal frames always store the VariableBinding for constants too.