### PR TITLE
String>>subStrings: splits incorrectly with multi-codeunit Chars

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/Categories/COMObjectRegistration.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Categories/COMObjectRegistration.cls
@@ -105,7 +105,7 @@ toolboxImage
 				ifFalse: 
 					[| id path pathAndId |
 					"Should be able to use PathParseIconLocation here, but it can't cope with spaces between the path and the icon id."
-					pathAndId := toolboxBitmap32 subStrings: $,.
+					pathAndId := $, split: toolboxBitmap32.
 					id := Integer readFrom: (pathAndId last readStream
 										skipSeparators;
 										yourself).

--- a/Core/Object Arts/Dolphin/Base/AnsiString.cls
+++ b/Core/Object Arts/Dolphin/Base/AnsiString.cls
@@ -98,16 +98,6 @@ first: anInteger
 		to: anInteger
 		startingAt: 1!
 
-includes: aCharacter
-	"Answer whether the <Character> argument is one of the elements of the receiver."
-
-	"Implementation Note: Ansi strings can only contain the base character set, all instances of which are unique."
-
-	^(self
-		nextIdentityIndexOf: aCharacter
-		from: 1
-		to: self size) ~~ 0!
-
 nextIndexOfCharacter: aCharacter from: startInteger to: stopInteger
 	aCharacter encoding ~~ #ansi ifTrue: [^0].
 	^self
@@ -186,7 +176,6 @@ unescapePercents
 !AnsiString categoriesFor: #decodeNextFrom:!encode/decode!private! !
 !AnsiString categoriesFor: #encodeOn:put:!encode/decode!private! !
 !AnsiString categoriesFor: #first:!copying!public! !
-!AnsiString categoriesFor: #includes:!public!searching! !
 !AnsiString categoriesFor: #nextIndexOfCharacter:from:to:!private!searching! !
 !AnsiString categoriesFor: #reverse!copying!public! !
 !AnsiString categoriesFor: #skipEncodingMarkerFrom:!encode/decode!private! !

--- a/Core/Object Arts/Dolphin/Base/Behavior.cls
+++ b/Core/Object Arts/Dolphin/Base/Behavior.cls
@@ -428,7 +428,7 @@ fullBindingFor: aString
 	(aString identityIncludes: $.)
 		ifTrue: 
 			[| parts env count |
-			parts := aString subStrings: $..
+			parts := $. split: aString.
 			"Fully qualified name always starts in Smalltalk"
 			env := Smalltalk.
 			count := parts size.

--- a/Core/Object Arts/Dolphin/Base/ByteArray.cls
+++ b/Core/Object Arts/Dolphin/Base/ByteArray.cls
@@ -17,14 +17,12 @@ ByteArray complies with the ANSI protocols:
 !ByteArray categoriesForClass!Collections-Arrayed! !
 !ByteArray methodsFor!
 
-_sameAsString: comparand
-	"Private - Answer whether the receiver collates the same as <readableString> 
-	argument, comparand.
-	This will only work if the receiver contains integers in the range of character
-	values, if not an exception will be raised.
+_sameAsString: aString
+	"Private - Answer whether the receiver collates the same as <readableString> argument.
+	This will only work if the receiver contains integers in the range of character values, if not an exception will be raised.
 	Implementation Note: Double dispatched from String>>sameAs:."
 
-	^(comparand _collate: self asString) == 0!
+	^(aString <=> self asString) == 0!
 
 = comperand
 	"Answer whether the receiver is equivalent to the <Object>, comperand.

--- a/Core/Object Arts/Dolphin/Base/Category.cls
+++ b/Core/Object Arts/Dolphin/Base/Category.cls
@@ -140,7 +140,7 @@ subNames
 	"Answer an OrderedCollection of the receivers name split
 	on category separator."
 
-	^self name subStrings: self class separator! !
+	^self class separator split: self name! !
 !Category categoriesFor: #<=!comparing!public! !
 !Category categoriesFor: #=!comparing!public! !
 !Category categoriesFor: #acceptsAdditions!public!testing! !

--- a/Core/Object Arts/Dolphin/Base/Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Character.cls
@@ -358,6 +358,14 @@ isWhitespace
 
 	^self isSeparator!
 
+join: aCollection
+	"Answer a new <String> composed from the elements of the <collection> argument separated by the instances of the receiver."
+
+	| stream |
+	stream := String writeStream: aCollection size * 6.
+	aCollection do: [:each | each displayOn: stream] separatedBy: [stream nextPut: self].
+	^stream contents!
+
 printEscapedOn: aStream
 	"Append the escaped literal representation of the receiver to the <puttableStream> argument."
 
@@ -395,7 +403,7 @@ split: aReadableString
 
 	"Implementation Note: Although this routine is rather more complex than it need be, the performance of #subStrings(:) is important, so it pays to optimize this routine. In particular we try to avoid performing any work in the common cases where the string is either empty, or does not contain the separator at all. However, we must be careful not to over optimize and prevent correct operation for wide (Unicode) strings."
 
-	| start answer size end |
+	| start answer size end codeUnits |
 	size := aReadableString size.
 	size == 0 ifTrue: [^{}].
 	end := aReadableString
@@ -405,9 +413,10 @@ split: aReadableString
 	end == 0 ifTrue: [^{aReadableString}].
 	answer := Array writeStream: 5.
 	start := 1.
+	codeUnits := aReadableString encodedSizeOf: self.
 	
 	[answer nextPut: (aReadableString copyFrom: start to: end - 1).
-	start := end + 1.
+	start := end + codeUnits.
 	end := aReadableString
 				nextIndexOf: self
 				from: start
@@ -417,6 +426,33 @@ split: aReadableString
 	"Copy any remaining chars after the last separator"
 	answer nextPut: (aReadableString copyFrom: start to: size).
 	^answer contents!
+
+split: aReadableString do: aMonadicValuable
+	"Evaluate the <monadicValuable> 2nd argument for each of the sub-strings of the <readableString> 1st argument that are separated by the receiver."
+
+	| start size end codeUnits |
+	size := aReadableString size.
+	end := aReadableString
+				nextIndexOf: self
+				from: 1
+				to: size.
+	end == 0
+		ifTrue: 
+			[aMonadicValuable value: aReadableString.
+			^self].
+	start := 1.
+	codeUnits := aReadableString encodedSizeOf: self.
+	
+	[aMonadicValuable value: (aReadableString copyFrom: start to: end - 1).
+	start := end + codeUnits.
+	end := aReadableString
+				nextIndexOf: self
+				from: start
+				to: size.
+	end == 0]
+			whileFalse.
+	"Evaluate for any remaining chars after the last separator"
+	aMonadicValuable value: (aReadableString copyFrom: start to: size)!
 
 to: aCharacter
 	"Answer a <sequencedReadableCollection> of <Character>s for each of the Unicode code points between the receiver's code point and that of the <Character> argument, aCharacter."
@@ -475,11 +511,13 @@ to: aCharacter
 !Character categoriesFor: #isUtf8Trail!public!testing! !
 !Character categoriesFor: #isVowel!public!testing! !
 !Character categoriesFor: #isWhitespace!public!testing! !
+!Character categoriesFor: #join:!public!tokenizing! !
 !Character categoriesFor: #printEscapedOn:!printing!public! !
 !Character categoriesFor: #printOn:!printing!public! !
 !Character categoriesFor: #setCode:!accessing!initializing!private! !
 !Character categoriesFor: #shallowCopy!copying!public! !
 !Character categoriesFor: #split:!public!tokenizing! !
+!Character categoriesFor: #split:do:!public!tokenizing! !
 !Character categoriesFor: #to:!converting!public! !
 
 Character methodProtocol: #Character attributes: #(#ansi #readOnly) selectors: #(#asLowercase #asString #asUppercase #codePoint #isAlphaNumeric #isDigit #isLetter #isLowercase #isUppercase)!

--- a/Core/Object Arts/Dolphin/Base/ClassDescription.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescription.cls
@@ -402,7 +402,7 @@ instVarNames
 
 	instanceVariables isNil ifTrue: [^#()].
 	^instanceVariables isString
-		ifTrue: [(instanceVariables subStrings: $\x20) reject: [:each | each isEmpty]]
+		ifTrue: [($\x20 split: instanceVariables) reject: [:each | each isEmpty]]
 		ifFalse: [instanceVariables]!
 
 isChanged

--- a/Core/Object Arts/Dolphin/Base/Deprecated/SymbolStringSearchPolicy.cls
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/SymbolStringSearchPolicy.cls
@@ -16,7 +16,7 @@ compare: operand1 with: operand2
 	"Answer whether the <Object>, operand1, is considered equivalent to the <Object> argument,
 	operand2, by this search policy."
 
-	^(operand1 trueCompare: operand2) == 0
+	^(operand1 <==> operand2) == 0
 !
 
 hash: operand

--- a/Core/Object Arts/Dolphin/Base/Dolphin Source Fileout.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Source Fileout.pax
@@ -387,7 +387,7 @@ fileOutProtocols: aCollection ofBehavior: aClassDescription
 	associating them with the <ClassDescription>, aClassDescription."
 
 	aCollection isEmpty ifTrue: [^self].
-	(aCollection asSortedCollection: [:a :b | (a name trueCompare: b name) <= 0]) do: 
+	(aCollection asSortedCollection: [:a :b | (a name <==> b name) <= 0]) do: 
 			[:p | 
 			stream
 				nextPutAll: aClassDescription name;
@@ -1034,7 +1034,7 @@ savePAXPrerequisiteNamesOn: target
 		nextPutAll: ' #(';
 		cr.
 	basePath := self path.
-	(self prerequisites asSortedCollection: [:a :b | (a name trueCompare: b name) < 0]) do: 
+	(self prerequisites asSortedCollection: [:a :b | (a name <==> b name) < 0]) do: 
 			[:each |
 			target
 				tab;
@@ -1348,7 +1348,7 @@ fileOutMethods: aCollection
 			"Note that the selectors will be filed out in sorted order, so we don't need to sort them"
 			(methodsByClass at: each methodClass ifAbsentPut: [OrderedCollection new]) add: each selector].
 	(methodsByClass associations 
-		asSortedCollection: [:a :b | (a key name trueCompare: b key name) <= 0]) 
+		asSortedCollection: [:a :b | (a key name <==> b key name) <= 0]) 
 			do: [:each | self fileOutMessages: each value ofBehavior: each key]!
 
 fileOutPoolDictionary: aPoolDictionary 

--- a/Core/Object Arts/Dolphin/Base/GUID.cls
+++ b/Core/Object Arts/Dolphin/Base/GUID.cls
@@ -20,13 +20,16 @@ Class Variables:
 !GUID categoriesForClass!External-Data-Structured-COM! !
 !GUID methodsFor!
 
-_collate: comperand
-	"Private - Answer the ordering relationship between the receiver
-	and the argument, comperand."
+<=> aGUID
+	"Answer the ordering relationship between the receiver and the argument.
+	Colloquially known as the spaceship operator."
 
 	| status answer |
 	status := ByteArray newFixed: 4.
-	answer := RPCLibrary default uuidCompare: self uuid2: comperand status: status.
+	answer := RPCLibrary default
+				uuidCompare: self
+				uuid2: aGUID
+				status: status.
 	status := status dwordAtOffset: 0.
 	status == 0 ifFalse: [RPCError signalWith: status].
 	^answer!
@@ -34,7 +37,7 @@ _collate: comperand
 = comperand
 	"Answer whether the receiver is equivalent to the <Object>, comperand."
 
-	^self species = comperand species and: [(self _collate: comperand) == 0]!
+	^self species = comperand species and: [self <=> comperand == 0]!
 
 asByteArray
 	"Answer the raw contents of the receiver as a byte array."
@@ -180,7 +183,7 @@ value: guidBytes
 	"Set the raw binary value of the receiver from those of the argument."
 
 	guidBytes replaceBytesOf: self from: 1 to: self class byteSize startingAt: 1! !
-!GUID categoriesFor: #_collate:!comparing!private! !
+!GUID categoriesFor: #<=>!comparing!public! !
 !GUID categoriesFor: #=!comparing!public! !
 !GUID categoriesFor: #asByteArray!converting!public! !
 !GUID categoriesFor: #asInteger!converting!public! !

--- a/Core/Object Arts/Dolphin/Base/MultiByteStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/MultiByteStringTest.cls
@@ -93,15 +93,46 @@ testEncodeOnPut
 						self assert: stream atEnd.
 						self assert: actual equals: each]]!
 
+testGothicSubStrings
+	"This is really a test of Character>>split: now with characters outside the basic plane that will require 4 or 2 code units for UTF-8 and UTF-16 respectively."
+
+	| subject actual |
+	subject := self
+				newCollection: '𐌼𐌰𐌲 𐌲𐌻𐌴𐍃 𐌹̈𐍄𐌰𐌽, 𐌽𐌹 𐌼𐌹𐍃 𐍅𐌿 𐌽𐌳𐌰𐌽 𐌱𐍂𐌹𐌲𐌲𐌹𐌸'.
+	"In UTF-8 the gothic characters are mostly 4 code units. In UTF-16 they will be mostly 2 code units."
+	actual := subject subStrings: $\x10330.
+	self assert: actual
+		equals: #('𐌼' '𐌲 𐌲𐌻𐌴𐍃 𐌹̈𐍄' '𐌽, 𐌽𐌹 𐌼𐌹𐍃 𐍅𐌿 𐌽𐌳' '𐌽 𐌱𐍂𐌹𐌲𐌲𐌹𐌸').
+	actual := subject subStrings: $\x20.
+	self assert: actual
+		equals: #('𐌼𐌰𐌲' '𐌲𐌻𐌴𐍃' '𐌹̈𐍄𐌰𐌽,' '𐌽𐌹' '𐌼𐌹𐍃' '𐍅𐌿' '𐌽𐌳𐌰𐌽' '𐌱𐍂𐌹𐌲𐌲𐌹𐌸').
+	"We can split on any codepoint, including one that is part of a composite glyph, in this case $̈, even though this isn't necessarily valid"
+	actual := subject subStrings: $\x308.
+	self assert: actual
+		equals: #('𐌼𐌰𐌲 𐌲𐌻𐌴𐍃 𐌹' '𐍄𐌰𐌽, 𐌽𐌹 𐌼𐌹𐍃 𐍅𐌿 𐌽𐌳𐌰𐌽 𐌱𐍂𐌹𐌲𐌲𐌹𐌸')!
+
+testIdentityIncludes
+	| subject pound dolphin foreign |
+	super testIdentityIncludes.
+	pound := Character value: 163.
+	dolphin := self collectionClass with: Character dolphin.
+	subject := 'a' , dolphin , 'b' , pound asString , 'c'.
+	{$a. Character dolphin. $\x1F42C. $b. pound. $c}
+		do: [:each | self assert: (subject identityIncludes: each)].
+	"Should include all the surrogates too"
+	dolphin do: [:each | self assert: (subject identityIncludes: each)].
+	foreign := self collectionClass == Utf8String
+				ifTrue: [dolphin asUtf16String]
+				ifFalse: [dolphin asUtf8String].
+	foreign do: [:each | self deny: (subject identityIncludes: each)]!
+
 testIncludes
 	| subject pound dolphin foreign |
 	super testIncludes.
 	pound := Character value: 163.
 	dolphin := self collectionClass with: Character dolphin.
 	subject := 'a' , dolphin , 'b' , pound asString , 'c'.
-	self assert: (subject includes: $b).
-	self assert: (subject includes: pound).
-	self assert: (subject includes: Character dolphin).
+	{$a. Character dolphin. $\x1F42C. $b. pound. $c} do: [:each | self assert: (subject includes: each)].
 	dolphin do: [:each | self assert: (subject includes: each)].
 	foreign := self collectionClass == Utf8String
 				ifTrue: [dolphin asUtf16String]
@@ -114,6 +145,21 @@ testReverseComposites
 	self assert: 'aeiöu' reverse equals: 'uöiea'.
 	self assert: ' กำ' reverse equals: 'กำ '!
 
+testRuneSubStrings
+	"This is really a test of Character>>split: with characters requiring 3 code units in UTF-8, although still only one in UTF-16"
+
+	| subject actual |
+	subject := self
+				newCollection: 'ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ
+ᛋᚳᛖᚪᛚ᛫ᚦᛖᚪᚻ᛫ᛗᚪᚾᚾᚪ᛫ᚷᛖᚻᚹᛦᛚᚳ᛫ᛗᛁᚳᛚᚢᚾ᛫ᚻᛦᛏ᛫ᛞᚫᛚᚪᚾ
+ᚷᛁᚠ᛫ᚻᛖ᛫ᚹᛁᛚᛖ᛫ᚠᚩᚱ᛫ᛞᚱᛁᚻᛏᚾᛖ᛫ᛞᚩᛗᛖᛋ᛫ᚻᛚᛇᛏᚪᚾ᛬'.
+	"In UTF-8 the runes are all 3 code units long, in UTF-16 they are in the basic plane, so 1 code unit"
+	actual := subject subStrings: $\x16EB.
+	self assert: actual
+		equals: #('ᚠᛇᚻ' 'ᛒᛦᚦ' 'ᚠᚱᚩᚠᚢᚱ' 'ᚠᛁᚱᚪ' 'ᚷᛖᚻᚹᛦᛚᚳᚢᛗ
+ᛋᚳᛖᚪᛚ' 'ᚦᛖᚪᚻ' 'ᛗᚪᚾᚾᚪ' 'ᚷᛖᚻᚹᛦᛚᚳ' 'ᛗᛁᚳᛚᚢᚾ' 'ᚻᛦᛏ' 'ᛞᚫᛚᚪᚾ
+ᚷᛁᚠ' 'ᚻᛖ' 'ᚹᛁᛚᛖ' 'ᚠᚩᚱ' 'ᛞᚱᛁᚻᛏᚾᛖ' 'ᛞᚩᛗᛖᛋ' 'ᚻᛚᛇᛏᚪᚾ᛬')!
+
 withAllTestCases
 	^super withAllTestCases , #('a 🐬 test' 'Приве́т नमस्ते שָׁלוֹם' 'áèȋöû')! !
 !MultiByteStringTest categoriesFor: #caseConversionCases!constants!private! !
@@ -123,7 +169,10 @@ withAllTestCases
 !MultiByteStringTest categoriesFor: #testBeginsWith!public!unit tests! !
 !MultiByteStringTest categoriesFor: #testBeginsWithIgnoreCase!public!unit tests! !
 !MultiByteStringTest categoriesFor: #testEncodeOnPut!public!unit tests! !
+!MultiByteStringTest categoriesFor: #testGothicSubStrings!public!unit tests! !
+!MultiByteStringTest categoriesFor: #testIdentityIncludes!public!unit tests! !
 !MultiByteStringTest categoriesFor: #testIncludes!public!unit tests! !
 !MultiByteStringTest categoriesFor: #testReverseComposites!public!unit tests! !
+!MultiByteStringTest categoriesFor: #testRuneSubStrings!public!unit tests! !
 !MultiByteStringTest categoriesFor: #withAllTestCases!constants!private! !
 

--- a/Core/Object Arts/Dolphin/Base/NUMBERFMTW.cls
+++ b/Core/Object Arts/Dolphin/Base/NUMBERFMTW.cls
@@ -121,7 +121,7 @@ numberGrouping
 numberGrouping: aString
 	| groups |
 	numberGrouping := nil.
-	groups := aString subStrings: $;.
+	groups := $; split: aString.
 	groups last = '0' ifTrue: [groups := groups resize: groups size - 1].
 	self Grouping: (groups inject: 0
 				into: 

--- a/Core/Object Arts/Dolphin/Base/Package.cls
+++ b/Core/Object Arts/Dolphin/Base/Package.cls
@@ -1692,7 +1692,7 @@ variableSortBlock
 	"Private - Answer a <dyadicValuable> sort block suitable for sorting global variable <Association>s
 	into alphabetic order."
 
-	^[:a :b | (a key trueCompare: b key) <= 0]!
+	^[:a :b | (a key <==> b key) <= 0]!
 
 versionIfRequired
 	Package manager versionPackageIfRequired: self!

--- a/Core/Object Arts/Dolphin/Base/REFGUID.cls
+++ b/Core/Object Arts/Dolphin/Base/REFGUID.cls
@@ -17,13 +17,12 @@ REFGUID fromAddress: Object guid yourAddress'!
 !REFGUID categoriesForClass!External-Data-Unstructured! !
 !REFGUID methodsFor!
 
-_collate: comperand
-	"Private - Answer the ordering relationship between the receiver
-	and the argument, comperand."
+<=> aGUID
+	"Answer the ordering relationship between the receiver and the argument."
 
 	| status answer |
 	status := ByteArray newFixed: 4.
-	answer := RPCLibrary default uuidCompare: self uuid2: comperand status: status.
+	answer := RPCLibrary default uuidCompare: self uuid2: aGUID status: status.
 	status := status dwordAtOffset: 0.
 	status == 0 ifFalse: [RPCError signalWith: status].
 	^answer!
@@ -31,7 +30,7 @@ _collate: comperand
 = comperand
 	"Answer whether the receiver is equivalent to the <Object>, comperand."
 
-	^self species = comperand species and: [(self _collate: comperand) == 0]!
+	^self species = comperand species and: [(self <=> comperand) == 0]!
 
 asString
 	"Answer a string representation of the receiver."
@@ -73,7 +72,7 @@ value: guid
 	"Set the 16-byte GUID pointed at by the receiver to the <GUID>, guid."
 
 	self replaceFrom: 1 to: 16 with: guid startingAt: 1! !
-!REFGUID categoriesFor: #_collate:!comparing!private! !
+!REFGUID categoriesFor: #<=>!comparing!public! !
 !REFGUID categoriesFor: #=!comparing!public! !
 !REFGUID categoriesFor: #asString!converting!public! !
 !REFGUID categoriesFor: #displayOn:!printing!public! !

--- a/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
@@ -51,7 +51,7 @@ _sameAsString: comparand
 	size := self size.
 	string2 := String new: size.
 	1 to: size do: [:i | string2 basicAt: i put: (self at: i)].
-	^(comparand _collate: string2) == 0!
+	^(comparand <=> string2) == 0!
 
 = comparand
 	"Answer whether the receiver and the <Object> argument, comparand,

--- a/Core/Object Arts/Dolphin/Base/SortedCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SortedCollection.cls
@@ -351,7 +351,7 @@ caseSensitiveSortBlock
 	case sensitive basis (String's implementation of the #<= message, used by the default sort
 	block, is case-insensitive).."
 
-	^[:a :b | (a trueCompare: b) <= 0]!
+	^[:a :b | (a <==> b) <= 0]!
 
 defaultSortBlock
 	"Answer a <dyadicValuable> that implements the default sort-order relationship."

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -53,37 +53,13 @@ N.B. Dolphin Strings are, unlike Smalltalk-80 strings, null-terminated. Space fo
 				nextPutAll: aSequencedReadableCollection;
 				contents]!
 
-_cmp: comparand
-	"Private - Answer the receiver's <integer> ordinal collation order with respect to 
-	the <readableString> argument, comparand. The answer is < 0 if
-	the receiver is ordinally before the argument, 0 if ordinally equivalent, or
-	> 0 if ordinally after the argument. This comparison is fast and locale insensitive."
+_cmp: aString
+	"Private - Answer the receiver's <integer> ordinal collation order with respect to the <readableString> argument.
+	The answer is < 0 if the receiver is ordinally before the argument, 0 if ordinally equivalent, or > 0 if ordinally after the argument. 
+	This comparison is fast and locale insensitive."
 
 	<primitive: 220>
 	^self primitiveFailed: _failureCode!
-
-_collate: comparand
-	"Private - Answer the receiver's <integer> collation order with respect to 
-	the <readableString> argument, comparand. The answer is < 0 if
-	the receiver is lexically before the argument, 0 if lexically equivalent, or
-	> 0 if lexically after the argument. The comparision is CASE INSENSITIVE.
-	The comparison respects the currently configured default locale of the
-	host operating system, and the performance may disappoint in some cases."
-
-	<primitive: 56>
-	| string1 string2 |
-	comparand isString ifFalse: [^self error: 'Invalid comparand'].
-	"The primitive works with any supported string encoding (ANSI, UTF-8 and UTF-16) and invokes
-	the OS StringCompare function, in essence as follows:"
-	string1 := self asUtf16String.
-	string2 := comparand asUtf16String.
-	^(KernelLibrary default
-		compareString: Win32Constants.LOCALE_USER_DEFAULT
-		dwCmpFlags: Win32Constants.NORM_IGNORECASE
-		lpString1: string1
-		cchCount1: string1 size
-		lpString2: string2
-		cchCount2: string2 size) - 2!
 
 _indexOfAnyInString: aString startingAt: anInteger
 	| span |
@@ -98,55 +74,88 @@ _indexOfAnyInString: aString startingAt: anInteger
 				ifTrue: [super _indexOfAnyInString: aString startingAt: anInteger]
 				ifFalse: [span + anInteger]]!
 
-_sameAsString: aString 
+_sameAsString: aString
 	"Private - Answer whether the receiver collates the same as argument, aString."
 
-	"Implementation Note: Double dispatched from String>>sameAs:. Works for any mix of encodings
-	because _collate: does."
+	"Implementation Note: Double dispatched from String>>sameAs:. Works for any mix of encodings because <=> does."
 
-	^self == aString or: [(aString _collate: self) == 0]!
+	^self == aString or: [aString <=> self == 0]!
 
-< comparand
-	"Answer whether the receiver is lexically less than the <readableString>, comparand,
-	ignoring case, according to the implementation defined collation sequence (see _collate:)."
+< aString
+	"Answer whether the receiver is lexically less than the <readableString> argument, ignoring case, according to the implementation defined collation sequence (see <=>)."
 
-	^(self _collate: comparand) < 0!
+	^self <=> aString < 0!
 
-<= comparand
-	"Answer whether the receiver is lexically less than or equal to the <readableString>, 
-	comparand, ignoring case, according to the implementation defined collation sequence 
-	(see _collate:). Note that this is the equivalent to 
+<= aString
+	"Answer whether the receiver is lexically less than or equal to the <readableString>, argument, ignoring case, according to the implementation defined collation sequence (see <=>)."
+
+	"Note that this is the equivalent to 
 		'self < comparand or: [self sameAs: comparand]'
 	and NOT
 		'self < comparand or: [self = comparand]
 	since String>>= is case sensitive."
 
-	^(self _collate: comparand) <= 0!
+	^self <=> aString <= 0!
 
-= comparand
-	"Answer whether the receiver and the <Object> argument, comparand, are both <String>s containing identical code points.
+<==> comparand
+	"Answer the receiver's <integer> collation order with respect to the <readableString> argument, comparand. 
+	Similar to the spaceship operator, <=>, but the comparison is comparison is CASE SENSITIVE."
+
+	"Implementation Note: CompareString performs a word-based comparison which keeps, for example, hyphenated words together with equivalent non-hyphenated words. This is useful, but slower than a basic string collation.
+	Also the comparison respects the currently configured default locale of the host operating system, and the performance may disappoint in some cases."
+
+	<primitive: 51>
+	| string1 string2 |
+	string1 := self asUtf16String.
+	string2 := comparand asUtf16String.
+	^(KernelLibrary default
+		compareString: Win32Constants.LOCALE_USER_DEFAULT
+		dwCmpFlags: 0
+		lpString1: string1
+		cchCount1: string1 size
+		lpString2: string2
+		cchCount2: string2 size) - 2!
+
+<=> aString
+	"Answer the receiver's <integer> collation order with respect to the <readableString> argument. Colloquially known as the spaceship operator.
+	The answer is < 0 if the receiver is lexically before the argument, 0 if lexically equivalent, or	> 0 if lexically after the argument. 
+	The comparision is CASE INSENSITIVE and respects the currently configured default locale of the host operating system.
+	Note that this can be a relatively complex comparison and may be substantially slower than a simple ordinal comparison."
+
+	<primitive: 56>
+	| string1 string2 |
+	aString isString ifFalse: [^self error: 'Invalid comparand'].
+	"The primitive works with any supported string encoding (ANSI, UTF-8 and UTF-16) and invokes the OS StringCompare function, in essence as follows:"
+	string1 := self asUtf16String.
+	string2 := aString asUtf16String.
+	^(KernelLibrary default
+		compareString: Win32Constants.LOCALE_USER_DEFAULT
+		dwCmpFlags: Win32Constants.NORM_IGNORECASE
+		lpString1: string1
+		cchCount1: string1 size
+		lpString2: string2
+		cchCount2: string2 size) - 2!
+
+= anObject
+	"Answer whether the receiver and the <Object> argument are both <String>s containing identical code points.
 	Note that <Symbol>s are now considered equal to <String>s with the same characters.
 
 	Primitive failure results:
-		InvalidParameter1  	- comparand is not a null-terminated object.
-		AssertionFailure		- comparand and/or receiver encoding not recognised."
+		InvalidParameter1  	- anObject is not a null-terminated object.
+		AssertionFailure		- anObject and/or receiver encoding not recognised."
 
 	<primitive: 219>
-	^self == comparand or: [comparand isString and: [(self _cmp: comparand) == 0]]!
+	^self == anObject or: [anObject isString and: [(self _cmp: anObject) == 0]]!
 
-> comparand
-	"Answer whether the receiver is lexically greater than the <readableString>, comparand,
-	ignoring case, according to the implementation defined collation sequence 
-	(see _collate:)."
+> aString
+	"Answer whether the receiver is lexically greater than the <readableString> argument, ignoring case, according to the implementation defined collation sequence (see <=>)."
 
-	^(self _collate: comparand) > 0!
+	^self <=> aString > 0!
 
->= comparand
-	"Answer whether the receiver is lexically greater than or equal to the 
-	<readableString> comparand, ignoring case, according to the implementation 
-	defined collation sequence (see _collate:)."
+>= aString
+	"Answer whether the receiver is lexically greater than or equal to the <readableString> argument, ignoring case, according to the implementation defined collation sequence (see <=>)."
 
-	^(self _collate: comparand) >= 0!
+	^self <=> aString >= 0!
 
 appendToStream: puttableStream
 	"Private - Append the receiver's elements to the argument, puttableStream.
@@ -593,7 +602,24 @@ hash
 	"FNV1a"
 	1 to: utf8 size do: [:i | hash := (hash bitXor: (utf8 basicAt: i)) * 16777619 bitAnd: 16rFFFFFFFF].
 	"Fold to 30 bits so is always positive SmallInteger"
-	^(hash bitShift: -30) bitXor: (hash bitAnd: 16r3FFFFFFF)!
+	^(hash bitShift: VMConstants.SmallIntegerMax highBit negated)
+		bitXor: (hash bitAnd: VMConstants.SmallIntegerMax)!
+
+identityIncludes: aCharacter
+	"Answer whether the <Character> argument is one of the elements of the receiver."
+
+	^(self
+		nextIdentityIndexOf: aCharacter
+		from: 1
+		to: self size) ~~ 0!
+
+includes: aCharacter
+	"Answer whether the <Character> argument is one of the elements of the receiver."
+
+	^(self
+		nextIndexOf: aCharacter
+		from: 1
+		to: self size) ~~ 0!
 
 indexOfAnyOf: aCollectionOfCharacters startingAt: anInteger 
 	"Answer the one-based integer index of the first encountered element of the receiver which
@@ -644,7 +670,7 @@ lines
 	separated by line delimiters. Blank lines are included.
 	N.B. It is assumed that a line delimiter consists of two characters."
 
-	^self subStrings: String lineDelimiter!
+	^String lineDelimiter split: self!
 
 lookup: keyInteger
 	"Answer the <Character> value named by the <Integer> argument, keyInteger, or nil if there is no such key in the receiver."
@@ -1109,29 +1135,6 @@ trimNulls
 	| len |
 	^(len := self strlen) = self size ifTrue: [self] ifFalse: [self copyFrom: 1 to: len]!
 
-trueCompare: comparand
-	"Private - Answer the receiver's <integer> collation order with respect to 
-	the <readableString> argument, comparand. The answer is < 0 if
-	the receiver is lexically before the argument, 0 if lexically equivalent, or
-	> 0 if lexically after the argument. The comparision is CASE SENSITIVE.
-	Implementation Note: lstrcmp() is used, which is a word based comparison
-	which keeps, for example, hyphenated words together with equivalent
-	non-hyphenated words. This is useful, but slower than a basic string collation.
-	Also the comparison respects the currently configured default locale of the
-	host operating system, and the performance may disappoint in some cases."
-
-	<primitive: 51>
-	| string1 string2 |
-	string1 := self asUtf16String.
-	string2 := comparand asUtf16String.
-	^(KernelLibrary default
-		compareString: Win32Constants.LOCALE_USER_DEFAULT
-		dwCmpFlags: 0
-		lpString1: string1
-		cchCount1: string1 size
-		lpString2: string2
-		cchCount2: string2 size) - 2!
-
 truncateTo: anInteger
 	"Answer a <readableString> of at most anInteger characters from the receiver."
 
@@ -1170,11 +1173,12 @@ withNormalizedLineDelimiters
 	^target contents! !
 !String categoriesFor: #,!copying!public! !
 !String categoriesFor: #_cmp:!comparing!private! !
-!String categoriesFor: #_collate:!comparing!private! !
 !String categoriesFor: #_indexOfAnyInString:startingAt:!double dispatch!private!searching! !
 !String categoriesFor: #_sameAsString:!comparing!private! !
 !String categoriesFor: #<!comparing!public! !
 !String categoriesFor: #<=!comparing!public! !
+!String categoriesFor: #<==>!comparing!public! !
+!String categoriesFor: #<=>!comparing!public! !
 !String categoriesFor: #=!comparing!public! !
 !String categoriesFor: #>!comparing!public! !
 !String categoriesFor: #>=!comparing!public! !
@@ -1226,6 +1230,8 @@ withNormalizedLineDelimiters
 !String categoriesFor: #formatWith:with:with:with:!printing!public! !
 !String categoriesFor: #formatWithArguments:!printing!public! !
 !String categoriesFor: #hash!comparing!public! !
+!String categoriesFor: #identityIncludes:!public!searching! !
+!String categoriesFor: #includes:!public!searching! !
 !String categoriesFor: #indexOfAnyOf:startingAt:!public!searching! !
 !String categoriesFor: #indexOfSubCollection:startingAt:!public!searching! !
 !String categoriesFor: #isLiteral!public!testing! !
@@ -1265,7 +1271,6 @@ withNormalizedLineDelimiters
 !String categoriesFor: #titleCased!converting!public! !
 !String categoriesFor: #trimBlanks!copying!public! !
 !String categoriesFor: #trimNulls!copying!public! !
-!String categoriesFor: #trueCompare:!comparing!private! !
 !String categoriesFor: #truncateTo:!converting!public! !
 !String categoriesFor: #unescapePercents!operations!public! !
 !String categoriesFor: #withNormalizedLineDelimiters!converting!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/CategoryTreeModel.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/CategoryTreeModel.cls
@@ -28,7 +28,7 @@ addCategory: aCategory
 	(name identityIncludes: sep)
 		ifTrue: 
 			[| names moniker |
-			names := name subStrings: sep.
+			names := sep split: name.
 			moniker := String writeStream.
 			names
 				from: 1

--- a/Core/Object Arts/Dolphin/IDE/Base/Splash/SeeingTheObjectsInside.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Splash/SeeingTheObjectsInside.cls
@@ -166,7 +166,7 @@ initialize
 	dolphinIntensity := 0.
 	self loadTextureMap: 'ObjectsInside'.
 	random := Random new.
-	copyright := VMLibrary default versionInfo legalCopyright subStrings: $..
+	copyright := $. split: VMLibrary default versionInfo legalCopyright.
 	info := Utf16String writeStream.
 	info nextPutAll: copyright first.
 	(copyright size > 1 and: [copyright second notEmpty])
@@ -224,11 +224,11 @@ loadTextureMap: mapName
 	baseScale := (scale x min: scale y) min: 1.
 	[map atEnd] whileFalse: 
 			[| elements pos ext bm |
-			elements := map nextLine subStrings: $,.
+			elements := $, split: map nextLine.
 			pos := elements second trimBlanks asNumber @ elements third trimBlanks asNumber.
 			ext := elements fourth trimBlanks asNumber @ elements fifth trimBlanks asNumber.
 			bm := GdiplusBitmap fromImage: texture crop: (pos extent: ext).
-			textureMap at: elements first put: (ObjectInside fromImage: bm scaledBy: baseScale )].
+			textureMap at: elements first put: (ObjectInside fromImage: bm scaledBy: baseScale)].
 	sun := textureMap removeKey: 'SeeingTheObjects.png'.
 	dolphins := {textureMap removeKey: 'Dolphin1.png'. textureMap removeKey: 'Dolphin2.png'}.
 	objects := textureMap values.

--- a/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
@@ -2535,7 +2535,7 @@ testPrimitiveStringCmp
 	"Test case sensitive string comparison primitive"
 
 	| method |
-	method := self createPrimitiveMethodLike: String >> #trueCompare:.
+	method := self createPrimitiveMethodLike: String >> #<==>.
 	"Note that we don't test that the primitive fails for a non-String receiver - in general primitives assume they are only used in methods of suitable receiver classes."
 	#(#('a' 'b' -1) #('A' 'a' 1) #('abc' 'ABC' -1) #('abc' 'abc' 0) #('' 'a' -1) #('a' 'ab' -1) #('ab' 'a' 1) #('a' 1 'InvalidParameter1'))
 		do: 
@@ -2554,7 +2554,7 @@ testPrimitiveStringCollate
 	"Test case insensitive string comparison primitive"
 
 	| method |
-	method := self createPrimitiveMethodLike: String >> #_collate:.
+	method := self createPrimitiveMethodLike: String >> #<=>.
 	"Note that we don't test that the primitive fails for a non-String receiver - in general primitives assume they are only used in methods of suitable receiver classes."
 	#(#('a' 'b' -1) #('b' 'a' 1) #('abc' 'ABC' 0) #('A' 'a' 0) #('' 'a' -1) #('a' 'ab' -1) #('ab' 'a' 1) #('a' 1 'InvalidParameter1'))
 		do: 

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/AXTypeLibRegistration.cls
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/AXTypeLibRegistration.cls
@@ -42,11 +42,9 @@ buildVersionNumbers
 	"Private -"
 
 	| versionParts |
-	versionParts := self versionString asUppercase subStrings: $..
+	versionParts := $. split: self versionString asUppercase.
 	major := Integer readFrom: (versionParts at: 1 ifAbsent: ['']) readStream radix: 16.
-	minor := Integer readFrom: (versionParts at: 2 ifAbsent: ['']) readStream radix: 16.
-
-!
+	minor := Integer readFrom: (versionParts at: 2 ifAbsent: ['']) readStream radix: 16!
 
 description
 	"Answer the description from the typelib's registration details."

--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinProduct.cls
@@ -185,7 +185,7 @@ encryptedClasses
 			classes := classes asArray select: [:each | self isSafeToEncrypt: each].
 			self shouldEncryptMetaclasses 
 				ifTrue: [classes := classes , (classes collect: [:each | each class])].
-			encryptedClasses := classes asSortedCollection: [:a :b | (a name trueCompare: b name) <= 0]].
+			encryptedClasses := classes asSortedCollection: [:a :b | (a name <==> b name) <= 0]].
 	^encryptedClasses!
 
 encryptedClasses: aCollectionOfClasses

