### PR TITLE
Work in progress on #898

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -352,7 +352,7 @@ SelectableListItemsTest subclass: #ListPresenterTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 SelectableListItemsTest subclass: #ListViewTest
-	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks'
+	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks timedout'
 	classVariableNames: ''
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 SelectableListItemsTest subclass: #ListViewTest
-	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks'
+	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks timedout'
 	classVariableNames: ''
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!
@@ -76,18 +76,39 @@ onSelectionChanged
 onSelectionChanging: aSelectionChangingEvent 
 	selectionChanging value: aSelectionChangingEvent!
 
+onTimerTick: wParam
+	wParam = self timeoutId ifTrue: [
+		timedout := true.
+		presenter view killTimer: self timeoutId.
+		presenter view postMessage: WM_MOUSEMOVE wParam: 0 lParam: 0]!
+
 sendClickEvent: aMouseEvent
+	| pos |
 	self assert: (aMouseEvent isLButtonDown or: [aMouseEvent isRButtonDown]).
 	"Note that the ListView appears to take hold of the message loop in its handler for WM_?BUTTONDOWN, so we post the up before sending the down.
 	The reason this works is that the 'up' will wait in the queue, but the 'down' will be sent straight to the window proc of the list view. That window
 	proc is of course the Dolphin wndproc, which will forward the message into the image, where it will eventually arrive in ListView>>onButtonPressed:
 	When ListView>>onButtonPressed: calls for default window processing (i.e. calls the ListView's actual wnd proc), the LV handler will then consume
 	the mouse up from the queue."
+	pos := POINTL new.
+	UserLibrary default getCursorPos: pos;
+		setCursorPosX: 0 y: 0.
+	SessionManager inputState pumpMessages.
 	presenter view
+		postMessage: aMouseEvent message
+			wParam: aMouseEvent wParam
+			lParam: aMouseEvent lParam;
 		postMessage: aMouseEvent message + 1
-		wParam: (aMouseEvent wParam maskClear: aMouseEvent buttonFlag)
-		lParam: aMouseEvent lParam.
-	self sendEvent: aMouseEvent!
+			wParam: (aMouseEvent wParam maskClear: aMouseEvent buttonFlag)
+			lParam: aMouseEvent lParam.
+	timedout := false.
+	presenter view setTimer: self timeoutId interval: 500.
+	"Dispatch the posted messages to the control"
+	SessionManager inputState pumpMessages.
+	presenter view killTimer: self timeoutId.
+	UserLibrary default setCursorPosX: pos x y: pos y.
+	"If this fires, it means the control did not return from the call to its window proc to handle the button down event in ListView>>onButtonPressed:"
+	self deny: timedout description: 'Control blocked in mouse down handler'!
 
 sendEvent: aMouseEvent 
 	^presenter view sendMessage: aMouseEvent message wParam: aMouseEvent wParam lParam: aMouseEvent lParam!
@@ -128,7 +149,9 @@ setUpForSelectionEventTesting
 	selectionChanged := 
 			[events addLast: ((SelectionChangedEvent forSource: presenter)
 						newSelections: presenter view selectionsByIndex;
-						yourself)]!
+						yourself)].
+	presenter when: #timerTick: send: #onTimerTick: to: self.
+	timedout := false!
 
 setUpForSelectionTesting
 	presenter
@@ -290,72 +313,60 @@ testSelectionEventsFromLeftClick
 	"Test that the expected sequence of selectionChanging: and selectionChanged events are raised for left-click selection.
 	The test sends simulated mouse clicks to the control to try and test the actual control integration."
 
-	| event changing changed click |
 	self setUpForSelectionEventTesting.
