### PR TITLE
Consolidate ListView 'moreParams' into inst vars and add spares

### DIFF
--- a/Core/Contributions/Solutions Software/EditableListView.cls
+++ b/Core/Contributions/Solutions Software/EditableListView.cls
@@ -1025,11 +1025,11 @@ columnClass
 
 stbConvert: instVarArray fromVersion: verInteger
 
-	| origInstVars instVars offset new |
-
+	| origInstVars instVars offset base new |
 	origInstVars := super stbConvert: instVarArray fromVersion: (verInteger <= 14 ifTrue: [11] ifFalse: [verInteger]).
 	instVars := origInstVars.
 	offset := 0.
+	base := ListView instSize.
 
 	verInteger < 12 ifTrue: 
 		["Added rowHeight"
@@ -1055,8 +1055,8 @@ stbConvert: instVarArray fromVersion: verInteger
 		new replaceFrom: 1 to: (##(self) instSize - 2) with: instVars startingAt: 1.
 		offset := offset + 2.
 
-		(new at: 36 "rowHeight") isNil ifTrue: [new at: 36 put: 1].
-		(new at: 33 "old isMultiSelect") == true
+		(new at: base + 6 "rowHeight") isNil ifTrue: [new at: base + 6 put: 1].
+		(new at: base + 3 "old isMultiSelect") == true
 			ifTrue: [(new instVarAt: 3) at: 1 put: ((new instVarAt: 3) first maskClear: LVS_SINGLESEL)]
 			ifFalse: [(new instVarAt: 3) at: 1 put: ((new instVarAt: 3) first maskSet: LVS_SINGLESEL)].
 
@@ -1073,8 +1073,8 @@ stbConvert: instVarArray fromVersion: verInteger
 	verInteger < 15 ifTrue:
 		["Renamed/reused inst vars. Clear out any old values no longer appropriate"
 		instVars 
-			at: 32 put: nil; "originalColumns - was multSelectStack"
-			at: 38 put: nil "headerControl - was hotItemAndColumn"].
+			at: base + 2 put: nil; "originalColumns - was multSelectStack"
+			at: base + 8 put: nil "headerControl - was hotItemAndColumn"].
 
 	^instVars!
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
@@ -211,8 +211,8 @@ ListControlView subclass: #IconicListAbstract
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 IconicListAbstract subclass: #ListView
-	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent moreParams'
-	classVariableNames: 'LvModes NoImageIndex RevertSelMessage SelectionStateMask UnknownItem'
+	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent lvFlags backImage backImageOffset backImageAlpha _unused34 _unused35 _unused36 _unused37 _unused38 _unused39 _unused40 _unused41 _unused42 _unused43 _unused44 _unused45'
+	classVariableNames: 'BackImageIsTiledMask LvModes NoImageIndex RevertSelMessage SelectionStateMask UnknownItem'
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!
 IconicListAbstract subclass: #TabView
@@ -246,7 +246,7 @@ resource_Default_view
 	ViewComposer openOn: (ResourceIdentifier class: self selector: #resource_Default_view)
 	"
 
-	^#(#'!!STL' 4 788558 10 ##(Smalltalk.STBViewProxy) ##(Smalltalk.ListView) 34 30 nil nil 34 2 8 1409372236 1025 416 590662 2 ##(Smalltalk.ListModel) 138 144 8 #() nil 1310726 ##(Smalltalk.IdentitySearchPolicy) 327686 ##(Smalltalk.Color) #default nil 5 nil nil nil 416 nil 8 1903904528 ##(Smalltalk.BasicListAbstract) ##(Smalltalk.IconicListAbstract) 1049926 1 ##(Smalltalk.IconImageManager) nil nil nil 328198 ##(Smalltalk.Point) 65 65 nil nil 138 144 34 1 920646 5 ##(Smalltalk.ListViewColumn) 8 'Column 1' 201 #left ##(Smalltalk.BasicListAbstract) 459270 ##(Smalltalk.Message) #<= 8 #() nil nil 416 nil 1 nil nil #largeIcons 528 nil 131169 nil 34 4 nil nil 658 1 1 nil 983302 ##(Smalltalk.MessageSequence) 138 144 34 2 721670 ##(Smalltalk.MessageSend) #createAt:extent: 34 2 658 3839 21 658 491 311 416 914 #text: 34 1 8 'Column 1' 416 983302 ##(Smalltalk.WINDOWPLACEMENT) 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 127 7 0 0 10 0 0 0 116 8 0 0 165 0 0 0] 8 #() 658 193 193 nil 27 )! !
+	^#(#'!!STL' 4 788558 10 ##(Smalltalk.STBViewProxy) ##(Smalltalk.ListView) 34 45 nil nil 34 2 8 1409372236 1025 416 590662 2 ##(Smalltalk.ListModel) 138 144 8 #() nil 1310726 ##(Smalltalk.IdentitySearchPolicy) 327686 ##(Smalltalk.Color) #default nil 5 nil nil nil 416 nil 8 1868909856 ##(Smalltalk.BasicListAbstract) ##(Smalltalk.IconicListAbstract) 1049926 1 ##(Smalltalk.IconImageManager) nil nil nil 328198 ##(Smalltalk.Point) 65 65 nil nil 138 144 34 1 920646 5 ##(Smalltalk.ListViewColumn) 8 'Column 1' 201 #left ##(Smalltalk.BasicListAbstract) 459270 ##(Smalltalk.Message) #<= 8 #() nil nil 416 nil 1 nil nil #largeIcons 528 nil 131169 nil 1 nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil 983302 ##(Smalltalk.MessageSequence) 138 144 34 2 721670 ##(Smalltalk.MessageSend) #createAt:extent: 34 2 658 7039 21 658 491 311 416 882 #text: 34 1 8 'Column 1' 416 983302 ##(Smalltalk.WINDOWPLACEMENT) 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 191 13 0 0 10 0 0 0 180 14 0 0 165 0 0 0] 8 #() 658 193 193 nil 35 )! !
 !FolderPresenter class categoriesFor: #resource_Default_view!public!resources-views! !
 
 !ListPresenter class methodsFor!
@@ -259,7 +259,7 @@ resource_Enhanced_list_view
 	ViewComposer openOn: (ResourceIdentifier class: self selector: #resource_Enhanced_list_view)
 	"
 
-	^#(#'!!STL' 4 788558 10 ##(Smalltalk.STBViewProxy) ##(Smalltalk.ListView) 34 30 nil nil 34 2 8 1409355853 1025 416 590662 2 ##(Smalltalk.ListModel) 138 144 8 #() nil 1310726 ##(Smalltalk.IdentitySearchPolicy) 327686 ##(Smalltalk.Color) #default nil 5 nil nil nil 416 nil 8 1903904528 459270 ##(Smalltalk.Message) #displayString 8 #() ##(Smalltalk.IconicListAbstract) 1049926 1 ##(Smalltalk.IconImageManager) nil nil nil nil nil nil 138 144 34 1 920646 5 ##(Smalltalk.ListViewColumn) 8 'Column 1' 201 #left 626 #displayString 656 626 #<= 8 #() nil nil 416 nil 1 nil nil #report 528 nil 131169 nil 34 4 nil nil 328198 ##(Smalltalk.Point) 1 1 nil 983302 ##(Smalltalk.MessageSequence) 138 144 34 2 721670 ##(Smalltalk.MessageSend) #createAt:extent: 34 2 850 3839 21 850 491 311 416 946 #text: 34 1 8 'Column 1' 416 983302 ##(Smalltalk.WINDOWPLACEMENT) 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 127 7 0 0 10 0 0 0 116 8 0 0 165 0 0 0] 8 #() 850 193 193 nil 27 )!
+	^#(#'!!STL' 4 788558 10 ##(Smalltalk.STBViewProxy) ##(Smalltalk.ListView) 34 45 nil nil 34 2 8 1409355853 1025 416 590662 2 ##(Smalltalk.ListModel) 138 144 8 #() nil 1310726 ##(Smalltalk.IdentitySearchPolicy) 327686 ##(Smalltalk.Color) #default nil 5 nil nil nil 416 nil 8 1868909856 459270 ##(Smalltalk.Message) #displayString 8 #() ##(Smalltalk.IconicListAbstract) 1049926 1 ##(Smalltalk.IconImageManager) nil nil nil nil nil nil 138 144 34 1 920646 5 ##(Smalltalk.ListViewColumn) 8 'Column 1' 201 #left 626 #displayString 656 626 #<= 8 #() nil nil 416 nil 1 nil nil #report 528 nil 131169 nil 1 nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil 983302 ##(Smalltalk.MessageSequence) 138 144 34 2 721670 ##(Smalltalk.MessageSend) #createAt:extent: 34 2 328198 ##(Smalltalk.Point) 7039 21 946 491 311 416 898 #text: 34 1 8 'Column 1' 416 983302 ##(Smalltalk.WINDOWPLACEMENT) 8 #[44 0 0 0 0 0 0 0 1 0 0 0 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 191 13 0 0 10 0 0 0 180 14 0 0 165 0 0 0] 8 #() 946 193 193 nil 35 )!
 
 resource_Tab_view
 	"Answer the literal data from which the 'Tab view' resource can be reconstituted.

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -1,32 +1,41 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 IconicListAbstract subclass: #ListView
-	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent moreParams'
-	classVariableNames: 'LvModes NoImageIndex RevertSelMessage SelectionStateMask UnknownItem'
+	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent lvFlags backImage backImageOffset backImageAlpha _unused34 _unused35 _unused36 _unused37 _unused38 _unused39 _unused40 _unused41 _unused42 _unused43 _unused44 _unused45'
+	classVariableNames: 'BackImageIsTiledMask LvModes NoImageIndex RevertSelMessage SelectionStateMask UnknownItem'
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!
 ListView guid: (GUID fromString: '{87b4c730-026e-11d3-9fd7-00a0cc3e4a32}')!
+ListView addClassConstant: 'BackImageIsTiledMask' value: 16r1!
 ListView addClassConstant: 'NoImageIndex' value: 16r0!
-ListView comment: 'ListView is the <listView> implementing the Windows "SysListView32" common control. It is for single selection use and, therefore, implements the <selectableItems> protocol for use with any <listModel>.
+ListView comment: '`ListView` is the `<listView>` implementing the Windows "SysListView32" common control. It is for single selection use and, therefore, implements the `<selectableItems>` protocol for use with any `<listModel>`.
 
-A ListView is capable of displaying it items in one of four modes (#smallIcons, #largeIcons, #list, #report) which can be set using the #viewMode aspect. In the first three of these modes the list effectively has only one column being displayed; this is the primary column. Columns are described using instances of ListViewColumn. See the comment for this class for details on how to set up a column to display the appropriate information for a list item.
+A `ListView` is capable of displaying it items in one of a number of modes, e.g. `#smallIcons`, `#largeIcons`, `#list`, and `#report` which can be set using the `#viewMode` aspect. In all but `#report` mode the list effectively has only one column being displayed; this is the primary column. Columns are described using instances of `ListViewColumn`. See the comment for this class for details on how to set up a column to display the appropriate information for a list item.
 
 The underlying Windows common control is a sophisticated one with many options. We have not attempted to wrap all of the features of this control within the ListView class. However, you should find that much of the most useful functionality is present.
 
-Instance Variables:
-	primaryColumn	<ListViewColumn> which is the main column in the list.
-	columns			<OrderedCollection> of <ListViewColumn>s which are displayed in #report mode (excluding the primary column).
-	viewMode		<Symbol> describing the mode in which the list is displaying items.
-	lastSel			<integer> index of the last selection made.
-	iconSpacing		<Point> or nil, representing the explicit spacing between icons in #smallIcons and #largeIcons view modes.
-	lvStyle			<integer> representing the Windows extended list view style.
-	_lvReserved1	Reserved for future system use. Do not use.
-	_lvReserved2	Reserved for future system use. Do not use.
+## Instance Variables:
+  `lastClickedColIndex`	`<integer>` index of the last column clicked for sorting
+  `columns`			`OrderedCollection` of `ListViewColumn`s which are displayed in `#report` mode.
+  `viewMode`			`Symbol` describing the mode in which the list is displaying items.
+  `lastSelIndices`		`Array` of `<integer>`. The indices of the last selected rows.
+  `iconSpacing`		`Point`, optional. Represents the explicit spacing between icons in icon view modes. Default is to use the control''s preferred spacing.
+  `lvStyle`				`<integer>`. List view extended style flags
+  `thumbnailExtent`		`Point`, optional, representing the size of icons when in `#thumbnail` view mode. Default is 64@64.
+  `lvFlags`				`<integer>` flags specific to list views
+  `backImage`			`<Bitmap>`, optional. Background image. Default, nil.
+  `backImageOffset`		`Point`, optional. Origin of the background image. Default is 0@0.
+  `backImageAlpha`		`<integer>`, optional. Alpha percent for the background image. Default is 100.
+  
+## Class Variables:
+  `BackImageIsTiledMask`	`<integer>`. Flag mask for backImageIsTiled.
+  `LvModes`				`IdentityDictionary` mapping symbolic view mode names to the corresponding list view style constants. 
+  `NoImageIndex`			`<integer>`
+  `RevertSelMessage`		`<integer>` holding the private ''RevertSelection'' message.
+  `SelectionStateMask`		`<integer>`
+  `UnknownItem`			`<Object>`
 
-Class Variables:
-	LvnMap			<Array> which is a map between integer Windows notification messages and <selector>s.
-	RevertSelMessage	<integer> holding the private ''RevertSelection'' message.
-	ViewModes			<IdentityDictionary> mapping symbolic view mode names to the corresponding list view style constants.
+
 '!
 !ListView categoriesForClass!MVP-Views! !
 !ListView methodsFor!
@@ -205,30 +214,24 @@ backcolorChanged
 	self backImage notNil ifTrue: [self backImageChanged]!
 
 backImage
-	^self moreParamsAt: 1!
+	^backImage!
 
 backImage: aBitmapOrNil 
-	self moreParamsAt: 1 put: aBitmapOrNil.
+	backImage := aBitmapOrNil.
 	self backImageChanged!
 
 backImageAlphaPercent
-	| percent |
-	percent := self moreParamsAt: 4.
-	percent ifNil: [self backImageAlphaPercent: (percent := 100)].
-	^percent!
+	^backImageAlpha ?? 100!
 
-backImageAlphaPercent: anInteger 
-	self backImage 
-		ifNotNil: 
-			[self moreParamsAt: 4 put: anInteger.
-			self backImageChanged]!
+backImageAlphaPercent: anInteger
+	backImageAlpha := anInteger.
+	backImage ifNotNil: [self backImageChanged]!
 
 backImageChanged
 	"Private - The background image has been changed; apply it into the receiver. We take a copy here
 	since Windows takes ownership of the bitmap handle that we give it"
 
-	| backImage bk isTiled offset |
-	backImage := self backImage.
+	| bk isTiled offset |
 	bk := LVBKIMAGEW new.
 	bk bitmap: (backImage notNil
 				ifTrue: 
@@ -243,26 +246,18 @@ backImageChanged
 	self lvmSetBkImage: bk!
 
 backImageIsTiled
-	| isTiled |
-	isTiled := self moreParamsAt: 2.
-	isTiled ifNil: [self backImageIsTiled: (isTiled := false)].
-	^isTiled!
+	^lvFlags allMask: BackImageIsTiledMask!
 
-backImageIsTiled: aBoolean 
-	self backImage 
-		ifNotNil: 
-			[self moreParamsAt: 2 put: aBoolean.
-			self backImageChanged]!
+backImageIsTiled: aBoolean
+	lvFlags := lvFlags mask: BackImageIsTiledMask set: aBoolean.
+	backImage ifNotNil: [self backImageChanged]!
 
 backImageOffset
-	| offset |
-	offset := self moreParamsAt: 3.
-	offset ifNil: [self backImageOffset: (offset := Point zero)].
-	^offset!
+	^backImageOffset ?? Point zero!
 
 backImageOffset: aPoint 
-	self moreParamsAt: 3 put: aPoint.
-	self backImageChanged!
+	backImageOffset := aPoint = Point zero ifFalse: [aPoint].
+	backImage ifNotNil: [self backImageChanged]!
 
 basicAdd: anObject atIndex: anInteger
 	"Private - Adds an item to the list view at the index given by anInteger"
@@ -1520,28 +1515,6 @@ maybeSelChanging: aSymbol
 			^self].
 	self onSelChanged!
 
-moreParams
-	"Private - A cheating way of adding additional instance parameters to the receiver without
-	having to worry about STB upgrading"
-
-	moreParams ifNil: [moreParams := Array new: 1].
-	^moreParams!
-
-moreParamsAt: n 
-	"Private - A cheating way of adding additional instance parameters to the receiver without
-	having to worry about STB upgrading"
-
-	self moreParams at: n ifPresent: [:x | ^x].
-	moreParams resize: n.
-	^nil!
-
-moreParamsAt: n put: anObject 
-	"Private - A cheating way of adding additional instance parameters to the receiver without
-	having to worry about STB upgrading"
-
-	self moreParams at: n.
-	^self moreParams at: n put: anObject!
-
 newSelectionsFromEvent: event
 	"Private - Answer a collection of the <integer> selections that would occur if the <MouseEvent>,
 	event, was was passed to the control."
@@ -2471,9 +2444,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #lvnMarqueeBegin:!event handling-win32!private! !
 !ListView categoriesFor: #lvnODStateChanged:!event handling-win32!private! !
 !ListView categoriesFor: #maybeSelChanging:!event handling!private! !
-!ListView categoriesFor: #moreParams!accessing!private! !
-!ListView categoriesFor: #moreParamsAt:!accessing!private! !
-!ListView categoriesFor: #moreParamsAt:put:!accessing!private! !
 !ListView categoriesFor: #newSelectionsFromEvent:!event handling!private! !
 !ListView categoriesFor: #nmClick:!event handling-win32!private! !
 !ListView categoriesFor: #nmNotify:!event handling-win32!private! !
@@ -2589,6 +2559,38 @@ onStartup
 			SelectionStateMask := LVIS_SELECTED]
 		ifFalse: [SelectionStateMask := ##(LVIS_SELECTED | LVIS_FOCUSED)]!
 
+stbConvert: instVarArray fromVersion: verInteger
+	| instVars |
+	instVars := instVarArray.
+	verInteger <= 13 ifTrue: [instVars := super stbConvert: instVars fromVersion: verInteger].
+	verInteger < 17
+		ifTrue: 
+			[| size lvFlags |
+			size := instVars size + 15.
+			instVars := (Array new: size)
+						replaceFrom: 1
+							to: 30
+							with: instVars
+							startingAt: 1;
+						replaceFrom: 46
+							to: size
+							with: instVars
+							startingAt: 31;
+						yourself.
+			lvFlags := 0.
+			(instVars at: 30)
+				ifNotNil: 
+					[:moreParams |
+					| backImageOffset |
+					(moreParams lookup: 2)
+						ifNotNil: [:isTiled | lvFlags := lvFlags mask: BackImageIsTiledMask set: isTiled].
+					backImageOffset := moreParams lookup: 3.
+					instVars at: 31 put: (moreParams lookup: 1).
+					instVars at: 32 put: (backImageOffset = Point zero ifFalse: [backImageOffset]).
+					instVars at: 33 put: (moreParams lookup: 4)].
+			instVars at: 30 put: lvFlags].
+	^instVars!
+
 stbConvertFromVersion10: anArray 
 	"Private - Perform an STB conversion from a version 10 <ListView> to version 11,
 	i.e. merge column and primaryColumns instance variables into one, and add a couple 
@@ -2630,6 +2632,14 @@ stbConvertFromVersion5: anArray
 
 	^(super stbConvertFromVersion5: anArray) copyWith: 0!
 
+stbVersion
+	"Versions:
+		1-13: See View
+		14-16: See EditableListView
+		17: Consolidates 4 vars using moreParams into inst vars and adds 12 spares"
+
+	^17!
+
 themePartName
 
 	^#ListView!
@@ -2645,10 +2655,12 @@ winClassName
 !ListView class categoriesFor: #icon!constants!public! !
 !ListView class categoriesFor: #initialize!development!initializing!private! !
 !ListView class categoriesFor: #onStartup!events-session!public! !
+!ListView class categoriesFor: #stbConvert:fromVersion:!binary filing!public! !
 !ListView class categoriesFor: #stbConvertFromVersion10:!binary filing!private! !
 !ListView class categoriesFor: #stbConvertFromVersion11:!binary filing!private! !
 !ListView class categoriesFor: #stbConvertFromVersion2:!binary filing!private! !
 !ListView class categoriesFor: #stbConvertFromVersion5:!binary filing!private! !
+!ListView class categoriesFor: #stbVersion!binary filing!public! !
 !ListView class categoriesFor: #themePartName!constants!public! !
 !ListView class categoriesFor: #viewModes!accessing!public! !
 !ListView class categoriesFor: #winClassName!constants!private! !


### PR DESCRIPTION
Define a new STB version and upgrade so more inst vars can be defined in
ListView. The new version is 17 to accommodate EditableListView, which
required some minor modifications so its own STB conversion is correct.