### PR TITLE
WCHARField's should read Character as UTF-16

### DIFF
--- a/Core/Object Arts/Dolphin/Base/AbstractCHARField.cls
+++ b/Core/Object Arts/Dolphin/Base/AbstractCHARField.cls
@@ -1,0 +1,37 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+ScalarField subclass: #AbstractCHARField
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+AbstractCHARField guid: (GUID fromString: '{225e024e-8ea6-493f-ad47-82a47ac5cb5c}')!
+AbstractCHARField comment: ''!
+!AbstractCHARField categoriesForClass!Unclassified! !
+!AbstractCHARField methodsFor!
+
+basicWriteInto: anExternalStructure value: anInteger
+	^self subclassResponsibility!
+
+fieldClassName
+	^#Character!
+
+printMutatorValueOn: aWriteStream parameter: aString
+	"Private - Print a suitable expression onto the specified <puttableStream> which will
+	evaluate to the the value to be stored into this field in an instance of the structure when
+	compiled into a mutator method where the value parameter is named by the <String> argument."
+
+	aWriteStream
+		nextPutAll: aString;
+		space;
+		display: #codePoint!
+
+writeInto: anExternalStructure value: aCharacter
+	"Private - Write the code point of the <Character>, aCharacter, into the <ExternalStructure>, anExternalStructure, at the receiver's offset."
+
+	^self basicWriteInto: anExternalStructure value: aCharacter codePoint! !
+!AbstractCHARField categoriesFor: #basicWriteInto:value:!accessing!public! !
+!AbstractCHARField categoriesFor: #fieldClassName!automatic generation!constants!development!private! !
+!AbstractCHARField categoriesFor: #printMutatorValueOn:parameter:!automatic generation!development!private! !
+!AbstractCHARField categoriesFor: #writeInto:value:!indirect accessing!private! !
+

--- a/Core/Object Arts/Dolphin/Base/CHARField.cls
+++ b/Core/Object Arts/Dolphin/Base/CHARField.cls
@@ -1,50 +1,25 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-ScalarField subclass: #CHARField
+AbstractCHARField subclass: #CHARField
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 CHARField guid: (GUID fromString: '{a70daacf-9954-43db-943f-1f8f245fcf07}')!
-CHARField comment: '<CHARField> is a <ScalarField> class to represent <ExternalStructure> fields that are 8-bit character code units.'!
+CHARField comment: '`CHARField` is a `ScalarField` class to describe `ExternalStructure` fields that are 8-bit character code units.'!
 !CHARField categoriesForClass!External-Data-Types! !
 !CHARField methodsFor!
 
-accessorMessage
-	"Private - Answer the receiver's 'accessorStem'."
-
-	^#byteAtOffset:put:!
-
-fieldClassName
-	^Character name!
-
-printMutatorValueOn: aWriteStream parameter: aString
-	"Private - Print a suitable expression onto the specified <puttableStream> which will
-	evaluate to the the value to be stored into this field in an instance of the structure when
-	compiled into a mutator method where the value parameter is named by the <String> argument."
-
-	aWriteStream
-		nextPutAll: aString;
-		space;
-		display: #codePoint!
+basicWriteInto: anExternalStructure value: anInteger
+	^anExternalStructure bytes byteAtOffset: offset put: anInteger!
 
 readFrom: anExternalStructure
 	"Private - Answer a <Character> for the 8-bit code unit at the receiver's offset in the
 	<ExternalStructure> argument."
 
-	^(Character value: (anExternalStructure bytes byteAtOffset: offset))!
-
-writeInto: anExternalStructure value: aCharacter
-	"Private - Write the 8-bit unsigned <integer> code unit of the <Character>, aCharacter,
-	into the <ExternalStructure>, anExternalStructure, at the receiver's offset. Raises an error
-	if the Character's code unit > 255."
-
-	^anExternalStructure bytes byteAtOffset: offset put: aCharacter codePoint! !
-!CHARField categoriesFor: #accessorMessage!initializing!private! !
-!CHARField categoriesFor: #fieldClassName!automatic generation!constants!development!private! !
-!CHARField categoriesFor: #printMutatorValueOn:parameter:!automatic generation!development!private! !
+	^(Character ansiValue: (anExternalStructure bytes byteAtOffset: offset))! !
+!CHARField categoriesFor: #basicWriteInto:value:!accessing!private! !
 !CHARField categoriesFor: #readFrom:!indirect accessing!private! !
