### PR TITLE
BindingReference equality was not correct

### DIFF
--- a/Core/Object Arts/Dolphin/Base/BindingReferenceTest.cls
+++ b/Core/Object Arts/Dolphin/Base/BindingReferenceTest.cls
@@ -15,7 +15,8 @@ subjectClass
 
 testAsQualifiedReference
 	self assert: 'Object' asQualifiedReference equals: #{Object}.
-	self assert: 'Smalltalk.Object' asQualifiedReference equals: #{Object}.
+	"Although these two binding refs would resolve to the same binding, they are not equivalent as one has a more specific path."
+	self deny: 'Smalltalk.Object' asQualifiedReference equals: #{Object}.
 	self assert: #{Object} asQualifiedReference identicalTo: #{Object}.
 	self assert: 'Object._EventsRegister' asQualifiedReference equals: #{Object._EventsRegister}!
 

--- a/Core/Object Arts/Dolphin/Base/Class.cls
+++ b/Core/Object Arts/Dolphin/Base/Class.cls
@@ -109,6 +109,12 @@ basicSharedPools: aCollection
 
 	sharedPools := aCollection!
 
+binding
+	"Answer the receiver's variable binding, raising an error if the receiver is unbound."
+
+	#{Announcement}.
+	^self fullyQualifiedReference binding!
+
 bindingFor: aString 
 	"Answer a variable binding for the named variable in the scope of this class. 
 	If there is no such variable, then answer nil.
@@ -117,6 +123,11 @@ bindingFor: aString
 	classPool isNil ifFalse: [(classPool bindingFor: aString) ifNotNil: [:classVar | ^classVar]].
 	self sharedPoolsDo: [:each | (each bindingFor: aString) ifNotNil: [:sharedVar | ^sharedVar]].
 	^superclass bindingFor: aString!
+
+bindingOrNil
+	"Answer the receiver's variable binding, or nil if unbound"
+
+	^self fullyQualifiedReference bindingOrNil!
 
 categories
 	"Answer a <Array> of <ClassCategory>s in which the receiver is included.
@@ -231,6 +242,11 @@ fileOutStem
 	"Private - Answer the default file name stem for the class to file out on."
 
 	^self name!
+
+fullyQualifiedReference
+	"Answer a <BindingReference> that represents a fully qualified reference to the receiver."
+
+	^self fullName asQualifiedReference!
 
 guid
 	"Answer the receiver's globally unique id (a 128-bit number allocated/set 
@@ -677,7 +693,9 @@ variableSubclass: aClassSymbol
 !Class categoriesFor: #basicClassPool!class variables!private! !
 !Class categoriesFor: #basicClassPool:!class variables!private! !
 !Class categoriesFor: #basicSharedPools:!accessing!private! !
+!Class categoriesFor: #binding!public! !
 !Class categoriesFor: #bindingFor:!binding!public! !
+!Class categoriesFor: #bindingOrNil!public! !
 !Class categoriesFor: #categories!categories-accessing!public! !
 !Class categoriesFor: #categories:!categories-accessing!public! !
 !Class categoriesFor: #categoriesForClass!private!source filing-class definition! !
@@ -694,6 +712,7 @@ variableSubclass: aClassSymbol
 !Class categoriesFor: #fileIn!development!public!source filing! !
 !Class categoriesFor: #fileOutName!development!private!source filing! !
 !Class categoriesFor: #fileOutStem!development!private!source filing! !
+!Class categoriesFor: #fullyQualifiedReference!public! !
 !Class categoriesFor: #guid!constants!public! !
 !Class categoriesFor: #guid:!class hierarchy-adding!private! !
 !Class categoriesFor: #includeInCategory:!categories-adding!public! !

--- a/Core/Object Arts/Dolphin/Base/ClassDescription.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescription.cls
@@ -172,7 +172,7 @@ classCategoryClass
 	"Private - Answer the class of object used to categorize classes.
 	Answer nil if the category system is not present."
 
-	^Smalltalk lookup: #ClassCategory!
+	^#{ClassCategory} valueOrNil!
 
 classPool
 	"Answer the dictionary of class variables."
@@ -338,10 +338,6 @@ fullName
 
 	^self name
 
-	!
-
-fullyQualifiedReference
-	^self fullName asQualifiedReference
 	!
 
 includesCategory: category
@@ -846,7 +842,6 @@ whichNonVirtualCategoriesIncludeSelector: aSelector
 !ClassDescription categoriesFor: #definition!public!source filing-class definition! !
 !ClassDescription categoriesFor: #displayOn:!displaying!public! !
 !ClassDescription categoriesFor: #fullName!accessing!public! !
