### PR TITLE
Add check to StructureArray>>with:do: that collections are same size

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/Automation/SAFEARRAY.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/SAFEARRAY.cls
@@ -393,7 +393,20 @@ vt
 	"Answer the receiver's variant type. This will depend on the element type,
 	but always includes the array modifier."
 
-	^self class vt bitOr: self elementClass vt! !
+	^self class vt bitOr: self elementClass vt!
+
+with: otherCollection do: operation
+	"Evaluate the <dyadicValuable> argument, operation, with each of 
+	the receiver's elements along with the corresponding element from the 
+	<sequencedReadableCollection> argument, otherCollection. 
+	Raise an exception if otherCollection is not the same size as the receiver."
+
+	self size = otherCollection size
+		ifFalse: [^self error: 'collections are of different sizes'].
+	self keysAndValuesDo: [:i :elem |
+		operation
+			value: elem
+			value: (otherCollection at: i)]! !
 !SAFEARRAY categoriesFor: #_deepenShallowCopy:trail:!copying!private! !
 !SAFEARRAY categoriesFor: #accessData!helpers!private! !
 !SAFEARRAY categoriesFor: #asObject!converting!public! !
@@ -437,6 +450,7 @@ vt
 !SAFEARRAY categoriesFor: #upperBound:!accessing!public! !
 !SAFEARRAY categoriesFor: #vartype!accessing!public! !
 !SAFEARRAY categoriesFor: #vt!constants!public! !
+!SAFEARRAY categoriesFor: #with:do:!enumerating!public! !
 
 SAFEARRAY methodProtocol: #variantCompatible attributes: #(#readOnly) selectors: #(#asVariant)!
 

--- a/Core/Object Arts/Dolphin/Base/ExternalArray.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalArray.cls
@@ -317,6 +317,12 @@ notEmpty
 
 	^self isEmpty not!
 
+packing
+	"Private - Answer the number of bytes between individual elements of the receiver.
+	This is the receiver's elementSize plus any padding necessary."
+
+	^self elementSize!
+
 replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart
 	"Private - Standard method for transfering bytes from one variable
 	byte object to another, normally double dispatched from #replaceFrom:to:with:startingAt:"
@@ -388,7 +394,25 @@ uncheckedFrom: startInteger to: stopInteger keysAndValuesDo: operation
 	"Subclasses should override this method in order to replace all #do: family enumerators 
 	(#do:, #keysAndValuesDo:, #from:to:do:, and,	of course, #from:to:keysAndValuesDo:)."
 
-	startInteger to: stopInteger do: [:i | operation value: i value: (self uncheckedAt: i)]! !
+	startInteger to: stopInteger do: [:i | operation value: i value: (self uncheckedAt: i)]!
+
+with: aCollection do: aDyadicValuable
+	"Evaluate the <dyadicValuable> argument with each of the receiver's elements along with the corresponding element from the <collection> argument, aCollection. The collection is enumerated in its #do: order."
+
+	"This should be used with care. In particular the element passed to the operation must not be captured since it is re-used for subsequent elements. In any case it will be a reference to the actual memory occupied by 
+	the array, which would be invalidated when the StructureArray is deallocated. If you do need to capture the elements, then you should make a copy of them."
+
+	| elem spacing |
+	self size = aCollection size
+		ifFalse: [^self error: 'collections are of different sizes'].
+	spacing := self packing.
+	elem := self elementClass newPointer.
+	aCollection inject: self yourAddress
+		into: 
+			[:addr :each |
+			elem initializeAtAddress: addr.
+			aDyadicValuable value: elem value: each.
+			addr + spacing]! !
 !ExternalArray categoriesFor: #=!public! !
 !ExternalArray categoriesFor: #anySatisfy:!enumerating!public! !
 !ExternalArray categoriesFor: #appendToStream:!double dispatch!private! !
@@ -425,6 +449,7 @@ uncheckedFrom: startInteger to: stopInteger keysAndValuesDo: operation
 !ExternalArray categoriesFor: #length:!accessing!public! !
 !ExternalArray categoriesFor: #lookup:!accessing!public! !
 !ExternalArray categoriesFor: #notEmpty!public!testing! !
+!ExternalArray categoriesFor: #packing!constants!private! !
 !ExternalArray categoriesFor: #replaceBytesOf:from:to:startingAt:!double dispatch!private! !
 !ExternalArray categoriesFor: #replaceElementsOf:from:to:startingAt:!private!replacing! !
 !ExternalArray categoriesFor: #replaceFrom:to:with:startingAt:!public!replacing! !
@@ -434,6 +459,7 @@ uncheckedFrom: startInteger to: stopInteger keysAndValuesDo: operation
 !ExternalArray categoriesFor: #uncheckedAt:!accessing!private! !
 !ExternalArray categoriesFor: #uncheckedAt:put:!accessing!private! !
 !ExternalArray categoriesFor: #uncheckedFrom:to:keysAndValuesDo:!enumerating!private! !
+!ExternalArray categoriesFor: #with:do:!enumerating!public! !
 
 !ExternalArray class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/ExternalArrayTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalArrayTest.cls
@@ -177,7 +177,32 @@ testFromToKeysAndValuesDo
 						from: each first
 						to: each last
 						keysAndValuesDo: [:eachKey :eachValue | ]]