-!CHARField categoriesFor: #writeInto:value:!indirect accessing!private! !
 
 !CHARField class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Character.cls
@@ -13,11 +13,27 @@ Character addClassConstant: 'Utf16SurrogateMask' value: 16rFC00!
 Character addClassConstant: 'Utf32Mask' value: 16r3000000!
 Character addClassConstant: 'Utf8Mask' value: 16r1000000!
 Character addClassConstant: 'Utf8SurrogateMask' value: 16rC0!
-Character comment: '`Character` is the class of objects which serve as the elemental values of Smalltalk Strings. 
+Character comment: '`Character` is the class of objects which serve as the elemental values of Smalltalk `Strings`.
 
 Each `Character` instance generally represents a specific Unicode [code point](https://en.wikipedia.org/wiki/Code_point). Note that this does not necessarily mean that each `Character` corresponds to a single user-perceived, visually distinct, character (aka grapheme cluster). Multiple `Character`s may compose into a single grapheme cluster when displayed, some examples of different types being `👨🏻‍🍳`, `ö`, and `กำ`. The 2nd example has more than one valid representation and can have either one or two code-points.
 
- `Character` instances may also represent partial or surrogate character code-units that are part of a multi-code-unit code-point. Such surrogate instances may result from indexed access into `UTFEncodedStrings` such as `Utf8String` or `Utf16String`, and can be distinguished through the use of the `isSurrogate`, `isUtf8Surrogate`, `isUtf16Surrogate` family of testing messages. In general it is recommended to stream over strings, rather than treating them as arrays of characters, in which case surrogates will not be encountered.
+ `Character` instances may also represent partial or surrogate character code-units that are part of a multi-code-unit code-point. Such surrogate instances may result from indexed access into `UTFEncodedStrings` such as `Utf8String` or `Utf16String`, and can be distinguished through the use of the `isSurrogate`, `isUtf8Surrogate`, `isUtf16Surrogate` family of testing messages. For example:
+
+```
+(Character dolphin asUtf8String at: 1) isUtf8Surrogate	"true"
+```
+
+A surrogate can be written into a `String` of the same encoding, e.g. a UTF-8 surrogate into a `Utf8String`, but not into a string with a different UTF encoding. Care is also needed to avoid constructing strings with partial characters by writing an incomplete, or misordered, set of surrogate code-unit characters into the string. It is also possible to work with surrogates and streams of the correct underlying encoding, for example:
+
+```
+i := 0. Character dolphin asUtf8String do: [:each | i := i + 1. Transcript nextPut: each]. Transcript nextPutAll: '' has ''; print: i; nextPutAll: '' UTF-8 code units''; cr; flush
+```
+
+However, in general it is recommended to stream over strings, rather than treating them as arrays of characters, in which case surrogates will not be encountered.
+
+```
+i := 0. Character dolphin asUtf8String readStream do: [:each | i := i + 1. Transcript nextPut: each]. Transcript nextPutAll: '' has ''; print: i; nextPutAll: '' codepoint(s)''; cr; flush
+```
 
 The instances for the first 256 code points are unique. Smalltalk characters have a literal syntax which is the ''$'' symbol followed by the normal printed representation of the character. 
 At present only byte characters (that are not control characters) have a printable literal representation. Dolphin also supports the following escaped literal formats to provide a literal representation of any character:
@@ -640,6 +656,16 @@ isValidCodePoint: anInteger
 							[anInteger <= Win32Constants.MAX_UCSCHAR and: 
 									[(anInteger >= 16rFDD0 and: [anInteger <= 16rFDEF or: [(anInteger bitAnd: 16rFFFE) == 16rFFFE]]) not]]]]!
 