-!ClassDescription categoriesFor: #fullyQualifiedReference!accessing!public! !
 !ClassDescription categoriesFor: #includesCategory:!categories-testing!public! !
 !ClassDescription categoriesFor: #includeSelector:inCategory:!categories-testing!public! !
 !ClassDescription categoriesFor: #indexOfInstVar:!instance variables!public! !

--- a/Core/Object Arts/Dolphin/Base/GeneralBindingReference.cls
+++ b/Core/Object Arts/Dolphin/Base/GeneralBindingReference.cls
@@ -12,9 +12,13 @@ GeneralBindingReference comment: 'Abstract superclass of binding references.'!
 !GeneralBindingReference methodsFor!
 
 = anObject
-	"Answer whether the receiver and the <Object> argument should be considered equivalent (in this case that they are a reference to the same variable binding)."
+	"Answer whether the receiver and the <Object> argument should be considered equivalent. Binding references are considered equivalent if they have the same path and starting point.
+	Note that two binding references that would resolve to the same actual variable binding may not be considered equivalent as the binding resolution is a dynamic quality determined 
+	at the time of resolution, and is not necessarily temporally stable. Equality of binding references is a static property based and is such that two equal references will always bind
+	to the same variable."
 
-	^self species == anObject species and: [self path = anObject path and: [self home = anObject home]]!
+	^self == anObject or: 
+			[self species == anObject species and: [self path = anObject path and: [self home == anObject home]]]!
 
 asQualifiedReference
 	"Answer the <BindingReference> equivalent of the receiver."
@@ -25,7 +29,7 @@ asString
 	"Answer a <readableString> that expresses the receiver as a qualified name in the context of the home namespace."
 
 	| strm |
-	strm := String writeStream.
+	strm := String writeStream: 20.
 	self displayOn: strm.
 	^strm contents!
 
@@ -48,7 +52,6 @@ displayOn: aStream
 	"Append, to aStream, a String whose characters are a representation of the receiver as a user
 	would want to see it (the qualified name)."
 
-	#todo.	"Forward to the home namespace to print complete qualified name"
 	path do: [:each | aStream nextPutAll: each] separatedBy: [aStream nextPut: $.]!
 
 hash
@@ -121,6 +124,12 @@ printOn: aStream
 		display: self;
 		nextPut: $}!
 
+refersToLiteral: anObject
+	"Private - Answer whether the receiver is a reference to the literal argument.
+	This assumes that the receiver is in the role of a literal. Normally this would only be true of LiteralBindingReferences, but other types of BindingReferences could find their way into literal frames if they result from the evaluation of a static expression."
+
+	^self = anObject or: [anObject notNil and: [self bindingOrNil refersToLiteral: anObject]]!
+
 simpleName
 	"Answer the unqualified name part of the receiver (the final component of the name)."
 
@@ -160,6 +169,7 @@ valueOrNil
 !GeneralBindingReference categoriesFor: #path!accessing!public! !
 !GeneralBindingReference categoriesFor: #path:!initializing!private! !
 !GeneralBindingReference categoriesFor: #printOn:!printing!public! !
+!GeneralBindingReference categoriesFor: #refersToLiteral:!public!testing! !
 !GeneralBindingReference categoriesFor: #simpleName!accessing!public! !
 !GeneralBindingReference categoriesFor: #storeOn:!public!storing! !
 !GeneralBindingReference categoriesFor: #value!accessing!public! !
@@ -226,9 +236,7 @@ path: aSequencedReadableCollection
 			(self isValidUnqualifiedName: last)
 				ifTrue: 
 					[self basicNew
-						path: ((depth > 1 and: [path first = 'Smalltalk'])
-									ifTrue: [path copyFrom: 2 to: depth]
-									ifFalse: [path]);
+						path: path;
 						yourself]
 				ifFalse: [self errorInvalidIdentifier: last]]!
 