--- a/Core/Object Arts/Dolphin/Lagoon/ElgamalSerialNumberProtector.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/ElgamalSerialNumberProtector.cls
@@ -20,7 +20,7 @@ Secondly, the encrypted form is rather long -- an order of magnitude longer than
 dataFromString: aString
 	"Private - Answer the raw encrypted data contained in the human-readable String."
 
-	^ (aString subStrings: '/') collect: [:each | self class integerFromReadableString: each].!
+	^($/ split: aString) collect: [:each | self class integerFromReadableString: each]!
 
 decrypt: anArrayOfLargeIntegers
 	"Answer anArrayOfLargeIntegers decrypted according to the encryption policy the receiver represents.

--- a/Core/Object Arts/Dolphin/MVP/Base/AcceleratorTable.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/AcceleratorTable.cls
@@ -207,7 +207,7 @@ splitKeyCode: anInteger
 splitKeyString: aString
 	"Answer an <Array> of <String>s containing the names of the keys specified in the <readableString> accelerator key chord, aString. Note that this must not contain any spaces."
 
-	^aString subStrings: self keySeparator!
+	^self keySeparator split: aString!
 
 stbConvertFrom: anSTBClassFormat 
 	"Version 1 changes format of the 'commands' (formerly 'accelerators') instance variable."