+isValidUtf16CodeUnit: anInteger
+	"Answer whether the <integer> argument is a valid as a code unit in the UTF-16 encoding."
+
+	^anInteger >= 0 and: 
+			[anInteger < 16rD800 or: 
+					[(anInteger bitAnd: 16rF800) == 16rD800 or: 
+							[anInteger < 16rFDD0 or: 
+									[anInteger > 16rFDEF
+										and: [anInteger <= Win32Constants.MAX_UCSCHAR and: [(anInteger allMask: 16rFFFE) not]]]]]]!
+
 lf
 	"Answer the linefeed control <Character>."
 
@@ -717,8 +743,11 @@ utf16Value: anInteger ifInvalid: exceptionHandler
 
 	^anInteger < 16r80
 		ifTrue: 
-			["Ascii"
-			CharacterSet at: anInteger + 1]
+			[anInteger < 0
+				ifTrue: [exceptionHandler value]
+				ifFalse: 
+					["Ascii"
+					CharacterSet at: anInteger + 1]]
 		ifFalse: 
 			[(AnsiCharacters lookup: anInteger)
 				ifNil: 
@@ -727,12 +756,12 @@ utf16Value: anInteger ifInvalid: exceptionHandler
 							["Surrogate"
 							self newCode: (Utf16Mask bitOr: anInteger)]
 						ifFalse: 
-							[(anInteger <= Win32Constants.MAX_UCSCHAR and: 
-									[(anInteger >= 16rFDD0 and: [anInteger <= 16rFDEF or: [(anInteger bitAnd: 16rFFFE) == 16rFFFE]]) not])
-								ifTrue: 
-									["Valid non-ascii/non-ansi code point"
-									self newCode: (Utf32Mask bitOr: anInteger)]
-								ifFalse: [exceptionHandler value]]]]!
+							[(anInteger <= Win32Constants.MAX_UCSCHAR
+								and: [anInteger < 16rFDD0 or: [anInteger > 16rFDEF and: [(anInteger allMask: 16rFFFE) not]]])
+									ifTrue: 
+										["Valid non-ascii/non-ansi code point"
+										self newCode: (Utf32Mask bitOr: anInteger)]
+									ifFalse: [exceptionHandler value]]]]!
 
 utf8Value: anInteger
 	"Answer a <Character> representing the <integer> UTF-8 code unit, anInteger.
@@ -769,6 +798,7 @@ value: anInteger
 !Character class categoriesFor: #euro!constants!public! !
 !Character class categoriesFor: #initialize!development!initializing!public! !
 !Character class categoriesFor: #isValidCodePoint:!enquiries!public! !
+!Character class categoriesFor: #isValidUtf16CodeUnit:!enquiries!public! !
 !Character class categoriesFor: #lf!constants!public! !
 !Character class categoriesFor: #new!instance creation!public! !
 !Character class categoriesFor: #newCode:!instance creation!private! !

--- a/Core/Object Arts/Dolphin/Base/CharacterTest.cls
+++ b/Core/Object Arts/Dolphin/Base/CharacterTest.cls
@@ -10,6 +10,19 @@ CharacterTest comment: ''!
 !CharacterTest categoriesForClass!Tests-Magnitude-General! !
 !CharacterTest methodsFor!
 
+nonCharacters
+	"Private - Unicode non-characters - see https://www.unicode.org/faq/private_use.html"
+
+	| nonchars |
+	nonchars := 16rFDD0 to: 16rFDEF.
+	0 to: 16r10
+		do: 
+			[:each |
+			| start |
+			start := (each << 16) + 16rFFFE.
+			nonchars := nonchars , (start to: start + 1)].
+	^nonchars!
+
 testAnsiValue
 	1 to: 256
 		do: [:each | self assert: (Character byteCharacterSet at: each) ansiValue equals: each - 1].
@@ -271,9 +284,12 @@ testIsUtf16SurrogateTests
 	- `Character>>isUtf16Surrogate`
 	- `Character>>isUtf16Lead`
 	- `Character>>isUtf16Trail`
