### PR TITLE
Fix #908: `IMatch>>value` returns Utf8String, should be Utf16String

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/Automation/ActiveX Automation Tests.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/ActiveX Automation Tests.pax
@@ -5,6 +5,7 @@ package paxVersion: 1;
 
 
 package classNames
+	add: #BSTRTest;
 	add: #IDispatchTest;
 	add: #SAFEARRAYTest;
 	add: #VARIANTTest;
@@ -32,6 +33,11 @@ package!
 
 "Class Definitions"!
 
+DolphinTest subclass: #BSTRTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
 DolphinTest subclass: #IDispatchTest
 	instanceVariableNames: ''
 	classVariableNames: ''

--- a/Core/Object Arts/Dolphin/ActiveX/Automation/BSTRTest.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/BSTRTest.cls
@@ -1,0 +1,40 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #BSTRTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+BSTRTest guid: (GUID fromString: '{d5abc1df-26e1-4722-bcb6-51e4b5c406f6}')!
+BSTRTest comment: ''!
+!BSTRTest categoriesForClass!Unclassified! !
+!BSTRTest methodsFor!
+
+stringConversionCases
+	^#('' 'a£🍺ö' 'Ḽơᶉëᶆ ȋṕšᶙṁ ḍỡḽǭᵳ ʂǐť ӓṁệẗ, ĉṓɲṩḙċťᶒțûɾ ấɖḯƥĭṩčįɳġ ḝłįʈ, șếᶑ ᶁⱺ ẽḭŭŝḿꝋď ṫĕᶆᶈṓɍ ỉñḉīḑȋᵭṵńť ṷŧ ḹẩḇőꝛế éȶ đꝍꞎôꝛȇ ᵯáꞡᶇā ąⱡîɋṹẵ')!
+
+testAsString
+	self stringConversionCases do: 
+			[:each |
+			| subject ptr |
+			subject := BSTR fromString: each.
+			self assert: subject asString isKindOf: Utf16String.
+			self assert: subject asString equals: each.
+			ptr := LPBSTR fromAddress: subject basicYourAddress.
+			self assert: ptr asString isKindOf: Utf16String.
+			self assert: ptr asString equals: each]!
+
+testAsUtf8String
+	self stringConversionCases do: 
+			[:each |
+			| subject ptr |
+			subject := BSTR fromString: each.
+			self assert: subject asUtf8String isKindOf: Utf8String.
+			self assert: subject asUtf8String equals: each.
+			ptr := LPBSTR fromAddress: subject basicYourAddress.
+			self assert: ptr asUtf8String isKindOf: Utf8String.
+			self assert: ptr asUtf8String equals: each]! !
+!BSTRTest categoriesFor: #stringConversionCases!constants!private! !
+!BSTRTest categoriesFor: #testAsString!public!unit tests! !
+!BSTRTest categoriesFor: #testAsUtf8String!public!unit tests! !
+

--- a/Core/Object Arts/Dolphin/ActiveX/Automation/LPBSTR.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/LPBSTR.cls
@@ -21,19 +21,23 @@ Note that because BSTR is an indirection class (BSTRs are pointers to strings), 
 !LPBSTR methodsFor!
 
 asString
-	"Answer a String composed of the characters of the receiver, or
-	the empty string if the receiver is a null pointer."
+	"Answer a `String` composed of the characters of the receiver, or the empty string if the receiver is a null pointer."
 
-	^self asUtf16String asString!
+	^self asUtf16String!
 
 asUtf16String
-	"Answer a Utf16String composed of the characters of the BSTR pointed at by the receiver
-	(assumed itself to be UTF-16 encoded), or the empty string if the referenced BSTR is a null
-	pointer (by convention a null BSTR is treated the same as an empty string)."
+	"Answer a `Utf16String` composed of the characters of the BSTR pointed at by the receiver (assumed itself to be UTF-16 encoded), or the empty string if the referenced BSTR is a null pointer (by convention a null BSTR is treated the same as an empty string)."
 
 	| bstr |
 	bstr := bytes uintPtrAtOffset: 0.
-	^Utf16String fromAddress: bstr length: (OLEAutLibrary default sysStringLen: bstr)!
+	^bstr == 0
+		ifTrue: [Utf16String empty]
+		ifFalse: [Utf16String fromAddress: bstr length: (OLEAutLibrary default sysStringLen: bstr)]!
+
+asUtf8String
+	"Answer a `Utf8String` containing the same code points as the UTF-16 encoded BSTR pointed at by the receiver, or the empty string if the referenced BSTR is a null pointer (by convention a null BSTR is treated the same as an empty string)."
+
+	^self asUtf16String asUtf8String!
 
 value
 	"Answer the <String> pointed at by the receiver (N.B. it is copied into Smalltalk space)"
@@ -55,6 +59,7 @@ value: aString
 	super value: bstr detach! !
 !LPBSTR categoriesFor: #asString!converting!public! !
 !LPBSTR categoriesFor: #asUtf16String!converting!public! !
+!LPBSTR categoriesFor: #asUtf8String!converting!public! !
 !LPBSTR categoriesFor: #value!accessing!public! !
 !LPBSTR categoriesFor: #value:!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/ActiveX/COM/BSTR.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/COM/BSTR.cls
@@ -23,9 +23,7 @@ BSTRs use finalization to safely manage the sys. alloc''d string, but they may b
 !BSTR methodsFor!
 
 asAnsiString
-	"Answer an ANSI-encoded string representation of the receiver. If any of the elements of the
-	receiver cannot be represented as ANSI code points, then these will be translated to the
-	default character ($?)."
+	"Answer an ANSI-encoded string representation of the receiver. If any of the elements of the receiver cannot be represented as ANSI code points, then these will be translated to the default replacement character ($?)."
 
 	^self asByteString: AnsiString!
 
@@ -54,16 +52,14 @@ asByteString: aClass
 	^buf!
 
 asString
-	"Answer an byte-encoded string representation of the receiver."
+	"Answer a <String> representation of the receiver."
 
-	^self asByteString: Utf8String!
+	^self asUtf16String!
 
 asUtf16String
-	"Answer a Utf16String composed of the characters of the receiver (assumed itself to be UTF-16
-	encoded), or the empty string if the receiver is a null pointer (by convention a null BSTR
-	is treated the same as an empty string)."
+	"Answer a `Utf16String` composed of the characters of the receiver (assumed itself to be UTF-16 encoded), or the empty string if the receiver is a null pointer (by convention a null BSTR is treated the same as an empty string)."
 
-	^Utf16String fromAddress: self length: self size!
+	^self isNull ifTrue: [Utf16String empty] ifFalse: [Utf16String fromAddress: self length: self size]!
 
 asUtf8String
 	"Answer a UTF-8 encoded <readableString> representation of the receiver."


### PR DESCRIPTION
Change BSTR>>asString to return a Utf16String, which is the native format. This means that, for example, the following works:
```smalltalk
input := 'This is a 🐬 another 🐬'.
regex := IRegExp2 pattern: 'a 🐬'.
matches := regex execute: input.
match := matches first.	"an IMatch2('a 🐬')"
match range size = match value size. "true"
```