--- a/Core/Object Arts/Dolphin/Base/GeneralBindingReferenceTest.cls
+++ b/Core/Object Arts/Dolphin/Base/GeneralBindingReferenceTest.cls
@@ -17,12 +17,12 @@ bindingTestCases
 	| missingNamespace |
 	missingNamespace := '_' , GUID newUnique idlString copyReplacing: $- withObject: $_.
 	^{#(#(#Object)).
-		{#(#Smalltalk #Object). #(#Object)}.
+		{#(#Smalltalk #Object). #(#Smalltalk #Object)}.
 		#(#(#OpcodePool #Nop)).
-		#(#(#Smalltalk #OpcodePool #Nop) #(#OpcodePool #Nop)).
+		#(#(#Smalltalk OpcodePool #Nop) #(#Smalltalk #OpcodePool #Nop)).
 		{{missingNamespace. '__MissingClass'}. nil}.
 		{{missingNamespace. 'Date'}. nil}.
-		{#(#Smalltalk #Object #_EventsRegister). #(#Object #_EventsRegister)}.
+		{#(#Object #_EventsRegister). #(#Object #_EventsRegister)}.
 }!
 
 newTestSubjectWithPath: anArrayOfStrings
@@ -82,15 +82,15 @@ testEquals
 	self assert: (self newTestSubjectWithPath: #('Smalltalk' 'Object'))
 		equals: (self newTestSubjectWithPathString: 'Smalltalk.Object').
 	self deny: (self newTestSubjectWithPath: #('Smalltalk')) equals: Object new.
-	"Different to VW behaviour."
-	self assert: (self newTestSubjectWithPath: #('Object'))
+	"BindingReference equality is a stable property based on the path and starting point. Different paths to the same target binding (of which there may be many) are not equal."
+	self deny: (self newTestSubjectWithPath: #('Object'))
 		equals: (self newTestSubjectWithPath: #('Smalltalk' 'Object'))!
 
 testHash
 	self assert: (self subjectClass path: #('Smalltalk' 'OpcodePool' 'Nop')) hash
 		equals: (self subjectClass pathString: 'Smalltalk.OpcodePool.Nop') hash.
-	"Different VW behaviour."
-	self assert: (self subjectClass path: #('Object')) hash
+	"Same target variable, but different paths, so different hashes."
+	self deny: (self subjectClass path: #('Object')) hash
 		equals: (self subjectClass path: #('Smalltalk' 'Object')) hash.
 	self deny: (self subjectClass path: #('Object')) hash
 		equals: (self subjectClass path: #('Smalltalk')) hash!
@@ -153,6 +153,29 @@ testPrintString
 			subject := self subjectClass path: each first.
 			self assert: subject printString equals: each last]!
 
+testRefersToLiteral
+	"A BindingReference matches literals for the same path..."
+
+	self assert: (Object fullyQualifiedReference refersToLiteral: #{Object}).
+	".. and the binding to which it would resolve ..."
+	self assert: (#{Object} refersToLiteral: Object binding).
+	"... but not the target value."
+	self deny: (#{Object} refersToLiteral: #{Object} value).
+	"BindingRef to a pool variable."
+	self assert: (#{_PrimitiveFailureCode.AccessViolation}
+				refersToLiteral: #{_PrimitiveFailureCode.AccessViolation}).
+	self assert: (#{_PrimitiveFailureCode.AccessViolation}
+				refersToLiteral: #{_PrimitiveFailureCode.AccessViolation} binding).
+	"Should a BindingRef implicitly refers to refs along its path? Not sure."
+	false
+		ifTrue: 
+			[self assert: (#{_PrimitiveFailureCode.AccessViolation} refersToLiteral: #{_PrimitiveFailureCode})].
+	#todo.	"This should be true, but at present is not because bindings do not know their scope."
+	false
+		ifTrue: 
+			[self
+				assert: (#{_PrimitiveFailureCode.AccessViolation} refersToLiteral: #{_PrimitiveFailureCode} binding)]!
+
 testSimpleName
 	self bindingTestCases do: 
 			[:each |
@@ -210,6 +233,7 @@ testValueOrNil
 !GeneralBindingReferenceTest categoriesFor: #testPath!public!unit tests! !
 !GeneralBindingReferenceTest categoriesFor: #testPathString!public!unit tests! !
 !GeneralBindingReferenceTest categoriesFor: #testPrintString!public!unit tests! !
+!GeneralBindingReferenceTest categoriesFor: #testRefersToLiteral!public!unit tests! !
 !GeneralBindingReferenceTest categoriesFor: #testSimpleName!public!unit tests! !
 !GeneralBindingReferenceTest categoriesFor: #testStoreString!public!unit tests! !
 !GeneralBindingReferenceTest categoriesFor: #testValue!public!unit tests! !


### PR DESCRIPTION
BindingReferences should only be equal if they contain the exact same path.
It should not be assumed that a ref implicitly rooted in Smalltalk is the
same as one explicitly rooted. BindingReference equality should not be
determined based on whether the refs would resolve to the same binding at
some particular point in time, but on whether they can always be expected
to resolve the same way together in a temporally invariant manner.