### PR TITLE
Throw a special subclass of Error from ProcessorScheduler>>cannotReturn:

### DIFF
--- a/Core/Object Arts/Dolphin/Base/CannotReturnError.cls
+++ b/Core/Object Arts/Dolphin/Base/CannotReturnError.cls
@@ -1,0 +1,16 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+Error subclass: #CannotReturnError
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+CannotReturnError guid: (GUID fromString: '{3986fbda-d1ac-42bd-81d9-060d7515a133}')!
+CannotReturnError comment: ''!
+!CannotReturnError categoriesForClass!Kernel-Exception Handling! !
+!CannotReturnError methodsFor!
+
+description
+	^'Cannot return ' , self tag basicPrintString , ' to expired context or across Processes'! !
+!CannotReturnError categoriesFor: #description!displaying!public! !
+

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -830,6 +830,11 @@ Error subclass: #BoundsError
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
+Error subclass: #CannotReturnError
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
 Error subclass: #ClassRemovalError
 	instanceVariableNames: 'originalError'
 	classVariableNames: ''

--- a/Core/Object Arts/Dolphin/Base/ProcessorScheduler.cls
+++ b/Core/Object Arts/Dolphin/Base/ProcessorScheduler.cls
@@ -157,8 +157,7 @@ cannotReturn: anObject
 	stack frame) then it is advisable to Kill the offending process, as further walkbacks
 	will occur if it is terminated normally."
 
-	^self error: ('Cannot return <1s> to expired context or across Processes'
-				expandMacrosWith: anObject basicPrintString)!
+	^CannotReturnError signalWith: anObject!
 
 constWrite: exceptionRecordBytes 
 	"Private - The VM generated a GP Fault interrupt. The argument is the relevant 


### PR DESCRIPTION
This is a very unusual error, and while catching it specifically in production code is probably a bad idea, there *are* some neat tricks you can pull in development... In particular, with this change I was able to create a method that wraps a block such that far returns return only from the block and not the enclosing method—handy for quick-and-dirty method-like constructs in a Workspace.