-				raise: BoundsError]! !
+				raise: BoundsError]!
+
+testWithDo
+	| count validationBlock subject |
+	count := 1.
+	validationBlock := 
+			[:a :b |
+			self assert: b equals: count.
+			self assert: a value equals: b.
+			count := count + 1.
+			a value: count].
+	#(1 2 5) do: 
+			[:each |
+			subject := self newNumericArray: each.
+			subject with: (1 to: each) do: validationBlock.
+			self assert: subject asArray equals: (2 to: each + 1).
+			count := 1].
+	subject := self newNumericArray: 5.
+	{0. 1. subject size - 1. subject size + 1} do: 
+			[:each |
+			self
+				should: [subject with: (1 to: each) do: [:a :b | ]]
+				raise: Error
+				matching: [:ex | ex description = 'collections are of different sizes']].
+	subject := self newNumericArray: 0.
+	subject with: (1 to: 0) do: [:a :b | self assert: false]! !
 !ExternalArrayTest categoriesFor: #arrayClass!constants!private! !
 !ExternalArrayTest categoriesFor: #arrayValueString:!private!unit tests! !
 !ExternalArrayTest categoriesFor: #canonicalizeValue:!private!unit tests! !
@@ -187,4 +212,5 @@ testFromToKeysAndValuesDo
 !ExternalArrayTest categoriesFor: #newNumericArray:!helpers!private! !
 !ExternalArrayTest categoriesFor: #testAtAndAtPut!public!unit tests! !
 !ExternalArrayTest categoriesFor: #testFromToKeysAndValuesDo!public!unit tests! !
+!ExternalArrayTest categoriesFor: #testWithDo!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/GenericExternalArray.cls
+++ b/Core/Object Arts/Dolphin/Base/GenericExternalArray.cls
@@ -58,12 +58,6 @@ owner: arrayOwner
 		ifTrue: [owner := nil. self beFinalizable]
 		ifFalse: [owner := arrayOwner. self beUnfinalizable]!
 
-packing
-	"Private - Answer the number of bytes between individual elements of the receiver.
-	This is the receiver's elementSize plus any padding necessary."
-
-	^self elementSize!
-
 uncheckedAt: anInteger 
 	"Private - Answer an instance of the receiver's elementClass which is a reference to the
 	element of the receiver at the specified <integer> index. No bounds checks are performed on
@@ -94,7 +88,6 @@ uncheckedFrom: startInteger to: stopInteger keysAndValuesDo: operation
 !GenericExternalArray categoriesFor: #needsFree!initializing!private!realizing/unrealizing! !
 !GenericExternalArray categoriesFor: #newElementAt:!helpers!private! !
 !GenericExternalArray categoriesFor: #owner:!accessing!private! !
-!GenericExternalArray categoriesFor: #packing!constants!private! !
 !GenericExternalArray categoriesFor: #uncheckedAt:!accessing!private! !
 !GenericExternalArray categoriesFor: #uncheckedFrom:to:keysAndValuesDo:!enumerating!private! !
 

--- a/Core/Object Arts/Dolphin/Base/StructureArray.cls
+++ b/Core/Object Arts/Dolphin/Base/StructureArray.cls
@@ -78,21 +78,7 @@ uncheckedAt: anInteger put: anObject
 		from: 1 + offset
 		to: offset + self elementSize
 		startingAt: 1.
-	^anObject!
-
-with: aCollection do: aDyadicValuable
-	"Private - Evaluate the <dyadicValuable> argument with each of the receiver's elements along with the corresponding element from the <collection> argument, aCollection. The collection is enumerated in its #do: order.
-	N.B. This is private because the element passed to the operation must not be captured since it is shared. StructureArrays are often initialized from Smalltalk arrays, and the elements passed are only transient references anyway."
-
-	| elem spacing |
-	spacing := self packing.
-	elem := elementClass newPointer.
-	aCollection inject: self yourAddress
-		into: 
-			[:addr :each |
-			elem initializeAtAddress: addr.
-			aDyadicValuable value: elem value: each.
-			addr + spacing]! !
+	^anObject! !
 !StructureArray categoriesFor: #alignment!constants!public! !
 !StructureArray categoriesFor: #basicFree!private!realizing/unrealizing! !
 !StructureArray categoriesFor: #elementClass:!accessing!private! !
@@ -100,7 +86,6 @@ with: aCollection do: aDyadicValuable
 !StructureArray categoriesFor: #initializePointer!initializing!private! !
 !StructureArray categoriesFor: #packing!constants!private! !
 !StructureArray categoriesFor: #uncheckedAt:put:!accessing!private! !
-!StructureArray categoriesFor: #with:do:!enumerating!private! !
 
 !StructureArray class methodsFor!
 


### PR DESCRIPTION
StructureArray>>with:do: may read memory outside the block referenced by
the SA if the 2nd collection is larger. It should be an error to attempt
to perform a with:do: operation with different sized collections.

While here, push up #with:do: to ExternalArray and add a simple unit test.