### PR TITLE
Use fixed width integer types in Compiler

### DIFF
--- a/Core/DolphinVM/CompilePrims.cpp
+++ b/Core/DolphinVM/CompilePrims.cpp
@@ -64,7 +64,7 @@ extern "C" Oop __stdcall PrimCompileForClass(Oop compilerOop, const char* szSour
 	if (piCompiler == NULL)
 		return Oop(GetVM()->NilPointer());
 
-	return (Oop)piCompiler->CompileForClass(GetVM(), compilerOop, szSource, (POTE)aClass, FLAGS(flags), notifier);
+	return (Oop)piCompiler->CompileForClass(GetVM(), compilerOop, szSource, (POTE)aClass, static_cast<FLAGS>(flags), notifier);
 }
 
 extern "C" Oop __stdcall PrimCompileForEval(Oop compilerOop, const char* szSource, Oop aClass, Oop aWorkspacePool, int flags, Oop notifier)
@@ -73,7 +73,7 @@ extern "C" Oop __stdcall PrimCompileForEval(Oop compilerOop, const char* szSourc
 	if (piCompiler == NULL)
 		return Oop(GetVM()->NilPointer());
 
-	return (Oop)piCompiler->CompileForEval(GetVM(), compilerOop, szSource, (POTE)aClass, (POTE)aWorkspacePool, FLAGS(flags), notifier);
+	return (Oop)piCompiler->CompileForEval(GetVM(), compilerOop, szSource, (POTE)aClass, (POTE)aWorkspacePool, static_cast<FLAGS>(flags), notifier);
 }
 
 

--- a/Core/DolphinVM/Compiler/Compiler.idl
+++ b/Core/DolphinVM/Compiler/Compiler.idl
@@ -144,7 +144,10 @@ library CompilerLib
 		CInfoLast = CInfoHardBreakpoint
 	} FirstAndLastCodes;
 
-	typedef enum FLAGS {Default=0x00, SyntaxCheckOnly=0x02, NoOptimize=0x08, TextMap=0x10, TempsMap=0x20, DebugMethod=0x40, Boot=0x80, ScanOnly=0x100, Interactive=0x200, SendYourself=0x400} FLAGS;
+	cpp_quote("#define class_CompilerFlags class CompilerFlags")
+	typedef enum class_CompilerFlags
+	{Default=0x00, SyntaxCheckOnly=0x02, NoOptimize=0x08, TextMap=0x10, TempsMap=0x20, DebugMethod=0x40, Boot=0x80, ScanOnly=0x100, Interactive=0x200, SendYourself=0x400} FLAGS;
+	cpp_quote("#undef CompilerFlags")
 
 	[
 		object,

--- a/Core/DolphinVM/Compiler/CompilerSupport.cpp
+++ b/Core/DolphinVM/Compiler/CompilerSupport.cpp
@@ -86,7 +86,7 @@ bool Compiler::CanUnderstand(POTE oteBehavior, POTE oteSelector)
 Oop Compiler::EvaluateExpression(LPUTF8 text, POTE oteMethod, Oop contextOop, POTE pools)
 {
 	STCompiledMethod& exprMethod = *(STCompiledMethod*)GetObj(oteMethod);
-	BYTE primitive = exprMethod.header.primitiveIndex;
+	auto primitive = exprMethod.header.primitiveIndex;
 	Oop result;
 	// As an optimization avoid calling back into Smalltalk if we the expression is of simple form, e.g. a class ref
 	switch (primitive)

--- a/Core/DolphinVM/Compiler/CompilerSupport.cpp
+++ b/Core/DolphinVM/Compiler/CompilerSupport.cpp
@@ -14,7 +14,7 @@ be thrown away eventually, or perhaps compiled into a separate DLL.
 
 #include "..\VMPointers.h"
 
-POTE Compiler::NewCompiledMethod(POTE classPointer, unsigned numBytes, const STMethodHeader& hdr)
+POTE Compiler::NewCompiledMethod(POTE classPointer, size_t numBytes, const STMethodHeader& hdr)
 {
 	//_ASSERTE(ObjectMemory::inheritsFrom(classPointer, GetVMPointers().ClassCompiledMethod));
 	// Note we subtract
@@ -22,7 +22,7 @@ POTE Compiler::NewCompiledMethod(POTE classPointer, unsigned numBytes, const STM
 		((sizeof(STCompiledMethod)
 			- sizeof(Oop)	// Deduct dummy literal frame entry (arrays cannot be zero sized in IDL)
 //			-sizeof(ObjectHeader)	// Deduct size of head which NewObjectWithPointers includes implicitly
-) / sizeof(Oop)) + GetLiteralCount());
+) / sizeof(Oop)) + LiteralCount);
 	STCompiledMethod* method = reinterpret_cast<STCompiledMethod*>(GetObj(methodPointer));
 	POTE bytes = m_piVM->NewByteArray(numBytes);
 	m_piVM->StorePointerWithValue((Oop*)&method->byteCodes, Oop(bytes));

--- a/Core/DolphinVM/Compiler/LexicalScope.h
+++ b/Core/DolphinVM/Compiler/LexicalScope.h
@@ -678,7 +678,7 @@ public:
 	////////////////////////////////////////////////////////////////
 	// Operations
 
-	void RenameTemporary(int, const Str&, const TEXTRANGE&);
+	void RenameTemporary(tempcount_t, const Str&, const TEXTRANGE&);
 	TempVarDecl* CopyTemp(TempVarDecl* pTemp, Compiler*);
 	TempVarRef* AddTempRef(TempVarDecl*, VarRefType, const TEXTRANGE&);
 	void CopyTemps(Compiler*);

--- a/Core/DolphinVM/Compiler/disasm.cpp
+++ b/Core/DolphinVM/Compiler/disasm.cpp
@@ -34,16 +34,16 @@ void Compiler::disassemble(wostream& stream)
 	LexicalScope* currentScope = m_allScopes[0];
 	int currentDepth = 0;
 	stream << std::endl;
-	size_t i=0;
-	const size_t size = GetCodeSize();
-	BytecodeDisassembler<Compiler> disassembler(*this);
-	while (i < size)
+	ip_t ip=ip_t::zero;
+	const ip_t last = LastIp;
+	BytecodeDisassembler<Compiler, ip_t> disassembler(*this);
+	while (ip <= LastIp)
 	{
-		disassembler.EmitIp(i, stream);
-		size_t len = disassembler.EmitRawBytes(i, stream);
+		disassembler.EmitIp(ip, stream);
+		size_t len = disassembler.EmitRawBytes(ip, stream);
 
 		// Scope changing, and getting deeper?
-		LexicalScope* newScope = m_bytecodes[i].pScope;
+		LexicalScope* newScope = m_bytecodes[ip].pScope;
 		stream << newScope << L' ';
 
 		char padChar = ' ';
@@ -55,13 +55,13 @@ void Compiler::disassemble(wostream& stream)
 			{
 				padChar = '-';
 			}
-			currentScope = m_bytecodes[i].pScope;
+			currentScope = m_bytecodes[ip].pScope;
 			currentDepth = newDepth;
 		}
 
 		// If next is in outer scope, want to print closing bracket now
-		bool lastInstr = i + len >= size;
-		int nextDepth = lastInstr ? 0 : m_bytecodes[i + len].pScope->GetLogicalDepth();
+		bool lastInstr = ip + len > last;
+		int nextDepth = lastInstr ? 0 : m_bytecodes[ip + len].pScope->GetLogicalDepth();
 
 		// If not on last bytecode, and scope will change, close the bracket
 		if (nextDepth < currentDepth)
@@ -79,14 +79,14 @@ void Compiler::disassemble(wostream& stream)
 			stream << padChar;
 		}
 
-		const TEXTMAPLIST::iterator it = FindTextMapEntry(i);
+		const TEXTMAPLIST::iterator it = FindTextMapEntry(ip);
 		if (it != m_textMaps.end())
 			stream << L'`';
 		else
 			stream << L' ';
 
-		disassembler.EmitDecodedInstructionAt(i, stream);
-		i += len;
+		disassembler.EmitDecodedInstructionAt(ip, stream);
+		ip += len;
 	}
 	stream << std::endl;
 }
@@ -105,3 +105,9 @@ std::wstring Compiler::DebugPrintString(Oop oop)
 	return result;
 }
 
+
+std::wostream& __stdcall operator<<(std::wostream& stream, const std::string& str)
+{
+	USES_CONVERSION;
+	return stream << static_cast<LPCWSTR>(A2W(str.c_str()));
+}