--- a/Core/Object Arts/Dolphin/MVP/Base/MenuItem.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/MenuItem.cls
@@ -215,7 +215,7 @@ fromString: menuString
 		ifTrue: [^DividerMenuItem perform: divider]
 		ifFalse: 
 			[| subStrings |
-			(subStrings := menuString subStrings: StringSeparator) size == 3
+			(subStrings := StringSeparator split: menuString) size == 3
 				ifTrue: 
 					[| commandDescription accel |
 					commandDescription := CommandDescription command: (subStrings at: 3) asSymbol.

--- a/Core/Object Arts/Dolphin/MVP/Metafiles/Metafile.cls
+++ b/Core/Object Arts/Dolphin/MVP/Metafiles/Metafile.cls
@@ -44,16 +44,16 @@ description
 	"Return the description string associated with the receiver, if any."
 
 	| count strings |
-	count := GDILibrary default 
+	count := GDILibrary default
 				getEnhMetaFileDescription: self asParameter
 				cchBuffer: 0
 				lpszDescription: nil.
 	strings := Utf16String newFixed: count.
-	GDILibrary default 
+	GDILibrary default
 		getEnhMetaFileDescription: self asParameter
 		cchBuffer: count
 		lpszDescription: strings.
-	^strings subStrings: Character null!
+	^$\0 split: strings!
 
 drawDisabledOn: aCanvas at: aPoint extent: sizePoint 
 	"Draw a disabled/grayed representation of the receiver on aCanvas at aPoint with extent sizePoint."

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/DurationToText.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/DurationToText.cls
@@ -41,7 +41,7 @@ rightToLeft: aString
 	| values |
 	(aString allSatisfy: [:each | '0123456789+-:.' includes: each]) ifFalse: [^self leftNullValue].
 	values := OrderedCollection new.
-	(aString subStrings: $:) reverseDo: [:each | values add: (Number fromString: each)].
+	($: split: aString) reverseDo: [:each | values add: (Number fromString: each)].
 	(values isEmpty or: [values size > 4]) ifTrue: [^self leftNullValue].
 	[values size < 4] whileTrue: [values add: 0].
 	^Duration

--- a/Core/Object Arts/Dolphin/System/Compiler/StSemanticAnalyser.cls
+++ b/Core/Object Arts/Dolphin/System/Compiler/StSemanticAnalyser.cls
@@ -323,21 +323,21 @@ checkSupersend: aMessageNode
 	methodClass superclass isNil
 		ifTrue: [^self signalError: CErrUndeclared forNode: aMessageNode receiver]!
 
-checkTryBlock: aMessageNode 
+checkTryBlock: aMessageNode
 	"Private - Warning if an exception guarded statement (i.e. a block sent #on:do:+) does not
 	appear to be correctly formed, or is using the deprecated VSE form with a niladic handler
 	block."
 
 	| args |
-	aMessageNode receiver isBlock 
+	aMessageNode receiver isBlock
 		ifFalse: 
 			["If the receiver is not a block, we can't make any assumptions about how it might implement on:do:+"
 			^self].
 	"Some quick checks to eliminate non-on:do: messages"
-	(aMessageNode isKeyword 
-		and: [aMessageNode selectorParts size even and: [aMessageNode selector beginsWith: #on:do:]]) 
+	(aMessageNode isKeyword
+		and: [aMessageNode selectorParts size even and: [aMessageNode selector beginsWith: #on:do:]])
 			ifFalse: [^self].
-	((aMessageNode selector subStrings: #on:do:) anySatisfy: [:each | each notEmpty]) ifTrue: [^self].
+	((#on:do: split: aMessageNode selector) anySatisfy: [:each | each notEmpty]) ifTrue: [^self].
 	"Message is of the form on:do:+, so check receiver and handler args"
 	self checkMessageHasNiladicBlockReceiver: aMessageNode.
 	args := aMessageNode arguments.

--- a/Core/Object Arts/Dolphin/System/Recent/AbstractRecentMenu.cls
+++ b/Core/Object Arts/Dolphin/System/Recent/AbstractRecentMenu.cls
@@ -43,7 +43,7 @@ isFullPathAlwaysRequired: aBoolean
 notEmpty
 	^self getRecentList notEmpty!
 
-onAboutToDisplayMenu: recentMenu 
+onAboutToDisplayMenu: recentMenu
 	"Private - The system is about to display the <Menu>, popup, this is our chance
 	to fiddle with it and display the recent files list if appropriate."
 
@@ -53,17 +53,18 @@ onAboutToDisplayMenu: recentMenu
 	recentList := self getRecentList.
 	basePath := File splitPathFrom: recentList first.
 	recentList do: 
-			[:each | 
+			[:each |
 			| nameToDisplay |
-			nameToDisplay := (each subStrings: ',') first.
-			nameToDisplay := self isFullPathAlwaysRequired 
+			nameToDisplay := ($, split: each) first.
+			nameToDisplay := self isFullPathAlwaysRequired
 						ifTrue: [nameToDisplay]
 						ifFalse: [(FolderRelativeFileLocator basePath: basePath) relativePathTo: nameToDisplay].
 			recentMenu addCommand: (Message selector: self openSelector argument: each)
 				description: nameToDisplay].
 	recentMenu
 		addSeparator;
-		addCommand: (MessageSend receiver: self selector: #clearRecentList) description: 'Clear Recent List'!
+		addCommand: (MessageSend receiver: self selector: #clearRecentList)
+			description: 'Clear Recent List'!
 
 openSelector
 	^openSelector!

--- a/Core/Object Arts/Dolphin/System/Win32/FileSystemChangeReader.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/FileSystemChangeReader.cls
@@ -86,8 +86,8 @@ filterString
 	self filters do: [:each | stream nextPutAll: each] separatedBy: [stream nextPut: $;].
 	^stream contents!
 
-filterString: aString 
-	self filters: (aString subStrings: $;)!
+filterString: aString
+	self filters: ($; split: aString)!
 
 free
 	"Free any external resources owned by the receiver."

--- a/Core/Object Arts/Samples/MVP/Generative Music/PlimboleShell.cls
+++ b/Core/Object Arts/Samples/MVP/Generative Music/PlimboleShell.cls
@@ -104,9 +104,9 @@ loadPalettes
 	| lines palettes |
 	lines := self palettesString lines.
 	palettes := lines collect: 
-					[:each | 
+					[:each |
 					| palette |
-					palette := (each subStrings: $#) allButFirst.
+					palette := ($# split: each) allButFirst.
 					palette := palette collect: [:c | Color fromHTMLSpec: '#' , c]].
 	^palettes!
 


### PR DESCRIPTION
Fix #887

Also adds spaceship operator(s) for Strings to replace the old private _collate: and trueCompare: methods.