### PR TITLE
Add Dolphin Sockets Tests to the regression tests

### DIFF
--- a/Core/Object Arts/Dolphin/Sockets/AbstractSocketTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/AbstractSocketTest.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 DolphinTest subclass: #AbstractSocketTest
 	instanceVariableNames: ''

--- a/Core/Object Arts/Dolphin/Sockets/Dolphin Sockets Tests.pax
+++ b/Core/Object Arts/Dolphin/Sockets/Dolphin Sockets Tests.pax
@@ -1,4 +1,4 @@
-| package |
+﻿| package |
 package := Package name: 'Dolphin Sockets Tests'.
 package paxVersion: 1;
 	basicComment: ''.
@@ -18,12 +18,11 @@ package binaryGlobalNames: (Set new
 package globalAliases: (Set new
 	yourself).
 
-package setPrerequisites: (IdentitySet new
-	add: '..\Base\Dolphin';
-	add: '..\Base\Dolphin Base Tests';
-	add: 'Dolphin Sockets';
-	add: 'Sockets Connection';
-	yourself).
+package setPrerequisites: #(
+	'..\Base\Dolphin'
+	'..\Base\Dolphin Base Tests'
+	'Dolphin Sockets'
+	'Sockets Connection').
 
 package!
 

--- a/Core/Object Arts/Dolphin/Sockets/InternetAddressTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/InternetAddressTest.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 DolphinTest subclass: #InternetAddressTest
 	instanceVariableNames: ''
@@ -17,19 +17,17 @@ testAllForHost
 	"Microsoft should have more than one IP associated with microsoft.com"
 	addresses := InternetAddress allForHost: 'microsoft.com'.
 	self assert: addresses size > 1.
-	self assert: (addresses anySatisfy: [:each | each ipAddress beginsWith: #[191 239]]).
 
 	"OA central"
 	addresses := InternetAddress allForHost: 'object-arts.com'.
-	self assert: addresses size = 1.
-	self assert: (addresses first host endsWith: 'cable.virginm.net')!
+	self assert: addresses size = 1!
 
 testHost
 	| name ip |
 	self isOnline ifFalse: [^self].
 	name := InternetAddress host: 'uk2.net'.
 	ip := InternetAddress ipAddress: name ipAddress.
-	self assert: ip host = name host!
+	self assert: (ip host endsWith: name host)!
 
 testIsIPString
 	self deny: (InternetAddress isIPString: '').

--- a/Core/Object Arts/Dolphin/Sockets/InternetAddressTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/InternetAddressTest.cls
@@ -11,23 +11,26 @@ InternetAddressTest comment: ''!
 !InternetAddressTest methodsFor!
 
 testAllForHost
-	| addresses oacom |
+	| addresses |
 	self isOnline ifFalse: [^self].
 
-	"Microsoft should have more than one IP associated with microsoft.com"
-	addresses := InternetAddress allForHost: 'microsoft.com'.
-	self assert: addresses size > 1.
+	"dns.google has two fixed and well-known IP addresses"
+	addresses := InternetAddress allForHost: 'dns.google'.
+	self assert: addresses size equals: 2.
+	self assert: (addresses collect: [:each | each ipAddress]) asSet
+		equals: #(#[8 8 4 4] #[8 8 8 8]) asSet.
 
-	"OA central"
-	addresses := InternetAddress allForHost: 'object-arts.com'.
-	self assert: addresses size = 1!
+	"google.com has only one"
+	addresses := InternetAddress allForHost: 'google.com'.
+	self assert: addresses size = 1.
+	self assert: (addresses first host endsWith: '1e100.net')!
 
 testHost
 	| name ip |
 	self isOnline ifFalse: [^self].
-	name := InternetAddress host: 'uk2.net'.
+	name := InternetAddress host: 'dns.google'.
 	ip := InternetAddress ipAddress: name ipAddress.
-	self assert: (ip host endsWith: name host)!
+	self assert: ip host equals: name host!
 
 testIsIPString
 	self deny: (InternetAddress isIPString: '').
@@ -48,9 +51,9 @@ testLocalHost
 	| local computerName |
 	computerName := SessionManager current computerName asLowercase.
 	local := InternetAddress localHost.
-	self assert: local host asUppercase = computerName asUppercase.
-	self assert: (((InternetAddress ipAddress: local ipAddress) host subStrings: $.) first 
-				sameAs: computerName)! !
+	self assert: local host asLowercase equals: computerName.
+	self assert: ((InternetAddress ipAddress: local ipAddress) host subStrings: $.) first asLowercase
+		equals: computerName! !
 !InternetAddressTest categoriesFor: #testAllForHost!public!unit tests! !
 !InternetAddressTest categoriesFor: #testHost!public!unit tests! !
 !InternetAddressTest categoriesFor: #testIsIPString!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Sockets/Socket2Test.cls
+++ b/Core/Object Arts/Dolphin/Sockets/Socket2Test.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 AbstractSocketTest subclass: #Socket2Test
 	instanceVariableNames: ''

--- a/Core/Object Arts/Dolphin/Sockets/SocketErrorTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/SocketErrorTest.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 DolphinTest subclass: #SocketErrorTest
 	instanceVariableNames: ''

--- a/Core/Object Arts/Dolphin/Sockets/SocketTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/SocketTest.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 AbstractSocketTest subclass: #SocketTest
 	instanceVariableNames: ''

--- a/RegressionTestsLoad.st
+++ b/RegressionTestsLoad.st
@@ -18,6 +18,7 @@ Package manager
 	install: 'Core\Object Arts\Dolphin\MVP\Dolphin MVP Tests.pax';
 	install: 'Core\Object Arts\Dolphin\IDE\Dolphin IDE Tests.pax';
 	install: 'Core\Object Arts\Dolphin\Lagoon\Lagoon Tests.pax';
+	install: 'Core\Object Arts\Dolphin\Sockets\Dolphin Sockets Tests.pax';
 	install: 'Core\Object Arts\Dolphin\System\STON\Dolphin STON Tests.pax';
 	yourself.
 !


### PR DESCRIPTION
There's not much there, but sure, why not run it. Had to remove a couple assertions about host names--it's hard to come up with a host name that has a stable IP address and reverse-DNS record...