### PR TITLE
Remove dependency to load Numerical Methods

### DIFF
--- a/Core/Contributions/Camp Smalltalk/Numerical Methods/dhbNumerics.pax
+++ b/Core/Contributions/Camp Smalltalk/Numerical Methods/dhbNumerics.pax
@@ -132,13 +132,9 @@ package globalAliases: (Set new
 	yourself).
 
 package setPrerequisites: (IdentitySet new
-	add: '..\..\ITC Gorisek\Dialect Abstraction Layer';
 	add: '..\..\Object Arts\Dolphin\Base\Dolphin';
 	add: '..\SUnit\SUnit';
 	yourself).
-
-package setManualPrerequisites: #(
-	'Dialect Abstraction Layer').
 
 package!
 


### PR DESCRIPTION
Currently the Numerical Methods Contributions classes are not loadable because a missing dependency on the unexisting Dialect Abstraction Layer, but it is not needed.
So I simply eliminated the dependency and was able to load the classes.