### PR TITLE
Cases missed "Use sized type for primitive method argument count parameter

### DIFF
--- a/Core/DolphinVM/ExternalBuf.cpp
+++ b/Core/DolphinVM/ExternalBuf.cpp
@@ -14,13 +14,13 @@
 #include "Interprt.h"
 #include "ExternalBuf.h"
 
-Oop * __fastcall Interpreter::primitiveAddressOf(Oop * const sp, unsigned argCount)
+Oop * __fastcall Interpreter::primitiveAddressOf(Oop * const sp, primargcount_t argCount)
 {
 	StoreUIntPtr()(sp, reinterpret_cast<uintptr_t>(reinterpret_cast<OTE*>(*sp)->m_location));
 	return sp;
 }
 
-Oop * __fastcall Interpreter::primitiveBytesIsNull(Oop * const sp, unsigned argCount)
+Oop * __fastcall Interpreter::primitiveBytesIsNull(Oop * const sp, primargcount_t argCount)
 {
 	AddressOTE* oteBytes = reinterpret_cast<AddressOTE*>(*sp);
 	MWORD size = oteBytes->bytesSize();
@@ -33,7 +33,7 @@ Oop * __fastcall Interpreter::primitiveBytesIsNull(Oop * const sp, unsigned argC
 		return primitiveFailure(_PrimitiveFailureCode::ObjectTypeMismatch);
 }
 
-Oop * __fastcall Interpreter::primitiveStructureIsNull(Oop * const sp, unsigned argCount)
+Oop * __fastcall Interpreter::primitiveStructureIsNull(Oop * const sp, primargcount_t argCount)
 {
 	StructureOTE* oteStruct = reinterpret_cast<StructureOTE*>(*sp);
 
@@ -80,7 +80,7 @@ Oop * __fastcall Interpreter::primitiveStructureIsNull(Oop * const sp, unsigned 
 	}
 }
 
-Oop * __fastcall Interpreter::primitiveDWORDAtPut(Oop * const sp, unsigned argCount)
+Oop * __fastcall Interpreter::primitiveDWORDAtPut(Oop * const sp, primargcount_t argCount)
 {
 	BytesOTE* oteReceiver = reinterpret_cast<BytesOTE*>(*(sp - 2));
 	Oop oopOffset = *(sp - 1);
@@ -138,7 +138,7 @@ Oop * __fastcall Interpreter::primitiveDWORDAtPut(Oop * const sp, unsigned argCo
 	}
 }
 
-Oop * __fastcall Interpreter::primitiveIndirectDWORDAtPut(Oop * const sp, unsigned argCount)
+Oop * __fastcall Interpreter::primitiveIndirectDWORDAtPut(Oop * const sp, primargcount_t argCount)
 {
 	AddressOTE* oteReceiver = reinterpret_cast<AddressOTE*>(*(sp - 2));
 	Oop oopOffset = *(sp - 1);
@@ -246,7 +246,7 @@ Oop * __fastcall Interpreter::primitiveSDWORDAtPut(Oop * const sp, unsigned)
 	}
 }
 
-Oop * __fastcall Interpreter::primitiveIndirectSDWORDAtPut(Oop * const sp, unsigned argCount)
+Oop * __fastcall Interpreter::primitiveIndirectSDWORDAtPut(Oop * const sp, primargcount_t argCount)
 {
 	AddressOTE* oteReceiver = reinterpret_cast<AddressOTE*>(*(sp - 2));
 	Oop oopOffset = *(sp - 1);

--- a/Core/DolphinVM/GCPrim.cpp
+++ b/Core/DolphinVM/GCPrim.cpp
@@ -91,7 +91,7 @@ void Interpreter::asyncGC(DWORD gcFlags)
 
 
 // This has been usurped for GC primitive
-Oop* __fastcall Interpreter::primitiveCoreLeft(Oop* const sp , unsigned argCount)
+Oop* __fastcall Interpreter::primitiveCoreLeft(Oop* const sp , primargcount_t argCount)
 {
 	CHECKREFERENCESSP(sp);
 

--- a/Core/DolphinVM/Interprt.h
+++ b/Core/DolphinVM/Interprt.h
@@ -492,7 +492,7 @@ public:
 	static Oop* __fastcall unusedPrimitive(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveActivateMethod(Oop* const sp, primargcount_t argCount);
 
-	template<int Index> static Oop * __fastcall primitiveReturnConst(Oop * const sp, unsigned argCount);
+	template<int Index> static Oop * __fastcall primitiveReturnConst(Oop * const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveReturnSelf(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveReturnLiteralZero(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveReturnInstVar(Oop* const sp, primargcount_t argCount);
@@ -636,7 +636,7 @@ public:
 	static Oop* __fastcall primitiveNew(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveNewWithArg(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveNewPinned(Oop* const sp, primargcount_t argCount);
-	static Oop* __fastcall primitiveNewInitializedObject(Oop* sp, unsigned argCount);
+	static Oop* __fastcall primitiveNewInitializedObject(Oop* sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveNewFromStack(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveNewVirtual(Oop* const sp, primargcount_t argCount);
 
@@ -658,11 +658,11 @@ public:
 	static Oop* __fastcall primitiveInstanceCounts(Oop* const sp, primargcount_t argCount);
 	
 	// Control Primitives
-	static Oop* __fastcall primitiveValue(Oop* const sp, unsigned argumentCount);
+	static Oop* __fastcall primitiveValue(Oop* const sp, primargcount_t argumentCount);
 	static Oop* __fastcall primitiveValueWithArgs(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveValueWithArgsThunk(Oop* const sp, primargcount_t argCount);
-	static Oop* __fastcall primitivePerform(Oop* const sp, unsigned argumentCount);
-	static Oop* __fastcall primitivePerformThunk(Oop* const sp, unsigned argumentCount);
+	static Oop* __fastcall primitivePerform(Oop* const sp, primargcount_t argumentCount);
+	static Oop* __fastcall primitivePerformThunk(Oop* const sp, primargcount_t argumentCount);
 	static Oop* __fastcall primitivePerformWithArgs(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitivePerformWithArgsThunk(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitivePerformMethod(Oop* const sp, primargcount_t argCount);
@@ -678,12 +678,12 @@ public:
 	static Oop* __fastcall primitiveSignalThunk(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveWait(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveWaitThunk(Oop* const sp, primargcount_t argCount);
-	static Oop* __fastcall primitiveResume(Oop* const sp, unsigned argumentCount);
-	static Oop* __fastcall primitiveResumeThunk(Oop* const sp, unsigned argumentCount);
-	static Oop* __fastcall primitiveYield(Oop* const sp, unsigned argumentCount);
-	static Oop* __fastcall primitiveYieldThunk(Oop* const sp, unsigned argumentCount);
-	static Oop* __fastcall primitiveSingleStep(Oop* const sp, unsigned argumentCount);
-	static Oop* __fastcall primitiveSingleStepThunk(Oop* const sp, unsigned argumentCount);
+	static Oop* __fastcall primitiveResume(Oop* const sp, primargcount_t argumentCount);
+	static Oop* __fastcall primitiveResumeThunk(Oop* const sp, primargcount_t argumentCount);
+	static Oop* __fastcall primitiveYield(Oop* const sp, primargcount_t argumentCount);
+	static Oop* __fastcall primitiveYieldThunk(Oop* const sp, primargcount_t argumentCount);
+	static Oop* __fastcall primitiveSingleStep(Oop* const sp, primargcount_t argumentCount);
+	static Oop* __fastcall primitiveSingleStepThunk(Oop* const sp, primargcount_t argumentCount);
 	static Oop* __fastcall primitiveSuspend(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveSuspendThunk(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveSetSignals(Oop* const sp, primargcount_t argCount);

--- a/Core/DolphinVM/LargeIntPrim.h
+++ b/Core/DolphinVM/LargeIntPrim.h
@@ -2,7 +2,7 @@
 #pragma once
 
 // Template for operations where the result is zero if the argument is SmallInteger zero
-template <class Op, class OpSingle> static Oop* __fastcall Interpreter::primitiveLargeIntegerOpZ(Oop* const sp, unsigned argc)
+template <class Op, class OpSingle> static Oop* __fastcall Interpreter::primitiveLargeIntegerOpZ(Oop* const sp, primargcount_t argc)
 {
 	Oop oopArg = *sp;
 	const LargeIntegerOTE* oteReceiver = reinterpret_cast<const LargeIntegerOTE*>(*(sp - 1));

--- a/Core/DolphinVM/alloc.cpp
+++ b/Core/DolphinVM/alloc.cpp
@@ -193,7 +193,7 @@ Oop* __fastcall Interpreter::primitiveNewFromStack(Oop* const stackPointer, unsi
 	}
 }
 
-Oop* __fastcall Interpreter::primitiveNewInitializedObject(Oop* sp, unsigned argCount)
+Oop* __fastcall Interpreter::primitiveNewInitializedObject(Oop* sp, primargcount_t argCount)
 {
 	Oop oopReceiver = *(sp - argCount);
 	BehaviorOTE* oteClass = reinterpret_cast<BehaviorOTE*>(oopReceiver);

--- a/Core/DolphinVM/primasm.asm
+++ b/Core/DolphinVM/primasm.asm
@@ -201,7 +201,7 @@ ALIGNPRIMITIVE
 @callPrimitiveValue@8 ENDP
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; int __fastcall Interpreter::primitiveValue(void*, unsigned argCount)
+; int __fastcall Interpreter::primitiveValue(void*, primargcount_t argCount)
 ;
 BEGINPRIMITIVE primitiveValue
 	mov		eax, edx								; Get argument count into EAX

--- a/Core/DolphinVM/process.cpp
+++ b/Core/DolphinVM/process.cpp
@@ -1404,7 +1404,7 @@ DWORD Semaphore::Wait(SemaphoreOTE* oteThis, ProcessOTE* oteProcess, int timeout
 
 // Uses, but does not modify, instructionPointer and stackPointer
 // Does not modify pHome or pMethod
-Oop* __fastcall Interpreter::primitiveResume(Oop* const sp, unsigned argumentCount)
+Oop* __fastcall Interpreter::primitiveResume(Oop* const sp, primargcount_t argumentCount)
 {
 #ifdef _DEBUG
 	//	if (abs(executionTrace) > 0)
@@ -1446,7 +1446,7 @@ Oop* __fastcall Interpreter::primitiveResume(Oop* const sp, unsigned argumentCou
 
 // Uses, but does not modify, instructionPointer and stackPointer
 // Does not modify pHome or pMethod
-Oop* __fastcall Interpreter::primitiveSingleStep(Oop* const sp, unsigned argumentCount)
+Oop* __fastcall Interpreter::primitiveSingleStep(Oop* const sp, primargcount_t argumentCount)
 {
 	SMALLINTEGER steps;
 	switch (argumentCount)

--- a/Core/DolphinVM/strgprim.cpp
+++ b/Core/DolphinVM/strgprim.cpp
@@ -748,7 +748,7 @@ Oop* __fastcall Interpreter::primitiveNewCharacter(Oop* const sp, primargcount_t
 
 // primitiveStringEqual does not use the comparison template because the result is a Boolean, not an Integer
 // 
-Oop* __fastcall Interpreter::primitiveStringEqual(Oop* sp, unsigned argc)
+Oop* __fastcall Interpreter::primitiveStringEqual(Oop* sp, primargcount_t argc)
 {
 	struct EqualA
 	{

--- a/Core/DolphinVM/thrdcall.cpp
+++ b/Core/DolphinVM/thrdcall.cpp
@@ -1094,7 +1094,7 @@ void OverlappedCall::ReincrementProcessReferences()
 ///////////////////////////////////////////////////////////////////////////////
 // Interpreter primitive 
 
-Oop* __fastcall Interpreter::primitiveAsyncDLL32Call(Oop* const, unsigned argCount)
+Oop* __fastcall Interpreter::primitiveAsyncDLL32Call(Oop* const, primargcount_t argCount)
 {
 	CompiledMethod* method = m_registers.m_oopNewMethod->m_location;
 


### PR DESCRIPTION
e7a82930e17face02c9a21e94a8f950f9fb7bc59 added a specific type for the
primitive method argument count parameter, but some cases were missed.