-	event := self mouseDownEventOnItem: 2 buttons: #(#left).
-	self sendClickEvent: event.
-	self assert: events size equals: 2.
-	changing := events first.
-	self assert: changing isKindOf: SelectionChangingEvent.
-	self assert: changing oldSelections equals: #().
-	self assert: changing newSelections equals: #(2).
-	changed := events last.
-	self assert: changed isKindOf: SelectionChangedEvent.
-	self assert: changed newSelections equals: #(2).
-	self assert: clicks size equals: 1.
-	click := clicks first.
-	self assert: click iItem equals: 2 - 1.
-	self assert: click position equals: event lParamX @ event lParamY.
-	"Send a shift-left-click event over a subsequent item."
-	events := OrderedCollection new.
-	clicks := OrderedCollection new.
-	event := self mouseDownEventOnItem: 4 buttons: #(#left #shift).
-	self sendClickEvent: event.
-	self assert: events size equals: 2.
-	changing := events first.
-	self assert: changing isKindOf: SelectionChangingEvent.
-	self assert: changing oldSelections equals: #(2).
-	self assert: changing newSelections equals: self expectedSelectionsForSendShiftClickTests.
-	changed := events last.
-	self assert: changed isKindOf: SelectionChangedEvent.
-	self assert: changed newSelections equals: self expectedSelectionsForSendShiftClickTests.
-	self assert: clicks size equals: 1.
-	self assert: clicks size equals: 1.
-	click := clicks first.
-	self assert: click iItem equals: 4 - 1.
-	self assert: click position equals: event lParamX @ event lParamY!
+	self verifyEventsFromClickConfirmed: #left!
 
 testSelectionEventsFromLeftClickDenied
 	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is denied
 	but without a prompt so the control still receives the mouse up."
 
-	| event changing |
 	self setUpForSelectionEventTesting.
-	event := self mouseDownEventOnItem: 2 buttons: #(#left).
 	selectionChanging := 
 			[:selChanging |
 			events addLast: selChanging.
 			selChanging value: false].
-	self sendClickEvent: event.
-	self assert: events size equals: 1.
-	changing := events first.
-	self assert: changing isKindOf: SelectionChangingEvent.
-	self assert: changing oldSelections equals: #().
-	self assert: changing newSelections equals: #(2).
-	"Because we didn't forward the button down event to the control, there should be no click notification."
-	self assert: clicks size equals: 0.
-	"Ensure there is a selection and then send a shift-left-click event over a subsequent item."
-	presenter view selectionByIndex: 2.
-	events := OrderedCollection new.
-	clicks := OrderedCollection new.
-	event := self mouseDownEventOnItem: 4 buttons: #(#left #shift).
-	self sendClickEvent: event.
-	self assert: events size equals: 1.
-	changing := events first.
-	self assert: changing isKindOf: SelectionChangingEvent.
-	self assert: changing oldSelections equals: #(2).
-	self assert: changing newSelections equals: self expectedSelectionsForSendShiftClickTests.
-	self assert: clicks size equals: 0!
+	self verifyEventsFromClickDenied: #left!
+
+testSelectionEventsFromLeftClickPromptConfirmed
+	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is confirmed with a prompt so the control does not receive the mouse up associated with the actual click.
+	Regression test for #898."
+
+	"Test fails because the listview blocks in a modal message loop in its WM_LBUTTONDOWN handler"
+	self skipIfCiBuild.
+	self setUpForSelectionEventTesting.
+	selectionChanging := 
+			[:selChanging |
+			| msg |
+			events addLast: selChanging.
+			"Consume the mouse up so the control does not receive it."
+			msg := MSG new.
+			UserLibrary default
+				getMessage: msg
+				hWnd: presenter view handle
+				wMsgFilterMin: WM_LBUTTONUP
+				wMsgFilterMax: WM_LBUTTONUP.
+			"Allow the selection change to proceed"
+			selChanging value: true].
+	self verifyEventsFromClickConfirmed: #left!
+
+testSelectionEventsFromLeftClickPromptDenied
+	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is denied with a prompt so the control does not receive the mouse up associated with the actual click."
+
+	self setUpForSelectionEventTesting.
+	selectionChanging := 
+			[:selChanging |
+			| msg |
+			events addLast: selChanging.
+			"Snaffle the mouse up to try and simulate the appearance of a prompt"
+			msg := MSG new.
+			UserLibrary default
+				getMessage: msg
+				hWnd: presenter view handle
+				wMsgFilterMin: WM_LBUTTONUP
+				wMsgFilterMax: WM_LBUTTONUP.
+			"Prevent the selection change from proceeding"
+			selChanging value: false].
+	self verifyEventsFromClickDenied: #left!
 
 testSelectionRemainsVisibleOnSort
 	"#1381"