+	- `Character class>>utf16Value:`
+	- `Character class>>isValidUtf16CodeUnit:`
+	Also tests `Character class>>isValidCodePoint:`
 	"
 
-	| str |
+	| str nonchars |
 	str := Character dolphin asUtf16String.
 	self assert: str size equals: 2.
 	self assert: str first isUtf16Surrogate.
@@ -282,6 +298,8 @@ testIsUtf16SurrogateTests
 		do: 
 			[:each |
 			| ch |
+			self assert: (Character isValidUtf16CodeUnit: each).
+			self assert: (Character isValidCodePoint: each).
 			ch := Character utf16Value: each.
 			self assert: ch isUtf8.
 			self deny: ch isSurrogate.
@@ -292,6 +310,8 @@ testIsUtf16SurrogateTests
 		do: 
 			[:each |
 			| ch |
+			self assert: (Character isValidUtf16CodeUnit: each).
+			self assert: (Character isValidCodePoint: each).
 			ch := Character utf16Value: each.
 			self deny: ch isUtf8.
 			self deny: ch isSurrogate.
@@ -302,6 +322,7 @@ testIsUtf16SurrogateTests
 		do: 
 			[:each |
 			| ch |
+			self assert: (Character isValidUtf16CodeUnit: each).
 			ch := Character utf16Value: each.
 			self deny: ch isUtf8.
 			self assert: ch isSurrogate.
@@ -312,34 +333,31 @@ testIsUtf16SurrogateTests
 		do: 
 			[:each |
 			| ch |
+			self assert: (Character isValidUtf16CodeUnit: each).
+			self deny: (Character isValidCodePoint: each).
 			ch := Character utf16Value: each.
 			self deny: ch isUtf8.
 			self assert: ch isSurrogate.
 			self assert: ch isUtf16Surrogate.
 			self deny: ch isUtf16Lead.
 			self assert: ch isUtf16Trail].
-	16rE000 to: 16rFDCF
-		do: 
+	nonchars := self nonCharacters.
+	((16rE000 to: 16rFFFF) difference: nonchars) do: 
 			[:each |
 			| ch |
+			self assert: (Character isValidUtf16CodeUnit: each).
+			self assert: (Character isValidCodePoint: each).
 			ch := Character utf16Value: each.
 			self deny: ch isUtf8.
 			self deny: ch isSurrogate.
 			self deny: ch isUtf16Surrogate.
 			self deny: ch isUtf16Lead.
 			self deny: ch isUtf16Trail].
-	"16rFDD0 to 16rFDEF are not valid"
-	16rFDF0 to: 16rFFFD
-		do: 
+	nonchars , {-1. Win32Constants.MAX_UCSCHAR + 1} do: 
 			[:each |
-			| ch |
-			ch := Character utf16Value: each.
-			self deny: ch isUtf8.
-			self deny: ch isSurrogate.
-			self deny: ch isUtf16Surrogate.
-			self deny: ch isUtf16Lead.
-			self deny: ch isUtf16Trail]
-	"16rFFFE and 16rFFFF are not valid"!
+			self deny: (Character isValidUtf16CodeUnit: each).
+			self deny: (Character isValidCodePoint: each).
+			self assertIsNil: (Character utf16Value: each ifInvalid: [])]!
 
 testIsUtf8SurrogateTests
 	"Exhaustively test Charcter>>isUtf8Surrogate, Character>>isUtf8Lead, Character>>isUtf8Trail."
@@ -433,6 +451,7 @@ testStb
 	bytes := Character dolphin binaryStoreBytes.
 	rehydrated := Object fromBinaryStoreBytes: bytes.
 	self assert: rehydrated equals: Character dolphin! !
+!CharacterTest categoriesFor: #nonCharacters!constants!private! !
 !CharacterTest categoriesFor: #testAnsiValue!public!unit tests! !
 !CharacterTest categoriesFor: #testAsciiValue!public!unit tests! !
 !CharacterTest categoriesFor: #testAsLowercase!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -47,6 +47,7 @@ package classNames
 	add: #ExternalAddressTest;
 	add: #ExternalArrayTest;
 	add: #ExternalDescriptorTest;
+	add: #ExternalFieldTest;
 	add: #ExternalLibraryTest;
 	add: #ExternalResourceLibraryTest;
 	add: #ExternalStructureTest;
@@ -118,6 +119,7 @@ package classNames
 	add: #UndefinedObjectTest;
 	add: #Utf16StringTest;
 	add: #Utf8StringTest;
+	add: #WCHARFieldTest;
 	add: #WindowsLocaleTest;
 	add: #WORDArrayTest;
 	add: #WriteStreamTest;
@@ -276,6 +278,11 @@ DolphinTest subclass: #ExternalDescriptorTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: 'ExtCallArgTypes'
+	classInstanceVariableNames: ''!
+DolphinTest subclass: #ExternalFieldTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #ExternalLibraryTest
 	instanceVariableNames: ''
@@ -578,6 +585,11 @@ ExternalArrayTest subclass: #WORDArrayTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 GenericExternalArrayTest subclass: #StructureArrayTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ExternalFieldTest subclass: #WCHARFieldTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -410,17 +410,17 @@ StructureArrayPointerField subclass: #PointerArrayPointerField
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
+ScalarField subclass: #AbstractCHARField
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
 ScalarField subclass: #BOOLField
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ScalarField subclass: #BYTEField
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
-ScalarField subclass: #CHARField
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -480,12 +480,17 @@ ScalarField subclass: #WORDField
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-BOOLField subclass: #BOOLEANField
+AbstractCHARField subclass: #CHARField
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-CHARField subclass: #WCHARField
+AbstractCHARField subclass: #WCHARField
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+BOOLField subclass: #BOOLEANField
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/Base/ExternalFieldTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalFieldTest.cls
@@ -1,0 +1,10 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #ExternalFieldTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ExternalFieldTest guid: (GUID fromString: '{d0a2c7ae-43c2-4b76-ad72-7d2df32edbc6}')!
+ExternalFieldTest comment: ''!
+!ExternalFieldTest categoriesForClass!Unclassified! !

--- a/Core/Object Arts/Dolphin/Base/WCHARField.cls
+++ b/Core/Object Arts/Dolphin/Base/WCHARField.cls
@@ -1,33 +1,24 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-CHARField subclass: #WCHARField
+AbstractCHARField subclass: #WCHARField
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 WCHARField guid: (GUID fromString: '{8ca9be68-ea0d-4658-bddb-fa9ac13c3927}')!
-WCHARField comment: '<WCHARField> is a <ScalarField> class to represent <ExternalStructure> fields that are 16-bit character code units.'!
+WCHARField comment: '`WCHARField` is a `ScalarField` class to describe `ExternalStructure` fields that are 16-bit character code units.'!
 !WCHARField categoriesForClass!External-Data-Types! !
 !WCHARField methodsFor!
 
-accessorMessage
-	"Private - Answer the receiver's 'accessorStem'."
-
-	^#wordAtOffset:put:!
+basicWriteInto: anExternalStructure value: anInteger
+	^anExternalStructure bytes wordAtOffset: offset put: anInteger!
 
 readFrom: anExternalStructure
-	"Private - Answer a <Boolean> of equivalent value to the 8-bit integer field at the
-	receiver's offset in the <ExternalStructure> argument, i.e. false if zero, true for 1..255."
+	"Private - Answer a <Character> representing the UTF-16 character at the receiver's offset in the <ExternalStructure> argument."
 
-	^Character value: (anExternalStructure bytes wordAtOffset: offset)!
-
-writeInto: anExternalStructure value: aCharacter
-	"Private - Write the <Charater's> 16-bit code unit value into anExternal at the receiver's offset."
-
-	anExternalStructure bytes wordAtOffset: offset put: aCharacter codePoint! !
-!WCHARField categoriesFor: #accessorMessage!automatic generation!private! !
+	^Character utf16Value: (anExternalStructure bytes wordAtOffset: offset)! !
+!WCHARField categoriesFor: #basicWriteInto:value:!accessing!private! !
 !WCHARField categoriesFor: #readFrom:!indirect accessing!private! !
-!WCHARField categoriesFor: #writeInto:value:!indirect accessing!private! !
 
 !WCHARField class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/WCHARFieldTest.cls
+++ b/Core/Object Arts/Dolphin/Base/WCHARFieldTest.cls
@@ -1,0 +1,29 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+ExternalFieldTest subclass: #WCHARFieldTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+WCHARFieldTest guid: (GUID fromString: '{5fae7240-e0b0-4632-b957-750ef821559c}')!
+WCHARFieldTest comment: ''!
+!WCHARFieldTest categoriesForClass!Unclassified! !
+!WCHARFieldTest methodsFor!
+
+testReadFrom
+	| struct dolphinString char subject |
+	struct := DWORD new.
+	dolphinString := Character dolphin asUtf16String.
+	struct bytes
+		wordAtOffset: 0 put: dolphinString first codeUnit;
+		wordAtOffset: 2 put: dolphinString last codeUnit.
+	subject := WCHARField new offset: 0; yourself.
+	char := (subject readFrom: struct).
+	self assert: char isUtf16Lead.
+	self assert: char equals: dolphinString first.
+	subject offset: 2.
+	char := (subject readFrom: struct).
+	self assert: char isUtf16Trail .
+	self assert: char equals: dolphinString last! !
+!WCHARFieldTest categoriesFor: #testReadFrom!public! !
+

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -133,6 +133,8 @@ package classNames
 package methodNames
 	add: #_FPIEEE_RECORD -> #printFieldsOn:limit:;
 	add: #_FPIEEE_VALUE -> #printFieldsOn:limit:;
+	add: #AbstractCHARField -> #characterCreationMessage;
+	add: #AbstractCHARField -> #printAccessorExpression:on:;
 	add: #AbstractDocumentShell -> #saveStateOn:;
 	add: #AndEnvironment -> #includesResource:;
 	add: #Array -> #assignToResourceIdentifier:;
@@ -177,7 +179,8 @@ package methodNames
 	add: #BrowserEnvironmentWrapper -> #includesResource:;
 	add: #BrowserEnvironmentWrapper -> #openEditor;
 	add: #Character -> #literalTextStyle;
-	add: #CHARField -> #printAccessorExpressionSuffixOn:;
+	add: #CHARField -> #accessorMessage;
+	add: #CHARField -> #characterCreationMessage;
 	add: #Class -> #changeIndex;
 	add: #Class -> #changeIndexValue:;
 	add: #Class -> #isAbstract;
@@ -427,6 +430,8 @@ package methodNames
 	add: #View -> #aspectDisplayOn:;
 	add: #View -> #publishedAspects;
 	add: #View -> #visualObjectAtPoint:;
+	add: #WCHARField -> #accessorMessage;
+	add: #WCHARField -> #characterCreationMessage;
 	add: #WINDOWPOS -> #printOn:;
 	add: 'AbstractCardContainer class' -> #publishedAspectsOfInstances;
 	add: 'AbstractCardContainer class' -> #publishedEventsOfInstances;
@@ -1402,6 +1407,30 @@ publishedEventsOfInstances
 !AbstractCardContainer class categoriesFor: #publishedAspectsOfInstances!constants!public! !
 !AbstractCardContainer class categoriesFor: #publishedEventsOfInstances!events!public! !
 
+!AbstractCHARField methodsFor!
+
+characterCreationMessage
+	^self subclassResponsibility!
+
+printAccessorExpression: aSymbol on: aWriteStream
+	"Private - Print a suitable statement or statement onto the specified <puttableStream> which
+	will read the value of this field from an instance of the structure. The field in question
+	is after the fields in the <sequencedReadableCollection> that is the 2nd argument."
+
+	aWriteStream
+		nextPut: $(;
+		print: Character;
+		space;
+		display: self characterCreationMessage;
+		space;
+		nextPutAll: '(bytes ';
+		display: self accessorMessage keywords first;
+		space.
+	self printOffsetExpression: aSymbol on: aWriteStream.
+	aWriteStream nextPutAll: '))'! !
+!AbstractCHARField categoriesFor: #characterCreationMessage!automatic generation!private! !
+!AbstractCHARField categoriesFor: #printAccessorExpression:on:!automatic generation!private! !
+
 !AbstractDocumentShell methodsFor!
 
 saveStateOn: aWriteStream 
@@ -1989,14 +2018,15 @@ literalTextStyle
 
 !CHARField methodsFor!
 
-printAccessorExpressionSuffixOn: aWriteStream
-	"Private - Print any extra messages/statements onto the <puttableStream> argument that are required to
-	configure the object being read from the structure instance."
+accessorMessage
+	"Private - Answer the receiver's 'accessorStem'."
 
-	aWriteStream
-		space;
-		display: #asCharacter! !
-!CHARField categoriesFor: #printAccessorExpressionSuffixOn:!automatic generation!private! !
+	^#byteAtOffset:put:!
+
+characterCreationMessage
+	^#ansiValue:! !
+!CHARField categoriesFor: #accessorMessage!public! !
+!CHARField categoriesFor: #characterCreationMessage!automatic generation!private! !
 
 !CheckBox class methodsFor!
 
@@ -7267,6 +7297,18 @@ publishedAspectsOfInstances
     		add: (Aspect string: #productVersionString) beReadOnly;
     		yourself! !
 !VS_FIXEDFILEINFO class categoriesFor: #publishedAspectsOfInstances!constants!public! !
+
+!WCHARField methodsFor!
+
+accessorMessage
+	"Private - Answer the receiver's 'accessorStem'."
+
+	^#wordAtOffset:put:!
+
+characterCreationMessage
+	^#utf16Value:! !
+!WCHARField categoriesFor: #accessorMessage!automatic generation!private! !
+!WCHARField categoriesFor: #characterCreationMessage!automatic generation!private! !
 
 !WeakSet class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Base/TEXTMETRICW.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/TEXTMETRICW.cls
@@ -74,7 +74,7 @@ tmAveCharWidth
 tmBreakChar
 	"Answer the <Character> value of the receiver's 'tmBreakChar' field."
 
-	^(bytes wordAtOffset: _OffsetOf_tmBreakChar) asCharacter!
+	^Character utf16Value: (bytes wordAtOffset: _OffsetOf_tmBreakChar)!
 
 tmCharSet
 	"Answer the <Integer> value of the receiver's 'tmCharSet' field."
@@ -84,7 +84,7 @@ tmCharSet
 tmDefaultChar
 	"Answer the <Character> value of the receiver's 'tmDefaultChar' field."
 
-	^(bytes wordAtOffset: _OffsetOf_tmDefaultChar) asCharacter!
+	^Character utf16Value: (bytes wordAtOffset: _OffsetOf_tmDefaultChar)!
 
 tmDescent
 	"Answer the <Integer> value of the receiver's 'tmDescent' field."
@@ -109,7 +109,7 @@ tmExternalLeading
 tmFirstChar
 	"Answer the <Character> value of the receiver's 'tmFirstChar' field."
 
-	^(bytes wordAtOffset: _OffsetOf_tmFirstChar) asCharacter!
+	^Character utf16Value: (bytes wordAtOffset: _OffsetOf_tmFirstChar)!
 
 tmHeight
 	"Answer the <Integer> value of the receiver's 'tmHeight' field."
@@ -129,7 +129,7 @@ tmItalic
 tmLastChar
 	"Answer the <Character> value of the receiver's 'tmLastChar' field."
 
-	^(bytes wordAtOffset: _OffsetOf_tmLastChar) asCharacter!
+	^Character utf16Value: (bytes wordAtOffset: _OffsetOf_tmLastChar)!
 
 tmMaxCharWidth
 	"Answer the <Integer> value of the receiver's 'tmMaxCharWidth' field."


### PR DESCRIPTION
If the WCHAR field contains a surrogate, it would not be instantiated
correctly through Character class>>value:, so WCHARField>>readFrom:
should use Character class>>utf16Value: