### PR TITLE
Move BoundsError under NotFoundError

### DIFF
--- a/Core/Object Arts/Dolphin/Base/BoundsError.cls
+++ b/Core/Object Arts/Dolphin/Base/BoundsError.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-Error subclass: #BoundsError
-	instanceVariableNames: 'receiver'
+NotFoundError subclass: #BoundsError
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -13,18 +13,6 @@ BoundsError comment: ''!
 _descriptionFormat
 	"Answer the description format string for the receiver."
 
-	^'Index %2 is out of bounds'!
-
-receiver
-	"Answer the object which generated the bounds error."
-	
-	^receiver!
-
-receiver: anObject
-	"Set the object which generated the bounds error to be anObject"
-	
-	receiver := anObject! !
+	^'Index %2 is out of bounds'! !
 !BoundsError categoriesFor: #_descriptionFormat!displaying!public! !
-!BoundsError categoriesFor: #receiver!accessing!public! !
-!BoundsError categoriesFor: #receiver:!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -825,11 +825,6 @@ Error subclass: #ArithmeticError
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-Error subclass: #BoundsError
-	instanceVariableNames: 'receiver'
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
 Error subclass: #ClassRemovalError
 	instanceVariableNames: 'originalError'
 	classVariableNames: ''
@@ -926,6 +921,11 @@ Win32Error subclass: #Win32Fault
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Win32Fault subclass: #GPFault
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+NotFoundError subclass: #BoundsError
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''


### PR DESCRIPTION
It shares the same notion of "receiver", and the "is-a" relationship seems justified--ask for element 11 of a size-10 Array, well, it isn't found, same as if you'd asked for key 11 in a Dictionary that doesn't contain it.