@@ -396,7 +407,69 @@ testSetTextImageDoesNotAffectSelection
 			self
 				shouldnt: [presenter selectionByIndex: 2]
 				trigger: #selectionChanging:
-				against: presenter]! !
+				against: presenter]!
+
+timeoutId
+	^171717!
+
+verifyEventsFromClickConfirmed: aSymbol
+	| changed changing click event |
+	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
+	self sendClickEvent: event.
+	self assert: events size equals: 2.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #().
+	self assert: changing newSelections equals: #(2).
+	changed := events last.
+	self assert: changed isKindOf: SelectionChangedEvent.
+	self assert: changed newSelections equals: #(2).
+	self assert: clicks size equals: 1.
+	click := clicks first.
+	self assert: click iItem equals: 2 - 1.
+	self assert: click position equals: event lParamX @ event lParamY.
+	"Send a shift-left-click event over a subsequent item."
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
+	event := self mouseDownEventOnItem: 4 buttons: {aSymbol. #shift}.
+	self sendClickEvent: event.
+	self assert: events size equals: 2.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #(2).
+	self assert: changing newSelections equals: self expectedSelectionsForSendShiftClickTests.
+	changed := events last.
+	self assert: changed isKindOf: SelectionChangedEvent.
+	self assert: changed newSelections equals: self expectedSelectionsForSendShiftClickTests.
+	self assert: clicks size equals: 1.
+	self assert: clicks size equals: 1.
+	click := clicks first.
+	self assert: click iItem equals: 4 - 1.
+	self assert: click position equals: event lParamX @ event lParamY!
+
+verifyEventsFromClickDenied: aSymbol
+	| event changing |
+	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
+	self sendClickEvent: event.
+	self assert: events size equals: 1.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #().
+	self assert: changing newSelections equals: #(2).
+	"Because we didn't forward the button down event to the control, there should be no click notification."
+	self assert: clicks size equals: 0.
+	"Ensure there is a selection and then send a shift-left-click event over a subsequent item."
+	presenter view selectionByIndex: 2.
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
+	event := self mouseDownEventOnItem: 4 buttons: {aSymbol. #shift}.
+	self sendClickEvent: event.
+	self assert: events size equals: 1.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #(2).
+	self assert: changing newSelections equals: self expectedSelectionsForSendShiftClickTests.
+	self assert: clicks size equals: 0! !
 !ListViewTest categoriesFor: #assertCaretVisible!helpers!private! !
 !ListViewTest categoriesFor: #classToTest!helpers!private! !
 !ListViewTest categoriesFor: #expectedSelectionsForSendShiftClickTests!constants!private! !
@@ -405,6 +478,7 @@ testSetTextImageDoesNotAffectSelection
 !ListViewTest categoriesFor: #mouseDownEventOnItem:buttons:!helpers!private! !
 !ListViewTest categoriesFor: #onSelectionChanged!helpers!private! !
 !ListViewTest categoriesFor: #onSelectionChanging:!helpers!private! !
+!ListViewTest categoriesFor: #onTimerTick:!helpers!private! !
 !ListViewTest categoriesFor: #sendClickEvent:!helpers!private! !
 !ListViewTest categoriesFor: #sendEvent:!helpers!private! !
 !ListViewTest categoriesFor: #setColumns:!helpers!private! !
@@ -421,7 +495,12 @@ testSetTextImageDoesNotAffectSelection
 !ListViewTest categoriesFor: #testProgrammaticSelectionVisible!public!unit tests! !
 !ListViewTest categoriesFor: #testSelectionEventsFromLeftClick!public!unit tests! !
 !ListViewTest categoriesFor: #testSelectionEventsFromLeftClickDenied!public!unit tests! !
+!ListViewTest categoriesFor: #testSelectionEventsFromLeftClickPromptConfirmed!public!unit tests! !
+!ListViewTest categoriesFor: #testSelectionEventsFromLeftClickPromptDenied!public!unit tests! !
 !ListViewTest categoriesFor: #testSelectionRemainsVisibleOnSort!public!unit tests! !
 !ListViewTest categoriesFor: #testSetTextBlockDoesNotAffectSelection!public!unit tests! !
 !ListViewTest categoriesFor: #testSetTextImageDoesNotAffectSelection!public!unit tests! !
+!ListViewTest categoriesFor: #timeoutId!constants!private! !
+!ListViewTest categoriesFor: #verifyEventsFromClickConfirmed:!helpers!private! !
+!ListViewTest categoriesFor: #verifyEventsFromClickDenied:!helpers!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -135,7 +135,7 @@ testNewSelectionsShiftClickWithSelectionMark
 testSelectionEventsFromLeftClick
 	"Fails because of duplicated selectionChanging: event. To be deleted when that bug is fixed."
 
-	self skip.
+	self skipIfCiBuild.
 	super testSelectionEventsFromLeftClick!
 
 testSelectionsByIndex

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/BasicListAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/BasicListAbstract.cls
@@ -174,14 +174,6 @@ refreshContents
 	self basicRefreshContents.
 	self onSelChanged!
 
-selectIndices: aCollection set: aBoolean 
-	"Private - Set/clear (dependeing on the boolean argument) the selection status of the items
-	in the receiver with the <integer> in the <collection>, argument."
-
-	self isMultiSelect 
-		ifTrue: [aCollection do: [:each | self selectIndex: each set: aBoolean]]
-		ifFalse: [self setSingleSelection: aCollection first]!
-
 selections: aCollection ifAbsent: aNiladicOrMonadicValuable
 	"Select the first occurrences of the specified collection of <Object>s in the receiver and
 	answer the new selection. If any of the elements of the collection are not present in the
@@ -262,7 +254,6 @@ updateSelectionCache
 !BasicListAbstract categoriesFor: #onSelChanging:cause:!event handling!private! !
 !BasicListAbstract categoriesFor: #onViewCreated!event handling!public! !
 !BasicListAbstract categoriesFor: #refreshContents!public!updating! !
-!BasicListAbstract categoriesFor: #selectIndices:set:!public!selection! !
 !BasicListAbstract categoriesFor: #selections:ifAbsent:!public!selection! !
 !BasicListAbstract categoriesFor: #selectionsByIndex:ifAbsent:!public!selection! !
 !BasicListAbstract categoriesFor: #selectionState!accessing!private! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
@@ -374,11 +374,13 @@ selectIndex: anInteger set: aBoolean
 
 	^self errorNotMultiSelect!
 
-selectIndices: indices set: aBoolean
-	"Private - Set/clear selection status of the items in the receiver with the <integer>
-	indices in the <collection>, indices."
-	
-	^self subclassResponsibility!
+selectIndices: aCollection set: aBoolean 
+	"Private - Set/clear (dependeing on the boolean argument) the selection status of the items
+	in the receiver with the <integer> in the <collection>, argument."
+
+	self isMultiSelect 
+		ifTrue: [aCollection do: [:each | self selectIndex: each set: aBoolean]]
+		ifFalse: [self setSingleSelection: aCollection first]!
 
 selection
 	"Answer the selected object, or signal an <Error> if there is no selection."

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
@@ -637,14 +637,6 @@ queryCommand: aCommandQuery
 renameIt
 	self canEditLabels ifTrue: [self editSelectionLabel]!
 
-selectIndices: aCollection set: aBoolean 
-	"Private - Set/clear (dependeing on the boolean argument) the selection status of the items
-	in the receiver with the <integer> in the <collection>, argument."
-
-	self isMultiSelect 
-		ifTrue: [aCollection do: [:each | self selectIndex: each set: aBoolean]]
-		ifFalse: [self setSingleSelection: aCollection first]!
-
 selectionState
 	^MessageSend 
 		receiver: self 
@@ -800,7 +792,6 @@ wmDestroy: message wParam: wParam lParam: lParam
 !IconicListAbstract categoriesFor: #positionForKeyboardContextMenu!enquiries!public! !
 !IconicListAbstract categoriesFor: #queryCommand:!commands!public! !
 !IconicListAbstract categoriesFor: #renameIt!commands!public! !
-!IconicListAbstract categoriesFor: #selectIndices:set:!public!selection! !
 !IconicListAbstract categoriesFor: #selectionState!accessing!private! !
 !IconicListAbstract categoriesFor: #setViewMode:!accessing!private! !
 !IconicListAbstract categoriesFor: #showDragDrop:highlight:!drag & drop!event handling!public! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -535,15 +535,17 @@ editLabelStyle
 
 	^LVS_EDITLABELS!
 
+ensureItemsVisible: indices
+	| caret |
+	caret := self caretIndex.
+	self ensureVisible: ((indices isEmpty or: [indices includes: caret])
+				ifTrue: [caret]
+				ifFalse: [indices first])!
+
 ensureSelectionVisible
 	"Ensure the selected item is visible, scrolling it into view if necessary."
 
-	| caret selected |
-	caret := self caretIndex.
-	selected := self selectionsByIndex.
-	self ensureVisible: ((selected isEmpty or: [selected includes: caret])
-				ifTrue: [caret]
-				ifFalse: [selected first])!
+	self ensureItemsVisible: self selectionsByIndex!
 
 ensureVisible: anInteger 
 	"Ensure the item with the specified index is visible, scrolling it into view if necessary."
@@ -634,12 +636,27 @@ getMultipleSelections
 
 	^self withOldWndProc: 
 			[| count index answer |
-			count := self selectedCount.
+			count := self getSelectedCount.
 			answer := Array new: count.
 			index := -1.
 			1 to: count
 				do: [:i | answer at: i put: (index := self lvmGetNextItem: index flags: LVNI_SELECTED) + 1].
 			answer]!
+
+getSelectedCount
+	"Private - Query the total number of items selected from the control."
+
+	^self sendMessage: LVM_GETSELECTEDCOUNT!
+
+getSelectionsByIndex
+	"Private - Query the actual current selections from the control."
+
+	^self isMultiSelect
+		ifTrue: [self getMultipleSelections]
+		ifFalse: 
+			[| index |
+			index := self getSingleSelection.
+			index == 0 ifTrue: [#()] ifFalse: [{index}]]!
 
 getSingleSelection
 	"Private - Answer the one-based <integer> index of the selected object in the receiver or
@@ -1034,9 +1051,6 @@ largeIconMode
 
 lastSelIndices
 	^lastSelIndices!
-
-lastSelIndices: anArray 
-	lastSelIndices := anArray!
 
 listMode
 	"Place the receiver in list mode"
@@ -1499,7 +1513,7 @@ lvnODStateChanged: pNMHDR
 
 	^nil!
 
-maybeSelChanging: aSymbol 
+maybeSelChanging: aSymbol
 	"Private - The selection may be changing as a result of a user action (e.g. due to a keypress). 
 	The argument is either #mouse, or #keyboard, indicating the source of the user input that
 	is initiating the selection change. Give the presenter/view a chance to change their mind."
@@ -1507,16 +1521,16 @@ maybeSelChanging: aSymbol
 	"See if the change is acceptable, and if not revert to original selection if there was one"
 
 	| curSel |
-	curSel := self selectionsByIndex.
+	curSel := self getSelectionsByIndex.
 	curSel = lastSelIndices ifTrue: [^self].
-	(self onSelChanging: curSel cause: aSymbol) 
+	(self onSelChanging: curSel cause: aSymbol)
 		ifFalse: 
-			[self 
+			[self
 				postMessage: RevertSelMessage
 				wParam: 0
 				lParam: 0.
 			^self].
-	self onSelChanged!
+	self onSelChanged: curSel!
 
 newSelectionsFromEvent: event
 	"Private - Answer a collection of the <integer> selections that would occur if the <MouseEvent>,
@@ -1526,7 +1540,7 @@ newSelectionsFromEvent: event
 	itemClicked := self itemFromPoint: event position.
 	"In single-select mode, the new selection is always the item clicked, or nothing if the click is outside all items."
 	self isMultiSelect ifFalse: [^itemClicked ifNil: [#()] ifNotNil: [:item | {item}]].
-	newSelections := self selectionsByIndex.
+	newSelections := self getSelectionsByIndex.
 	anyKeysDown := event isShiftDown or: [event isCtrlDown].
 	"If the click is outside all items, and ctrl or shift is down, nothing changes."
 	(itemClicked isNil and: [anyKeysDown]) ifTrue: [^newSelections].
@@ -1619,16 +1633,20 @@ nmRClick: pNMHDR
 	self isMultiSelect ifTrue: [self maybeSelChanging: #mouse].
 	^super nmRClick: pNMHDR!
 
+nmSelChanged: anExternalAddress 
+	"Private - Default handler for the ??N_SELCHANGED notification message."
+
+	"We don't expect to receive this for ListViews."
+
+	self shouldNotImplement!
+
 notificationClass
 	"Private - Answer the class of NM_XXXXVIEW structure associated with the receiver."
 
 	^NMLISTVIEW!
 
 onButtonPressed: aMouseEvent
-	"Private - Common handler for a button down mouse event. Look for potential
-	selection change events, and fire a #selectionChanging: event if necessary.
-	The mouse event is only allowed to propagate to the control if we are happy that 
-	the selection should indeed be changed."
+	"Private - Common handler for a button down mouse event. Look for potential selection change events, and fire a #selectionChanging: event if necessary. The mouse event is only allowed to propagate to the control if we are happy that the selection should indeed be changed."
 
 	| indices |
 	indices := self newSelectionsFromEvent: aMouseEvent.
@@ -1638,7 +1656,7 @@ onButtonPressed: aMouseEvent
 			[(self onSelChanging: indices cause: #mouse)
 				ifTrue: 
 					[| answer |
-					"Selection change permitted?"
+					"Selection change permitted"
 					answer := aMouseEvent defaultWindowProcessing.
 					self onSelChanged.	"Selection may have changed"
 					answer]
@@ -1803,6 +1821,13 @@ onRightButtonPressed: aMouseEvent
 	self presenter trigger: #rightButtonPressed: with: aMouseEvent.
 	^self onButtonPressed: aMouseEvent!
 
+onSelChanged
+	"Private - Handle a selection change event by forwarding to the presenter."
+
+	| selections |
+	selections := self getSelectionsByIndex.
+	selections = lastSelIndices ifFalse: [self onSelChanged: selections]!
+
 onSelChanged: anArray 
 	lastSelIndices := anArray.
 	super onSelChanged: anArray!
@@ -1828,7 +1853,7 @@ onSelRemoved
 	"Private - A selected item has been removed. Update the receiver's selection state to
 	account."
 
-	self onSelChanged: self selectionsByIndex!
+	self onSelChanged: self getSelectionsByIndex!
 
 onViewCreated
 	"The receiver window has been created. Copy the info held
@@ -1961,7 +1986,7 @@ selectAll
 selectedCount
 	"Private - Answer the total number of items selected in the receiver."
 
-	^self sendMessage: LVM_GETSELECTEDCOUNT!
+	^lastSelIndices size!
 
 selectIndex: anInteger set: aBoolean
 	"Private - Set/reset the selection state of the object at the specified one-based <integer>
@@ -1986,8 +2011,13 @@ selections: aCollection ifAbsent: aNiladicOrMonadicValuable
 	self setSelectionsByIndex: indices.
 	^missing isEmpty ifTrue: [aCollection] ifFalse: [aNiladicOrMonadicValuable cull: missing]!
 
+selectionsByIndex
+	"Answer an <Array> of the <integer> the indices of the selected items 	in the receiver in ascending order. The array will be empty if there is no selection."
+
+	^lastSelIndices!
+
 selectionsByIndex: aCollection ifAbsent: exceptionHandler
-	"Select the objects identified by the <collection> of <integer> indices, indices, in the
+	"Select the objects identified by the <collection> of <integer> indices, aCollection, in the
 	receiver. If any of the indices are out of bounds, then evaluate the <monadicValuable>,
 	exceptionHandler, passing it a <collection> of the offending indices. For backwards
 	compatibility with the superclass implementation, exceptionHandler can also be a
@@ -2027,13 +2057,14 @@ setControlBackcolor: aColor
 setIconSpacing: aPointOrNil
 	self lvmSetIconSpacing: aPointOrNil ?? (-1 @ -1)!
 
-setSelectionsByIndex: indices 
+setSelectionsByIndex: indices
+	| selections |
 	(indices noDifference: lastSelIndices) ifTrue: [^self].
 	self basicSelectionsByIndex: indices.
-	self ensureSelectionVisible.
-	"Note: We have to check again whether the selection has changed because of the single-select
-	case - onSelChanged does this."
-	self onSelChanged!
+	"Use the actual selections that resulted"
+	selections := self getSelectionsByIndex.
+	self ensureItemsVisible: selections.
+	self onSelChanged: selections!
 
 setSingleSelection: anInteger 
 	self selectIndex: anInteger set: anInteger ~~ 0!
@@ -2223,7 +2254,10 @@ updateItem: anObject atIndex: anInteger
 				afterIndex: anInteger - 1]!
 
 updateSelectionCache
-	lastSelIndices notEmpty ifTrue: [lastSelIndices := self selectionsByIndex]!
+	"Private - The receiver's model is being modified, so we may need to account for selection changes caused by that.
+	Of course this can't add a selection if there is none."
+
+	lastSelIndices notEmpty ifTrue: [lastSelIndices := self getSelectionsByIndex]!
 
 viewMode
 	"Answer the view mode of the receiver.
@@ -2318,6 +2352,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #defaultWindowStyle!constants!private! !
 !ListView categoriesFor: #dispatchRegistered:wParam:lParam:!operations!private! !
 !ListView categoriesFor: #editLabelStyle!constants!private! !
+!ListView categoriesFor: #ensureItemsVisible:!helpers!private! !
 !ListView categoriesFor: #ensureSelectionVisible!public!selection! !
 !ListView categoriesFor: #ensureVisible:!operations!public! !
 !ListView categoriesFor: #errorInCommonControlCall:!exceptions!private! !
@@ -2327,6 +2362,8 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #forgetLastClickedColumn!helpers!private! !
 !ListView categoriesFor: #getItemText:!accessing!private! !
 !ListView categoriesFor: #getMultipleSelections!private!selection! !
+!ListView categoriesFor: #getSelectedCount!private!selection! !
+!ListView categoriesFor: #getSelectionsByIndex!private!selection! !
 !ListView categoriesFor: #getSingleSelection!private!selection! !
 !ListView categoriesFor: #getThumbnailOf:!helpers!private! !
 !ListView categoriesFor: #hasBorderSelect!accessing-styles!public! !
@@ -2381,7 +2418,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #largeIconExtent:!constants!public! !
 !ListView categoriesFor: #largeIconMode!commands!public! !
 !ListView categoriesFor: #lastSelIndices!accessing!private! !
-!ListView categoriesFor: #lastSelIndices:!accessing!private! !
 !ListView categoriesFor: #listMode!commands!public! !
 !ListView categoriesFor: #listViewStyleAllMask:!accessing-styles!private! !
 !ListView categoriesFor: #listViewStyleMask:set:!accessing-styles!private! !
@@ -2408,7 +2444,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #lvmGetNextItem:flags:!accessing!private! !
 !ListView categoriesFor: #lvmGetOrigin!accessing!private! !
 !ListView categoriesFor: #lvmGetStringWidth:!accessing!private! !
-!ListView categoriesFor: #lvmGetSubItemRect:subitem:bounding:!private! !
+!ListView categoriesFor: #lvmGetSubItemRect:subitem:bounding:!geometry!private! !
 !ListView categoriesFor: #lvmGetView!accessing-styles!private! !
 !ListView categoriesFor: #lvmGetViewRect!geometry!private! !
 !ListView categoriesFor: #lvmInsertAt:column:!adding!private! !
@@ -2452,6 +2488,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #nmClick:!event handling-win32!private! !
 !ListView categoriesFor: #nmNotify:!event handling-win32!private! !
 !ListView categoriesFor: #nmRClick:!event handling-win32!private! !
+!ListView categoriesFor: #nmSelChanged:!event handling-win32!private! !
 !ListView categoriesFor: #notificationClass!constants!private! !
 !ListView categoriesFor: #onButtonPressed:!event handling!private! !
 !ListView categoriesFor: #onDisplayDetailsRequired:!event handling!private! !
@@ -2464,6 +2501,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #onLeftButtonPressed:!event handling!public! !
 !ListView categoriesFor: #onPositionChanged:!event handling!public! !
 !ListView categoriesFor: #onRightButtonPressed:!event handling!public! !
+!ListView categoriesFor: #onSelChanged!private!selection! !
 !ListView categoriesFor: #onSelChanged:!event handling!private! !
 !ListView categoriesFor: #onSelChanging:cause:!event handling!private! !
 !ListView categoriesFor: #onSelRemoved!public!selection! !
@@ -2483,6 +2521,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #selectedCount!private!selection! !
 !ListView categoriesFor: #selectIndex:set:!private!selection!wine fix! !
 !ListView categoriesFor: #selections:ifAbsent:!public!selection! !
+!ListView categoriesFor: #selectionsByIndex!public!selection! !
 !ListView categoriesFor: #selectionsByIndex:ifAbsent:!public!selection! !
 !ListView categoriesFor: #setColumnIcon:atIndex:!helpers!private! !
 !ListView categoriesFor: #setControlBackcolor:!helpers!private! !
@@ -2497,7 +2536,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #smallIconMode!commands!public! !
 !ListView categoriesFor: #sortOnColumn:!columns!public!sorting! !
 !ListView categoriesFor: #state!accessing!private! !
-!ListView categoriesFor: #stateImageFromRow:!private! !
+!ListView categoriesFor: #stateImageFromRow:!helpers!private! !
 !ListView categoriesFor: #subItemRectRow:column:!geometry!public! !
 !ListView categoriesFor: #text:!accessing!public! !
 !ListView categoriesFor: #textFromRow:!adapters!private! !


### PR DESCRIPTION
Adds tests for the scenario in the bug where the ListView WM_LBUTTONDOWN
handler blocks and does not return until there is a mouse move over a
Dolphin window.

The ListView now uses its selection cache to answer selection queries
rather than querying the control every time. I made this change to reduce
the volume of output from debugging instrumentation I was using when
constructing the tests, but it should improve performance of many common
scenarios using ListViews.