### PR TITLE
Corrected number of array elements in comment

### DIFF
--- a/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/BootSessionManager.cls
@@ -111,7 +111,7 @@ primaryStartup
 	self openSources!
 
 productDetails
-	"Private - Answers a five element<Array> describing this version of the development environment
+	"Private - Answers an eight element<Array> describing this version of the development environment
 
 	1. <readableString> Product name 
 	2. <readableString> Short product name
@@ -126,7 +126,7 @@ productDetails
 	^productDetails!
 
 productDetails: anArray
-	"Private - Sets the receiver's product details to a five element<Array> 
+	"Private - Sets the receiver's product details to an eight element<Array> 
 	describing this version of the development environment"
 
 	productDetails := anArray!

--- a/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
@@ -458,7 +458,7 @@ productDetails
 	^productDetails!
 
 productDetails: anArray
-	"Private - Sets the receiver's product details to a five element<Array> 
+	"Private - Sets the receiver's product details to an eight element<Array> 
 	describing this version of the development environment"
 
 	productDetails := anArray.


### PR DESCRIPTION
The descriptions in each of  BootSessionManager>>productDetails and productDetails:  needed a tidyup, as there's eight elements in the array, not just the original five. When was it ever five elements anyhow? Same applies to DevelopmentSessionManager>>productDetails and productDetails:

Cheers.