--- a/Core/DolphinVM/Compiler/disasm.cpp
+++ b/Core/DolphinVM/Compiler/disasm.cpp
@@ -24,15 +24,15 @@ void Compiler::disassemble()
 
 void Compiler::disassemble(wostream& stream)
 {
-	int maxDepth = 0;
+	unsigned maxDepth = 0;
 	for (size_t i = 0; i < m_allScopes.size(); i++)
 	{
-		int depth = m_allScopes[i]->GetLogicalDepth();
+		unsigned depth = m_allScopes[i]->GetLogicalDepth();
 		if (depth > maxDepth) maxDepth = depth;
 	}
 
 	LexicalScope* currentScope = m_allScopes[0];
-	int currentDepth = 0;
+	unsigned currentDepth = 0;
 	stream << std::endl;
 	ip_t ip=ip_t::zero;
 	const ip_t last = LastIp;
@@ -50,7 +50,7 @@ void Compiler::disassemble(wostream& stream)
 		// If new nested scope, want to print opening bracket
 		if (currentScope != newScope)
 		{
-			int newDepth = newScope->GetLogicalDepth();
+			unsigned newDepth = newScope->GetLogicalDepth();
 			if (!(newDepth < currentDepth))
 			{
 				padChar = '-';
@@ -61,7 +61,7 @@ void Compiler::disassemble(wostream& stream)
 
 		// If next is in outer scope, want to print closing bracket now
 		bool lastInstr = ip + len > last;
-		int nextDepth = lastInstr ? 0 : m_bytecodes[ip + len].pScope->GetLogicalDepth();
+		unsigned nextDepth = lastInstr ? 0 : m_bytecodes[ip + len].pScope->GetLogicalDepth();
 
 		// If not on last bytecode, and scope will change, close the bracket
 		if (nextDepth < currentDepth)
@@ -69,7 +69,7 @@ void Compiler::disassemble(wostream& stream)
 			padChar = '-';
 		}
 
-		int j;
+		unsigned j;
 		for (j = 0; j < currentDepth; j++)
 		{
 			stream<< L"|";

--- a/Core/DolphinVM/Compiler/lexer.cpp
+++ b/Core/DolphinVM/Compiler/lexer.cpp
@@ -27,17 +27,17 @@ static const uint8_t LITERAL = '#';
 
 Lexer::Lexer()
 {
-	m_base = 0;
+	m_base = textpos_t::start;
 	m_buffer = (LPUTF8)"";
 	m_cc = '\0';
-	m_cp = NULL;
+	m_cp = nullptr;
 	m_integer = 0;
-	m_lastTokenRange = { 0, 0 };
+	m_lastTokenRange = { textpos_t::start, textpos_t::start };
 	m_lineno = 0;
-	m_thisTokenRange = { 0, 0 };
-	m_token = NULL;
-	m_tokenType = None;
-	tp = NULL;
+	m_thisTokenRange = { textpos_t::start, textpos_t::start };
+	m_token = nullptr;
+	m_tokenType = TokenType::None;
+	tp = nullptr;
 	m_locale = _create_locale(LC_ALL, "C");
 	m_piVM = nullptr;
 }
@@ -50,7 +50,7 @@ Lexer::~Lexer()
 
 void Lexer::CompileError(int code, Oop extra)
 {
-	CompileErrorV(ThisTokenRange(), code, extra, 0);
+	CompileErrorV(ThisTokenRange, code, extra, 0);
 }
 
 void Lexer::CompileError(const TEXTRANGE& range, int code, Oop extra)
@@ -66,15 +66,15 @@ void Lexer::CompileErrorV(const TEXTRANGE& range, int code, ...)
 	va_end(extras);
 }
 
-void Lexer::SetText(const uint8_t* compiletext, int offset)
+void Lexer::SetText(const uint8_t* compiletext, textpos_t offset)
 {
-	m_tokenType = None;
+	m_tokenType = TokenType::None;
 	m_buffer = compiletext;
 	m_cp = m_buffer.c_str();
 	m_token = new uint8_t[m_buffer.size() + 1];
 	m_lineno = 1;
 	m_base = offset;
-	AdvanceCharPtr(offset);
+	AdvanceCharPtr(static_cast<size_t>(offset));
 }
 
 // ANSI Binary chars are ...
@@ -131,7 +131,7 @@ inline void Lexer::SkipBlanks()
 
 void Lexer::SkipComments()
 {
-	int commentStart = CharPosition();
+	textpos_t commentStart = CharPosition;
 	while (m_cc == COMMENTDELIM)
 	{
 		uint8_t ch;
@@ -143,7 +143,7 @@ void Lexer::SkipComments()
 		if (!ch)
 		{
 			// Break out at EOF 
-			CompileError(TEXTRANGE(commentStart, CharPosition()), LErrCommentNotClosed);
+			CompileError(TEXTRANGE(commentStart, CharPosition), LErrCommentNotClosed);
 		}
 
 		const uint8_t* ep = m_cp;
@@ -157,7 +157,7 @@ inline bool issign(uint8_t ch)
 	return ch == '-' || ch == '+';
 }
 
-double Lexer::ThisTokenFloat() const
+double Lexer::get_ThisTokenFloat() const
 {
 	_CRT_DOUBLE result;
 	int retval = _atodbl_l(&result, (LPSTR)m_token, m_locale);
@@ -175,7 +175,7 @@ void Lexer::ScanFloat()
 	uint8_t ch = NextChar();
 	if (isdigit(PeekAtChar()))
 	{
-		m_tokenType = FloatingConst;
+		m_tokenType = TokenType::FloatingConst;
 
 		do
 		{
@@ -231,7 +231,7 @@ int Lexer::DigitValue(uint8_t ch) const
 void Lexer::ScanInteger(int radix)
 {
 	m_integer = 0;
-	m_tokenType = SmallIntegerConst;
+	m_tokenType = TokenType::SmallIntegerConst;
 	int digit = DigitValue(PeekAtChar());
 
 	int maxval = INT_MAX / radix;
@@ -240,7 +240,7 @@ void Lexer::ScanInteger(int radix)
 	{
 		*tp++ = NextChar();
 
-		if (m_tokenType == SmallIntegerConst)
+		if (m_tokenType == TokenType::SmallIntegerConst)
 		{
 			if (m_integer < maxval || (m_integer == maxval && digit <= INT_MAX % radix))
 			{
@@ -249,7 +249,7 @@ void Lexer::ScanInteger(int radix)
 			}
 			else
 				// It will have to be left to Smalltalk to calc the large integer value
-				m_tokenType = LargeIntegerConst;
+				m_tokenType = TokenType::LargeIntegerConst;
 		}
 
 		digit = DigitValue(PeekAtChar());
@@ -276,7 +276,7 @@ void Lexer::ScanExponentInteger()
 		{
 			*tp++ = NextChar();
 		} while (isdigit(PeekAtChar()));
-		m_tokenType = LargeIntegerConst;
+		m_tokenType = TokenType::LargeIntegerConst;
 	}
 	else
 	{
@@ -304,7 +304,7 @@ void Lexer::ScanNumber()
 	{
 	case 'r':
 	{
-		if (m_tokenType != SmallIntegerConst)
+		if (m_tokenType != TokenType::SmallIntegerConst)
 			return;
 
 		if (m_integer >= 2 && m_integer <= 36)
@@ -333,7 +333,7 @@ void Lexer::ScanNumber()
 		while (isdigit(PeekAtChar()))
 			*tp++ = NextChar();
 
-		m_tokenType = ScaledDecimalConst;
+		m_tokenType = TokenType::ScaledDecimalConst;
 		break;
 
 	case '.':
@@ -349,7 +349,7 @@ void Lexer::ScanNumber()
 			while (isdigit(PeekAtChar()))
 				*tp++ = NextChar();
 
-			m_tokenType = ScaledDecimalConst;
+			m_tokenType = TokenType::ScaledDecimalConst;
 		}
 		break;
 
@@ -365,7 +365,7 @@ void Lexer::ScanNumber()
 }
 
 // Read string up to terminating quote, ignoring embedded double quotes
-Lexer::TokenType Lexer::ScanString(int stringStart)
+Lexer::TokenType Lexer::ScanString(textpos_t stringStart)
 {
 	uint8_t ch;
 	bool isAscii = true;
@@ -374,7 +374,7 @@ Lexer::TokenType Lexer::ScanString(int stringStart)
 		ch = NextChar();
 		if (!ch)
 		{
-			CompileError(TEXTRANGE(stringStart, CharPosition()), LErrStringNotClosed);
+			CompileError(TEXTRANGE(stringStart, CharPosition), LErrStringNotClosed);
 		}
 		else
 		{
@@ -393,7 +393,7 @@ Lexer::TokenType Lexer::ScanString(int stringStart)
 		}
 	} while (ch);
 
-	return isAscii ? AnsiStringConst : Utf8StringConst;
+	return isAscii ? TokenType::AnsiStringConst : TokenType::Utf8StringConst;
 }
 
 void Lexer::ScanName()
@@ -401,13 +401,13 @@ void Lexer::ScanName()
 	while (isIdentifierSubsequent(NextChar()))
 		*tp++ = m_cc;
 	*tp = 0;
-	LPUTF8 tok = ThisTokenText();
+	LPUTF8 tok = ThisTokenText;
 	if (!strcmp((LPCSTR)tok, "true"))
-		m_tokenType = TrueConst;
+		m_tokenType = TokenType::TrueConst;
 	else if (!strcmp((LPCSTR)tok, "false"))
-		m_tokenType = FalseConst;
+		m_tokenType = TokenType::FalseConst;
 	else if (!strcmp((LPCSTR)tok, "nil"))
-		m_tokenType = NilConst;
+		m_tokenType = TokenType::NilConst;
 }
 
 void Lexer::ScanQualifiedName()
@@ -415,9 +415,9 @@ void Lexer::ScanQualifiedName()
 	LPUTF8 endLastWord = tp;
 	*tp++ = m_cc;
 	ScanName();
-	if (m_tokenType != NameConst)
+	if (m_tokenType != TokenType::NameConst)
 	{
-		m_tokenType = NameConst;
+		m_tokenType = TokenType::NameConst;
 	}
 	else
 	{
@@ -430,9 +430,9 @@ void Lexer::ScanQualifiedName()
 
 void Lexer::ScanIdentifierOrKeyword()
 {
-	m_tokenType = NameConst;
+	m_tokenType = TokenType::NameConst;
 	ScanName();
-	if (m_tokenType == NameConst && m_cc == '.' && isLetter(PeekAtChar()))
+	if (m_tokenType == TokenType::NameConst && m_cc == '.' && isLetter(PeekAtChar()))
 		ScanQualifiedName();
 	else
 	{
@@ -441,7 +441,7 @@ void Lexer::ScanIdentifierOrKeyword()
 		if (m_cc == ':' && PeekAtChar() != '=')
 		{
 			*tp++ = m_cc;
-			m_tokenType = NameColon;
+			m_tokenType = TokenType::NameColon;
 		}
 		else
 		{
@@ -452,7 +452,7 @@ void Lexer::ScanIdentifierOrKeyword()
 
 void Lexer::ScanSymbol()
 {
-	uint8_t* lastColon = NULL;
+	uint8_t* lastColon = nullptr;
 	while (isIdentifierFirst(m_cc))
 	{
 		*tp++ = m_cc;
@@ -470,7 +470,7 @@ void Lexer::ScanSymbol()
 		}
 	}
 
-	if (lastColon != NULL && *(tp - 1) != ':')
+	if (lastColon != nullptr && *(tp - 1) != ':')
 	{
 		m_cp = m_cp - (tp - lastColon);
 		tp = lastColon + 1;
@@ -499,30 +499,30 @@ void Lexer::ScanLiteral()
 	if (isIdentifierFirst(m_cc))
 	{
 		ScanSymbol();
-		m_tokenType = SymbolConst;
+		m_tokenType = TokenType::SymbolConst;
 	}
 
 	else if (isAnsiBinaryChar(m_cc))
 	{
 		ScanBinary();
-		m_tokenType = SymbolConst;
+		m_tokenType = TokenType::SymbolConst;
 	}
 
 	else if (m_cc == STRINGDELIM)
 	{
 		// Quoted Symbol
-		ScanString(CharPosition());
-		m_tokenType = SymbolConst;
+		ScanString(CharPosition);
+		m_tokenType = TokenType::SymbolConst;
 	}
 
 	else if (m_cc == '(')
 	{
-		m_tokenType = ArrayBegin;
+		m_tokenType = TokenType::ArrayBegin;
 	}
 
 	else if (m_cc == '[')
 	{
-		m_tokenType = ByteArrayBegin;
+		m_tokenType = TokenType::ByteArrayBegin;
 	}
 
 	else if (m_cc == LITERAL)
@@ -530,13 +530,13 @@ void Lexer::ScanLiteral()
 		// Second hash, so should be a constant expression ##(xxx)
 		NextChar();
 		if (m_cc != '(')
-			CompileError(TEXTRANGE(CharPosition(), CharPosition()), LErrExpectExtendedLiteral);
-		m_tokenType = ExprConstBegin;
+			CompileError(TEXTRANGE(CharPosition, CharPosition), LErrExpectExtendedLiteral);
+		m_tokenType = TokenType::ExprConstBegin;
 	}
 
 	else
 	{
-		m_thisTokenRange.m_stop = CharPosition();
+		m_thisTokenRange.m_stop = CharPosition;
 		CompileError(LErrExpectConst);
 	}
 }
@@ -551,7 +551,7 @@ Lexer::TokenType Lexer::NextToken()
 	SkipComments();
 
 	// Start remembering this token
-	int start = CharPosition();
+	textpos_t start = CharPosition;
 	m_thisTokenRange.m_start = start;
 
 	tp = m_token;
@@ -563,7 +563,7 @@ Lexer::TokenType Lexer::NextToken()
 	{
 		// Hit EOF straightaway - so be careful not to write another Null term into the token
 		// as this would involve writing off the end of the token buffer
-		m_tokenType = Eof;
+		m_tokenType = TokenType::Eof;
 		m_thisTokenRange.m_stop = start;
 		m_thisTokenRange.m_start = start + 1;
 	}
@@ -583,7 +583,7 @@ Lexer::TokenType Lexer::NextToken()
 		{
 			Step();
 			ScanNumber();
-			if (m_tokenType == SmallIntegerConst)
+			if (m_tokenType == TokenType::SmallIntegerConst)
 				m_integer *= -1;
 		}
 		else if (ch == LITERAL)
@@ -593,7 +593,7 @@ Lexer::TokenType Lexer::NextToken()
 
 		else if (ch == STRINGDELIM)
 		{
-			int stringStart = CharPosition();
+			textpos_t stringStart = CharPosition;
 			// String constant; remove quote
 			tp--;
 			m_tokenType = ScanString(stringStart);
@@ -606,58 +606,58 @@ Lexer::TokenType Lexer::NextToken()
 
 		else if (ch == '^')
 		{
-			m_tokenType = Return;
+			m_tokenType = TokenType::Return;
 		}
 
 		else if (ch == ':')
 		{
 			if (PeekAtChar() == '=')
 			{
-				m_tokenType = Assignment;
+				m_tokenType = TokenType::Assignment;
 				*tp++ = NextChar();
 			}
 			else
-				m_tokenType = Special;
+				m_tokenType = TokenType::Special;
 		}
 
 		else if (ch == ')')
 		{
-			m_tokenType = CloseParen;
+			m_tokenType = TokenType::CloseParen;
 		}
 
 		else if (ch == '.')
 		{
-			m_tokenType = CloseStatement;
+			m_tokenType = TokenType::CloseStatement;
 		}
 
 		else if (ch == ']')
 		{
-			m_tokenType = CloseSquare;
+			m_tokenType = TokenType::CloseSquare;
 		}
 
 		else if (ch == '}')
 		{
-			m_tokenType = CloseBrace;
+			m_tokenType = TokenType::CloseBrace;
 		}
 
 		else if (ch == ';')
 		{
-			m_tokenType = Cascade;
+			m_tokenType = TokenType::Cascade;
 		}
 
 		else if (IsASingleBinaryChar(ch))
 		{
 			// Single binary expressions
-			m_tokenType = Binary;
+			m_tokenType = TokenType::Binary;
 		}
 
 		else if (isAnsiBinaryChar(ch))
 		{
-			m_tokenType = Binary;
+			m_tokenType = TokenType::Binary;
 		}
 		else
 		{
-			int pos = CharPosition();
+			textpos_t pos = CharPosition;
 			int cp = ReadUtf8(ch);
 			CompileError(TEXTRANGE(pos, pos), LErrBadChar, (Oop)m_piVM->NewCharacter(cp < 0 ? 0xFFFD : cp));
 		}
@@ -665,7 +665,7 @@ Lexer::TokenType Lexer::NextToken()
 		*tp = '\0';
 	}
 
-	m_thisTokenRange.m_stop = CharPosition();
+	m_thisTokenRange.m_stop = CharPosition;
 	return m_tokenType;
 }
 
@@ -720,7 +720,7 @@ int Lexer::ReadUtf8(uint8_t ch)
 
 void Lexer::ScanLiteralCharacter()
 {
-	m_tokenType = CharConst;
+	m_tokenType = TokenType::CharConst;
 	m_integer = 0;
 
 	// This is one of the few places we need to be aware of UTF-8 encoding. Generally the only chars that are significant to the compiler are
@@ -732,7 +732,7 @@ void Lexer::ScanLiteralCharacter()
 	if (codePoint == 0)
 	{
 		// Reached EOF
-		int pos = CharPosition();
+		textpos_t pos = CharPosition;
 		m_thisTokenRange.m_stop = pos;
 		CompileError(LErrExpectChar);
 		return;
@@ -779,7 +779,7 @@ void Lexer::ScanLiteralCharacter()
 			codePoint = ReadHexCodePoint();
 			if (codePoint < 0)
 			{
-				int pos = CharPosition();
+				textpos_t pos = CharPosition;
 				m_thisTokenRange.m_stop = pos;
 				CompileError(LErrExpectCodePoint);
 				return;
@@ -792,7 +792,7 @@ void Lexer::ScanLiteralCharacter()
 
 	if (codePoint > MaxCodePoint || U_IS_UNICODE_NONCHAR(codePoint))
 	{
-		int pos = CharPosition();
+		textpos_t pos = CharPosition;
 		m_thisTokenRange.m_stop = pos;
 		CompileError(LErrBadCodePoint);
 	}
@@ -1025,7 +1025,7 @@ unsigned long Lexer::strtoxl(
 			number = LONG_MAX;
 	}
 
-	if (endptr != NULL)
+	if (endptr != nullptr)
 		/* store pointer to char that stopped the scan */
 		*endptr = p;
 

--- a/Core/DolphinVM/Compiler/lexer.h
+++ b/Core/DolphinVM/Compiler/lexer.h
@@ -56,7 +56,7 @@ public:
 	void ScanNumber();
 	int DigitValue(uint8_t ch) const;
 
-	enum class radix_t { Min = 2, Decimal=10, Hex=16, Max = 26 };
+	enum class radix_t { Min = 2, Decimal=10, Hex=16, Max = 36 };
 	void ScanInteger(radix_t radix);
 	void ScanFloat();
 	void ScanExponentInteger();

--- a/Core/DolphinVM/Compiler/lexer.h
+++ b/Core/DolphinVM/Compiler/lexer.h
@@ -55,7 +55,9 @@ public:
 	TokenType ScanString(textpos_t);
 	void ScanNumber();
 	int DigitValue(uint8_t ch) const;
-	void ScanInteger(int radix);
+
+	enum class radix_t { Min = 2, Decimal=10, Hex=16, Max = 26 };
+	void ScanInteger(radix_t radix);
 	void ScanFloat();
 	void ScanExponentInteger();
 	void ScanIdentifierOrKeyword();
@@ -130,11 +132,11 @@ public:
 	void CompileErrorV(const TEXTRANGE& range, int code, ...);
 
 protected:
-	enum { MaxCodePoint = 0x10FFFF };
+	static constexpr char32_t MaxCodePoint = MAX_UCSCHAR;
 
 	virtual void _CompileErrorV(int code, const TEXTRANGE& range, va_list)=0;
 	
-	uint8_t PeekAtChar(int lookAhead=0) const;
+	uint8_t PeekAtChar(size_t lookAhead=0) const;
 	bool IsASingleBinaryChar(uint8_t ch) const;
 	
 	TEXTRANGE CompileTextRange() const
@@ -240,9 +242,9 @@ protected:
 	IDolphin* m_piVM;
 
 private:
-	int ReadUtf8();
-	int ReadUtf8(uint8_t ch);
-	int ReadHexCodePoint();
+	int32_t ReadUtf8();
+	int32_t ReadUtf8(uint8_t ch);
+	int32_t ReadHexCodePoint();
 	uint8_t NextChar();
 
 private:
@@ -298,7 +300,7 @@ inline uint8_t Lexer::Step()
 	return ch;
 }
 
-inline uint8_t Lexer::PeekAtChar(int lookAhead) const
+inline uint8_t Lexer::PeekAtChar(size_t lookAhead) const
 {
 	return m_cp[lookAhead];
 }

--- a/Core/DolphinVM/Compiler/optimizer.cpp
+++ b/Core/DolphinVM/Compiler/optimizer.cpp
@@ -16,7 +16,7 @@ Smalltalk compiler bytecode optimizer.
 #define CHECKREFERENCES
 
 #ifdef _DEBUG
-static int compilationTrace = 0;
+static int compilationTrace = 1;
 
 #elif !defined(USE_VM_DLL)
 #undef NDEBUG
@@ -25,19 +25,19 @@ static int compilationTrace = 0;
 #define _ASSERTE assert
 #endif
 
-const int BlockCopyInstructionLength = 7;
+const size_t BlockCopyInstructionLength = 7;
 
 //////////////////////////////////////////////////
 // Some helpers for optimisation
 
 //////////////////////////////////////////////////
 
-inline int Compiler::Pass2()
+inline unsigned Compiler::Pass2()
 {
 	// Optimise generated code
-	int blockCount = FixupTempsAndBlocks();
+	unsigned blockCount = FixupTempsAndBlocks();
 	RemoveNops();
-	if (WantOptimize())
+	if (WantOptimize)
 		Optimize();
 	FixupJumps();
 	return blockCount;
@@ -45,12 +45,12 @@ inline int Compiler::Pass2()
 
 void Compiler::RemoveNops()
 {
-	int i=0;
-	while (i<GetCodeSize())		// Note that codeSize can change (reduce) as Nops removed
+	ip_t i=ip_t::zero;
+	while (i<=LastIp)		// Note that codeSize can change (reduce) as Nops removed
 	{
 		const BYTECODE& bc = m_bytecodes[i];
-		_ASSERTE(bc.isOpCode());
-		_ASSERTE(!bc.isJumpSource() || (bc.target >= 0 && bc.target < GetCodeSize()));
+		_ASSERTE(bc.IsOpCode);
+		_ASSERTE(!bc.IsJumpSource || (bc.target >= ip_t::zero && bc.target <= LastIp));
 
 		VerifyTextMap();
 
@@ -63,7 +63,7 @@ void Compiler::RemoveNops()
 			break;
 
 		default:
-			i += bc.instructionLength();
+			i += bc.InstructionLength;
 			break;
 		}
 	}
@@ -117,39 +117,39 @@ void Compiler::Optimize()
 // optimization when removing jumps, and to correctly
 // remove multi-byte instructions, which was not always done
 // before
-inline int Compiler::RemoveInstruction(int ip)
+inline size_t Compiler::RemoveInstruction(ip_t ip)
 {
-	_ASSERTE(ip < GetCodeSize());
+	_ASSERTE(ip <= LastIp);
 	BYTECODE& bc = m_bytecodes[ip];
 	// We should be removing an instruction 
-	_ASSERTE(bc.isOpCode());
+	_ASSERTE(bc.IsOpCode);
 
 #ifdef _DEBUG
 	{
 		const TEXTMAPLIST::iterator it = FindTextMapEntry(ip);
 		if (it != m_textMaps.end())
 		{
-			int prevIP = ip - 1;
-			while (prevIP >= 0 && (m_bytecodes[prevIP].isData() || m_bytecodes[prevIP].byte == Nop))
-				prevIP--;
-			const BYTECODE* prev = prevIP < 0 ? NULL : &m_bytecodes[prevIP];
-			bool isFirstInBlock = bc.pScope != NULL && bc.pScope->IsBlock() 
-				&& (bc.pScope->GetInitialIP() == ip || prev->byte == BlockCopy || bc.pScope != prev->pScope);
-			_ASSERTE(ip == 0 || isFirstInBlock);
+			ip_t prevIP = ip - 1;
+			while (prevIP >= ip_t::zero && (m_bytecodes[prevIP].IsData || m_bytecodes[prevIP].byte == Nop))
+				--prevIP;
+			const BYTECODE* prev = prevIP < ip_t::zero ? nullptr : &m_bytecodes[prevIP];
+			bool isFirstInBlock = bc.pScope != nullptr && bc.pScope->IsBlock 
+				&& (bc.pScope->InitialIP == ip || (prev != nullptr && (prev->byte == BlockCopy || bc.pScope != prev->pScope)));
+			_ASSERTE(ip == ip_t::zero || isFirstInBlock);
 		}
 	}
 #endif
 
 	// We're about to remove an unreachable jump, so we want to inform
 	// its jump target in case that can be optimized away too
-	if (bc.isJumpSource())
+	if (bc.IsJumpSource)
 	{
-		_ASSERTE(bc.target < GetCodeSize());
+		_ASSERTE(bc.target <= LastIp);
 		BYTECODE& target = m_bytecodes[bc.target];
 		target.removeJumpTo();
 	}
 	
-	int len = bc.instructionLength();
+	size_t len = bc.InstructionLength;
 	RemoveBytes(ip, len);
 
 	return len;
@@ -159,22 +159,22 @@ inline int Compiler::RemoveInstruction(int ip)
 // Remove a sequence of bytes from the code array
 // Adjusts any jumps that occur over the boundary
 // This is very slow if the bytecode array is large
-void Compiler::RemoveBytes(int ip, int count)
+void Compiler::RemoveBytes(ip_t ip, size_t count)
 {
-	_ASSERTE(ip >= 0 && count > 0);
-	int size = GetCodeSize();
-	const int next = ip + count;
-	_ASSERTE(ip >=0 && next <= size);
+	_ASSERTE(ip >= ip_t::zero && count > 0);
+	ip_t last = LastIp;
+	const ip_t next = ip + count;
+	_ASSERTE(next <= last+1);
 	const BYTECODE& bc = m_bytecodes[ip];
 	WORD jumpsTo = bc.jumpsTo;
 
 	const BYTECODES::iterator begin = m_bytecodes.begin();
-	m_bytecodes.erase(begin + ip, begin + next);
+	m_bytecodes.erase(begin + static_cast<size_t>(ip), begin + static_cast<size_t>(next));
 	
-	size -= count;
-	if (ip < size)
+	last -= count;
+	if (ip <= last)
 	{
-		_ASSERTE(jumpsTo == 0 || m_bytecodes[ip].isOpCode());
+		_ASSERTE(jumpsTo == 0 || m_bytecodes[ip].IsOpCode);
 		// Following byte may become jump target
 		m_bytecodes[ip].jumpsTo += jumpsTo;
 	}
@@ -187,17 +187,17 @@ void Compiler::RemoveBytes(int ip, int count)
 
 	// Adjust any jumps to targets past the removal point as the target will have shuffled up
 	{
-		for (int i = 0; i < size;)
+		for (ip_t i = ip_t::zero; i < last;)
 		{
 			BYTECODE& bc = m_bytecodes[i];
-			_ASSERTE(bc.isOpCode());
-			if (bc.isJumpSource())
+			_ASSERTE(bc.IsOpCode);
+			if (bc.IsJumpSource)
 			{
-				_ASSERTE(bc.target < size + count);
+				_ASSERTE(bc.target <= last + count);
 				// This is a jump. Does it cross the boundary
 				if (bc.target >= next)
 					bc.target -= count;		// Yes, adjust absolute target
-				_ASSERTE(bc.target >= 0);
+				_ASSERTE(bc.target >= ip_t::zero);
 			}
 
 			i += lengthOfByteCode(bc.byte);
@@ -206,17 +206,17 @@ void Compiler::RemoveBytes(int ip, int count)
 	
 	// Adjust ip of any TextMaps
 	{
-		const int textMapCount = m_textMaps.size();
-		for (int i = 0; i < textMapCount; i++)
+		const size_t textMapCount = m_textMaps.size();
+		for (size_t i = 0; i < textMapCount; i++)
 		{
 			TEXTMAP& textMap = m_textMaps[i];
 			// If the text map entry is in the range of removed bytes, adjust it to point at the next instruction
 			// If the text map is for a later instruction, then adjust its ip to keep pointing at the same (moved up) instruction
-			int mapIp = textMap.ip;
+			ip_t mapIp = textMap.ip;
 			if (mapIp > ip)
 			{
 				textMap.ip = mapIp < next ? ip : mapIp - count;
-				_ASSERTE(textMap.ip >= 0 && textMap.ip < size);
+				_ASSERTE(textMap.ip <= last);
 				AssertValidIpForTextMapEntry(textMap.ip, false);
 			}
 		}
@@ -229,12 +229,12 @@ inline int decodeOuterTempRef(BYTE byte, int& index)
 	return byte >> OuterTempIndexBits;
 }
 
-bool Compiler::AdjustTextMapEntry(int ip, int newIP)
+bool Compiler::AdjustTextMapEntry(ip_t ip, ip_t newIP)
 {
-	if (!WantTextMap()) return true;
+	if (!WantTextMap) return true;
 
-	const int count = m_textMaps.size();
-	for (int i = 0; i < count; i++)
+	const size_t count = m_textMaps.size();
+	for (size_t i = 0; i < count; i++)
 	{
 		TEXTMAP& textMap = m_textMaps[i];
 		if (textMap.ip == ip)
@@ -246,25 +246,26 @@ bool Compiler::AdjustTextMapEntry(int ip, int newIP)
 	return false;
 }
 
-int Compiler::OptimizePairs()
+unsigned Compiler::OptimizePairs()
 {
 	// Optimize pairs of instructions.
 	// Returns a count of the optimizations done.
-	int count=0, i=0;
-	while (i < GetCodeSize())
+	unsigned count = 0;
+	ip_t i = ip_t::zero;
+	while (i <= LastIp)
 	{
 		VerifyTextMap();
 		BYTECODE& bytecode1=m_bytecodes[i];
-		const int len1 = bytecode1.instructionLength();
-		const int next = i+len1;
-		if (next >= GetCodeSize())
+		const size_t len1 = bytecode1.InstructionLength;
+		const ip_t next = i+len1;
+		if (next > LastIp)
 			break;					// bytecode1 is last instruction
 		BYTECODE& bytecode2=m_bytecodes[next];
 		
-		_ASSERTE(bytecode1.isOpCode() && bytecode2.isOpCode());
+		_ASSERTE(bytecode1.IsOpCode && bytecode2.IsOpCode);
 		
 		// We can't perform any of these optimizations if the second byte code is a jump target
-		if (!bytecode2.isJumpTarget())
+		if (!bytecode2.IsJumpTarget)
 		{
 			BYTE byte1 = bytecode1.byte;
 			BYTE byte2 = bytecode2.byte;
@@ -274,7 +275,7 @@ int Compiler::OptimizePairs()
 			// by a return special but only if the second is not a jump
 			// target.
 			//
-			if (bytecode1.isPseudoPush() && byte2 == ReturnMessageStackTop)
+			if (bytecode1.IsPseudoPush && byte2 == ReturnMessageStackTop)
 			{
 				// Can avoid need to modify text map if we remove the push and adjust the return instruction
 				bytecode2.byte = FirstPseudoReturn + (byte1 - FirstPseudoPush);
@@ -284,7 +285,7 @@ int Compiler::OptimizePairs()
 			}
 
 			// We must perform same optimisation in debug code to keep the text maps synchronised
-			else if (bytecode1.isPseudoPush() && byte2 == Break && m_bytecodes[next+1].byte == ReturnMessageStackTop)
+			else if (bytecode1.IsPseudoPush && byte2 == Break && m_bytecodes[next+1].byte == ReturnMessageStackTop)
 			{
 				m_bytecodes[next+1].byte = FirstPseudoReturn + (byte1 - FirstPseudoPush);
 				RemoveInstruction(i);
@@ -304,7 +305,7 @@ int Compiler::OptimizePairs()
 			}
 			
 			// Quite a lot of pushes are redundant, and can be removed...
-			else if (bytecode1.isPush())
+			else if (bytecode1.IsPush)
 			{
 				// A push immediately followed by a pop that is not immediately
 				// jumped to can be replaced by nothing.
@@ -315,7 +316,7 @@ int Compiler::OptimizePairs()
 					(byte1==ShortPushNil && byte2 == LongJumpIfNotNil) 
 					)
 				{
-					_ASSERTE(!bytecode2.isJumpTarget());
+					_ASSERTE(!bytecode2.IsJumpTarget);
 					if (byte2 != PopStackTop)
 						VoidTextMapEntry(next);
 					RemoveInstruction(i);
@@ -325,9 +326,9 @@ int Compiler::OptimizePairs()
 				}
 				
 				// Push followed by pseudo return is redundant, and can be removed leaving on the return
-				else if (bytecode2.isPseudoReturn())
+				else if (bytecode2.IsPseudoReturn)
 				{
-					_ASSERTE(!bytecode2.isJumpTarget());
+					_ASSERTE(!bytecode2.IsJumpTarget);
 					RemoveInstruction(i);
 					count++;
 					continue;	// Continue optimization on the pseudo return now move to i
@@ -337,7 +338,7 @@ int Compiler::OptimizePairs()
 				{
 					// If push true followed by jump if true (which is not a jump target)
 					// then equivalent to an unconditional jump
-					_ASSERTE(!bytecode2.isJumpTarget());
+					_ASSERTE(!bytecode2.IsJumpTarget);
 					VoidTextMapEntry(i+1);
 					bytecode2.byte = LongJump;
 					RemoveInstruction(i);	// Remove the push ...
@@ -348,7 +349,7 @@ int Compiler::OptimizePairs()
 				{
 					// If push false followed by jump if false (which is not a jump target)
 					// then equivalent to an unconditional jump
-					_ASSERTE(!bytecode2.isJumpTarget());
+					_ASSERTE(!bytecode2.IsJumpTarget);
 					VoidTextMapEntry(i+1);
 					bytecode2.byte = LongJump;
 					RemoveInstruction(i);	// Remove the push ...
@@ -359,7 +360,7 @@ int Compiler::OptimizePairs()
 				{
 					// If push nil followed by jump if nil (which is not a jump target)
 					// then equivalent to an unconditional jump
-					_ASSERTE(!bytecode2.isJumpTarget());
+					_ASSERTE(!bytecode2.IsJumpTarget);
 					VoidTextMapEntry(i+1);
 					bytecode2.byte = LongJump;
 					RemoveInstruction(i);	// Remove the push ...
@@ -454,7 +455,7 @@ int Compiler::OptimizePairs()
 				{
 					if (byte2 == SpecialSendIdentical)
 					{
-						_ASSERTE(!bytecode1.isJumpSource());
+						_ASSERTE(!bytecode1.IsJumpSource);
 						bytecode2.byte = IsZero;
 						RemoveInstruction(i);
 						count++;
@@ -464,7 +465,7 @@ int Compiler::OptimizePairs()
 					//else if (byte2 == SendArithmeticAdd || byte2 == SendArithmeticSub)
 					//{
 					//	// Subtract or add zero is, of course, redundant
-					//	_ASSERTE(!bytecode1.isJumpSource());
+					//	_ASSERTE(!bytecode1.IsJumpSource);
 					//	RemoveInstruction(i+1);
 					//	RemoveInstruction(i);
 					//	count++;
@@ -474,7 +475,7 @@ int Compiler::OptimizePairs()
 			}
 			
 			// Check for unreachable code (remember the following byte is known not to be a jump target)
-			else if (bytecode1.isReturn() || bytecode1.isLongJump())
+			else if (bytecode1.IsReturn || bytecode1.IsLongJump)
 			{
 				VerifyJumps();
 				VoidTextMapEntry(next);
@@ -485,13 +486,13 @@ int Compiler::OptimizePairs()
 				continue;
 			}
 			
-			else if (bytecode1.isExtendedStore())
+			else if (bytecode1.IsExtendedStore)
 			{
 				// A store instruction followed by a pop that is not immediately
 				// jumped to can be coerced (heh heh) into a pop and store.
 				if (byte2==PopStackTop)
 				{
-					_ASSERTE(!bytecode2.isJumpTarget());
+					_ASSERTE(!bytecode2.IsJumpTarget);
 					if (byte1 == StoreOuterTemp)
 					{
 						// Remove the popStack
@@ -529,9 +530,9 @@ int Compiler::OptimizePairs()
 						
 						// Now there may be a shorter form of instruction that 
 						// we can use
-						_ASSERTE(m_bytecodes[i+1].isData());
+						_ASSERTE(m_bytecodes[i+1].IsData);
 						
-						_ASSERTE(i+1 < GetCodeSize());
+						_ASSERTE(i+1 <= LastIp);
 						int index = m_bytecodes[i+1].byte;
 						if (bytecode1.byte == PopStoreInstVar && index < NumShortPopStoreInstVars)
 						{
@@ -551,7 +552,7 @@ int Compiler::OptimizePairs()
 			}
 
 			// Same as above for the next ShortStoreTemp instruction
-			else if (bytecode1.isShortStoreTemp())
+			else if (bytecode1.IsShortStoreTemp)
 			{
 				 if (byte2 == PopStackTop)
 				 {
@@ -564,9 +565,9 @@ int Compiler::OptimizePairs()
 				 }
 			}
 
-			else if (byte1 == SpecialSendIsNil && bytecode2.isJumpSource())
+			else if (byte1 == SpecialSendIsNil && bytecode2.IsJumpSource)
 			{
-				_ASSERTE(bytecode2.instructionLength() == 3);
+				_ASSERTE(bytecode2.InstructionLength == 3);
 				if (byte2 == LongJumpIfTrue)
 				{
 					bytecode2.byte = LongJumpIfNil;
@@ -589,9 +590,9 @@ int Compiler::OptimizePairs()
 					continue;	// A new instruction will now be at i to be considered, so don't advance
 				}
 			}
-			else if (byte1 == SpecialSendNotNil && bytecode2.isJumpSource())
+			else if (byte1 == SpecialSendNotNil && bytecode2.IsJumpSource)
 			{
-				_ASSERTE(bytecode2.instructionLength() == 3);
+				_ASSERTE(bytecode2.InstructionLength == 3);
 				if (byte2 == LongJumpIfTrue)
 				{
 					bytecode2.byte = LongJumpIfNotNil;
@@ -616,7 +617,7 @@ int Compiler::OptimizePairs()
 				if (byte2 == ReturnMessageStackTop)
 				{
 					// A Dup immediately before a Return ToS is redundant
-					_ASSERTE(!bytecode2.isJumpTarget());
+					_ASSERTE(!bytecode2.IsJumpTarget);
 					bytecode1.byte = ReturnMessageStackTop;
 					count++;
 					// Leave the other return to be removed as unreachable code
@@ -628,15 +629,15 @@ int Compiler::OptimizePairs()
 					BYTECODE& target = m_bytecodes[bytecode2.target];
 					if (target.byte == PopStackTop && target.jumpsTo == 1)
 					{
-						int nilBranch = next + bytecode2.instructionLength();
+						ip_t nilBranch = next + bytecode2.InstructionLength;
 						BYTECODE& bytecode3 = m_bytecodes[nilBranch];
-						if (bytecode3.byte = PopStackTop)
+						if (bytecode3.byte == PopStackTop)
 						{
 							// Remove Dup and Pop from first branch, and retarget jump over to next after the pop
 							target.removeJumpTo();
 							m_bytecodes[++bytecode2.target].addJumpTo();
 
-							_ASSERTE(!m_bytecodes[nilBranch].isJumpTarget());
+							_ASSERTE(!m_bytecodes[nilBranch].IsJumpTarget);
 							// Remove Pop from nil branch
 							RemoveInstruction(nilBranch);
 							// Remove Dup
@@ -647,7 +648,7 @@ int Compiler::OptimizePairs()
 					}
 				}
 			}
-			else if ((bytecode1.isShortPopStoreTemp() && bytecode2.isShortPushTemp())
+			else if ((bytecode1.IsShortPopStoreTemp && bytecode2.IsShortPushTemp)
 						&& (bytecode1.indexOfShortPopStoreTemp() == bytecode2.indexOfShortPushTemp()))
 			{
 				// Replace a PopStore[n], Push[n], sequence with a store
@@ -669,12 +670,12 @@ int Compiler::OptimizePairs()
 				count++;
 				continue;	// A new instruction will now be at i to be considered, so don't advance
 			}
-			else if (bytecode1.isLongConditionalJump() && bytecode2.isLongJump()
+			else if (bytecode1.IsLongConditionalJump && bytecode2.IsLongJump
 				&&  bytecode1.target == next + 3)
 			{
 				// Conditional jump over unconditional jump can be replaced with 
 				// inverted conditional jump to unconditional jump's target
-				BYTE invertedJmp;
+				uint8_t invertedJmp;
 				switch (bytecode1.byte)
 				{
 				case LongJumpIfTrue:
@@ -708,7 +709,7 @@ int Compiler::OptimizePairs()
 		
 		// A store into a temp followed by a return from method is redundant, even if
 		// either is a jump target
-		if (bytecode1.isStoreStackTemp() && bytecode2.isReturn())
+		if (bytecode1.IsStoreStackTemp && bytecode2.IsReturn)
 		{
 			// bytecode1 is a Store (assignment) and might have a text map entry (the Store for
 			// an ifNotNil: block will not).
@@ -723,9 +724,9 @@ int Compiler::OptimizePairs()
 		
 		VerifyJumps();
 
-		// Bytecode may have been replaced, so move to next based on the one there now
-		_ASSERTE(m_bytecodes[i].isOpCode());
-		const int len = m_bytecodes[i].instructionLength();
+		// m_bytecodes may have been replaced, so move to next based on the one there now
+		_ASSERTE(m_bytecodes[i].IsOpCode);
+		const size_t len = m_bytecodes[i].InstructionLength;
 		i += len;
 	}
 	return count;
@@ -735,31 +736,32 @@ int Compiler::OptimizePairs()
 // here generates incorrect code for CombinePairs1 and it fails to spot Push Temp;Send Zero Args pairs.
 #pragma optimize("g", off)
 
-int Compiler::CombinePairs()
+unsigned Compiler::CombinePairs()
 {
 	return CombinePairs1() + CombinePairs2();
 }
 
 // Combine pairs of instructions into the more favoured macro instructions. This should be done
 // before CombinePairs2(). Returns a count of the optimizations done.
-int Compiler::CombinePairs1()
+unsigned Compiler::CombinePairs1()
 {
-	int count=0, i=0;
-	while (i < GetCodeSize())
+	unsigned count = 0;
+	ip_t i=ip_t::zero;
+	while (i <= LastIp)
 	{
 		VerifyTextMap();
 		BYTECODE& bytecode1=m_bytecodes[i];
-		const int len1 = bytecode1.instructionLength();
+		const size_t len1 = bytecode1.InstructionLength;
 		
-		const int next = i+len1;
-		if (next >= GetCodeSize())
+		const ip_t next = i+len1;
+		if (next > LastIp)
 			break;					// bytecode1 is last instruction
 		BYTECODE& bytecode2=m_bytecodes[next];
 		
-		_ASSERTE(bytecode1.isOpCode() && bytecode2.isOpCode());
+		_ASSERTE(bytecode1.IsOpCode && bytecode2.IsOpCode);
 
 		// We can't perform any of these optimizations if the second byte code is a jump target
-		if (!bytecode2.isJumpTarget())
+		if (!bytecode2.IsJumpTarget)
 		{
 			const BYTE byte1 = bytecode1.byte;
 			const BYTE byte2 = bytecode2.byte;
@@ -772,10 +774,10 @@ int Compiler::CombinePairs1()
 			{
 				if (byte2 == Send)
 				{
-					_ASSERTE(m_bytecodes[next+1].isData());
-					int m = m_bytecodes[next+1].byte;
+					_ASSERTE(m_bytecodes[next+1].IsData);
+					uint8_t m = m_bytecodes[next+1].byte;
 					_ASSERTE(SendXLiteralBits == 5);
-					int argCount = m >> SendXLiteralBits;
+					uint8_t argCount = m >> SendXLiteralBits;
 					if (argCount == 0)
 					{
 						// Push Self will become the Send Self instruction
@@ -787,7 +789,7 @@ int Compiler::CombinePairs1()
 						RemoveByte(next+1);
 					}
 				}
-				else if (bytecode2.isShortSendWithNoArgs())
+				else if (bytecode2.IsShortSendWithNoArgs)
 				{
 					_ASSERTE(len1 == 1);
 					VERIFY(AdjustTextMapEntry(next, i));
@@ -809,11 +811,11 @@ int Compiler::CombinePairs1()
 			} 
 
 			// Look for opportunities to combine push temp with subsequent zero arg send
-			else if (bytecode1.isShortPushTemp())
+			else if (bytecode1.IsShortPushTemp)
 			{
 				int n = bytecode1.indexOfShortPushTemp();
 
-				if (bytecode2.isShortSendWithNoArgs())
+				if (bytecode2.IsShortSendWithNoArgs)
 				{
 					// Push Temp has become the Send Temp instruction
 					VERIFY(AdjustTextMapEntry(next, i));
@@ -829,10 +831,10 @@ int Compiler::CombinePairs1()
 				}
 				else if (byte2 == Send)
 				{
-					_ASSERTE(m_bytecodes[next+1].isData());
-					int m = m_bytecodes[next+1].byte;
+					_ASSERTE(m_bytecodes[next+1].IsData);
+					uint8_t m = m_bytecodes[next+1].byte;
 					_ASSERTE(SendXLiteralBits <= 5);
-					int argCount = m >> SendXLiteralBits;
+					uint8_t argCount = m >> SendXLiteralBits;
 					if (argCount == 0)
 					{
 						// Push Temp will become the Send Temp instruction
@@ -856,11 +858,11 @@ int Compiler::CombinePairs1()
 
 					// byte2 cannot possibly be the last instruction
 					BYTECODE& bytecode3=m_bytecodes[next+1];
-					if (!bytecode3.isJumpTarget())
+					if (!bytecode3.IsJumpTarget)
 					{
-						if (bytecode3.isShortPopStoreTemp())
+						if (bytecode3.IsShortPopStoreTemp)
 						{
-							int m =  bytecode3.indexOfShortPopStoreTemp();
+							uint8_t m = bytecode3.indexOfShortPopStoreTemp();
 							if (m == n)
 							{
 								VERIFY(AdjustTextMapEntry(next, i));
@@ -873,9 +875,9 @@ int Compiler::CombinePairs1()
 								count++;
 							}
 						}
-						else if (bytecode3.isShortStoreTemp())
+						else if (bytecode3.IsShortStoreTemp)
 						{
-							int m =  bytecode3.indexOfShortStoreTemp();
+							uint8_t m = bytecode3.indexOfShortStoreTemp();
 							if (m == n)
 							{
 								bytecode1.byte = byte2 == IncrementStackTop ? IncrementPushTemp : DecrementPushTemp;
@@ -891,7 +893,7 @@ int Compiler::CombinePairs1()
 						}
 						else if (bytecode3.byte == PopStoreTemp || bytecode3.byte == StoreTemp)
 						{
-							int m = m_bytecodes[next+2].byte;
+							uint8_t m = m_bytecodes[next+2].byte;
 							if (m == n)
 							{
 								bytecode1.byte = bytecode3.byte == PopStoreTemp 
@@ -910,24 +912,24 @@ int Compiler::CombinePairs1()
 			}
 			else if (byte1 == PushTemp)
 			{
-				_ASSERTE(m_bytecodes[i+1].isData());
-				int n = m_bytecodes[i+1].byte;
+				_ASSERTE(m_bytecodes[i+1].IsData);
+				uint8_t n = m_bytecodes[i+1].byte;
 
 				if (byte2 == Send)
 				{
 					 if (n <= MAXFORBITS(3))
 					 {
-						_ASSERTE(m_bytecodes[next+1].isData());
+						_ASSERTE(m_bytecodes[next+1].IsData);
 						_ASSERTE(SendXLiteralBits <= 5);
-						int m = m_bytecodes[next+1].byte;
-						int argCount = m >> SendXLiteralBits;
+						uint8_t m = m_bytecodes[next+1].byte;
+						uint8_t argCount = m >> SendXLiteralBits;
 						if (argCount == 0)
 						{
 							DebugBreak();
 						}
 					 }
 				}
-				else if (bytecode2.isShortSendWithNoArgs())
+				else if (bytecode2.IsShortSendWithNoArgs)
 				{
 					if (n <= MAXFORBITS(3))
 					{
@@ -950,7 +952,7 @@ int Compiler::CombinePairs1()
 
 					// byte2 cannot possibly be the last instruction
 					BYTECODE& bytecode3=m_bytecodes[next+1];
-					if (!bytecode3.isJumpTarget())
+					if (!bytecode3.IsJumpTarget)
 					{
 						if (bytecode3.byte == PopStoreTemp || bytecode3.byte == StoreTemp)
 						{
@@ -978,9 +980,9 @@ int Compiler::CombinePairs1()
 			}
 		}
 		
-		// Bytecode may have been replaced, so move to next based on the one there now
-		_ASSERTE(m_bytecodes[i].isOpCode());
-		const int len = m_bytecodes[i].instructionLength();
+		// m_bytecodes may have been replaced, so move to next based on the one there now
+		_ASSERTE(m_bytecodes[i].IsOpCode);
+		const size_t len = m_bytecodes[i].InstructionLength;
 		i += len;
 	}
 	return count;
@@ -988,27 +990,28 @@ int Compiler::CombinePairs1()
 
 // Combine pairs of instructions into the less favoured macro instructions. This should be done
 // after CombinePairs1(). Returns a count of the optimizations done.
-int Compiler::CombinePairs2()
+unsigned Compiler::CombinePairs2()
 {
-	int count=0, i=0;
-	while (i < GetCodeSize())
+	unsigned count = 0;
+	ip_t i = ip_t::zero;
+	while (i <= LastIp)
 	{
 		VerifyTextMap();
 		BYTECODE& bytecode1=m_bytecodes[i];
-		const int len1 = bytecode1.instructionLength();
+		const size_t len1 = bytecode1.InstructionLength;
 		
-		const int next = i+len1;
-		if (next >= GetCodeSize())
+		const ip_t next = i+len1;
+		if (next > LastIp)
 			break;					// bytecode1 is last instruction
 		BYTECODE& bytecode2=m_bytecodes[next];
 		
-		_ASSERTE(bytecode1.isOpCode() && bytecode2.isOpCode());
+		_ASSERTE(bytecode1.IsOpCode && bytecode2.IsOpCode);
 
 		BYTE byte1 = bytecode1.byte;
 		BYTE byte2 = bytecode2.byte;
 
 		// We can't perform any of these optimizations if the second byte code is a jump target
-		if (!bytecode2.isJumpTarget())
+		if (!bytecode2.IsJumpTarget)
 		{
 			if (byte1 == PopStackTop)
 			{
@@ -1038,7 +1041,7 @@ int Compiler::CombinePairs2()
 					count++;
 				}
 
-				else if (bytecode2.isShortPushTemp() && (bytecode2.indexOfShortPushTemp() < NumShortPopPushTemps))
+				else if (bytecode2.IsShortPushTemp && (bytecode2.indexOfShortPushTemp() < NumShortPopPushTemps))
 				{
 					// Pop followed by a push of a temp is common in a sequence of statements where
 					// messages are sent to a temp
@@ -1052,7 +1055,7 @@ int Compiler::CombinePairs2()
 
 			else if (byte1 == ShortPushSelf)
 			{
-				if (bytecode2.isPushTemp())
+				if (bytecode2.IsPushTemp)
 				{
 					// A pair of push self and then pushing a temp is very common, being the prelude
 					// to sending a one (or more) arg message to self
@@ -1091,24 +1094,24 @@ int Compiler::CombinePairs2()
 
 			// Look for opportunities to combine pairs of push temp instructions into one
 			// Pairs of temp pushes are common before sending 1 or more argument messages
-			else if (bytecode1.isShortPushTemp())
+			else if (bytecode1.IsShortPushTemp)
 			{
 				int n = bytecode1.indexOfShortPushTemp();
 
 				if (byte2 == PushTemp)
 				{
-					_ASSERTE(m_bytecodes[next+1].isData());
-					int m = m_bytecodes[next+1].byte;
+					_ASSERTE(m_bytecodes[next+1].IsData);
+					uint8_t m = m_bytecodes[next+1].byte;
 					if (m < MAXFORBITS(4))
 					{
 						bytecode1.byte = PushTempPair;
 						RemoveBytes(next, 1);
-						_ASSERTE(m_bytecodes[next].isData());
+						_ASSERTE(m_bytecodes[next].IsData);
 						m_bytecodes[next].byte = n << 4 | m;
 						count++;
 					}
 				}
-				else if (bytecode2.isShortPushTemp())
+				else if (bytecode2.IsShortPushTemp)
 				{
 					int m = bytecode2.indexOfShortPushTemp();
 					_ASSERTE(n <= MAXFORBITS(4));
@@ -1122,16 +1125,16 @@ int Compiler::CombinePairs2()
 
 			else if (byte1 == PushTemp)
 			{
-				_ASSERTE(m_bytecodes[i+1].isData());
+				_ASSERTE(m_bytecodes[i+1].IsData);
 				int n = m_bytecodes[i+1].byte;
 
-				if (bytecode2.isPushTemp())
+				if (bytecode2.IsPushTemp)
 				{
 					if (n <= MAXFORBITS(4))
 					{
 						if (byte2 == PushTemp)
 						{
-							_ASSERTE(m_bytecodes[next+1].isData());
+							_ASSERTE(m_bytecodes[next+1].IsData);
 							int m = m_bytecodes[next+1].byte;
 							if (m <= MAXFORBITS(4))
 							{
@@ -1143,7 +1146,7 @@ int Compiler::CombinePairs2()
 						}
 						else
 						{
-							_ASSERTE(bytecode2.isShortPushTemp());
+							_ASSERTE(bytecode2.IsShortPushTemp);
 							int m = bytecode2.indexOfShortPushTemp();
 							_ASSERTE(n <= MAXFORBITS(4));
 							_ASSERTE(m <= MAXFORBITS(4));
@@ -1157,9 +1160,9 @@ int Compiler::CombinePairs2()
 			}
 		}
 		
-		// Bytecode may have been replaced, so move to next based on the one there now
-		_ASSERTE(m_bytecodes[i].isOpCode());
-		const int len = m_bytecodes[i].instructionLength();
+		// m_bytecodes may have been replaced, so move to next based on the one there now
+		_ASSERTE(m_bytecodes[i].IsOpCode);
+		const size_t len = m_bytecodes[i].InstructionLength;
 		i += len;
 	}
 	return count;
@@ -1169,78 +1172,79 @@ int Compiler::CombinePairs2()
 
 void Compiler::FixupJumps()
 {
-	const int loopEnd = GetCodeSize();
-	int i=0;
+	const ip_t last = LastIp;
+	ip_t i = ip_t::zero;
 	LexicalScope* pCurrentScope = GetMethodScope();
-	pCurrentScope->SetInitialIP(0);
+	pCurrentScope->InitialIP = ip_t::zero;
 
-	while (i<loopEnd)
+	while (i<=last)
 	{
-		_ASSERTE(m_bytecodes[i].isOpCode());
+		_ASSERTE(m_bytecodes[i].IsOpCode);
 
 		//_CrtCheckMemory();
-		if (m_bytecodes[i].isJumpSource())
+		if (m_bytecodes[i].IsJumpSource)
 		{
-			_ASSERTE(m_bytecodes[i].isJumpInstruction());
+			_ASSERTE(m_bytecodes[i].IsJumpInstruction);
 
 			FixupJump(i);
-			_ASSERTE(m_bytecodes[i].isJumpInstruction());
+			_ASSERTE(m_bytecodes[i].IsJumpInstruction);
 		}
 		else
-			_ASSERTE(!m_bytecodes[i].isJumpInstruction());
+			_ASSERTE(!m_bytecodes[i].IsJumpInstruction);
 	
 		// Patch up the ip range of the scopes as we encounter them
 		if (m_bytecodes[i].pScope != pCurrentScope)
 		{
 			// Note that setting of the final IP may happen more than once
 			// as the block goes in and out of scope
-			pCurrentScope->SetFinalIP(i-1);
+			pCurrentScope->FinalIP = i-1;
 			pCurrentScope = m_bytecodes[i].pScope;
-			_ASSERTE(pCurrentScope != NULL);
+			_ASSERTE(pCurrentScope != nullptr);
 			// Patch up the initialIP of the scope for the temps map
 			pCurrentScope->MaybeSetInitialIP(i);
 		}
 
-		_ASSERTE(m_bytecodes[i].isOpCode());
-		int len = m_bytecodes[i].instructionLength();
+		_ASSERTE(m_bytecodes[i].IsOpCode);
+		size_t len = m_bytecodes[i].InstructionLength;
 		i += len;
 		// Code size cannot shrink
-		_ASSERTE(GetCodeSize() == loopEnd);
+		_ASSERTE(LastIp == last);
 	}
 
-	pCurrentScope->SetFinalIP(GetCodeSize()-1);
-	_ASSERTE(GetMethodScope()->GetFinalIP() == GetCodeSize()-1);
+	pCurrentScope->FinalIP = LastIp;
+	_ASSERTE(GetMethodScope()->FinalIP == LastIp);
 }
 
-int Compiler::OptimizeJumps()
+unsigned Compiler::OptimizeJumps()
 {
 	// Run through seeing if any jumps can be removed or retargeted.
 	// Return a count of the number of jumps replaced.
 	//
-	int count=0, i=0;
-	while (i<GetCodeSize())
+	unsigned count = 0;
+	ip_t i = ip_t::zero;
+	while (i<=LastIp)
 	{
 		VerifyTextMap();
 		BYTECODE& bytecode = m_bytecodes[i];
-		_ASSERTE(bytecode.isOpCode());
-		int len = bytecode.instructionLength();
-		if (bytecode.isJumpSource())
+		_ASSERTE(bytecode.IsOpCode);
+		size_t len = bytecode.InstructionLength;
+		if (bytecode.IsJumpSource)
 		{
 			// At this stage all jumps should be long
-			_ASSERTE(bytecode.byte == BlockCopy || bytecode.instructionLength() == 3);
+			_ASSERTE(bytecode.byte == BlockCopy || bytecode.InstructionLength == 3);
 
 			// Compute relative distance from this instructions
 			// (N.B. Bear in mind that jumps start after the instruction itself, but the distance
 			// we calculate here is from the jump itself)
-			int currentTarget = bytecode.target;
-			_ASSERTE(currentTarget >= 0 && currentTarget < GetCodeSize());
+			ip_t currentTarget = bytecode.target;
+			_ASSERTE(currentTarget <= LastIp);
 			BYTECODE& target = m_bytecodes[currentTarget];
-			_ASSERTE(target.isJumpTarget());
+			_ASSERTE(target.IsJumpTarget);
 			BYTE targetByte = target.byte;
 
-			int distance = currentTarget-i;
-			int offset = distance - len;
-			if (!offset)
+			intptr_t distance = static_cast<intptr_t>(currentTarget) - static_cast<intptr_t>(i);
+			intptr_t offset = distance - len;
+			if (offset == 0)
 			{
 				_ASSERTE(bytecode.byte != BlockCopy);
 
@@ -1261,7 +1265,7 @@ int Compiler::OptimizeJumps()
 				continue;	// Go round again at same IP
 			}
 			
-			if (target.isJumpSource())
+			if (target.IsJumpSource)
 			{
 				if (target.byte == LongJump)
 				{
@@ -1270,8 +1274,8 @@ int Compiler::OptimizeJumps()
 					{
 						// Any jump to an unconditional jump can be redirected to its
 						// eventual target.
-						int eventualtarget=target.target;
-						_ASSERTE(eventualtarget >= 0 && eventualtarget < GetCodeSize());
+						ip_t eventualtarget=target.target;
+						_ASSERTE(eventualtarget <= LastIp);
 						target.removeJumpTo();		// We're no longer jumping to original target
 						SetJumpTarget(i, eventualtarget);
 						count++;
@@ -1283,36 +1287,36 @@ int Compiler::OptimizeJumps()
 					// Unconditional jump to a conditional jump can be replaced
 					// with a conditional jump (of the same type) to the same target
 					// and an unconditional jump to the location after the original cond jump target
-					_ASSERTE(target.isLongConditionalJump());
+					_ASSERTE(target.IsLongConditionalJump);
 					_ASSERTE(len == 3);
 					bytecode.byte = target.byte;
-					int eventualtarget = target.target;
-					_ASSERTE(eventualtarget >= 0 && eventualtarget < GetCodeSize());
+					ip_t eventualtarget = target.target;
+					_ASSERTE(eventualtarget <= LastIp);
 					target.removeJumpTo();		// We're no longer jumping to original target
 					SetJumpTarget(i, eventualtarget);
 					m_codePointer = i + len;
 					m_pCurrentScope = bytecode.pScope;
 					GenJump(LongJump, currentTarget+3);
-					m_pCurrentScope = NULL;
+					m_pCurrentScope = nullptr;
 					count++;
 					continue;	// Reconsider this jump as may be in a chain
 				}
 			}
-			else if (target.isPush())
+			else if (target.IsPush)
 			{
 				// If jumping to push followed by pop, can skip to the next instruction
 				// This is quite a common result of conditional expressions
 				
 				// Can't be last byte (wouldn't make sense, as need a return)
-				int next = currentTarget + target.instructionLength();
-				_ASSERTE(next < GetCodeSize());
+				ip_t next = currentTarget + target.InstructionLength;
+				_ASSERTE(next <= LastIp);
 				BYTECODE& nextAfterTarget=m_bytecodes[next];
 				if (nextAfterTarget.byte == PopStackTop)
 				{
-					_ASSERTE(nextAfterTarget.instructionLength() == 1);
+					_ASSERTE(nextAfterTarget.InstructionLength == 1);
 					// Yup its a jump to a no-op, so retarget to following byte
 					target.removeJumpTo();
-					_ASSERTE(next+1 < GetCodeSize());	// Again, must be at least a ret to follow
+					_ASSERTE(next+1 <= LastIp);	// Again, must be at least a ret to follow
 					SetJumpTarget(i, next+1);
 					count++;
 					continue;	// Reconsider this jump as may be in a chain
@@ -1327,45 +1331,46 @@ int Compiler::OptimizeJumps()
 	return count;
 }
 
-int Compiler::InlineReturns()
+unsigned Compiler::InlineReturns()
 {
 	// Jumps to return instructions can be replaced by the return instruction
 	// Note that this is done last in optimisation as quite often such jumps
 	// can be removed altogether due to elimination of unreachable/redundant code.
 	//
-	int count=0, i=0;
-	while (i<GetCodeSize())
+	unsigned count = 0;
+	ip_t i = ip_t::zero;
+	while (i<=LastIp)
 	{
 		//_CrtCheckMemory();
 		BYTECODE& bytecode = m_bytecodes[i];
-		_ASSERTE(bytecode.isOpCode());
-		int len = bytecode.instructionLength();
-		if (bytecode.isJumpSource())
+		_ASSERTE(bytecode.IsOpCode);
+		size_t len = bytecode.InstructionLength;
+		if (bytecode.IsJumpSource)
 		{
 			// At this stage all jumps should be long
-			_ASSERTE(bytecode.byte == BlockCopy || bytecode.instructionLength() == 3);
+			_ASSERTE(bytecode.byte == BlockCopy || bytecode.InstructionLength == 3);
 
 			// Compute relative distance from this instructions
 			// (N.B. Bear in mind that jumps start after the instruction itself, but the distance
 			// we calculate here is from the jump itself)
-			int currentTarget = bytecode.target;
-			_ASSERTE(currentTarget >= 0 && currentTarget < GetCodeSize());
+			ip_t currentTarget = bytecode.target;
+			_ASSERTE(currentTarget <= LastIp);
 			BYTECODE& target = m_bytecodes[currentTarget];
-			_ASSERTE(target.isJumpTarget());
+			_ASSERTE(target.IsJumpTarget);
 			BYTE targetByte = target.byte;
 
 			// Unconditional Jumps to return instructions can be replaced with the return instruction
 			if (bytecode.byte == LongJump)
 			{
-				if (target.isReturn())
+				if (target.IsReturn)
 				{
 					// All return instructions must be 1 byte long
-					_ASSERTE(target.instructionLength() == 1);
+					_ASSERTE(target.InstructionLength == 1);
 					len = 1;
 					bytecode.byte = targetByte;
 					target.removeJumpTo();
 					bytecode.makeNonJump();
-					if (WantTextMap())
+					if (WantTextMap)
 					{
 						// N.B. We need to copy the text map entry for the target
 						TEXTMAP tm = *FindTextMapEntry(currentTarget);
@@ -1376,10 +1381,10 @@ int Compiler::InlineReturns()
 					count++;
 				}
 				// We need to perform the same optimisation in debug methods to ensure the text maps match
-				else if (targetByte == Break && m_bytecodes[currentTarget+1].isReturn())
+				else if (targetByte == Break && m_bytecodes[currentTarget+1].IsReturn)
 				{
 					// All return instructions must be 1 byte long
-					_ASSERTE(target.instructionLength() == 1);
+					_ASSERTE(target.InstructionLength == 1);
 					
 					const BYTECODE& returnOp = m_bytecodes[currentTarget+1];
 
@@ -1389,14 +1394,14 @@ int Compiler::InlineReturns()
 					// and therefore there is no code inline in the method to jump over. We have to special case
 					// this to avoid creating inconsistent text maps. You would think the code sequence '[[]]'
 					// would never appear in a method, but EventsCollection>>triggerEvent: contains it!
-					if (!(returnOp.byte == ReturnBlockStackTop && m_bytecodes[i+len].pScope->GetRealScope()->IsEmptyBlock()))
+					if (!(returnOp.byte == ReturnBlockStackTop && m_bytecodes[i+len].pScope->RealScope->IsEmptyBlock))
 					{
 						len = 2;
 						bytecode.byte = Break;
 						target.removeJumpTo();
 						bytecode.makeNonJump();
 						m_bytecodes[i+1].makeOpCode(m_bytecodes[currentTarget+1].byte, bytecode.pScope);
-						if (WantTextMap())
+						if (WantTextMap)
 						{
 							// N.B. We need to copy the text map entry for the target
 							TEXTMAPLIST::const_iterator it = FindTextMapEntry(currentTarget+1);
@@ -1409,17 +1414,17 @@ int Compiler::InlineReturns()
 				}
 				else if (targetByte == PopStackTop)
 				{
-					if (m_bytecodes[currentTarget+1].isReturn())//.byte == ReturnSelf)
+					if (m_bytecodes[currentTarget+1].IsReturn)//.byte == ReturnSelf)
 					{
 						// All return instructions must be 1 byte long
-						_ASSERTE(target.instructionLength() == 1);
+						_ASSERTE(target.InstructionLength == 1);
 						len = 2;
 
 						bytecode.byte = targetByte;
 						target.removeJumpTo();
 						bytecode.makeNonJump();
 						m_bytecodes[i+1].makeOpCode(m_bytecodes[currentTarget+1].byte, bytecode.pScope);
-						if (WantTextMap())
+						if (WantTextMap)
 						{
 							// N.B. We need to copy the text map entry for the return after the target
 							TEXTMAPLIST::const_iterator it = FindTextMapEntry(currentTarget+1);
@@ -1430,10 +1435,10 @@ int Compiler::InlineReturns()
 						count++;
 					}
 					else if (m_bytecodes[currentTarget+1].byte == Break 
-							&& m_bytecodes[currentTarget+2].isReturn()) //.byte == ReturnSelf)
+							&& m_bytecodes[currentTarget+2].IsReturn) //.byte == ReturnSelf)
 					{
 						// All return instructions must be 1 byte long
-						_ASSERTE(target.instructionLength() == 1);
+						_ASSERTE(target.InstructionLength == 1);
 						len = 3;
 
 						bytecode.byte = targetByte;
@@ -1441,7 +1446,7 @@ int Compiler::InlineReturns()
 						bytecode.makeNonJump();
 						m_bytecodes[i+1].makeOpCode(Break, bytecode.pScope);
 						m_bytecodes[i+2].makeOpCode(m_bytecodes[currentTarget+2].byte, bytecode.pScope);
-						if (WantTextMap())
+						if (WantTextMap)
 						{
 							// N.B. We need to copy the text map entry for the return after the target
 							TEXTMAPLIST::const_iterator it = FindTextMapEntry(currentTarget+2);
@@ -1451,21 +1456,21 @@ int Compiler::InlineReturns()
 						count++;
 					}
 				}
-				else if (target.isPseudoPush())	
+				else if (target.IsPseudoPush)	
 				{
 					// Inline jump to Push [Self|True|False|Nil]; Return sequence
 
-					if (m_bytecodes[currentTarget+1].isReturnStackTop())
+					if (m_bytecodes[currentTarget+1].IsReturnStackTop)
 					{
 						// All return instructions must be 1 byte long
-						_ASSERTE(target.instructionLength() == 1);
+						_ASSERTE(target.InstructionLength == 1);
 						len = 2;
 
 						bytecode.byte = targetByte;
 						target.removeJumpTo();
 						bytecode.makeNonJump();
 						m_bytecodes[i+1].makeOpCode(m_bytecodes[currentTarget+1].byte, bytecode.pScope);
-						if (WantTextMap())
+						if (WantTextMap)
 						{
 							// N.B. We need to copy the text map entry for the return after the target
 							TEXTMAPLIST::const_iterator it = FindTextMapEntry(currentTarget+1);
@@ -1475,10 +1480,10 @@ int Compiler::InlineReturns()
 						RemoveByte(i+2);
 						count++;
 					}
-					else if (m_bytecodes[currentTarget+1].byte == Break && m_bytecodes[currentTarget+2].isReturnStackTop())
+					else if (m_bytecodes[currentTarget+1].byte == Break && m_bytecodes[currentTarget+2].IsReturnStackTop)
 					{
 						// All return instructions must be 1 byte long
-						_ASSERTE(target.instructionLength() == 1);
+						_ASSERTE(target.InstructionLength == 1);
 						len = 3;
 
 						bytecode.byte = targetByte;
@@ -1486,7 +1491,7 @@ int Compiler::InlineReturns()
 						bytecode.makeNonJump();
 						m_bytecodes[i+1].makeOpCode(Break, bytecode.pScope);
 						m_bytecodes[i+2].makeOpCode(m_bytecodes[currentTarget+2].byte, bytecode.pScope);
-						if (WantTextMap())
+						if (WantTextMap)
 						{
 							// N.B. We need to copy the text map entry for the return after the target
 							TEXTMAPLIST::const_iterator it = FindTextMapEntry(currentTarget+2);
@@ -1502,7 +1507,7 @@ int Compiler::InlineReturns()
 		// other is a jump target. Note that we do this after inlining any returns to ensure that
 		// we inline the 'correct' return (the correct one is the one associated with the right text
 		// map entry). T
-		else if (bytecode.isReturn() && i + len < GetCodeSize() && bytecode.byte == m_bytecodes[i+len].byte)
+		else if (bytecode.IsReturn && i + len <= LastIp && bytecode.byte == m_bytecodes[i+len].byte)
 		{
 			VERIFY(VoidTextMapEntry(i));
 			BYTE duplicateReturn = bytecode.byte;
@@ -1524,16 +1529,16 @@ int Compiler::InlineReturns()
 // allow us to take account of the size of the current extension for forward jumps, as otherwise we may
 // miss an opportunity to optimize jumps which are currently near, but could be short if it were not for
 // the extension byte of the Near Jump
-inline static bool isInShortJumpRange(int distance, unsigned extensionBytes)
+inline static bool isInShortJumpRange(intptr_t distance, size_t extensionBytes)
 {
-	int offset = distance - 2;	// Allow for the instruction itself
+	intptr_t offset = distance - 2;	// Allow for the instruction itself
 	return offset >= 0 && (offset - extensionBytes) < NumShortJumps;
 }
 
 // Answer whether the supplied distance is within the possible jump range from the jump
 // instruction. assuming that the current instruction has 'extensionBytes' bytes of extensions.
 //
-inline static bool isInNearJumpRange(int distance, unsigned extensionBytes)
+inline static bool isInNearJumpRange(intptr_t distance, unsigned extensionBytes)
 {
 #if defined(_DEBUG) && !defined(USE_VM_DLL)
 	if (distance == 0)
@@ -1543,9 +1548,9 @@ inline static bool isInNearJumpRange(int distance, unsigned extensionBytes)
 	
 	// If the jump instruction is at 1, then the IP after interpreting it will be 3
 	// so the offsets will be distance - 2
-	int offset = distance - 2;
+	intptr_t offset = distance - 2;
 	
-	return offset < 0 ?
+	return offset < 0?
 		// We must take account of the size of the Near Jump instruction (2) when deciding whether a 
 		// Near jump is possible since the offset always starts from the next instruction (i.e. 
 		// offset 0 is the next instruction). The offset accounts for the opcode, but not the extension
@@ -1558,41 +1563,42 @@ inline static bool isInNearJumpRange(int distance, unsigned extensionBytes)
 
 // Is distance within the range of jumps possible from the current long jump instruction (accounting for
 // the size of the instruction). 
-inline static bool isInLongJumpRange(int distance)
+inline static bool isInLongJumpRange(intptr_t distance)
 {
-	int offset = distance - 3;
+	intptr_t offset = distance - 3;
 	return offset >= MaxBackwardsLongJump && offset <= MaxForwardsLongJump;
 }
 
-int Compiler::ShortenJumps()
+unsigned Compiler::ShortenJumps()
 {
 	// Run through seeing if any shorter jumps can be used. Return a count
 	// of the number of jumps shortened.
 	//
-	int count=0, i=0;
-	while (i<GetCodeSize())
+	unsigned count = 0;
+	ip_t i = ip_t::zero;
+	while (i<=LastIp)
 	{
 		//_CrtCheckMemory();
 		// Fix up jumps
 		BYTECODE& bytecode = m_bytecodes[i];
-		_ASSERTE(bytecode.isOpCode());
-		if (bytecode.isJumpSource())
+		_ASSERTE(bytecode.IsOpCode);
+		if (bytecode.IsJumpSource)
 		{
 			// Compute relative distance from this instructions
 			// (N.B. Bear in mind that jumps start after the instruction itself, but the distance
 			// we calculate here is from the jump itself)
-			_ASSERTE(bytecode.target >= 0 && bytecode.target < GetCodeSize());
+			_ASSERTE(bytecode.target >= ip_t::zero && bytecode.target <= LastIp);
 			BYTECODE& target = m_bytecodes[bytecode.target];
-			_ASSERTE(target.isJumpTarget());
-			BYTE targetByte = target.byte;
-			int distance = bytecode.target - i;
+			_ASSERTE(target.IsJumpTarget);
+			uint8_t targetByte = target.byte;
+			intptr_t distance = static_cast<intptr_t>(bytecode.target) - static_cast<intptr_t>(i);
 			switch (bytecode.byte)
 			{
 				
 				//////////////////////////////////////////////////////////////////////////////////
 				// Single byte Short jumps. Obviously these cannot be shorted further
 			case ShortJump:
-				_ASSERTE(!target.isReturn());
+				_ASSERTE(!target.IsReturn);
 			case ShortJumpIfFalse:
 				break;
 				
@@ -1601,7 +1607,7 @@ int Compiler::ShortenJumps()
 				
 			case NearJump:
 				// Unconditional Jumps to return instructions can be replaced with the return instruction
-				_ASSERTE(!target.isReturn());
+				_ASSERTE(!target.IsReturn);
 				if (isInShortJumpRange(distance, 1))		// Account for extension
 				{
 					// Can shorten to short jump
@@ -1635,7 +1641,7 @@ int Compiler::ShortenJumps()
 			case LongJump:
 				// Unconditional Jumps to return instructions should have been replaced with the 
 				// return instruction
-				_ASSERTE(!target.isReturn());
+				_ASSERTE(!target.IsReturn);
 				if (isInNearJumpRange(distance, 2))
 				{
 					// Can shorten to near jump
@@ -1697,7 +1703,7 @@ int Compiler::ShortenJumps()
 				_ASSERTE(0);
 			}
 		}
-		int len = m_bytecodes[i].instructionLength();
+		size_t len = m_bytecodes[i].InstructionLength;
 		i += len;
 	}
 	return count;
@@ -1711,13 +1717,13 @@ int Compiler::ShortenJumps()
 // not read by fetching). In the case of the short instructions the VM adds an additional 1 to the jump offset
 // to extend the range of jumps that can be handled by a short jump (since jump 0 is effectively jump to the 
 // next instruction, which is not much use) - i.e. the zero based offset in the instruction is converted to 1 based.
-void Compiler::FixupJump(int pos)
+void Compiler::FixupJump(ip_t pos)
 {
 	// Fixes up the jump at pos
-	const int targetIP = m_bytecodes[pos].target;
-	_ASSERTE(targetIP >= 0 && targetIP < GetCodeSize());
-	_ASSERTE(m_bytecodes[targetIP].isJumpTarget());	// Otherwise optimization could have gone wrong
-	int distance=targetIP - pos;
+	const ip_t targetIP = m_bytecodes[pos].target;
+	_ASSERTE(targetIP <= LastIp);
+	_ASSERTE(m_bytecodes[targetIP].IsJumpTarget);	// Otherwise optimization could have gone wrong
+	intptr_t distance=static_cast<intptr_t>(targetIP) - static_cast<intptr_t>(pos);
 	
 	switch (m_bytecodes[pos].byte)
 	{
@@ -1726,30 +1732,30 @@ void Compiler::FixupJump(int pos)
 		{
 			// Short jumps
 			_ASSERTE(isInShortJumpRange(distance,0));
-			int offset = distance - 2;				// IP advanced over instruction, and VM adds 1 too to
+			intptr_t offset = distance - 2;				// IP advanced over instruction, and VM adds 1 too to
 			// extend the useful range of short jumps (no point jumping
 			// to the next instruction)
-			_ASSERTE(pos+distance < GetCodeSize());
-			m_bytecodes[pos].byte += offset;
+			_ASSERTE(pos+distance <= LastIp);
+			m_bytecodes[pos].byte += static_cast<uint8_t>(offset);
 		}
 		break;
 		
 	case NearJump:
 	case NearJumpIfFalse:
-		_ASSERTE(!WantOptimize() || !isInShortJumpRange(distance, 1));	// Why not optimized?
+		_ASSERTE(!WantOptimize || !isInShortJumpRange(distance, 1));	// Why not optimized?
 	case NearJumpIfTrue:
 	case NearJumpIfNil:
 	case NearJumpIfNotNil:
 		{
 			// Unconditional jump
 			_ASSERTE(isInNearJumpRange(distance, 1));
-			int offset = distance - 2;				// IP inc'd for instruction and extension byte
+			intptr_t offset = distance - 2;	// IP inc'd for instruction and extension byte
 			
-			_ASSERTE(!WantOptimize() || offset != 0);	// Why not optimized out?
+			_ASSERTE(!WantOptimize || offset != 0);	// Why not optimized out?
 			_ASSERTE(offset >= -128 && offset <= 127);
 			
-			_ASSERTE(pos+distance < GetCodeSize());
-			m_bytecodes[pos+1].byte = offset;
+			_ASSERTE(pos+distance <= LastIp);
+			m_bytecodes[pos+1].byte = static_cast<uint8_t>(offset);
 		}
 		break;
 		
@@ -1765,29 +1771,29 @@ void Compiler::FixupJump(int pos)
 	#define MASK_BYTE(op) (op)
 #endif
 			// Unconditional jump
-			_ASSERTE(!WantOptimize() || !isInNearJumpRange(distance,2));	// Why not optimized?
-			int offset = distance - 3;				// IP inc'd for instruction, and extension bytes
+			_ASSERTE(!WantOptimize || !isInNearJumpRange(distance,2));	// Why not optimized?
+			ptrdiff_t offset = distance - 3;				// IP inc'd for instruction, and extension bytes
 			if (offset < MaxBackwardsLongJump || offset > MaxForwardsLongJump)
 			{
 				CompileError(CErrMethodTooLarge);
 			}
-			_ASSERTE(pos+distance < GetCodeSize());
-			m_bytecodes[pos+1].byte = BYTE(MASK_BYTE(offset));
-			m_bytecodes[pos + 2].byte = BYTE(MASK_BYTE(offset >> 8));
+			_ASSERTE(pos+distance <= LastIp);
+			m_bytecodes[pos+1].byte = static_cast<uint8_t>(MASK_BYTE(offset));
+			m_bytecodes[pos + 2].byte = static_cast<uint8_t>(MASK_BYTE(offset >> 8));
 		}
 		break;
 		
 	case BlockCopy:
 		{
 			// BlockCopy contains an implicit jump
-			int offset = distance - BlockCopyInstructionLength;				// IP inc'd for instruction, and extension bytes
+			intptr_t offset = distance - BlockCopyInstructionLength;				// IP inc'd for instruction, and extension bytes
 			if (offset < MaxBackwardsLongJump || offset > MaxForwardsLongJump)
 			{
 				CompileError(CErrMethodTooLarge);
 			}
-			_ASSERTE(pos+distance < GetCodeSize());
-			m_bytecodes[pos + 5].byte = BYTE(MASK_BYTE(offset));
-			m_bytecodes[pos + 6].byte = BYTE(MASK_BYTE(offset >> 8));
+			_ASSERTE(pos+distance <= LastIp);
+			m_bytecodes[pos + 5].byte =static_cast<uint8_t>(MASK_BYTE(offset));
+			m_bytecodes[pos + 6].byte =static_cast<uint8_t>(MASK_BYTE(offset >> 8));
 		}
 		break;
 		
@@ -1808,19 +1814,19 @@ POTE Compiler::NewMethod()
 	// Must do this before generate the bytecodes as the textmaps may be offset if packed
 	VerifyTextMap(true);
 
-	if (!m_ok || WantSyntaxCheckOnly())
+	if (!m_ok || WantSyntaxCheckOnly)
 		return m_piVM->NilPointer();
 
 	int blockCount = Pass2();
 	
-	_ASSERTE(sizeof(STMethodHeader) == sizeof(MWORD));
-	_ASSERTE(GetLiteralCount()<=LITERALLIMIT);
+	_ASSERTE(sizeof(STMethodHeader) == sizeof(uintptr_t));
+	_ASSERTE(LiteralCount<=LITERALLIMIT);
 	
 	// As we keep the class of the method in the method, we no longer need to store the super
 	// class as an extra literal
 	
 	STMethodHeader hdr;
-	*(MWORD*)&hdr = 0;
+	*(uintptr_t*)&hdr = 0;
 	
 	// Set the needsContext flag if any literal blocks (non-optimized) are used
 	// within this method.
@@ -1835,19 +1841,19 @@ POTE Compiler::NewMethod()
 	// Need this in case we choose to gen some code
 	m_pCurrentScope = pMethodScope;
 	_ASSERTE(pMethodScope->GetCopiedTemps().size() == 0);
-	int numEnvTemps = pMethodScope->GetSharedTempsCount();
-	bool bHasFarReturn = pMethodScope->HasFarReturn();
+	tempcount_t numEnvTemps = pMethodScope->SharedTempsCount;
+	bool bHasFarReturn = pMethodScope->HasFarReturn;
 	bool bNeedsContext = bHasFarReturn || numEnvTemps > 0;
 
-	BYTE byte1=m_bytecodes[0].byte;
-	BYTE byte2=Nop;
-	BYTE byte3=Nop;
-	int len = GetCodeSize();
+	uint8_t byte0=m_bytecodes[ip_t::zero].byte;
+	uint8_t byte1=Nop;
+	uint8_t byte2=Nop;
+	size_t len = CodeSize;
 	if (len > 1)
 	{
-		byte2 = m_bytecodes[1].byte;
+		byte1 = m_bytecodes[ip_t::one].byte;
 		if (len > 2)
-			byte3=m_bytecodes[2].byte;
+			byte2=m_bytecodes[ip_t::two].byte;
 	}
 
 	if (m_primitiveIndex!=0)
@@ -1856,89 +1862,89 @@ POTE Compiler::NewMethod()
 		// This is not a valid assertion, since primitive methods
 		// can have any form of Smalltalk backup code
 		//_ASSERTE(!hdr.m_needsContextFlag);
-		MakeQuickMethod(hdr, STPrimitives(m_primitiveIndex));
+		MakeQuickMethod(hdr, static_cast<STPrimitives>(m_primitiveIndex));
 		//classRequired=true;
 	}
-	else if (m_bytecodes[0].isPseudoReturn())
+	else if (m_bytecodes[ip_t::zero].IsPseudoReturn)
 	{
 		//_ASSERTE(!bNeedsContext); Not a valid assertion, since could have a block after the return at the top
 		// Primitive return of self, true, false, nil
-		MakeQuickMethod(hdr, STPrimitives(PRIMITIVE_RETURN_SELF + (byte1 - FirstPseudoReturn)));
+		MakeQuickMethod(hdr, static_cast<STPrimitives>(PRIMITIVE_RETURN_SELF + (byte0 - FirstPseudoReturn)));
 		
 		// We go ahead and generate the bytes anyway, as they'll fit in a SmallInteger and
 		// may be of interest for debugging/browsing
-		_ASSERTE(GetCodeSize() < sizeof(MWORD));
+		_ASSERTE(CodeSize < sizeof(uintptr_t));
 	}
-	else if (byte1 == ShortPushConst && byte2 == ReturnMessageStackTop)
+	else if (byte0 == ShortPushConst && byte1 == ReturnMessageStackTop)
 	{
 		// Primitive return of literal zero
 		_ASSERTE(!bNeedsContext);
-		_ASSERTE(GetLiteralCount()>0);
+		_ASSERTE(LiteralCount>0);
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_LITERAL_ZERO);
 
 		// Note that in this case the literal may be a clean block, in which case the code size
 		// may well be greater than will fit in a SmallInteger
-		// _ASSERTE(GetCodeSize() < sizeof(MWORD));
+		// _ASSERTE(CodeSize < sizeof(uintptr_t));
 	}
-	else if (m_bytecodes[0].isShortPushConst() && byte2 == ReturnMessageStackTop && GetCodeSize() == 2)
+	else if (m_bytecodes[ip_t::zero].IsShortPushConst && byte1 == ReturnMessageStackTop && CodeSize == 2)
 	{
 		// Primitive return of literal zero from a ##() expression that generated literal frame entries
 		_ASSERTE(!bNeedsContext);
-		_ASSERTE(GetLiteralCount()>1);
-		int index = m_bytecodes[0].indexOfShortPushConst();
+		_ASSERTE(LiteralCount>1);
+		int index = m_bytecodes[ip_t::zero].indexOfShortPushConst();
 		Oop tmp = m_literalFrame[0];
 		m_literalFrame[0] = m_literalFrame[index];
 		m_literalFrame[index] = tmp;
-		m_bytecodes[0].byte = ShortPushConst;
+		m_bytecodes[ip_t::zero].byte = ShortPushConst;
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_LITERAL_ZERO);
 	}
-	else if (byte1 == ShortPushStatic && byte2 == ReturnMessageStackTop)
+	else if (byte0 == ShortPushStatic && byte1 == ReturnMessageStackTop)
 	{
 		// Primitive return of literal zero
 		_ASSERTE(!bNeedsContext);
-		_ASSERTE(GetLiteralCount()>0);
+		_ASSERTE(LiteralCount>0);
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_STATIC_ZERO);
 
 		// Note that in this case the literal may be a clean block, in which case the code size
 		// may well be greater than will fit in a SmallInteger
-		// _ASSERTE(GetCodeSize() < sizeof(MWORD));
+		// _ASSERTE(CodeSize < sizeof(uintptr_t));
 	}
-	else if (m_bytecodes[0].isShortPushStatic() && byte2 == ReturnMessageStackTop && GetCodeSize() == 2)
+	else if (m_bytecodes[ip_t::zero].IsShortPushStatic && byte1 == ReturnMessageStackTop && CodeSize == 2)
 	{
 		// Primitive return of literal zero from a ##() expression that generated literal frame entries
 		_ASSERTE(!bNeedsContext);
-		_ASSERTE(GetLiteralCount()>1);
-		int index = m_bytecodes[0].indexOfShortPushStatic();
+		_ASSERTE(LiteralCount>1);
+		int index = m_bytecodes[ip_t::zero].indexOfShortPushStatic();
 		Oop tmp = m_literalFrame[0];
 		m_literalFrame[0] = m_literalFrame[index];
 		m_literalFrame[index] = tmp;
-		m_bytecodes[0].byte = ShortPushStatic;
+		m_bytecodes[ip_t::zero].byte = ShortPushStatic;
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_STATIC_ZERO);
 	}
-	else if (m_bytecodes[0].isShortPushInstVar() && byte2 == ReturnMessageStackTop && GetArgumentCount() == 0)
+	else if (m_bytecodes[ip_t::zero].IsShortPushInstVar && byte1 == ReturnMessageStackTop && ArgumentCount == 0)
 	{
 		// instance variable accessor method (<=15)
 		_ASSERTE(!bNeedsContext);
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_INSTVAR);
 		
 		// Convert to long form to simplify the interpreter's code to exec. this quick method.
-		byte2 = m_bytecodes[0].indexOfPushInstVar();
-		m_bytecodes[0].byte = PushInstVar;
-		m_codePointer = 1;
-		GenData(byte2);
+		byte1 = m_bytecodes[ip_t::zero].indexOfPushInstVar();
+		m_bytecodes[ip_t::zero].byte = PushInstVar;
+		m_codePointer = ip_t::one;
+		GenData(byte1);
 		m_codePointer++;
-		byte3 = ReturnMessageStackTop;
+		byte2 = ReturnMessageStackTop;
 
 		// We must adjust the debug info to account for the longer (two byte) first instruction
 		//_ASSERTE(m_allScopes.size() == 1); Some inlined scopes may have been optimised away
-		_ASSERTE(pMethodScope->GetFinalIP() == 1);
-		pMethodScope->SetFinalIP(2);
+		_ASSERTE(pMethodScope->FinalIP == ip_t::one);
+		pMethodScope->FinalIP = ip_t::two;
 
 		// We must go ahead and generate the bytes anyway as they are needed by the interpreter to 
 		// determine which inst. var to push (they'll fit in a SmallInteger anyway)
-		_ASSERTE(GetCodeSize() == 3);
+		_ASSERTE(CodeSize == 3);
 	}
-	else if (isPushInstVarX(byte1, byte2) && byte3 == ReturnMessageStackTop && GetArgumentCount() == 0)
+	else if (isPushInstVarX(byte0, byte1) && byte2 == ReturnMessageStackTop && ArgumentCount == 0)
 	{
 		// instance variable accessor method (>15)
 		_ASSERTE(!bNeedsContext);
@@ -1946,17 +1952,17 @@ POTE Compiler::NewMethod()
 		
 		// We must go ahead and generate the bytes anyway as they are needed by the interpreter to 
 		// determine which inst. var to push (they'll fit in a SmallInteger anyway)
-		_ASSERTE(GetCodeSize() == 3);
+		_ASSERTE(CodeSize == 3);
 	}
-	else if (byte2 == ReturnMessageStackTop && m_bytecodes[0].isShortPushImmediate())
+	else if (byte1 == ReturnMessageStackTop && m_bytecodes[ip_t::zero].IsShortPushImmediate)
 	{
-		_ASSERTE(GetCodeSize() == 2 || !WantOptimize());
-		_ASSERTE(m_bytecodes[1].isOpCode());
+		_ASSERTE(CodeSize == 2 || !WantOptimize);
+		_ASSERTE(m_bytecodes[ip_t::one].IsOpCode);
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_LITERAL_ZERO);
 
 		_ASSERTE(m_primitiveIndex == 0);
-		Oop literalInt = IntegerObjectOf(byte1-ShortPushMinusOne-1);
-		if (GetLiteralCount() > 0)
+		Oop literalInt = IntegerObjectOf(byte0-ShortPushMinusOne-1);
+		if (LiteralCount > 0)
 		{
 			m_literalFrame.push_back(m_literalFrame[0]);
 			m_literalFrame[0] = literalInt;
@@ -1964,14 +1970,14 @@ POTE Compiler::NewMethod()
 		else
 			AddToFrameUnconditional(literalInt, TEXTRANGE());
 	}
-	else if (byte1 == PushImmediate && byte3 == ReturnMessageStackTop)
+	else if (byte0 == PushImmediate && byte2 == ReturnMessageStackTop)
 	{
-		_ASSERTE(GetCodeSize() == 3 || !WantOptimize());
-		_ASSERTE(m_bytecodes[2].isOpCode());
+		_ASSERTE(CodeSize == 3 || !WantOptimize);
+		_ASSERTE(m_bytecodes[ip_t::two].IsOpCode);
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_LITERAL_ZERO);
 		_ASSERTE(m_primitiveIndex == 0);
-		SBYTE immediateByte = SBYTE(byte2);
-		if (GetLiteralCount() > 0)
+		int8_t immediateByte = static_cast<int8_t>(byte1);
+		if (LiteralCount > 0)
 		{
 			m_literalFrame.push_back(m_literalFrame[0]);
 			m_literalFrame[0] = IntegerObjectOf(immediateByte);
@@ -1979,14 +1985,14 @@ POTE Compiler::NewMethod()
 		else
 			AddToFrameUnconditional(IntegerObjectOf(immediateByte), TEXTRANGE());
 	}
-	else if (byte1 == LongPushImmediate && m_bytecodes[3].byte == ReturnMessageStackTop)
+	else if (byte0 == LongPushImmediate && m_bytecodes[ip_t::three].byte == ReturnMessageStackTop)
 	{
-		_ASSERTE(GetCodeSize() >= 4);
-		_ASSERTE(m_bytecodes[3].isOpCode());
+		_ASSERTE(CodeSize >= 4);
+		_ASSERTE(m_bytecodes[ip_t::three].IsOpCode);
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_LITERAL_ZERO);
 		_ASSERTE(m_primitiveIndex == 0);
-		SWORD immediateWord = SWORD(byte3 << 8) + byte2;
-		if (GetLiteralCount() > 0)
+		int16_t immediateWord = static_cast<int16_t>(byte2 << 8) + byte1;
+		if (LiteralCount > 0)
 		{
 			m_literalFrame.push_back(m_literalFrame[0]);
 			m_literalFrame[0] = IntegerObjectOf(immediateWord);
@@ -1994,20 +2000,21 @@ POTE Compiler::NewMethod()
 		else
 			AddToFrameUnconditional(IntegerObjectOf(immediateWord), TEXTRANGE());
 		// We can save space by replacing the LongPushImmediate instruction with 2-byte argument with a single byte push const 0
-		m_bytecodes[0].byte = ShortPushConst;
-		RemoveBytes(1, 2);
+		m_bytecodes[ip_t::zero].byte = ShortPushConst;
+		RemoveBytes(ip_t::one, 2);
 	}
-	else if (byte1 == ExLongPushImmediate && m_bytecodes[ExLongPushImmediateInstructionSize].byte == ReturnMessageStackTop)
+	else if (byte0 == ExLongPushImmediate && m_bytecodes[static_cast<ip_t>(ExLongPushImmediateInstructionSize)].byte == ReturnMessageStackTop)
 	{
-		_ASSERTE(GetCodeSize() >= 4);
-		_ASSERTE(m_bytecodes[ExLongPushImmediateInstructionSize].isOpCode());
+		_ASSERTE(CodeSize >= 4);
+		const ip_t longPush = static_cast<ip_t>(ExLongPushImmediateInstructionSize);
+		_ASSERTE(m_bytecodes[longPush].IsOpCode);
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_LITERAL_ZERO);
 		_ASSERTE(m_primitiveIndex == 0);
-		SDWORD immediateValue = static_cast<SDWORD>((m_bytecodes[ExLongPushImmediateInstructionSize-1].byte << 24) 
-									| (m_bytecodes[ExLongPushImmediateInstructionSize - 2].byte << 16) 
-									| (m_bytecodes[ExLongPushImmediateInstructionSize - 3].byte << 8) 
-									| m_bytecodes[ExLongPushImmediateInstructionSize - 4].byte);
-		if (GetLiteralCount() > 0)
+		int32_t immediateValue = static_cast<int32_t>((m_bytecodes[longPush - 1].byte << 24) 
+									| (m_bytecodes[longPush - 2].byte << 16) 
+									| (m_bytecodes[longPush - 3].byte << 8) 
+									| m_bytecodes[longPush - 4].byte);
+		if (LiteralCount > 0)
 		{
 			m_literalFrame.push_back(m_literalFrame[0]);
 			m_literalFrame[0] = IntegerObjectOf(immediateValue);
@@ -2015,17 +2022,17 @@ POTE Compiler::NewMethod()
 		else
 			AddToFrameUnconditional(IntegerObjectOf(immediateValue), TEXTRANGE());
 		// We can save space by replacing the ExLongPushImmediate instruction with 4-byte argument with a single byte push const 0
-		m_bytecodes[0].byte = ShortPushConst;
-		RemoveBytes(1, ExLongPushImmediateInstructionSize-1);
+		m_bytecodes[ip_t::zero].byte = ShortPushConst;
+		RemoveBytes(ip_t::one, ExLongPushImmediateInstructionSize-1);
 	}
-	else if (byte1 == PushChar && byte3 == ReturnMessageStackTop)
+	else if (byte0 == PushChar && byte2 == ReturnMessageStackTop)
 	{
-		_ASSERTE(GetCodeSize() == 3 || !WantOptimize());
-		_ASSERTE(m_bytecodes[2].isOpCode());
+		_ASSERTE(CodeSize == 3 || !WantOptimize);
+		_ASSERTE(m_bytecodes[ip_t::two].IsOpCode);
 		MakeQuickMethod(hdr, PRIMITIVE_RETURN_LITERAL_ZERO);
 		_ASSERTE(m_primitiveIndex == 0);
-		Oop oopChar = reinterpret_cast<Oop>(m_piVM->NewCharacter(byte2));
-		if (GetLiteralCount() > 0)
+		Oop oopChar = reinterpret_cast<Oop>(m_piVM->NewCharacter(byte1));
+		if (LiteralCount > 0)
 		{
 			m_literalFrame.push_back(m_literalFrame[0]);
 			m_literalFrame[0] = oopChar;
@@ -2033,13 +2040,13 @@ POTE Compiler::NewMethod()
 		else
 			AddToFrameUnconditional(oopChar, TEXTRANGE());
 	}
-	else if ((byte1 == ShortPushTemp && GetArgumentCount() == 1 && GetCodeSize() <= sizeof(MWORD))
-		&& ((byte2 == PopStoreInstVar && m_bytecodes[3].byte == ReturnSelf)
-			||(m_bytecodes[1].isShortPopStoreInstVar() && byte3 == ReturnSelf)))
+	else if ((byte0 == ShortPushTemp && ArgumentCount == 1 && CodeSize <= sizeof(uintptr_t))
+		&& ((byte1 == PopStoreInstVar && m_bytecodes[ip_t::three].byte == ReturnSelf)
+			||(m_bytecodes[ip_t::one].IsShortPopStoreInstVar && byte2 == ReturnSelf)))
 	{
 		// instance variable set method
 		_ASSERTE(!bNeedsContext);
-		_ASSERTE((byte1 & 1) != 0);		// First must be odd, as VM assumes will be a packed method
+		_ASSERTE((byte0 & 1) != 0);		// First must be odd, as VM assumes will be a packed method
 
 		MakeQuickMethod(hdr, PRIMITIVE_SET_INSTVAR);
 		
@@ -2062,35 +2069,35 @@ POTE Compiler::NewMethod()
 		hdr.envTempCount = numEnvTemps + 1;
 	}
 
-	_ASSERTE(pMethodScope->GetStackSize() <= TEMPORARYLIMIT);
-	_ASSERTE(GetArgumentCount() <= ARGLIMIT);
-	hdr.stackTempCount = pMethodScope->GetStackTempCount();
-	hdr.argumentCount = GetArgumentCount();
+	_ASSERTE(pMethodScope->StackSize <= TEMPORARYLIMIT);
+	_ASSERTE(ArgumentCount <= ARGLIMIT);
+	hdr.stackTempCount = static_cast<uint8_t>(pMethodScope->StackTempCount);
+	hdr.argumentCount = static_cast<uint8_t>(ArgumentCount);
 	
 	// Allocate CompiledMethod and install the header
-	POTE method = NewCompiledMethod(m_compiledMethodClass, GetCodeSize(), hdr);
+	POTE method = NewCompiledMethod(m_compiledMethodClass, CodeSize, hdr);
 	STCompiledMethod& cmpldMethod = *(STCompiledMethod*)GetObj(method);
 	
 	// May have been changed above
-	byte1 = m_bytecodes[0].byte;
+	byte0 = m_bytecodes[ip_t::zero].byte;
 
 	// Install bytecodes
-	if (!WantDebugMethod() //&& blockCount == 0
-		&& (GetCodeSize() < sizeof(MWORD) 
-			|| (GetCodeSize() == sizeof(MWORD) && ((byte1 & 1) != 0))))
+	if (!WantDebugMethod //&& blockCount == 0
+		&& (CodeSize < sizeof(uintptr_t) 
+			|| (CodeSize == sizeof(uintptr_t) && ((byte0 & 1) != 0))))
 	{
 		Oop bytes = IntegerObjectOf(0);
 		BYTE* pByteCodes = (BYTE*)&bytes;
 		// IX86 is a little endian machine, so first must be odd for SmallInteger flag
-		if ((byte1 & 1) == 0)
+		if ((byte0 & 1) == 0)
 		{
 			*pByteCodes++ = Nop;
 			// Must adjust the debug info maps to account for the leading Nop
 			// Method scope expands for leading Nop
-			pMethodScope->SetFinalIP(pMethodScope->GetFinalIP() + 1);
+			pMethodScope->FinalIP = pMethodScope->FinalIP + 1;
 			// Should only be here for 3 byte methods, so don't nested scopes are unlikely, but possible
-			const int count = m_allScopes.size();
-			for (int i = 1; i < count; i++)
+			const size_t count = m_allScopes.size();
+			for (size_t i = 1; i < count; i++)
 			{
 				LexicalScope* pScope = m_allScopes[i];
 				pScope->IncrementIPs();
@@ -2098,22 +2105,22 @@ POTE Compiler::NewMethod()
 
 			// Adjust ip of any TextMaps
 			{
-				const int loopEnd = m_textMaps.size();
-				for (int i = 0; i < loopEnd; i++)
+				const size_t loopEnd = m_textMaps.size();
+				for (size_t i = 0; i < loopEnd; i++)
 					m_textMaps[i].ip++;
 			}
 		}
-		const int loopEnd = GetCodeSize();
-		for (int i=0; i<loopEnd && i < sizeof(MWORD); i++)
-			pByteCodes[i] = m_bytecodes[i].byte;
+		const size_t loopEnd = CodeSize;
+		for (size_t i=0; i<loopEnd && i < sizeof(uintptr_t); i++)
+			pByteCodes[i] = m_bytecodes[static_cast<ip_t>(i)].byte;
 		m_piVM->StorePointerWithValue(&cmpldMethod.byteCodes, bytes);
 	}
 	else
 	{
 		BYTE* pByteCodes = FetchBytesOf(POTE(cmpldMethod.byteCodes));
-		const int loopEnd = GetCodeSize();
-		for (int i=0; i<loopEnd; i++)
-			pByteCodes[i] = m_bytecodes[i].byte;
+		const ip_t loopEnd = LastIp;
+		for (ip_t i=ip_t::zero; i<=loopEnd; i++)
+			pByteCodes[static_cast<size_t>(i)] = m_bytecodes[i].byte;
 		m_piVM->MakeImmutable(cmpldMethod.byteCodes, TRUE);
 	}
 	
@@ -2122,22 +2129,22 @@ POTE Compiler::NewMethod()
 	PatchCleanBlockLiterals(method);
 
 	// Install literals
-	const int loopEnd = GetLiteralCount();
-	for (int i=0; i<loopEnd; i++)
+	const size_t loopEnd = LiteralCount;
+	for (size_t i=0; i<loopEnd; i++)
 	{
 		Oop oopLiteral = m_literalFrame[i];
 		_ASSERTE(oopLiteral != NULL);
 		m_piVM->StorePointerWithValue(&cmpldMethod.aLiterals[i], oopLiteral);
 	}
 	
-	m_piVM->StorePointerWithValue((Oop*)&cmpldMethod.selector, Oop(NewUtf8String(GetSelector())));
+	m_piVM->StorePointerWithValue((Oop*)&cmpldMethod.selector, Oop(NewUtf8String(Selector)));
 	m_piVM->StorePointerWithValue((Oop*)&cmpldMethod.methodClass, Oop(m_class));
 
 #if defined(_DEBUG)
 	{
 		char buf[512];
 		wsprintf(buf, "Compiling %s>>%s for %s, %s\n", GetClassName().c_str(), m_selector.c_str(), 
-			WantDebugMethod() ? "debug" : "release", m_ok ? "succeeded" : "failed");
+			WantDebugMethod ? "debug" : "release", m_ok ? "succeeded" : "failed");
 		OutputDebugString(buf);
 		
 		if (m_ok && compilationTrace > 0)
@@ -2158,11 +2165,11 @@ POTE Compiler::NewMethod()
 
 void Compiler::PatchCleanBlockLiterals(POTE oteMethod)
 {
-	const int count = m_allScopes.size();
-	for (int i = 1; i < count; i++)
+	const size_t count = m_allScopes.size();
+	for (size_t i = 1; i < count; i++)
 	{
 		LexicalScope* pScope = m_allScopes[i];
-		if (pScope->IsCleanBlock())
+		if (pScope->IsCleanBlock)
 		{
 			pScope->PatchBlockLiteral(m_piVM, oteMethod);
 		}
@@ -2191,7 +2198,7 @@ int Compiler::FixupTempsAndBlocks()
 		LexicalScope* pScope = (*sit);
 		pScope->CopyTemps(this);
 
-		if (!pScope->IsOptimizedBlock())
+		if (!pScope->IsOptimizedBlock)
 		{
 			pScope->AllocTempIndices(this);
 		}
@@ -2223,9 +2230,9 @@ int Compiler::FixupTempsAndBlocks()
 // when copying temps.
 void Compiler::PatchOptimizedScopes()
 {
-	const int count = m_allScopes.size();
+	const size_t count = m_allScopes.size();
 	_ASSERTE(count >= 1);
-	for (int i = 1; i < count; i++)
+	for (size_t i = 1; i < count; i++)
 	{
 		LexicalScope* pScope = m_allScopes[i];
 		pScope->PatchOptimized(this);
@@ -2234,13 +2241,13 @@ void Compiler::PatchOptimizedScopes()
 
 void Compiler::DetermineTempUsage()
 {
-	const int count = GetCodeSize();
-	for (int i = 0; i < count;)
+	const ip_t last = LastIp;
+	for (ip_t i = ip_t::zero; i <= last;)
 	{
 		const BYTECODE& bytecode1 = m_bytecodes[i];
-		int len1 = bytecode1.instructionLength();
+		size_t len1 = bytecode1.InstructionLength;
 
-		_ASSERTE(!bytecode1.isPushTemp());
+		_ASSERTE(!bytecode1.IsPushTemp);
 
 		switch(bytecode1.byte)
 		{
@@ -2268,14 +2275,14 @@ void Compiler::DetermineTempUsage()
 	}
 }
 
-int Compiler::FixupTempRefs()
+unsigned Compiler::FixupTempRefs()
 {
-	int fixed=0;
-	const int count = GetCodeSize();
-	for (int i = 0; i < count;)
+	unsigned fixed=0;
+	const ip_t last = LastIp;
+	for (ip_t i = ip_t::zero; i <= last;)
 	{
 		const BYTECODE& bytecode1 = m_bytecodes[i];
-		const int len1 = bytecode1.instructionLength();
+		const size_t len1 = bytecode1.InstructionLength;
 
 		switch(bytecode1.byte)
 		{
@@ -2299,113 +2306,113 @@ int Compiler::FixupTempRefs()
 	return fixed;
 }
 
-void Compiler::FixupTempRef(int i)
+void Compiler::FixupTempRef(ip_t i)
 {
 	BYTECODE& byte1 = m_bytecodes[i];
 	BYTECODE& byte2 = m_bytecodes[i+1];
 	BYTECODE& byte3 = m_bytecodes[i+2];
-	_ASSERTE(byte1.isOpCode());
-	_ASSERTE(byte2.isData());
-	_ASSERTE(byte3.isData());
+	_ASSERTE(byte1.IsOpCode);
+	_ASSERTE(byte2.IsData);
+	_ASSERTE(byte3.IsData);
 
 	TempVarRef* pVarRef = byte1.pVarRef;
-	_ASSERTE(pVarRef != NULL);
-	TempVarDecl* pDecl = pVarRef->GetDecl();
-	int index = pDecl->GetIndex();
-	_ASSERTE(index >= 0 && index < 255);
+	_ASSERTE(pVarRef != nullptr);
+	TempVarDecl* pDecl = pVarRef->Decl;
+	size_t index = pDecl->Index;
+	_ASSERTE(index != -1 && index < UINT8_MAX);
 	// Temp refs should by now be pointing at real decls in unoptimized scopes
-	_ASSERTE(!pDecl->GetScope()->IsOptimizedBlock());
+	_ASSERTE(!pDecl->Scope->IsOptimizedBlock);
 
 	bool bIsPush = byte1.byte == LongPushOuterTemp;
 
-	TempVarType varType = pDecl->GetVarType();
+	TempVarType varType = pDecl->VarType;
 	switch(varType)
 	{
-	case tvtCopy:
-	case tvtStack:
-	case tvtCopied:
+	case TempVarType::Copy:
+	case TempVarType::Stack:
+	case TempVarType::Copied:
 		if (bIsPush)
 		{
 			if (index < NumShortPushTemps)
 			{
-				byte1.byte = ShortPushTemp + index;
+				byte1.byte = ShortPushTemp + static_cast<uint8_t>(index);
 				byte2.makeNop(byte1.pScope);
 			}
 			else
 			{
 				byte1.byte = PushTemp;
-				byte2.byte = index;
+				byte2.byte = static_cast<uint8_t>(index);
 			}
 		}
 		else
 		{
 			if (index < NumShortStoreTemps)
 			{
-				byte1.byte = ShortStoreTemp + index;
+				byte1.byte = ShortStoreTemp + static_cast<uint8_t>(index);
 				byte2.makeNop(byte1.pScope);
 			}
 			else
 			{
 				byte1.byte = StoreTemp;
-				byte2.byte = index;
+				byte2.byte = static_cast<uint8_t>(index);
 			}
 		}
 		byte3.makeNop(byte1.pScope);
 		break;
 
-	case tvtShared:
+	case TempVarType::Shared:
 		{
-			int outer = pVarRef->GetActualDistance();
-			_ASSERTE(outer >= 0 && outer < 256);
-			TempVarDecl* pDecl = pVarRef->GetDecl();
-			_ASSERTE(pDecl == pVarRef->GetDecl()->GetActualDecl());
+			unsigned outer = pVarRef->GetActualDistance();
+			_ASSERTE(outer <= UINT8_MAX);
+			TempVarDecl* pDecl = pVarRef->Decl;
+			_ASSERTE(pDecl == pVarRef->Decl->ActualDecl);
 			if (outer > 0)
-				pVarRef->GetScope()->SetReferencesOuterTempsIn(pDecl->GetScope());
+				pVarRef->Scope->SetReferencesOuterTempsIn(pDecl->Scope);
 
-			_ASSERTE(index < pDecl->GetScope()->GetSharedTempsCount());
+			_ASSERTE(index < pDecl->Scope->SharedTempsCount);
 
 			if (outer < 2 && index < NumPushContextTemps && bIsPush)
 			{
-				byte1.byte = (outer == 0 ? ShortPushContextTemp : ShortPushOuterTemp) + index;
+				byte1.byte = (outer == 0 ? ShortPushContextTemp : ShortPushOuterTemp) + static_cast<uint8_t>(index);
 				byte2.makeNop(byte1.pScope);
 				byte3.makeNop(byte1.pScope);
 			}
 			else if (outer <= OuterTempMaxDepth && index <= OuterTempMaxIndex)
 			{
 				byte1.byte = bIsPush ? PushOuterTemp : StoreOuterTemp;
-				byte2.byte = (outer << OuterTempIndexBits) | index;
+				byte2.byte = (outer << OuterTempIndexBits) | static_cast<uint8_t>(index);
 				byte3.makeNop(byte1.pScope);
 			}
 			else
 			{
 				byte2.byte = outer;
-				byte3.byte = index;
+				byte3.byte = static_cast<uint8_t>(index);
 			}
 		}
 		break;
 
-	case tvtUnaccessed:
+	case TempVarType::Unaccessed:
 	default:
 		{
-			TempVarDecl* pDecl = pVarRef->GetDecl();
-			InternalError(__FILE__, __LINE__, pVarRef->GetTextRange(), 
+			TempVarDecl* pDecl = pVarRef->Decl;
+			InternalError(__FILE__, __LINE__, pVarRef->TextRange, 
 				"Invalid temp variable state %d for '%s'", 
-				pVarRef->GetVarType(), pVarRef->GetName().c_str());
+				pVarRef->VarType, pVarRef->Name.c_str());
 		}
 		break;
 	};
 }
 
-int Compiler::PatchBlocks()
+unsigned Compiler::PatchBlocks()
 {
-	int i=0;
-	int blockCount = 0;
-	while (i < GetCodeSize())
+	ip_t i=ip_t::zero;
+	unsigned blockCount = 0;
+	while (i <= LastIp)
 	{
 		VerifyTextMap(true);
 
-		BYTECODE& bytecode1 = m_bytecodes[i];
-		int len1 = bytecode1.instructionLength();
+		const BYTECODE& bytecode1 = m_bytecodes[i];
+		size_t len1 = bytecode1.InstructionLength;
 
 		switch(bytecode1.byte)
 		{
@@ -2427,25 +2434,25 @@ int Compiler::PatchBlocks()
 // Push any copied values in reverse order for the block at the specified position in the bytecodes
 // Answers the number of extra bytes generated to push copied values. These are generated
 // before the block.
-int Compiler::PatchBlockAt(int i)
+size_t Compiler::PatchBlockAt(ip_t i)
 {
 	BYTECODE& byte1 = m_bytecodes[i];
 	_ASSERTE(byte1.byte == BlockCopy);
 	LexicalScope* pScope = byte1.pScope;
-	_ASSERTE(pScope != NULL);
+	_ASSERTE(pScope != nullptr);
 	// Self and far return flags should have been propagated by now
-	_ASSERTE(!pScope->NeedsSelf() || pScope->GetOuter()->NeedsSelf());
-	_ASSERTE(!pScope->HasFarReturn() || pScope->GetOuter()->HasFarReturn());
+	_ASSERTE(!pScope->NeedsSelf || pScope->Outer->NeedsSelf);
+	_ASSERTE(!pScope->HasFarReturn || pScope->Outer->HasFarReturn);
 
-	if (pScope->IsCleanBlock())
+	if (pScope->IsCleanBlock)
 	{
 		MakeCleanBlockAt(i);
 		return 0;
 	}
 
 	// From now on we don't want this instruction to appear to be part of this block's scope
-	LexicalScope* pOuter = pScope->GetOuter();
-	_ASSERTE(pOuter != NULL);
+	LexicalScope* pOuter = pScope->Outer;
+	_ASSERTE(pOuter != nullptr);
 	byte1.pScope = pOuter;
 
 	//	BlockCopy
@@ -2455,21 +2462,21 @@ int Compiler::PatchBlockAt(int i)
 	//	+4	nCopiedTemps
 	//	+5	jumpOffset1
 	//		jumpOffset2
-	_ASSERTE(m_bytecodes[i+1].byte == pScope->GetArgumentCount());
-	m_bytecodes[i+2].byte = pScope->GetStackTempCount();
+	_ASSERTE(m_bytecodes[i+1].byte == pScope->ArgumentCount);
+	m_bytecodes[i+2].byte = static_cast<uint8_t>(pScope->StackTempCount);
 
 	// Note that the env size includes the env temps and copied temps
-	int nEnvSize = pScope->GetSharedTempsCount();
-	_ASSERTE(nEnvSize < 128);
-	int needsOuter = pScope->NeedsOuter();
-	m_bytecodes[i+3].byte = (nEnvSize << 1) | needsOuter;
+	tempcount_t nEnvSize = pScope->SharedTempsCount;
+	_ASSERTE(nEnvSize <= INT8_MAX);
+	bool needsOuter = pScope->NeedsOuter;
+	m_bytecodes[i+3].byte = static_cast<uint8_t>((nEnvSize << 1) | (needsOuter ? 1 : 0));
 
-	int nCopied = pScope->GetCopiedValuesCount();
-	_ASSERTE(nCopied < 128);
-	m_bytecodes[i+4].byte = (nCopied << 1) | (pScope->NeedsSelf() ?1:0);
+	tempcount_t nCopied = pScope->CopiedValuesCount;
+	_ASSERTE(nCopied <= INT8_MAX);
+	m_bytecodes[i+4].byte = static_cast<uint8_t>((nCopied << 1) | (pScope->NeedsSelf ?1:0));
 
 	// This text map is needed by the Debugger to remap the initial IP of block frames.
-	int blockStart = pScope->GetTextRange().m_start;
+	textpos_t blockStart = pScope->TextRange.m_start;
 	InsertTextMapEntry(i + BlockCopyInstructionLength, blockStart, blockStart-1);
 
 	if (nCopied == 0)
@@ -2478,48 +2485,49 @@ int Compiler::PatchBlockAt(int i)
 	////////////////////////////////////////////////////////////////////////////////////////
 	// Generate push temp instructions for all values to be copied from enclosing scope
 	//
-	_ASSERTE(m_codePointer == GetCodeSize());
-	_ASSERTE(!byte1.isJumpTarget());
+	_ASSERTE(m_codePointer == LastIp+1);
+	_ASSERTE(!byte1.IsJumpTarget);
 	m_codePointer = i;
 
-	m_pCurrentScope = pOuter->GetRealScope();
+	m_pCurrentScope = pOuter->RealScope;
 
-	int extraBytes = 0;
+	size_t extraBytes = 0;
 	DECLLIST& copiedTemps = pScope->GetCopiedTemps();
 	const DECLLIST::reverse_iterator loopEnd = copiedTemps.rend();
 	for (DECLLIST::reverse_iterator it = copiedTemps.rbegin(); it != loopEnd; it++)
 	{
 		TempVarDecl* pCopy = (*it);
-		TempVarDecl* pCopyFrom = pCopy->GetOuter();
-		_ASSERTE(pCopyFrom != NULL && !pCopyFrom->GetScope()->IsOptimizedBlock());
-		if (pCopyFrom == NULL || pCopyFrom->GetScope() != m_pCurrentScope)
-			InternalError(__FILE__, __LINE__, pCopy->GetTextRange(), "Copied temp '%s' not found in outer scope", pCopy->GetName().c_str());
+		TempVarDecl* pCopyFrom = pCopy->Outer;
+		_ASSERTE(pCopyFrom != nullptr && !pCopyFrom->Scope->IsOptimizedBlock);
+		if (pCopyFrom == nullptr || pCopyFrom->Scope != m_pCurrentScope)
+			InternalError(__FILE__, __LINE__, pCopy->TextRange, "Copied temp '%s' not found in outer scope", pCopy->Name.c_str());
 
 		// Its a copied value, so must be local to this environment
 		extraBytes += GenPushCopiedValue(pCopyFrom);
 	}
 
-	m_pCurrentScope = NULL;
+	m_pCurrentScope = nullptr;
 
-	m_codePointer = GetCodeSize();
+	// TODO: Is this right? Looks to be off by one
+	m_codePointer = LastIp + 1;
 
 	return extraBytes;
 }
 
-void Compiler::MakeCleanBlockAt(int i)
+void Compiler::MakeCleanBlockAt(ip_t i)
 {
 	BYTECODE& byte1 = m_bytecodes[i];
-	_ASSERTE(byte1.byte = BlockCopy);
-	_ASSERTE(byte1.instructionLength() == BlockCopyInstructionLength);
-	int initIP = i + BlockCopyInstructionLength;
+	_ASSERTE(byte1.byte == BlockCopy);
+	_ASSERTE(byte1.InstructionLength == BlockCopyInstructionLength);
+	ip_t initIP = i + BlockCopyInstructionLength;
 	BYTECODE& firstInBlock = m_bytecodes[initIP];
-	BYTECODE& secondInBlock = m_bytecodes[initIP + firstInBlock.instructionLength()];
+	BYTECODE& secondInBlock = m_bytecodes[initIP + firstInBlock.InstructionLength];
 
 	LexicalScope* pScope = byte1.pScope;
-	_ASSERTE(pScope->IsBlock());
+	_ASSERTE(pScope->IsBlock);
 
-	LexicalScope* pOuter = pScope->GetOuter(); 
-	_ASSERTE(pOuter != NULL);
+	LexicalScope* pOuter = pScope->Outer; 
+	_ASSERTE(pOuter != nullptr);
 	byte1.pScope = pOuter;
 
 	// If a Clean block, then we can patch out the block copy replacing it
@@ -2527,16 +2535,16 @@ void Compiler::MakeCleanBlockAt(int i)
 	// over the blocks bytecodes.
 
 	const VMPointers& vmPointers = GetVMPointers();
-	POTE blockPointer = WantDebugMethod() ? vmPointers.EmptyDebugBlock : vmPointers.EmptyBlock;
-	bool isEmptyBlock = pScope->IsEmptyBlock();
+	POTE blockPointer = WantDebugMethod ? vmPointers.EmptyDebugBlock : vmPointers.EmptyBlock;
+	bool isEmptyBlock = pScope->IsEmptyBlock;
 	bool useEmptyBlock = isEmptyBlock && blockPointer != Nil() 
 		// We don't want to generate empty block form for the empty block itself
-		&& this->GetTextLength() != 2;
+		&& this->TextLength != 2;
 
 	if (useEmptyBlock)
 	{
-		_ASSERTE(!firstInBlock.isJumpTarget());
-		_ASSERTE(!secondInBlock.isJumpTarget());
+		_ASSERTE(!firstInBlock.IsJumpTarget);
+		_ASSERTE(!secondInBlock.IsJumpTarget);
 	}
 	else
 	{
@@ -2549,24 +2557,24 @@ void Compiler::MakeCleanBlockAt(int i)
 		pScope->SetCleanBlockLiteral(blockPointer);
 	}
 
-	int index = AddToFrame(reinterpret_cast<Oop>(blockPointer), pScope->GetTextRange());
+	size_t index = AddToFrame(reinterpret_cast<Oop>(blockPointer), pScope->TextRange);
 	if (index < NumShortPushConsts)		// In range of short instructions ?
 	{
-		byte1.byte = ShortPushConst + index;
+		byte1.byte = ShortPushConst + static_cast<uint8_t>(index);
 		UngenData(i+1, byte1.pScope);
 		UngenData(i+2, byte1.pScope);
 	}
-	else if (index < 256)				// In range of single extended instructions ?
+	else if (index <= UINT8_MAX)				// In range of single extended instructions ?
 	{
 		byte1.byte = PushConst;
-		m_bytecodes[i+1].byte = index;
+		m_bytecodes[i+1].byte = static_cast<uint8_t>(index);
 		UngenData(i+2, byte1.pScope);
 	}
 	else
 	{
 		byte1.byte = LongPushConst;
-		m_bytecodes[i+1].byte = index & 0xFF;
-		m_bytecodes[i+2].byte = index >> 8;
+		m_bytecodes[i+1].byte = index & UINT8_MAX;
+		m_bytecodes[i+2].byte = (index >> 8) & UINT8_MAX;
 	}
 
 	// The block copy is no longer a jump, being replaced by byte 4 (or not at all if empty)
@@ -2575,12 +2583,12 @@ void Compiler::MakeCleanBlockAt(int i)
 	initIP = i;
 	if (useEmptyBlock)
 	{
-		int j=i+3;
+		ip_t j=i+3;
 		for(;j<i+BlockCopyInstructionLength;j++)
 			UngenData(j, pOuter);
 		while(m_bytecodes[j].byte != ReturnBlockStackTop)
 		{
-			_ASSERTE(m_bytecodes[j].isOpCode());
+			_ASSERTE(m_bytecodes[j].IsOpCode);
 			UngenInstruction(j);
 			j++;
 		}
@@ -2599,7 +2607,7 @@ void Compiler::MakeCleanBlockAt(int i)
 		// +5 and +6 remain the jump offset
 
 		initIP += BlockCopyInstructionLength;
-		_ASSERTE(m_bytecodes[initIP].isOpCode());
+		_ASSERTE(m_bytecodes[initIP].IsOpCode);
 		// We must mark the blocks first bytecode as a jump target to prevent
 		// it being treated as unreachable code
 		m_bytecodes[initIP].addJumpTo();
@@ -2608,7 +2616,7 @@ void Compiler::MakeCleanBlockAt(int i)
 	if (!useEmptyBlock)
 	{
 		// This text map is needed by the Debugger to remap the initial IP of block frames.
-		int blockStart = pScope->GetTextRange().m_start;
+		textpos_t blockStart = pScope->TextRange.m_start;
 		InsertTextMapEntry(initIP, blockStart, blockStart-1);
 	}
 }

--- a/Core/DolphinVM/Compiler/str.h
+++ b/Core/DolphinVM/Compiler/str.h
@@ -6,7 +6,7 @@ A simple String class (again)
 Now mapped onto the Standard Template Library string class (BSM, Sep 2002)
 */
 #pragma once
-
+#include "EnumHelpers.h"
 #include <string>
 typedef std::basic_string<uint8_t, std::char_traits<uint8_t>, std::allocator<uint8_t>> Str;
 
@@ -19,7 +19,7 @@ inline Str MakeString(IDolphin* piVM, const POTE stringPointer)
 	else
 	{
 		_ASSERTE(IsAString(stringPointer));
-		MWORD stringLen=FetchByteLengthOf(stringPointer);
+		size_t stringLen=FetchByteLengthOf(stringPointer);
 		BYTE* bytes = FetchBytesOf(stringPointer);
 		return Str((const uint8_t*)bytes, stringLen);
 	}
@@ -31,8 +31,8 @@ inline Str MakeString(IDolphin* piVM, const POTE stringPointer)
 // Expand this string to have (insert) for every occurence of (ch)
 inline void InsertStringFor(Str& str, const uint8_t* insert, uint8_t ch)
 {
-	unsigned i=0;
-	int insertlen = strlen((const char*)insert);
+	size_t i=0;
+	size_t insertlen = strlen((const char*)insert);
 	while (i < str.size() && (i = str.find(ch, i)) != Str::npos)
 	{
 		str.replace(i, 1, insert, insertlen);
@@ -40,19 +40,8 @@ inline void InsertStringFor(Str& str, const uint8_t* insert, uint8_t ch)
 	}
 }
 
-struct TEXTRANGE
-{
-	int m_start;
-	int m_stop;
-
-	TEXTRANGE(int start=0, int stop=-1) : m_start(start), m_stop(stop)
-	{}
-
-	int span() const { return m_stop - m_start + 1; }
-};
-
-inline std::wostream& operator<<(std::wostream& stream, const std::string& str)
+inline std::wostream& operator<<(std::wostream& stream, const Str& str)
 {
 	USES_CONVERSION;
-	return stream << static_cast<LPCWSTR>(A2W(str.c_str()));
+	return stream << static_cast<LPCWSTR>(A2W(reinterpret_cast<const char*>(str.c_str())));
 }

--- a/Core/DolphinVM/Compiler/str.h
+++ b/Core/DolphinVM/Compiler/str.h
@@ -20,7 +20,7 @@ inline Str MakeString(IDolphin* piVM, const POTE stringPointer)
 	{
 		_ASSERTE(IsAString(stringPointer));
 		size_t stringLen=FetchByteLengthOf(stringPointer);
-		BYTE* bytes = FetchBytesOf(stringPointer);
+		auto bytes = FetchBytesOf(stringPointer);
 		return Str((const uint8_t*)bytes, stringLen);
 	}
 }

--- a/Core/DolphinVM/DolphinSmalltalk.idl
+++ b/Core/DolphinVM/DolphinSmalltalk.idl
@@ -13,16 +13,31 @@ import "ocidl.idl";
 //typedef unsigned int        *PUINT;
 //#include "winver.h"
 
-typedef signed char		SBYTE;
-typedef unsigned char	BYTE;
-typedef short			SWORD;
-typedef long			SDWORD;
-typedef SDWORD			NTSTATUS;
+// Unfortunately we can't include stdint.h without getting a lot of errors from definitions we don't need
+//#define _VCRUNTIME_H
+//#include <stdint.h>
 
-typedef UINT_PTR	MWORD;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef signed int	int32_t;
+typedef unsigned int uint32_t;
+typedef signed long long int64_t;
+typedef unsigned long long uint64_t;
+
+#ifdef _M_X64
+typedef int64_t intptr_t;
+typedef uint64_t uintptr_t;
+#else
+typedef int32_t intptr_t;
+typedef uint32_t uintptr_t;
+#endif
+
+// SDWORD is used in the definition of the original Dolphin COM interfaces. We can't change this now.
+typedef int32_t		SDWORD;
 
 cpp_quote("#if !defined(POTE_DEFINED)")
-typedef MWORD Oop;
+typedef uintptr_t Oop;
 typedef void* POTE;
 cpp_quote("#define POTE_DEFINED")
 cpp_quote("#endif")
@@ -221,6 +236,15 @@ library DolphinVM
 		POTE NewUtf8String([in]LPCSTR szValue, [in, defaultvalue(-1)]int len);
 	};
 
+	cpp_quote("#ifndef INTPTR_MAX")
+	cpp_quote("#define DEFINED_INTPTR_MAX")
+#ifdef _M_X64
+	cpp_quote("#define INTPTR_MAX 9223372036854775807i64")
+#else
+	cpp_quote("#define INTPTR_MAX 2147483647i32")
+#endif
+	cpp_quote("#endif")
+
 	// Please do not rely on any of the internal representation exposed by these inline
 	// functions, as it may change in future.
 	cpp_quote("__inline STVarObject* GetObj(POTE ote)")
@@ -233,18 +257,18 @@ library DolphinVM
 	cpp_quote("	return objectPointer & 1;")
 	cpp_quote("}")
 
-	cpp_quote("__inline SDWORD IntegerValueOf(Oop objectPointer)")
+	cpp_quote("__inline intptr_t IntegerValueOf(Oop objectPointer)")
 	cpp_quote("{")
 	cpp_quote("	// Use cast to ensure shift is signed arithmetic")
-	cpp_quote("	return ((SDWORD)(objectPointer)) >> 1;")
+	cpp_quote("	return ((intptr_t)(objectPointer)) >> 1;")
 	cpp_quote("}")
 
-	cpp_quote("__inline Oop IntegerObjectOf(SDWORD value) 			")
+	cpp_quote("__inline Oop IntegerObjectOf(intptr_t value) 			")
 	cpp_quote("{")
 	cpp_quote("	return (Oop)(((value) << 1) | 1);")
 	cpp_quote("}")
 
-	cpp_quote("__inline BOOL IsIntegerValue(SDWORD valueWord)")
+	cpp_quote("__inline BOOL IsIntegerValue(intptr_t valueWord)")
 	cpp_quote("{")
 	cpp_quote("	return (valueWord >= MinSmallInteger && valueWord <= MaxSmallInteger);")
 	cpp_quote("}")
@@ -255,20 +279,25 @@ library DolphinVM
 	cpp_quote("	return pObj->fields;")
 	cpp_quote("}")
 
-	cpp_quote("__inline MWORD FetchByteLengthOf(POTE ote)")
+	cpp_quote("__inline size_t FetchByteLengthOf(POTE ote)")
 	cpp_quote("{")
-	cpp_quote("	return (((MWORD*)ote)[2]) & 0x7FFFFFFF;")
+	cpp_quote("	return (((size_t*)ote)[2]) & INTPTR_MAX;")
 	cpp_quote("}")
 
-	cpp_quote("__inline MWORD FetchWordLengthOf(POTE ote)")
+	cpp_quote("__inline size_t FetchWordLengthOf(POTE ote)")
 	cpp_quote("{")
-	cpp_quote("	return FetchByteLengthOf(ote)/sizeof(MWORD);")
+	cpp_quote("	return FetchByteLengthOf(ote)/sizeof(uintptr_t);")
 	cpp_quote("}")
 
 	cpp_quote("__inline BOOL IsAString(const POTE ote)")
 	cpp_quote("{")
-	cpp_quote("	return (((MWORD*)ote)[3] & 0x12) == 0x10;")
+	cpp_quote("	return (((uintptr_t*)ote)[3] & 0x12) == 0x10;")
 	cpp_quote("}")
+
+	cpp_quote("#ifdef DEFINED_INTPTR_MAX")
+	cpp_quote("	#undef INTPTR_MAX")
+	cpp_quote("	#undef DEFINED_INTPTR_MAX")
+	cpp_quote("#endif")
 
 	[
 		object,
@@ -406,3 +435,4 @@ library DolphinVM
 		interface IDolphinStart;
 	};
 };
+

--- a/Core/DolphinVM/DolphinX.h
+++ b/Core/DolphinVM/DolphinX.h
@@ -9,45 +9,45 @@ namespace DolphinX {
 	enum { LibCallArgArray };
 
 	// External call primitives
-	enum { CallbackPrim=0, VirtualCallPrim=80, AsyncLibCallPrim=48, LibCallPrim=96 };
+	enum class ExtCallPrimitive : uint8_t { Callback=0, VirtualCall=80, AsyncLibCall=48, LibCall=96 };
 
 	// Calling conventions (fastcall not supported)
-	enum ExtCallDeclSpecs { ExtCallStdCall, ExtCallCDecl, ExtCallThisCall, ExtCallFastCall, NumCallConventions };
+	enum class ExtCallDeclSpec : uint8_t { StdCall, CDecl, ThisCall, FastCall, NumCallConventions };
 
 	// Argument types
 	// Note that differentiation between signed and unsigned types is only
 	// really relevant to return values if using SmallIntegers
 	// VOID is only supported as a return type 
-	enum ExtCallArgTypes {
-		ExtCallArgVOID			=0,
-		ExtCallArgLPVOID,		//1
-		ExtCallArgCHAR,			//2
-		ExtCallArgBYTE,			//3
-		ExtCallArgSBYTE,		//4
-		ExtCallArgWORD,			//5
-		ExtCallArgSWORD,		//6
-		ExtCallArgDWORD,		//7
-		ExtCallArgSDWORD,		//8
-		ExtCallArgBOOL,			//9
-		ExtCallArgHANDLE,		//10
-		ExtCallArgDOUBLE,		//11
-		ExtCallArgLPSTR,		//12
-		ExtCallArgOOP,			//13
-		ExtCallArgFLOAT,		//14
-		ExtCallArgLPPVOID,		//15
-		ExtCallArgHRESULT,		//16
-		ExtCallArgLPWSTR,		//17		OLECHAR*, Unicode string
-		ExtCallArgQWORD,		//18		Unsigned 64-bit LARGE_INTEGER
-		ExtCallArgSQWORD,		//19		Signed 64-bit LARGE_INTEGER
-		ExtCallArgOTE,			//20		Same as Oop, but disallows immediate objects
-		ExtCallArgBSTR,			//21		VB String
-		ExtCallArgVARIANT,		//22		VB Variant type
-		ExtCallArgDATE,			//23		VB Date type
-		ExtCallArgVARBOOL,		//24		VB Boolean type
-		ExtCallArgGUID,			//25		GUID (128-bit unique number)
-		ExtCallArgUINTPTR,		//26
-		ExtCallArgINTPTR,		//27
-		ExtCallArgNTSTATUS,		//28
+	enum class ExtCallArgType : uint8_t {
+		Void			=0,
+		LPVoid,		//1
+		Char,			//2
+		UInt8,			//3
+		Int8,		//4
+		UInt16,			//5
+		Int16,		//6
+		UInt32,		//7
+		Int32,		//8
+		Bool,			//9
+		Handle,		//10
+		Double,		//11
+		LPStr,		//12
+		Oop,			//13
+		Float,		//14
+		LPPVoid,		//15
+		HResult,		//16
+		LPWStr,		//17		OLECHAR*, Unicode string
+		UInt64,		//18		Unsigned 64-bit LARGE_INTEGER
+		Int64,		//19		Signed 64-bit LARGE_INTEGER
+		Ote,			//20		Same as Oop, but disallows immediate objects
+		Bstr,			//21		VB String
+		Variant,		//22		VB Variant type
+		Date,			//23		VB Date type
+		VarBool,		//24		VB Boolean type
+		Guid,			//25		GUID (128-bit unique number)
+		UIntPtr,		//26
+		IntPtr,		//27
+		NTStatus,		//28
 								//29
 								//30
 								//31
@@ -69,12 +69,12 @@ namespace DolphinX {
 								//47
 								//48
 								//49
-		ExtCallArgSTRUCT=50,	//50	Was 26
-		ExtCallArgSTRUCT4,		//51	Was 27
-		ExtCallArgSTRUCT8,		//52	Was 28
-		ExtCallArgLP,			//53	Was 29
-		ExtCallArgLPP,			//54	Was 30
-		ExtCallArgCOMPTR,		//55	Was 31
+		Struct=50,	//50	Was 26
+		Struct32,		//51	Was 27
+		Struct64,		//52	Was 28
+		LPStruct,			//53	Was 29
+		LPPStruct,			//54	Was 30
+		ComPtr,		//55	Was 31
 		ExtCallArgMax=63
 	};
 
@@ -86,11 +86,11 @@ namespace DolphinX {
 
 	struct CallDescriptor
 	{
-		BYTE			m_callConv;
-		BYTE			m_argsLen;
-		BYTE			m_returnParm;
-		BYTE			m_return;
-		BYTE			m_args[];
+		uint8_t			m_callConv;
+		uint8_t			m_argsLen;
+		uint8_t			m_returnParm;
+		uint8_t			m_return;
+		uint8_t			m_args[];
 	};
 
 	struct ExternalMethodDescriptor

--- a/Core/DolphinVM/EnumHelpers.h
+++ b/Core/DolphinVM/EnumHelpers.h
@@ -1,0 +1,133 @@
+#pragma once
+
+template<typename T> struct EnableBitOperators : std::false_type { };
+
+template<typename T>
+typename std::enable_if<EnableBitOperators<T>::value, T>::type
+operator |(const T lhs, const T rhs)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	return static_cast<T> (
+		static_cast<underlying>(lhs) |
+		static_cast<underlying>(rhs)
+		);
+}
+
+template<typename T>
+typename std::enable_if<EnableBitOperators<T>::value, T>::type
+operator &(const T lhs, const T rhs)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	return static_cast<T> (
+		static_cast<underlying>(lhs) &
+		static_cast<underlying>(rhs)
+		);
+}
+
+template<typename T>
+typename std::enable_if<EnableBitOperators<T>::value, T>::type
+operator ~(const T rhs)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	return static_cast<T> (
+		~static_cast<underlying>(rhs)
+		);
+}
+
+template<typename T>
+typename std::enable_if<EnableBitOperators<T>::value, bool>::type
+operator !(const T rhs)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	return static_cast<underlying>(rhs) == 0;
+}
+
+#define ENABLE_BITMASK_OPERATORS(x) \
+	template<> struct EnableBitOperators<x> : std::true_type { };
+
+///////////////////////////////////////////////////////////////////////////////
+// Integer types
+//
+
+template<typename T> struct EnableIntOperators : std::false_type { };
+
+// operator++() - prefix
+template<typename T>
+typename std::enable_if<EnableIntOperators<T>::value, T>::type
+operator++(T& x)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	return x = static_cast<T>(static_cast<underlying>(x) + 1);
+}
+
+// operator++(int) - postfix
+template<typename T>
+typename std::enable_if<EnableIntOperators<T>::value, T>::type
+operator++(T& x, int)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	T current = x;
+	x = static_cast<T>(static_cast<underlying>(x) + 1);
+	return current;
+}
+
+template<typename T>
+typename std::enable_if<EnableIntOperators<T>::value, T>::type&
+operator--(T& x)
+{
+	_ASSERTE(x > T::npos);
+	using underlying = typename std::underlying_type<T>::type;
+	auto r = static_cast<underlying>(x) - 1;
+	return x = static_cast<T>(r);
+}
+
+template<typename T>
+typename std::enable_if<EnableIntOperators<T>::value, T>::type&
+operator--(T& x, int)
+{
+	_ASSERTE(x > T::npos);
+	using underlying = typename std::underlying_type<T>::type;
+	T current = x;
+	auto r = static_cast<underlying>(x) - 1;
+	x = static_cast<T>(r);
+	return current;
+}
+
+template<typename T, typename I>
+typename std::enable_if<EnableIntOperators<T>::value, T>::type&
+operator+=(T& x, const I offset)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	return x = static_cast<T>(static_cast<underlying>(x) + offset);
+}
+
+template<typename T, typename I>
+typename std::enable_if<EnableIntOperators<T>::value, T>::type&
+operator-=(T& x, const I offset)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	underlying r = static_cast<underlying>(x) - offset;
+	_ASSERTE(r >= static_cast<underlying>(T::npos));
+	return x = static_cast<T>(r);
+}
+
+template<typename T, typename I>
+const typename std::enable_if<EnableIntOperators<T>::value, T>::type
+operator+(const T x, const I y)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	return static_cast<T>(static_cast<underlying>(x) + static_cast<underlying>(y));
+}
+
+template<typename T, typename I>
+const typename std::enable_if<EnableIntOperators<T>::value, T>::type
+operator-(const T x, const I y)
+{
+	using underlying = typename std::underlying_type<T>::type;
+	underlying r = static_cast<underlying>(x) - static_cast<underlying>(y);
+	_ASSERTE(r >= static_cast<underlying>(T::npos));
+	return static_cast<T>(r);
+}
+
+#define ENABLE_INT_OPERATORS(x) \
+	template<> struct EnableIntOperators<x> : std::true_type { };

--- a/Core/DolphinVM/InProcStub/StdAfx.h
+++ b/Core/DolphinVM/InProcStub/StdAfx.h
@@ -13,8 +13,10 @@
 #define _ATL_DEBUG_INTERFACES
 #endif
 
+#include <stdint.h>
+
 #define UMDF_USING_NTSTATUS
-typedef long NTSTATUS;
+typedef int32_t NTSTATUS;
 #include <ntstatus.h>
 
 #include <atlbase.h>

--- a/Core/DolphinVM/InProcToGo/StdAfx.h
+++ b/Core/DolphinVM/InProcToGo/StdAfx.h
@@ -13,8 +13,10 @@
 #define _ATL_DEBUG_INTERFACES
 #endif
 
+#include <stdint.h>
+
 #define UMDF_USING_NTSTATUS
-typedef long NTSTATUS;
+typedef int32_t NTSTATUS;
 #include <ntstatus.h>
 
 #include <atlbase.h>

--- a/Core/DolphinVM/STMethodHeader.h
+++ b/Core/DolphinVM/STMethodHeader.h
@@ -28,10 +28,10 @@ typedef enum {
 
 typedef struct STMethodHeader
 {
-	BYTE isInt 				: 1;	// MUST be 1 (to avoid treatment as object)
-	BYTE isPrivate			: 1;
-	BYTE envTempCount		: 6;	// Note that this is actually count+1
-	BYTE stackTempCount;
-	BYTE argumentCount;
-	BYTE primitiveIndex;
+	uint8_t isInt 				: 1;	// MUST be 1 (to avoid treatment as object)
+	uint8_t isPrivate			: 1;
+	uint8_t envTempCount		: 6;	// Note that this is actually count+1
+	uint8_t stackTempCount;
+	uint8_t argumentCount;
+	uint8_t primitiveIndex;
 } STMethodHeader;

--- a/Core/DolphinVM/bytecdes.h
+++ b/Core/DolphinVM/bytecdes.h
@@ -33,8 +33,10 @@ enum { NumShortSendsWith2Args = 8 };
 
 // N.B. These sizes are offsets from the instruction FOLLOWING the jump (the IP is assumed to
 // have advanced to the next instruction by the time the offset is added to IP)
-enum { MaxBackwardsLongJump = -32768, MaxForwardsLongJump = 32767 };
-enum { MaxBackwardsNearJump = -128, MaxForwardsNearJump = 127 };
+static constexpr int MaxBackwardsLongJump = INT16_MIN;
+static constexpr int MaxForwardsLongJump = INT16_MAX;
+static constexpr int MaxBackwardsNearJump = INT8_MIN;
+static constexpr int MaxForwardsNearJump = INT8_MAX;
 
 enum { 
 	FirstSingleByteInstruction = 0, 
@@ -274,17 +276,17 @@ enum { OuterTempMaxDepth	= MAXFORBITS(OuterTempDepthBits) };
 #pragma warning(disable:4201)
 struct BlockCopyExtension
 {
-	BYTE	argCount;
-	BYTE	stackTempsCount;
-	BYTE	needsOuter:1;
-	BYTE	envTempsCount:7;
-	BYTE	needsSelf:1;
-	BYTE	copiedValuesCount:7;
+	uint8_t	argCount;
+	uint8_t	stackTempsCount;
+	uint8_t	needsOuter:1;
+	uint8_t	envTempsCount:7;
+	uint8_t	needsSelf:1;
+	uint8_t	copiedValuesCount:7;
 };
 
 enum { ExLongPushImmediateInstructionSize = 5, BlockCopyInstructionSize = 7 };
 
-inline int lengthOfByteCode(BYTE opCode)
+inline int lengthOfByteCode(uint8_t opCode)
 {
 	return opCode < FirstDoubleByteInstruction ? 1 : 
 				opCode < FirstTripleByteInstruction ? 2 : 

--- a/Core/DolphinVM/disassembler.h
+++ b/Core/DolphinVM/disassembler.h
@@ -658,7 +658,7 @@ public:
 
 
 		default:
-			stream << L"UNHANDLED BYTE CODE " << opcode << L"!!!";
+			stream << L"UNHANDLED BYTECODE " << opcode << L"!!!";
 			break;
 		}
 		stream << std::endl;

--- a/Core/DolphinVM/disassembler.h
+++ b/Core/DolphinVM/disassembler.h
@@ -8,9 +8,9 @@ enum JumpType { Jump, JumpIfTrue, JumpIfFalse, JumpIfNil, JumpIfNotNil };
 #define min(a,b)            (((a) < (b)) ? (a) : (b))
 #endif
 
-std::wostream& operator<<(std::wostream& stream, const std::string& str);
+std::wostream& __stdcall operator<<(std::wostream& stream, const std::string& str);
 
-template <class T> class BytecodeDisassembler
+template <class T, class I> class BytecodeDisassembler
 {
 	T& context;
 public:
@@ -19,7 +19,7 @@ public:
 	{}
 
 	//void Disassemble(T context, std::wostream& stream);
-	size_t DisassembleAt(size_t ip, std::wostream& stream)
+	size_t DisassembleAt(I ip, std::wostream& stream)
 	{
 		EmitIp(ip, stream);
 		size_t len = EmitRawBytes(ip, stream);
@@ -31,25 +31,25 @@ private:
 	size_t GetCodeSize() { 
 		return context.GetCodeSize(); 
 	}
-	BYTE GetBytecode(size_t ip) {
+	uint8_t GetBytecode(I ip) {
 		return context.GetBytecode(ip);
 	}
 
 public:
-	void EmitIp(size_t ip, std::wostream& stream)
+	void EmitIp(I ip, std::wostream& stream)
 	{
 		// Print one-based ip as this is how they are disassembled in the image
-		stream << std::dec << setw(5) << (ip + 1) << L":";
+		stream << std::dec << setw(5) << static_cast<uintptr_t>(ip + 1) << L":";
 	}
 
-	size_t EmitRawBytes(size_t ip, std::wostream& stream)
+	size_t EmitRawBytes(I ip, std::wostream& stream)
 	{
-		int len = lengthOfByteCode(GetBytecode(ip));
+		size_t len = lengthOfByteCode(GetBytecode(ip));
 		stream << std::hex << uppercase << setfill(L'0');
-		int j;
+		size_t j;
 		for (j = 0; j < min(len, 3); j++)
 		{
-			stream << L' ' << setw(2) << static_cast<unsigned>(GetBytecode(ip + j));
+			stream << L' ' << setw(2) << static_cast<uint32_t>(GetBytecode(ip + j));
 		}
 		if (len > 3)
 		{
@@ -64,9 +64,9 @@ public:
 		return len;
 	}
 
-	void BytecodeDisassembler::EmitDecodedInstructionAt(size_t ip, std::wostream& stream)
+	void BytecodeDisassembler::EmitDecodedInstructionAt(I ip, std::wostream& stream)
 	{
-		const BYTE opcode = GetBytecode(ip);
+		const uint8_t opcode = GetBytecode(ip);
 
 		switch (opcode)
 		{
@@ -307,8 +307,8 @@ public:
 		case  ShortJump + 6:
 		case  ShortJump + 7:
 		{
-			BYTE offset = opcode - ShortJump;
-			PrintJumpInstruction(ip, stream, Jump, offset, offset + ip + 1 + 1);
+			int8_t offset = opcode - ShortJump;
+			PrintJumpInstruction(ip, stream, Jump, offset, offset + static_cast<intptr_t>(ip) + 1 + 1);
 		}
 		break;
 
@@ -321,8 +321,8 @@ public:
 		case  ShortJumpIfFalse + 6:
 		case  ShortJumpIfFalse + 7:
 		{
-			BYTE offset = opcode - ShortJumpIfFalse;
-			PrintJumpInstruction(ip, stream, JumpIfFalse, offset, offset + ip + 1 + 1);
+			int8_t offset = opcode - ShortJumpIfFalse;
+			PrintJumpInstruction(ip, stream, JumpIfFalse, offset, offset + static_cast<intptr_t>(ip) + 1 + 1);
 		}
 		break;
 
@@ -355,11 +355,10 @@ public:
 		case ShortSpecialSend + 26:
 		case ShortSpecialSend + 27:
 		case ShortSpecialSend + 28:
-		case ShortSpecialSend + 29:
 		case ShortSpecialSend + 30:
 		case ShortSpecialSend + 31:
 		{
-			stream << L"Special Send #" << context.GetSpecialSelector(opcode - ShortSpecialSend).c_str();
+			stream << L"Special Send #" << context.GetSpecialSelector(opcode - ShortSpecialSend);
 		}
 		break;
 
@@ -439,7 +438,7 @@ public:
 
 		case PushOuterTemp:
 		{
-			BYTE operand = GetBytecode(ip + 1);
+			uint8_t operand = GetBytecode(ip + 1);
 			stream << L"Push Outer[" << std::dec << static_cast<int>(operand >> 5);
 			PrintTempInstruction(ip, stream, "]", (operand & 0x1F));
 		}
@@ -463,7 +462,7 @@ public:
 
 		case StoreOuterTemp:
 		{
-			BYTE operand = GetBytecode(ip + 1);
+			uint8_t operand = GetBytecode(ip + 1);
 			stream << L"Store Outer[" << std::dec << static_cast<int>(operand >> 5);
 			PrintTempInstruction(ip, stream, "]", (operand & 0x1F));
 		}
@@ -483,7 +482,7 @@ public:
 
 		case PopStoreOuterTemp:
 		{
-			BYTE operand = GetBytecode(ip + 1);
+			uint8_t operand = GetBytecode(ip + 1);
 			stream << L"Pop Outer[" << std::dec << static_cast<int>(operand >> 5);
 			PrintTempInstruction(ip, stream, "]", operand & 0x1F);
 		}
@@ -494,7 +493,7 @@ public:
 			break;
 
 		case PushImmediate:
-			PrintPushImmediate(ip, stream, static_cast<SBYTE>(GetBytecode(ip + 1)), 1);
+			PrintPushImmediate(ip, stream, static_cast<int8_t>(GetBytecode(ip + 1)), 1);
 			break;
 
 		case PushChar:
@@ -503,14 +502,14 @@ public:
 
 		case Send:
 		{
-			BYTE operand = GetBytecode(ip + 1);
+			uint8_t operand = GetBytecode(ip + 1);
 			PrintSendInstruction(ip, stream, operand & SendXMaxLiteral, operand >> SendXLiteralBits);
 		}
 		break;
 
 		case Supersend:
 		{
-			BYTE operand = GetBytecode(ip + 1);
+			uint8_t operand = GetBytecode(ip + 1);
 			stream << L"Super ";
 			PrintSendInstruction(ip, stream, operand & SendXMaxLiteral, operand >> SendXLiteralBits);
 		}
@@ -522,14 +521,14 @@ public:
 		case NearJumpIfNil:
 		case NearJumpIfNotNil:
 		{
-			SBYTE offset = static_cast<SBYTE>(GetBytecode(ip + 1));
-			PrintJumpInstruction(ip, stream, (JumpType)(opcode - NearJump), offset, ip + offset + 2);
+			int8_t offset = static_cast<int8_t>(GetBytecode(ip + 1));
+			PrintJumpInstruction(ip, stream, (JumpType)(opcode - NearJump), offset, static_cast<intptr_t>(ip) + offset + 2);
 		}
 		break;
 
 		case SendTempWithNoArgs:
 		{
-			BYTE operand = GetBytecode(ip + 1);
+			uint8_t operand = GetBytecode(ip + 1);
 			PrintTempInstruction(ip, stream, "Push", operand >> SendXLiteralBits);
 			stream << L"; ";
 			PrintSendInstruction(ip, stream, operand & SendXMaxLiteral, 0);
@@ -546,7 +545,7 @@ public:
 
 		case PushTempPair:
 		{
-			BYTE operand = GetBytecode(ip + 1);
+			uint8_t operand = GetBytecode(ip + 1);
 			PrintTempInstruction(ip, stream, "Push", operand >> 4);
 			PrintTempInstruction(ip + 1, stream, "; Push", operand & 0xF);
 		}
@@ -554,19 +553,19 @@ public:
 
 		// Three bytes from here on ...
 		case LongPushConst:
-			PrintStaticInstruction(ip, stream, "Push Const", (GetBytecode(ip + 2) << 8) + GetBytecode(ip + 1));
+			PrintStaticInstruction(ip, stream, "Push Const", (static_cast<size_t>(GetBytecode(ip + 2)) << 8) + GetBytecode(ip + 1));
 			break;
 
 		case LongPushStatic:
-			PrintStaticInstruction(ip, stream, "Push Static", (GetBytecode(ip + 2) << 8) + GetBytecode(ip + 1));
+			PrintStaticInstruction(ip, stream, "Push Static", (static_cast<size_t>(GetBytecode(ip + 2)) << 8) + GetBytecode(ip + 1));
 			break;
 
 		case LongStoreStatic:
-			PrintStaticInstruction(ip, stream, "Store Static", (GetBytecode(ip + 2) << 8) + GetBytecode(ip + 1));
+			PrintStaticInstruction(ip, stream, "Store Static", (static_cast<size_t>(GetBytecode(ip + 2)) << 8) + GetBytecode(ip + 1));
 			break;
 
 		case LongPushImmediate:
-			PrintPushImmediate(ip, stream, (SWORD)((GetBytecode(ip + 2) << 8) + GetBytecode(ip + 1)), 2);
+			PrintPushImmediate(ip, stream, static_cast<int16_t>((GetBytecode(ip + 2) << 8) + GetBytecode(ip + 1)), 2);
 			break;
 
 		case LongSend:
@@ -585,8 +584,8 @@ public:
 		case LongJumpIfNil:
 		case LongJumpIfNotNil:
 		{
-			SWORD offset = (SWORD)((GetBytecode(ip + 2) << 8) + GetBytecode(ip + 1));
-			PrintJumpInstruction(ip, stream, (JumpType)(opcode - LongJump), offset, ip + 3 + offset);
+			int16_t offset = static_cast<int16_t>((GetBytecode(ip + 2) << 8ui32) + GetBytecode(ip + 1));
+			PrintJumpInstruction(ip, stream, static_cast<JumpType>(opcode - LongJump), offset, static_cast<intptr_t>(ip) + 3 + offset);
 		}
 		break;
 
@@ -639,22 +638,22 @@ public:
 				stream << L"needs self, ";
 			if (GetBytecode(ip + 3) & 1)
 				stream << L"needs outer, ";
-			int length = (GetBytecode(ip + 6) << 8) + GetBytecode(ip + 5);
+			int length = (GetBytecode(ip + 6) << 8ui32) + GetBytecode(ip + 5);
 			stream << L"length: " << length;
 		}
 		break;
 
 		case ExLongSend:
-			PrintSendInstruction(ip, stream, (GetBytecode(ip + 3) << 8) + GetBytecode(ip + 2), GetBytecode(ip + 1));
+			PrintSendInstruction(ip, stream, (GetBytecode(ip + 3) << 8ui32) + GetBytecode(ip + 2), GetBytecode(ip + 1));
 			break;
 
 		case ExLongSupersend:
 			stream << L"Super ";
-			PrintSendInstruction(ip, stream, (GetBytecode(ip + 3) << 8) + GetBytecode(ip + 2), GetBytecode(ip + 1));
+			PrintSendInstruction(ip, stream, (GetBytecode(ip + 3) << 8ui32) + GetBytecode(ip + 2), GetBytecode(ip + 1));
 			break;
 
 		case ExLongPushImmediate:
-			PrintPushImmediate(ip, stream, (GetBytecode(ip + 4) << 24) + (GetBytecode(ip + 3) << 16) + (GetBytecode(ip + 2) << 8) + GetBytecode(ip + 1), 4);
+			PrintPushImmediate(ip, stream, (GetBytecode(ip + 4) << 24ui32) + (GetBytecode(ip + 3) << 16ui32) + (GetBytecode(ip + 2) << 8ui32) + GetBytecode(ip + 1), 4);
 			break;
 
 
@@ -666,7 +665,7 @@ public:
 		stream.flush();
 	}
 
-	void BytecodeDisassembler::PrintJumpInstruction(size_t ip, std::wostream& stream, JumpType jumpType, SWORD offset, size_t target)
+	void BytecodeDisassembler::PrintJumpInstruction(I ip, std::wostream& stream, JumpType jumpType, int16_t offset, size_t target)
 	{
 		const char* JumpNames[] = { "Jump", "Jump If True", "Jump If False", "Jump If Nil", "Jump If Not Nil" };
 		stream << JumpNames[jumpType] << L' ';
@@ -677,28 +676,28 @@ public:
 		stream << std::dec << static_cast<int>(offset) << L" to " << (target + 1);
 	}
 
-	void BytecodeDisassembler::PrintStaticInstruction(size_t ip, std::wostream& stream, const char* type, size_t index)
+	void BytecodeDisassembler::PrintStaticInstruction(I ip, std::wostream& stream, const char* type, size_t index)
 	{
 		stream << type << L" [" << std::dec << index << L"]: " << context.GetLiteralAsString(index);
 	}
 
-	void BytecodeDisassembler::PrintInstVarInstruction(size_t ip, std::wostream& stream, const char* type, size_t index)
+	void BytecodeDisassembler::PrintInstVarInstruction(I ip, std::wostream& stream, const char* type, size_t index)
 	{
 		stream << type << L" InstVar[" << std::dec << index << L"]: " << context.GetInstVar(index).c_str();
 	}
 
-	void BytecodeDisassembler::PrintSendInstruction(size_t ip, std::wostream& stream, int index, int argumentCount)
+	void BytecodeDisassembler::PrintSendInstruction(I ip, std::wostream& stream, int index, int argumentCount)
 	{
 		wstring selector = context.GetLiteralAsString(index);
 		stream << L"Send[" << std::dec << index << L"]: #" << selector << L" with " << argumentCount << (argumentCount == 1 ? L" arg" : L" args");
 	}
 
-	void BytecodeDisassembler::PrintTempInstruction(size_t ip, std::wostream& stream, const char* type, size_t index)
+	void BytecodeDisassembler::PrintTempInstruction(I ip, std::wostream& stream, const char* type, size_t index)
 	{
 		stream << type << L" Temp[" << std::dec << index << L"]";
 	}
 
-	void BytecodeDisassembler::PrintPushImmediate(size_t ip, std::wostream& stream, int value, int byteSize)
+	void BytecodeDisassembler::PrintPushImmediate(I ip, std::wostream& stream, int value, int byteSize)
 	{
 		stream << L"Push " << std::dec << value;
 		if (byteSize > 0)

--- a/Core/DolphinVM/extcall.cpp
+++ b/Core/DolphinVM/extcall.cpp
@@ -227,146 +227,146 @@ unsigned Interpreter::pushArgsAt(const ExternalDescriptor* descriptor, BYTE* lpP
 	{
 		BYTE arg = types->m_args[i++];
 		// Similar to primitiveDLL32Call return values, but VOID is not supported as a parameter type
-		switch(ExtCallArgTypes(arg))
+		switch(ExtCallArgType(arg))
 		{
-			case ExtCallArgVOID:					// Not a valid argument
+			case ExtCallArgType::Void:					// Not a valid argument
 				HARDASSERT(FALSE);
 				pushNil();
 				lpParms += sizeof(MWORD);
 				break;
 
-			case ExtCallArgLPVOID:
+			case ExtCallArgType::LPVoid:
 				pushNewObject((OTE*)ExternalAddress::New(*(BYTE**)lpParms));
 				lpParms += sizeof(BYTE*);
 				break;
 
-			case ExtCallArgCHAR:
+			case ExtCallArgType::Char:
 				pushObject((OTE*)Character::NewUnicode(*reinterpret_cast<MWORD*>(lpParms)));
 				lpParms += sizeof(MWORD);
 				break;
 
-			case ExtCallArgBYTE:
+			case ExtCallArgType::UInt8:
 				pushSmallInteger(*lpParms);
 				lpParms += sizeof(MWORD);
 				break;
 
-			case ExtCallArgSBYTE:
+			case ExtCallArgType::Int8:
 				pushSmallInteger(*reinterpret_cast<char*>(lpParms));
 				lpParms += sizeof(MWORD);
 				break;
 			
-			case ExtCallArgWORD:
+			case ExtCallArgType::UInt16:
 				pushSmallInteger(*reinterpret_cast<WORD*>(lpParms));
 				lpParms += sizeof(MWORD);
 				break;
 
-			case ExtCallArgSWORD:
+			case ExtCallArgType::Int16:
 				pushSmallInteger(*reinterpret_cast<SWORD*>(lpParms));
 				lpParms += sizeof(MWORD);
 				break;
 
-			case ExtCallArgDWORD:
+			case ExtCallArgType::UInt32:
 				pushUnsigned32(*reinterpret_cast<DWORD*>(lpParms));
 				lpParms += sizeof(DWORD);
 				break;
 
-			case ExtCallArgSDWORD:
-			case ExtCallArgHRESULT:
-			case ExtCallArgNTSTATUS:
+			case ExtCallArgType::Int32:
+			case ExtCallArgType::HResult:
+			case ExtCallArgType::NTStatus:
 				pushSigned32(*reinterpret_cast<SDWORD*>(lpParms));
 				lpParms += sizeof(SDWORD);
 				break;
 
-			case ExtCallArgBOOL:
+			case ExtCallArgType::Bool:
 				pushBool(*reinterpret_cast<BOOL*>(lpParms));
 				lpParms += sizeof(MWORD);
 				break;
 
-			case ExtCallArgHANDLE:
+			case ExtCallArgType::Handle:
 				pushHandle(*reinterpret_cast<HANDLE*>(lpParms));
 				lpParms += sizeof(HANDLE);
 				break;
 
-			case ExtCallArgDOUBLE:
+			case ExtCallArgType::Double:
 				push(*reinterpret_cast<double*>(lpParms));
 				// Yup, even doubles passed on main stack
 				lpParms += sizeof(DOUBLE);
 				break;
 
-			case ExtCallArgLPSTR:
+			case ExtCallArgType::LPStr:
 				push(*reinterpret_cast<LPCSTR*>(lpParms));
 				lpParms += sizeof(LPCSTR);
 				break;
 
-			case ExtCallArgOOP:
-			case ExtCallArgOTE:
+			case ExtCallArgType::Oop:
+			case ExtCallArgType::Ote:
 				push(*reinterpret_cast<Oop*>(lpParms));
 				lpParms += sizeof(Oop);
 				break;
 
-			case ExtCallArgFLOAT:
+			case ExtCallArgType::Float:
 				push(static_cast<double>(*reinterpret_cast<float*>(lpParms)));
 				// Yup, even doubles passed on main stack
 				lpParms += sizeof(FLOAT);
 				break;
 
-			case ExtCallArgLPPVOID:
+			case ExtCallArgType::LPPVoid:
 				// Push an LPVOID* instance onto the stack
 				pushNewObject(ExternalStructure::NewPointer(Pointers.ClassLPVOID, *(BYTE**)lpParms));
 				lpParms += sizeof(BYTE*);
 				break;
 
-			case ExtCallArgLPWSTR:
+			case ExtCallArgType::LPWStr:
 				push(*reinterpret_cast<LPWSTR*>(lpParms));
 				lpParms += sizeof(LPWSTR);
 				break;
 				
-			case ExtCallArgQWORD:
+			case ExtCallArgType::UInt64:
 				push(Integer::NewUnsigned64(*reinterpret_cast<ULONGLONG*>(lpParms)));
 				lpParms += sizeof(ULARGE_INTEGER);
 				break;
 				
-			case ExtCallArgSQWORD:
+			case ExtCallArgType::Int64:
 				push(Integer::NewSigned64(*reinterpret_cast<LONGLONG*>(lpParms)));
 				lpParms += sizeof(LONGLONG);
 				break;
 			
-			case ExtCallArgBSTR:
+			case ExtCallArgType::Bstr:
 				push(*reinterpret_cast<LPWSTR*>(lpParms));
 				lpParms += sizeof(BSTR);
 				break;
 				
-			case ExtCallArgVARIANT:
+			case ExtCallArgType::Variant:
 				pushNewObject(ExternalStructure::New(Pointers.ClassVARIANT, lpParms));
 				lpParms += sizeof(VARIANT);
 				break;
 
-			case ExtCallArgDATE:
+			case ExtCallArgType::Date:
 				pushNewObject(ExternalStructure::New(Pointers.ClassDATE, lpParms));
 				lpParms += sizeof(DATE);
 				break;
 
-			case ExtCallArgVARBOOL:
+			case ExtCallArgType::VarBool:
 				pushBool(*reinterpret_cast<VARIANT_BOOL*>(lpParms));
 				lpParms += sizeof(MWORD);				// Note passes as 32-bit
 				break;
 
-			case ExtCallArgGUID:
+			case ExtCallArgType::Guid:
 				pushNewObject((OTE*)NewGUID(reinterpret_cast<GUID*>(lpParms)));
 				lpParms += sizeof(GUID);
 				break;
 
-			case ExtCallArgUINTPTR:
+			case ExtCallArgType::UIntPtr:
 				pushUIntPtr(*reinterpret_cast<UINT_PTR*>(lpParms));
 				lpParms += sizeof(UINT_PTR);
 				break;
 
-			case ExtCallArgINTPTR:
+			case ExtCallArgType::IntPtr:
 				pushIntPtr(*reinterpret_cast<INT_PTR*>(lpParms));
 				lpParms += sizeof(INT_PTR);
 				break;
 
-			case ExtCallArgSTRUCT:
+			case ExtCallArgType::Struct:
 				{
 					arg = types->m_args[i++];
 					BehaviorOTE* behaviorPointer = reinterpret_cast<BehaviorOTE*>(descriptor->m_literals[arg]);
@@ -375,7 +375,7 @@ unsigned Interpreter::pushArgsAt(const ExternalDescriptor* descriptor, BYTE* lpP
 				}
 				break;
 
-			case ExtCallArgSTRUCT4:
+			case ExtCallArgType::Struct32:
 				{
 					arg = types->m_args[i++];
 					BehaviorOTE* behaviorPointer = reinterpret_cast<BehaviorOTE*>(descriptor->m_literals[arg]);
@@ -384,7 +384,7 @@ unsigned Interpreter::pushArgsAt(const ExternalDescriptor* descriptor, BYTE* lpP
 				}
 				break;
 
-			case ExtCallArgSTRUCT8:
+			case ExtCallArgType::Struct64:
 				{
 					arg = types->m_args[i++];
 					BehaviorOTE* behaviorPointer = reinterpret_cast<BehaviorOTE*>(descriptor->m_literals[arg]);
@@ -393,7 +393,7 @@ unsigned Interpreter::pushArgsAt(const ExternalDescriptor* descriptor, BYTE* lpP
 				}
 				break;
 
-			case ExtCallArgLP:
+			case ExtCallArgType::LPStruct:
 				{
 					arg = types->m_args[i++];
 					BehaviorOTE* behaviorPointer = reinterpret_cast<BehaviorOTE*>(descriptor->m_literals[arg]);
@@ -402,13 +402,13 @@ unsigned Interpreter::pushArgsAt(const ExternalDescriptor* descriptor, BYTE* lpP
 				}
 				break;
 
-			case ExtCallArgLPP:							// Not a valid argument
+			case ExtCallArgType::LPPStruct:							// Not a valid argument
 				arg = types->m_args[i++];
 				pushNewObject(ExternalStructure::NewPointer(Pointers.ClassLPVOID, *(BYTE**)lpParms));
 				lpParms += sizeof(BYTE*);
 				break;
 
-			case ExtCallArgCOMPTR:
+			case ExtCallArgType::ComPtr:
 				{
 					arg = types->m_args[i++];
 					IUnknown* punk = *(IUnknown**)lpParms;

--- a/Core/DolphinVM/ist.h
+++ b/Core/DolphinVM/ist.h
@@ -75,15 +75,19 @@
 #pragma warning(pop)
 #include <functional>
 
+typedef _Return_type_success_(return >= 0) int32_t NTSTATUS;
+#define NTSTATUS_DEFINED
+#define _NTDEF_
+
 #include "Environ.h"
 
-typedef signed char		SBYTE;
-typedef short			SWORD;
-typedef long			SDWORD;
+typedef int8_t		SBYTE;
+typedef int16_t		SWORD;
+typedef int32_t		SDWORD;
 
 // The basic word size of the machine
-typedef UINT_PTR	MWORD;
-typedef INT_PTR 	SMALLINTEGER;	// Optimized SmallInteger; same size as MWORD
+typedef uintptr_t	MWORD;
+typedef intptr_t 	SMALLINTEGER;	// Optimized SmallInteger; same size as MWORD
 typedef MWORD		SMALLUNSIGNED;	// Unsigned optimized SmallInteger; same size as MWORD	
 typedef MWORD		Oop;
 

--- a/Core/DolphinVM/textrange.h
+++ b/Core/DolphinVM/textrange.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "EnumHelpers.h"
+
+enum class textpos_t : intptr_t { npos = -1, start };
+ENABLE_INT_OPERATORS(textpos_t)
+
+struct TEXTRANGE
+{
+	textpos_t m_start;
+	textpos_t m_stop;
+
+	TEXTRANGE(textpos_t start = textpos_t::start, textpos_t stop = textpos_t::npos) : m_start(start), m_stop(stop)
+	{}
+
+	__declspec(property(get = GetSpan)) intptr_t Span;
+	intptr_t GetSpan() const { return (intptr_t)m_stop - (intptr_t)m_start + 1; }
+};
+


### PR DESCRIPTION
Generally replace BYTE, DWORD, etc, with corresponding C standard types uint8_t, uint32_t, etc.
Also, for future 64-bit compatibility, replace unsigned and int in most cases with an integer type that is the same as the machine word size. For example size_t is used for variables that can be used as indexes and memory sizes.
- Contributes to #535
- Contributes to #531
- Also address many code analysis issues from VS19 in-IDE parser
  - e.g. Use of enum class in preference to unscoped enums
- Define specific integer types (using enum class) for IPs and text positions to help identify
errors