### PR TITLE
Work in progress on #898: Refactor ListControlView>>selectionsByIndex, etc

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Base/MouseEvent.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/MouseEvent.cls
@@ -25,6 +25,9 @@ buttonFlag
 
 	^self button ifNil: [0] ifNotNil: [:button | self class wParamFlags at: button]!
 
+isButtonDown
+	^wParam anyMask: ##(MK_LBUTTON | MK_RBUTTON | MK_MBUTTON | MK_XBUTTON1 | MK_XBUTTON2)!
+
 isCtrlDown
 	"Answer whether the control key is down."
 
@@ -45,6 +48,9 @@ isRButtonDown
 
 	^wParam anyMask: MK_RBUTTON!
 
+isSelectionButtonDown
+	^wParam anyMask: ##(MK_LBUTTON | MK_RBUTTON)!
+
 isShiftDown
 	"Answer whether the shift key is down."
 
@@ -55,15 +61,28 @@ isXButtonDown: anInteger
 
 	(anInteger between: 1 and: 2)
 		ifFalse: [self error: 'Invalid X button number: ' , anInteger displayString].
-	^wParam anyMask: (MK_XBUTTON1 bitShift: anInteger - 1)! !
+	^wParam anyMask: (MK_XBUTTON1 bitShift: anInteger - 1)!
+
+printWParamOn: aStream
+	| first |
+	first := true.
+	#('MK_CONTROL' 'MK_SHIFT' 'MK_LBUTTON' 'MK_RBUTTON' 'MK_MBUTTON' 'MK_XBUTTON1' 'MK_XBUTTON2') do: 
+			[:each |
+			(wParam allMask: (Win32Constants at: each))
+				ifTrue: 
+					[first ifTrue: [first := false] ifFalse: [aStream nextPut: $|].
+					aStream nextPutAll: each]]! !
 !MouseEvent categoriesFor: #button!accessing!public! !
 !MouseEvent categoriesFor: #buttonFlag!accessing!public! !
+!MouseEvent categoriesFor: #isButtonDown!helpers!private! !
 !MouseEvent categoriesFor: #isCtrlDown!public!testing! !
 !MouseEvent categoriesFor: #isLButtonDown!public!testing! !
 !MouseEvent categoriesFor: #isMButtonDown!public!testing! !
 !MouseEvent categoriesFor: #isRButtonDown!public!testing! !
+!MouseEvent categoriesFor: #isSelectionButtonDown!public!testing! !
 !MouseEvent categoriesFor: #isShiftDown!public!testing! !
 !MouseEvent categoriesFor: #isXButtonDown:!public!testing! !
+!MouseEvent categoriesFor: #printWParamOn:!development!printing!private! !
 
 !MouseEvent class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Base/PointEvent.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/PointEvent.cls
@@ -15,6 +15,12 @@ position
 
 	^self x @ self y!
 
+printLParamOn: aStream 
+	"Private - Append a textual representation of the receiver's lParam to aStream, in a format
+	appropriate for the type of event."
+
+	aStream print: self position!
+
 screenPosition
 	"Answer the point stored in the receiver's lParam mapped to screen coordinates"
 
@@ -30,6 +36,7 @@ y
 
 	^self lParamY! !
 !PointEvent categoriesFor: #position!accessing!public! !
+!PointEvent categoriesFor: #printLParamOn:!printing!private! !
 !PointEvent categoriesFor: #screenPosition!accessing!public! !
 !PointEvent categoriesFor: #x!accessing!public! !
 !PointEvent categoriesFor: #y!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/WindowsEvent.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/WindowsEvent.cls
@@ -75,13 +75,21 @@ printOn: aStream
 	aStream
 		print: self window;
 		space.
-	msg isNil ifTrue: [self message printOn: aStream base: 16 showRadix: true] ifFalse: [aStream nextPutAll: msg].
-	aStream
-		space;
-		print: self wParam;
-		space.
+	msg isNil
+		ifTrue: 
+			[self message
+				printOn: aStream
+				base: 16
+				showRadix: true]
+		ifFalse: [aStream nextPutAll: msg].
+	aStream space.
+	self printWParamOn: aStream.
+	aStream space.
 	self printLParamOn: aStream.
 	aStream nextPut: $)!
+
+printWParamOn: aStream
+	aStream print: self wParam!
 
 window: aView message: msgInteger wParam: wInteger lParam: lInteger
 	"Private - Initialize the receiver's instance variables from the parameters."
@@ -101,8 +109,9 @@ wParam
 !WindowsEvent categoriesFor: #lResult!accessing!public! !
 !WindowsEvent categoriesFor: #lResult:!accessing!not an aspect!public! !
 !WindowsEvent categoriesFor: #message!accessing!private! !
-!WindowsEvent categoriesFor: #printLParamOn:!printing!private! !
+!WindowsEvent categoriesFor: #printLParamOn:!development!printing!private! !
 !WindowsEvent categoriesFor: #printOn:!development!printing!public! !
+!WindowsEvent categoriesFor: #printWParamOn:!development!printing!private! !
 !WindowsEvent categoriesFor: #window:message:wParam:lParam:!initializing!private! !
 !WindowsEvent categoriesFor: #wParam!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Deprecated/MultipleSelectionListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Deprecated/MultipleSelectionListView.cls
@@ -32,7 +32,7 @@ selection: newSelection ifAbsent: exceptionHandler
 selectionByIndex
 	"Legacy behaviour was to redefine the result to be a collection."
 
-	^self getMultipleSelections!
+	^self selectionsByIndex!
 
 selectionByIndex: anInteger ifAbsent: exceptionHandler 
 	"Legacy behaviour for backwards compatibility."

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -25,6 +25,7 @@ package classNames
 	add: #LayoutManagerTest;
 	add: #LinkButtonTest;
 	add: #ListBoxTest;
+	add: #ListControlTest;
 	add: #ListPresenterTest;
 	add: #ListViewTest;
 	add: #MockScintillaView;
@@ -341,7 +342,7 @@ SelectableItemsTest subclass: #SelectableTreeItemsTest
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-SelectableListItemsTest subclass: #ListBoxTest
+SelectableListItemsTest subclass: #ListControlTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -351,14 +352,19 @@ SelectableListItemsTest subclass: #ListPresenterTest
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-SelectableListItemsTest subclass: #ListViewTest
-	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks timedout'
-	classVariableNames: ''
-	poolDictionaries: 'ListViewConstants'
-	classInstanceVariableNames: ''!
 SelectableListItemsTest subclass: #TabViewTest
 	instanceVariableNames: ''
 	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ListControlTest subclass: #ListBoxTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ListControlTest subclass: #ListViewTest
+	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks timedout'
+	classVariableNames: 'Test898'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ListBoxTest subclass: #MultiSelectListBoxTest

--- a/Core/Object Arts/Dolphin/MVP/ListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListBoxTest.cls
@@ -1,6 +1,6 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-SelectableListItemsTest subclass: #ListBoxTest
+ListControlTest subclass: #ListBoxTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -14,17 +14,41 @@ ListBoxTest comment: ''!
 classToTest
 	^ListBox!
 
-testLastSelectionCacheUpdatedOnRemove
-	"#717"
+newSelectionAfterLeftClickOutsideList: anArrayOfInteger 
+	^anArrayOfInteger!
 
-	| objects |
-	objects := self objectsToTest.
-	presenter model addAll: objects.
-	self assert: presenter hasSelection not.
-	presenter selection: objects second.
-	self assert: (presenter instVarNamed: 'lastSelIndices') equals: #(2).
-	presenter model removeAtIndex: 1.
-	self assert: (presenter instVarNamed: 'lastSelIndices') equals: #(1)! !
+sendClickEvent: aMouseEvent
+	| keyState newKeyState |
+	"The ListBox control ignores the button/key state flags the mouse messages and uses the keyboard state, so unfortunately we have to set that.
+	We use an ensure: block to prevent keys appearing stuck down if there is an error, but stopping in the debugger after the key state is set, but before the ensure block is run, will leave the shift and/or control keys stuck down. Hitting the actual keys will clear this though."
+	keyState := Keyboard default getState.
+	newKeyState := keyState copy.
+	aMouseEvent isCtrlDown ifTrue: [newKeyState at: VK_CONTROL + 1 put: 128].
+	aMouseEvent isShiftDown ifTrue: [newKeyState at: VK_SHIFT + 1 put: 128].
+	self postClickEvent: aMouseEvent.
+	
+	[newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: newKeyState].
+	"Dispatch the posted messages to the control"
+	SessionManager inputState pumpMessages]
+			ensure: [newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: keyState]]!
+
+testNewSelectionsClickOutsideListWithModifiers
+	| event selection expected |
+	self setUpForSelectionTesting.
+	selection := #(1).
+	"Behaviour of the ListBox in multi-select mode differs from the ListView in that clicking past the end is the same as clicking at the end."
+	OrderedCollection new
+		add: #(#(#control) #(1 10));
+		add: {#(#shift). 1 to: 10};
+		add: {#(#control #shift). 1 to: 10};
+		do: 
+				[:pair |
+				presenter selectionsByIndex: selection.
+				event := self mouseDownEventOnItem: 0 buttons: (pair first copyWith: #left).
+				expected := self isMultiSelect ifTrue: [pair second] ifFalse: [selection].
+				self verifyNewSelectionsFromEvent: event equals: expected]! !
 !ListBoxTest categoriesFor: #classToTest!helpers!private! !
-!ListBoxTest categoriesFor: #testLastSelectionCacheUpdatedOnRemove!public!unit tests! !
+!ListBoxTest categoriesFor: #newSelectionAfterLeftClickOutsideList:!helpers!private! !
+!ListBoxTest categoriesFor: #sendClickEvent:!helpers!private! !
+!ListBoxTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
@@ -1,0 +1,343 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+SelectableListItemsTest subclass: #ListControlTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ListControlTest guid: (GUID fromString: '{a10a1ba0-5afc-41f3-8b51-2b9e52718424}')!
+ListControlTest isAbstract: true!
+ListControlTest comment: ''!
+!ListControlTest categoriesForClass!Unclassified! !
+!ListControlTest methodsFor!
+
+assertCaretVisible
+	| pos view |
+	view := presenter view.
+	pos := (view itemRect: view caretIndex) origin.
+	self assert: (view rectangle containsPoint: pos)!
+
+isMultiSelect
+	"Private - Is this a test of a list control in multi-select mode?"
+
+	^presenter view isMultiSelect!
+
+mouseDownEventOnItem: itemIndex buttons: anArray
+	| mouseButton keys position |
+	mouseButton := anArray intersection: #(#left #right #middle).
+	self assert: mouseButton size equals: 1.
+	mouseButton := mouseButton anyOne.
+	keys := (anArray collect: [:each | MouseEvent wParamFlags at: each]) fold: [:a :b | a bitOr: b].
+	position := itemIndex == 0
+				ifTrue: [presenter clientExtent - (1 @ 1)]
+				ifFalse: [(presenter itemRect: itemIndex) origin + (1 @ 1)].
+	^MouseEvent
+		window: presenter
+		message: (##(IdentityDictionary new
+				at: #left put: WM_LBUTTONDOWN;
+				at: #right put: WM_RBUTTONDOWN;
+				at: #middle put: WM_MBUTTONDOWN;
+				yourself) at: mouseButton)
+		wParam: keys
+		lParam: position asDword!
+
+newSelectionAfterLeftClickOutsideList: anArrayOfInteger 
+	^self subclassResponsibility!
+
+postClickEvent: aMouseEvent
+	self assert: aMouseEvent isButtonDown.
+	"Clear the message queue"
+	SessionManager inputState pumpMessages.
+	"Post a matched mouse down/up pair to the control"
+	presenter view
+		postMessage: aMouseEvent message
+			wParam: aMouseEvent wParam
+			lParam: aMouseEvent lParam;
+		postMessage: aMouseEvent message + 1
+			wParam: (aMouseEvent wParam maskClear: aMouseEvent buttonFlag)
+			lParam: aMouseEvent lParam!
+
+sendClickEvent: aMouseEvent
+	self subclassResponsibility!
+
+setUpForSelectionTesting
+	presenter list: (1 to: 10) asOrderedCollection!
+
+testLastSelectionCacheUpdatedOnRemove
+	"#717"
+
+	| objects |
+	objects := self objectsToTest.
+	presenter model addAll: objects.
+	self assert: presenter hasSelection not.
+	presenter selection: objects second.
+	self assert: presenter lastSelIndices equals: #(2).
+	presenter model removeAtIndex: 1.
+	self assert: presenter lastSelIndices equals: #(1).
+	"Remainder of the test is for multi-select mode only"
+	self isMultiSelect ifFalse: [^self].
+	presenter selectionsByIndex: #(2 4).
+	self assert: presenter lastSelIndices equals: #(2 4).
+	self
+		shouldnt: 
+			[presenter model removeAll: (Array with: presenter model first with: (presenter model at: 3))]
+		triggerAnyOf: #(#selectionChanging: #selectionChanged)
+		against: presenter.
+	self assert: presenter lastSelIndices equals: #(1 2).
+	self
+		should: [presenter model removeAll: presenter model copy]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter lastSelIndices equals: #().
+	presenter model addAll: self objectsToTest.
+	presenter selectionsByIndex: #(1 3 5).
+	self assert: presenter lastSelIndices equals: #(1 3 5).
+	self
+		should: [presenter model remove: presenter model last]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter lastSelIndices equals: #(1 3)!
+
+testNewSelectionsClickOutsideListWithModifiers
+	"ListView and ListBox behaviour differs"
+
+	self subclassResponsibility!
+
+testNewSelectionsCtrlClickOnSelectedItem
+	| event expected |
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(1 3).
+	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
+	"Ctrl-click over selected item makes no different in single-select mode"
+	expected := {self isMultiSelect ifTrue: [3] ifFalse: [1]}.
+	self verifyNewSelectionsFromEvent: event equals: expected.
+	presenter selectionsByIndex: #(1).
+	self isMultiSelect ifTrue: [expected := #()].
+	self verifyNewSelectionsFromEvent: event equals: expected!
+
+testNewSelectionsCtrlClickOnUnselectedItem
+	| event expected |
+	self setUpForSelectionTesting.
+	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
+	self verifyNewSelectionsFromEvent: event equals: #(1).
+	presenter selectionsByIndex: #(3).
+	expected := self isMultiSelect ifTrue: [#(1 3)] ifFalse: [#(1)].
+	self verifyNewSelectionsFromEvent: event equals: expected!
+
+testNewSelectionsInitialShiftClick
+	| event |
+	self setUpForSelectionTesting.
+	event := self mouseDownEventOnItem: 1 buttons: #(#left #shift).
+	self verifyNewSelectionsFromEvent: event equals: #(1).
+	"Note that we have to clear the anchorIndex to reset to 'initial' state where a shift-click in a multi-select list will only select the clicked item and not a range. Unfortunately the only way to remove an existing anchor in a traditional ListBox is to delete the item. LB_SETANCHORINDEX returns LB_ERR when passed 0. The equivalent ListView operation to clear the anchor does work and is necessary because deleting the item does not remove the anchor. So we do both."
+	presenter model removeAtIndex: 1.
+	presenter view anchorIndex: 0.
+	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
+	self verifyNewSelectionsFromEvent: event equals: #(3)!
+
+testNewSelectionsLeftClickOutsideList
+	| event |
+	self setUpForSelectionTesting.
+	event := self mouseDownEventOnItem: 0 buttons: #(#left).
+	self verifyNewSelectionsFromEvent: event equals: #().
+	presenter selectionsByIndex: #(3).
+	self verifyNewSelectionsFromEvent: event equals: (self newSelectionAfterLeftClickOutsideList: #(3))!
+
+testNewSelectionsNonLeftClicksWithModifiers
+	"Single selection ListView will always change the selection for right button clicks, regardless of modifiers"
+
+	| selections |
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(1 3 5).
+	selections := presenter selectionsByIndex.
+	"Right or middle clicks with any modifiers will never modify the selection. Just cover a few example cases."
+	#(#(4 #(#right #control)) #(2 #(#middle #shift)) #(3 #(#right #control #shift)) #(0 #(#middle #control)))
+		do: 
+			[:pair |
+			| event expected |
+			event := self mouseDownEventOnItem: pair first buttons: pair second.
+			expected := (event isRButtonDown and: [self isMultiSelect not])
+						ifTrue: [{pair first}]
+						ifFalse: [selections].
+			self verifyNewSelectionsFromEvent: event equals: expected.
+			selections := expected]!
+
+testNewSelectionsRightClickOutsideSelection
+	| event |
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(1 3 5).
+	event := self mouseDownEventOnItem: 2 buttons: #(#right).
+	self verifyNewSelectionsFromEvent: event equals: #(2)!
+
+testNewSelectionsRightClickWithinSelection
+	| event selections |
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(3 5).
+	selections := presenter selectionsByIndex.
+	event := self mouseDownEventOnItem: 3 buttons: #(#right).
+	self verifyNewSelectionsFromEvent: event equals: selections!
+
+testNewSelectionsSimpleLeftClick
+	| event |
+	self setUpForSelectionTesting.
+	event := self mouseDownEventOnItem: 1 buttons: #(#left).
+	self verifyNewSelectionsFromEvent: event equals: #(1).
+	presenter selectionsByIndex: #(3).
+	self verifyNewSelectionsFromEvent: event equals: #(1)!
+
+testProgrammaticSelectionVisible
+	"#1381"
+
+	"Note that the last selection is the one with the caret, and therefore it is that which should be visible"
+
+	| view |
+	view := presenter view.
+	view list: (0 to: 100) asOrderedCollection.
+	#(#(100) #(50 100) #(100 50) #(1)) do: 
+			[:each | 
+			view selections: each.
+			self assertCaretVisible]!
+
+testSelectionsByIndex
+	self isMultiSelect
+		ifTrue: [self verifyMultiSelectionsByIndex]
+		ifFalse: [self verifySingleSelectionsByIndex]!
+
+verifyMultiSelectionsByIndex
+	| objects sel |
+	objects := self objectsToTest.
+	presenter model addAll: objects.
+	"Select a single object"
+	sel := Array with: objects size.
+	self
+		should: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: sel.
+	"Selecting same element should be a no-op"
+	self
+		shouldnt: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: sel.
+	"Selecting a pair including the existing selection"
+	sel := Array with: 1 with: objects size.
+	self
+		should: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: sel.
+	"Selecting same pair should be a no-op"
+	self
+		shouldnt: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: sel.
+	"Selecting single item from existing selection should remove other selections"
+	sel := #(1).
+	self
+		should: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: sel.
+	"Selecting a different pair not including the existing single selection"
+	sel := Array with: 2 with: objects size - 1.
+	self
+		should: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: sel.
+	"#selectionByIndex: should also clear other selections"
+	sel := sel copyFrom: 2.
+	self
+		should: [presenter selectionByIndex: sel first]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: sel!
+
+verifyNewSelectionsFromEvent: aMouseEvent equals: anArray
+	self sendClickEvent: aMouseEvent.
+	self assert: presenter view selectionsByIndex equals: anArray!
+
+verifySingleSelectionsByIndex
+	| objects sel |
+	objects := self objectsToTest.
+	self deny: self isMultiSelect.
+	presenter model addAll: objects.
+	"Select a single object"
+	sel := {1}.
+	self
+		should: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: sel.
+	"Selecting same element should be a no-op"
+	self
+		shouldnt: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: sel.
+	"Selecting a pair including the existing selection, but as that is first this is not a selection change."
+	sel := {1. objects size}.
+	self
+		shouldnt: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: {sel first}.
+	"Selecting a different pair not including the existing single selection is a selection change"
+	sel := {2. objects size}.
+	self
+		should: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: {sel first}.
+	self
+		shouldnt: [presenter selectionsByIndex: sel]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: {sel first}.	"#selectionByIndex: (singular) of the same selection should still be a no-op"
+	self
+		shouldnt: [presenter selectionByIndex: sel first]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: {sel first}.
+	"#selectionByIndex: of the same different selection should change"
+	self
+		should: [presenter selectionByIndex: 3]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: {3}.
+	"Empty selection"
+	self
+		should: [presenter selectionsByIndex: #()]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: #().
+	self
+		shouldnt: [presenter selectionsByIndex: #()]
+		trigger: #selectionChanged
+		against: presenter.
+	self assert: presenter selectionsByIndex equals: #()! !
+!ListControlTest categoriesFor: #assertCaretVisible!helpers!private! !
+!ListControlTest categoriesFor: #isMultiSelect!private!testing! !
+!ListControlTest categoriesFor: #mouseDownEventOnItem:buttons:!helpers!private! !
+!ListControlTest categoriesFor: #newSelectionAfterLeftClickOutsideList:!constants!private! !
+!ListControlTest categoriesFor: #postClickEvent:!helpers!private! !
+!ListControlTest categoriesFor: #sendClickEvent:!helpers!private! !
+!ListControlTest categoriesFor: #setUpForSelectionTesting!helpers!private! !
+!ListControlTest categoriesFor: #testLastSelectionCacheUpdatedOnRemove!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsCtrlClickOnSelectedItem!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsCtrlClickOnUnselectedItem!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsInitialShiftClick!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsLeftClickOutsideList!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsNonLeftClicksWithModifiers!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsRightClickOutsideSelection!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsRightClickWithinSelection!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsSimpleLeftClick!public!unit tests! !
+!ListControlTest categoriesFor: #testProgrammaticSelectionVisible!public!unit tests! !
+!ListControlTest categoriesFor: #testSelectionsByIndex!public!unit tests! !
+!ListControlTest categoriesFor: #verifyMultiSelectionsByIndex!helpers!private! !
+!ListControlTest categoriesFor: #verifyNewSelectionsFromEvent:equals:!helpers!private! !
+!ListControlTest categoriesFor: #verifySingleSelectionsByIndex!helpers!private! !
+

--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -1,21 +1,16 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-SelectableListItemsTest subclass: #ListViewTest
+ListControlTest subclass: #ListViewTest
 	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks timedout'
-	classVariableNames: ''
-	poolDictionaries: 'ListViewConstants'
+	classVariableNames: 'Test898'
+	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ListViewTest guid: (GUID fromString: '{bce10a8d-244e-4377-846c-bcbef9d853a1}')!
 ListViewTest isAbstract: true!
+ListViewTest addClassConstant: 'Test898' value: false!
 ListViewTest comment: ''!
 !ListViewTest categoriesForClass!Unclassified! !
 !ListViewTest methodsFor!
-
-assertCaretVisible
-	| pos view |
-	view := presenter view.
-	pos := (view itemRect: view caretIndex) origin.
-	self assert: (view rectangle containsPoint: pos)!
 
 classToTest
 	^ListView!
@@ -33,7 +28,7 @@ getColumns
 			col := LVCOLUMNW new.
 			col newTextBuffer: 256.
 			(presenter view
-				sendMessage: LVM_GETCOLUMNW
+				sendMessage: ListViewConstants.LVM_GETCOLUMNW
 				wParam: each
 				lpParam: col) asBoolean
 				ifTrue: 
@@ -51,24 +46,11 @@ getItem: anInteger
 	presenter view lvmGetItem: item.
 	^item!
 
-mouseDownEventOnItem: itemIndex buttons: anArray
-	| mouseButton keys position |
-	mouseButton := anArray intersection: #(#left #right #middle).
-	self assert: mouseButton size equals: 1.
-	mouseButton := mouseButton anyOne.
-	keys := (anArray collect: [:each | MouseEvent wParamFlags at: each]) fold: [:a :b | a bitOr: b].
-	position := itemIndex == 0
-				ifTrue: [presenter clientExtent - (1 @ 1)]
-				ifFalse: [(presenter itemRect: itemIndex) origin + (1 @ 1)].
-	^MouseEvent
-		window: presenter
-		message: (##(IdentityDictionary new
-				at: #left put: WM_LBUTTONDOWN;
-				at: #right put: WM_RBUTTONDOWN;
-				at: #middle put: WM_MBUTTONDOWN;
-				yourself) at: mouseButton)
-		wParam: keys
-		lParam: position asDword!
+newSelectionAfterLeftClickOutsideList: anArrayOfInteger 
+	^#()!
+
+newSelectionsFromEvent: aMouseEvent
+	^presenter view newSelectionsFromEvent: aMouseEvent!
 
 onSelectionChanged
 	selectionChanged value!
@@ -80,38 +62,26 @@ onTimerTick: wParam
 	wParam = self timeoutId ifTrue: [
 		timedout := true.
 		presenter view killTimer: self timeoutId.
+		"Post a mouse move so that the ListView control returns from its WM_?BUTTONDOWN handler"
 		presenter view postMessage: WM_MOUSEMOVE wParam: 0 lParam: 0]!
 
 sendClickEvent: aMouseEvent
 	| pos |
-	self assert: (aMouseEvent isLButtonDown or: [aMouseEvent isRButtonDown]).
-	"Note that the ListView appears to take hold of the message loop in its handler for WM_?BUTTONDOWN, so we post the up before sending the down.
-	The reason this works is that the 'up' will wait in the queue, but the 'down' will be sent straight to the window proc of the list view. That window
-	proc is of course the Dolphin wndproc, which will forward the message into the image, where it will eventually arrive in ListView>>onButtonPressed:
-	When ListView>>onButtonPressed: calls for default window processing (i.e. calls the ListView's actual wnd proc), the LV handler will then consume
-	the mouse up from the queue."
+	"The mouse needs to be outside any Dolphin window in order to cause the control's WM_?BUTTONDOWN handler to block in the way described in #898"
 	pos := POINTL new.
-	UserLibrary default getCursorPos: pos;
+	UserLibrary default
+		getCursorPos: pos;
 		setCursorPosX: 0 y: 0.
-	SessionManager inputState pumpMessages.
-	presenter view
-		postMessage: aMouseEvent message
-			wParam: aMouseEvent wParam
-			lParam: aMouseEvent lParam;
-		postMessage: aMouseEvent message + 1
-			wParam: (aMouseEvent wParam maskClear: aMouseEvent buttonFlag)
-			lParam: aMouseEvent lParam.
+	self postClickEvent: aMouseEvent.
+	"Schedule a WM_TIMER so that we can detect the control's WM_?BUTTONDOWN handler not returning"
 	timedout := false.
 	presenter view setTimer: self timeoutId interval: 500.
-	"Dispatch the posted messages to the control"
+	"Dispatch the posted mouse down/up messages to the control"
 	SessionManager inputState pumpMessages.
 	presenter view killTimer: self timeoutId.
 	UserLibrary default setCursorPosX: pos x y: pos y.
 	"If this fires, it means the control did not return from the call to its window proc to handle the button down event in ListView>>onButtonPressed:"
 	self deny: timedout description: 'Control blocked in mouse down handler'!
-
-sendEvent: aMouseEvent 
-	^presenter view sendMessage: aMouseEvent message wParam: aMouseEvent wParam lParam: aMouseEvent lParam!
 
 setColumns: cols
 	| list |
@@ -154,9 +124,11 @@ setUpForSelectionEventTesting
 	timedout := false!
 
 setUpForSelectionTesting
-	presenter
-		list: (1 to: 10);
-		viewMode: #list!
+	super setUpForSelectionTesting.
+	presenter view viewMode: #list!
+
+skip898
+	self skipUnless: [Test898]!
 
 sortSelections
 	^self subclassResponsibility!
@@ -254,85 +226,13 @@ testColumnsList
 	"Remove them all"
 	self setColumns: #()!
 
-testLastSelectionCacheUpdatedOnRemove
-	"#717"
-
-	| objects |
-	objects := self objectsToTest.
-	presenter model addAll: objects.
-	self assert: presenter hasSelection not.
-	presenter selection: objects second.
-	self assert: (presenter instVarNamed: 'lastSelIndices') equals: #(2).
-	presenter model removeAtIndex: 1.
-	self assert: (presenter instVarNamed: 'lastSelIndices') equals: #(1)!
-
-testNewSelectionsLeftClickOutsideList
-	| event |
-	self setUpForSelectionTesting.
-	event := self mouseDownEventOnItem: 0 buttons: #(#left).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #().
-	presenter selectionsByIndex: #(3).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #()!
-
-testNewSelectionsSimpleLeftClick
-	| event |
-	self setUpForSelectionTesting.
-	event := self mouseDownEventOnItem: 1 buttons: #(#left).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1).
-	presenter selectionsByIndex: #(3).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1)!
-
-testNilRow
-	"#2157"
-
-	| m c item txt |
-	presenter viewMode: #report.
-	m := ListModel on: #(nil) , (1 to: 5).
-	presenter model: m.
-	c := presenter view columnAtIndex: 1.
-	txt := 'this is nil'.
-	c getTextBlock: [:it | it ifNil: [txt]].
-	item := self getItem: 1.
-	self assert: item pszText equals: txt.
-	self assert: item iImage equals: nil icon imageIndex - 1!
-
-testProgrammaticSelectionVisible
-	"#1381"
-
-	"Note that the last selection is the one with the caret, and therefore it is that which should be visible"
-
-	| view |
-	view := presenter view.
-	view list: (0 to: 100) asOrderedCollection.
-	#(#(100) #(50 100) #(100 50) #(1)) do: 
-			[:each | 
-			view selections: each.
-			self assertCaretVisible]!
-
-testSelectionEventsFromLeftClick
-	"Test that the expected sequence of selectionChanging: and selectionChanged events are raised for left-click selection.
-	The test sends simulated mouse clicks to the control to try and test the actual control integration."
-
-	self setUpForSelectionEventTesting.
-	self verifyEventsFromClickConfirmed: #left!
-
-testSelectionEventsFromLeftClickDenied
-	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is denied
-	but without a prompt so the control still receives the mouse up."
-
-	self setUpForSelectionEventTesting.
-	selectionChanging := 
-			[:selChanging |
-			events addLast: selChanging.
-			selChanging value: false].
-	self verifyEventsFromClickDenied: #left!
-
-testSelectionEventsFromLeftClickPromptConfirmed
+testEventsFromClickSelectChangeConfirmed
 	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is confirmed with a prompt so the control does not receive the mouse up associated with the actual click.
 	Regression test for #898."
 
 	"Test fails because the listview blocks in a modal message loop in its WM_LBUTTONDOWN handler"
-	self skipIfCiBuild.
+
+	self skip898.
 	self setUpForSelectionEventTesting.
 	selectionChanging := 
 			[:selChanging |
@@ -347,17 +247,17 @@ testSelectionEventsFromLeftClickPromptConfirmed
 				wMsgFilterMax: WM_LBUTTONUP.
 			"Allow the selection change to proceed"
 			selChanging value: true].
-	self verifyEventsFromClickConfirmed: #left!
+	self verifyEventsFromClickSelectionChangeAccepted: #left!
 
-testSelectionEventsFromLeftClickPromptDenied
-	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is denied with a prompt so the control does not receive the mouse up associated with the actual click."
+testEventsFromClickSelectChangeRefused
+	"Test that the expected sequence of selection events are raised for left-click selection, simulating the selectionChanging: event being refused by user in response to a prompt so the control does not receive the mouse up associated with the actual click."
 
 	self setUpForSelectionEventTesting.
 	selectionChanging := 
 			[:selChanging |
 			| msg |
 			events addLast: selChanging.
-			"Snaffle the mouse up to try and simulate the appearance of a prompt"
+			"Snaffle the mouse up as the control will lose focus/activation as soon as the prompt is opened"
 			msg := MSG new.
 			UserLibrary default
 				getMessage: msg
@@ -366,7 +266,53 @@ testSelectionEventsFromLeftClickPromptDenied
 				wMsgFilterMax: WM_LBUTTONUP.
 			"Prevent the selection change from proceeding"
 			selChanging value: false].
-	self verifyEventsFromClickDenied: #left!
+	self verifyEventsFromClickSelectionChangeRejected: #left!
+
+testEventsFromClickSelectionChangePermitted
+	"Test that the expected sequence of selectionChanging: and selectionChanged events are raised for left-click selection with the selection change permitted without a prompt.
+	The test sends simulated mouse clicks to the control to try and test the actual control integration."
+
+	self setUpForSelectionEventTesting.
+	self verifyEventsFromClickSelectionChangeAccepted: #left!
+
+testEventsFromClickSelectionChangeRejected
+	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is rejected but without a prompt so the control still receives the mouse up."
+
+	self setUpForSelectionEventTesting.
+	selectionChanging := 
+			[:selChanging |
+			events addLast: selChanging.
+			selChanging value: false].
+	self verifyEventsFromClickSelectionChangeRejected: #left!
+
+testNewSelectionsClickOutsideListWithModifiers
+	| event selection expected |
+	self setUpForSelectionTesting.
+	selection := #(1).
+	expected := self isMultiSelect ifTrue: [selection] ifFalse: [#()].
+	OrderedCollection new
+		add: #(#control);
+		add: #(#shift);
+		add: #(#control #shift);
+		do: 
+				[:modifiers |
+				presenter selectionsByIndex: selection.
+				event := self mouseDownEventOnItem: 0 buttons: (modifiers copyWith: #left).
+				self verifyNewSelectionsFromEvent: event equals: expected]!
+
+testNilRow
+	"#2157"
+
+	| m c item txt |
+	presenter viewMode: #report.
+	m := ListModel on: #(nil) , (1 to: 5).
+	presenter model: m.
+	c := presenter view columnAtIndex: 1.
+	txt := 'this is nil'.
+	c getTextBlock: [:it | it ifNil: [txt]].
+	item := self getItem: 1.
+	self assert: item pszText equals: txt.
+	self assert: item iImage equals: nil icon imageIndex - 1!
 
 testSelectionRemainsVisibleOnSort
 	"#1381"
@@ -412,7 +358,7 @@ testSetTextImageDoesNotAffectSelection
 timeoutId
 	^171717!
 
-verifyEventsFromClickConfirmed: aSymbol
+verifyEventsFromClickSelectionChangeAccepted: aSymbol
 	| changed changing click event |
 	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
 	self sendClickEvent: event.
@@ -447,7 +393,7 @@ verifyEventsFromClickConfirmed: aSymbol
 	self assert: click iItem equals: 4 - 1.
 	self assert: click position equals: event lParamX @ event lParamY!
 
-verifyEventsFromClickDenied: aSymbol
+verifyEventsFromClickSelectionChangeRejected: aSymbol
 	| event changing |
 	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
 	self sendClickEvent: event.
@@ -469,38 +415,40 @@ verifyEventsFromClickDenied: aSymbol
 	self assert: changing isKindOf: SelectionChangingEvent.
 	self assert: changing oldSelections equals: #(2).
 	self assert: changing newSelections equals: self expectedSelectionsForSendShiftClickTests.
-	self assert: clicks size equals: 0! !
-!ListViewTest categoriesFor: #assertCaretVisible!helpers!private! !
+	self assert: clicks size equals: 0!
+
+verifyNewSelectionsFromEvent: aMouseEvent equals: anArray
+	self assert: (presenter view newSelectionsFromEvent: aMouseEvent) equals: anArray.
+	super verifyNewSelectionsFromEvent: aMouseEvent equals: anArray! !
 !ListViewTest categoriesFor: #classToTest!helpers!private! !
 !ListViewTest categoriesFor: #expectedSelectionsForSendShiftClickTests!constants!private! !
 !ListViewTest categoriesFor: #getColumns!helpers!private! !
 !ListViewTest categoriesFor: #getItem:!helpers!private! !
-!ListViewTest categoriesFor: #mouseDownEventOnItem:buttons:!helpers!private! !
-!ListViewTest categoriesFor: #onSelectionChanged!helpers!private! !
-!ListViewTest categoriesFor: #onSelectionChanging:!helpers!private! !
-!ListViewTest categoriesFor: #onTimerTick:!helpers!private! !
+!ListViewTest categoriesFor: #newSelectionAfterLeftClickOutsideList:!constants!private! !
+!ListViewTest categoriesFor: #newSelectionsFromEvent:!helpers!private! !
+!ListViewTest categoriesFor: #onSelectionChanged!event handling!private! !
+!ListViewTest categoriesFor: #onSelectionChanging:!event handling!private! !
+!ListViewTest categoriesFor: #onTimerTick:!event handling!private! !
 !ListViewTest categoriesFor: #sendClickEvent:!helpers!private! !
-!ListViewTest categoriesFor: #sendEvent:!helpers!private! !
 !ListViewTest categoriesFor: #setColumns:!helpers!private! !
 !ListViewTest categoriesFor: #setUpForSelectionEventTesting!helpers!private! !
 !ListViewTest categoriesFor: #setUpForSelectionTesting!helpers!private! !
+!ListViewTest categoriesFor: #skip898!private!unit tests! !
 !ListViewTest categoriesFor: #sortSelections!helpers!public! !
 !ListViewTest categoriesFor: #testBackImage!public!unit tests! !
 !ListViewTest categoriesFor: #testChangeViewMode!public!unit tests! !
 !ListViewTest categoriesFor: #testColumnsList!public!unit tests! !
-!ListViewTest categoriesFor: #testLastSelectionCacheUpdatedOnRemove!public!unit tests! !
-!ListViewTest categoriesFor: #testNewSelectionsLeftClickOutsideList!public!unit tests! !
-!ListViewTest categoriesFor: #testNewSelectionsSimpleLeftClick!public!unit tests! !
+!ListViewTest categoriesFor: #testEventsFromClickSelectChangeConfirmed!public!unit tests! !
+!ListViewTest categoriesFor: #testEventsFromClickSelectChangeRefused!public!unit tests! !
+!ListViewTest categoriesFor: #testEventsFromClickSelectionChangePermitted!public!unit tests! !
+!ListViewTest categoriesFor: #testEventsFromClickSelectionChangeRejected!public!unit tests! !
+!ListViewTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !
 !ListViewTest categoriesFor: #testNilRow!public!unit tests! !
-!ListViewTest categoriesFor: #testProgrammaticSelectionVisible!public!unit tests! !
-!ListViewTest categoriesFor: #testSelectionEventsFromLeftClick!public!unit tests! !
-!ListViewTest categoriesFor: #testSelectionEventsFromLeftClickDenied!public!unit tests! !
-!ListViewTest categoriesFor: #testSelectionEventsFromLeftClickPromptConfirmed!public!unit tests! !
-!ListViewTest categoriesFor: #testSelectionEventsFromLeftClickPromptDenied!public!unit tests! !
 !ListViewTest categoriesFor: #testSelectionRemainsVisibleOnSort!public!unit tests! !
 !ListViewTest categoriesFor: #testSetTextBlockDoesNotAffectSelection!public!unit tests! !
 !ListViewTest categoriesFor: #testSetTextImageDoesNotAffectSelection!public!unit tests! !
 !ListViewTest categoriesFor: #timeoutId!constants!private! !
-!ListViewTest categoriesFor: #verifyEventsFromClickConfirmed:!helpers!private! !
-!ListViewTest categoriesFor: #verifyEventsFromClickDenied:!helpers!private! !
+!ListViewTest categoriesFor: #verifyEventsFromClickSelectionChangeAccepted:!helpers!private! !
+!ListViewTest categoriesFor: #verifyEventsFromClickSelectionChangeRejected:!helpers!private! !
+!ListViewTest categoriesFor: #verifyNewSelectionsFromEvent:equals:!helpers!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListBoxTest.cls
@@ -12,85 +12,55 @@ MultiSelectListBoxTest comment: 'Test a ListBox in multi-select mode. Inherited 
 
 initializePresenter
 	super initializePresenter.
-	presenter view selectionMode: #multi!
+	presenter view isMultiSelect: true!
 
-testLastSelectionCacheUpdatedOnRemove
-	super testLastSelectionCacheUpdatedOnRemove.
-	presenter selectionsByIndex: #(2 4).
-	self assert: (presenter instVarNamed: 'lastSelIndices') equals: #(2 4).
-	self
-		shouldnt: 
-			[presenter model removeAll: (Array with: presenter model first with: (presenter model at: 3))]
-		triggerAnyOf: #(#selectionChanging: #selectionChanged)
-		against: presenter.
-	self assert: (presenter instVarNamed: 'lastSelIndices') equals: #(1 2).
-	self
-		should: [presenter model removeAll: presenter model copy]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: (presenter instVarNamed: 'lastSelIndices') equals: #().
-	presenter model addAll: self objectsToTest.
-	presenter selectionsByIndex: #(1 3 5).
-	self assert: (presenter instVarNamed: 'lastSelIndices') equals: #(1 3 5).
-	self
-		should: [presenter model remove: presenter model last]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: (presenter instVarNamed: 'lastSelIndices') equals: #(1 3)!
+testNewSelectionsCtrlShiftClickAdditive
+	| event |
+	self setUpForSelectionTesting.
+	presenter
+		selectionsByIndex: #(1 3);
+		anchorIndex: 3.
+	event := self mouseDownEventOnItem: 7 buttons: #(#left #control #shift).
+	self verifyNewSelectionsFromEvent: event equals: #(1 3 4 5 6 7).
+	presenter selectionsByIndex: #(1 3 5 7).
+	"Programatically changing selection in a ListBox does change the anchor (because it expects that the anchor is part of the selection, unsually the last selected item), unlike a ListView."
+	self assert: presenter anchorIndex equals: 7.
+	presenter anchorIndex: 3.
+	self verifyNewSelectionsFromEvent: event equals: #(1 3 4 5 6 7)!
 
-testSelectionsByIndex
-	| objects sel |
-	objects := self objectsToTest.
-	presenter view isMultiSelect: true.
-	presenter model addAll: objects.
-	"Select a single object"
-	sel := Array with: objects size.
-	self
-		should: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting same element should be a no-op"
-	self
-		shouldnt: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting a pair including the existing selection"
-	sel := Array with: 1 with: objects size.
-	self
-		should: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting same pair should be a no-op"
-	self
-		shouldnt: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting single item from existing selection should remove other selections"
-	sel := #(1).
-	self
-		should: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting a different pair not including the existing single selection"
-	sel := Array with: 2 with: objects size - 1.
-	self
-		should: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"#selectionByIndex: should also clear other selections"
-	sel := sel copyFrom: 2.
-	self
-		should: [presenter selectionByIndex: sel first]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel! !
-!MultiSelectListBoxTest categoriesFor: #initializePresenter!public!Running! !
-!MultiSelectListBoxTest categoriesFor: #testLastSelectionCacheUpdatedOnRemove!public!unit tests! !
-!MultiSelectListBoxTest categoriesFor: #testSelectionsByIndex!public!unit tests! !
+testNewSelectionsCtrlShiftClickSubtractive
+	| event |
+	self setUpForSelectionTesting.
+	presenter
+		selectionsByIndex: #(1 2 3 4 5 7);
+		anchorIndex: 6.
+	event := self mouseDownEventOnItem: 2 buttons: #(#left #control #shift).
+	"ListBox does not seem to have the issue that we have with ListView where the ctrl-shift-left-clicked item is retained in the selection when it should not be"
+	self verifyNewSelectionsFromEvent: event equals: #(1 7).
+	self assert: presenter caretIndex equals: 2.
+	presenter selectionsByIndex: #(1 3 5 7).
+	"Unlike ListView, programmatically changing the selection moves the anchor, so we must reset it."
+	presenter anchorIndex: 6.
+	self verifyNewSelectionsFromEvent: event equals: #(1 7)!
+
+testNewSelectionsShiftClickWithSelectionMark
+	| event |
+	self setUpForSelectionTesting.
+	event := self mouseDownEventOnItem: 5 buttons: #(#left #shift).
+	#(#() #(3) #(1 2 3) #(3 4 5 6)) do: 
+			[:oldSelections |
+			| expected |
+			presenter selectionsByIndex: oldSelections.
+			"Changing the selections in a ListBox moves the anchor (because it expects that the anchor is effectively the last selected item), so we must reset it each time."
+			presenter anchorIndex: 3.
+			self assert: presenter anchorIndex equals: 3.
+			"In a ListBox, unlike a ListView, the current selection does matter. If the anchor is set to an item in the selection, then that item will still be selected on a Shift-Click. If the anchor is not a selected item, then the selection will on Shift-Click will not include it."
+			expected := (oldSelections includes: 3) ifTrue: [#(3 4 5)] ifFalse: [#(4 5)].
+			self verifyNewSelectionsFromEvent: event equals: expected].
+	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
+	self verifyNewSelectionsFromEvent: event equals: #(3)! !
+!MultiSelectListBoxTest categoriesFor: #initializePresenter!private!Running! !
+!MultiSelectListBoxTest categoriesFor: #testNewSelectionsCtrlShiftClickAdditive!public!unit tests! !
+!MultiSelectListBoxTest categoriesFor: #testNewSelectionsCtrlShiftClickSubtractive!public!unit tests! !
+!MultiSelectListBoxTest categoriesFor: #testNewSelectionsShiftClickWithSelectionMark!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -20,35 +20,11 @@ initializePresenter
 sortSelections
 	^#(49 50)!
 
-testNewSelectionsClickOutsideListWithModifiers
-	| event |
-	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(1).
-	OrderedCollection new
-		add: #(#control);
-		add: #(#shift);
-		add: #(#control #shift);
-		do: 
-				[:modifiers |
-				event := self mouseDownEventOnItem: 0 buttons: (modifiers copyWith: #left).
-				self assert: (presenter newSelectionsFromEvent: event) equals: #(1)]!
+testEventsFromClickSelectionChangePermitted
+	"Fails because of duplicated selectionChanging: event. To be deleted when that bug is fixed."
 
-testNewSelectionsCtrlClickOnSelectedItem
-	| event |
-	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(1 3).
-	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(3).
-	presenter selectionsByIndex: #(1).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #()!
-
-testNewSelectionsCtrlClickOnUnselectedItem
-	| event |
-	self setUpForSelectionTesting.
-	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1).
-	presenter selectionsByIndex: #(3).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1 3)!
+	self skip898.
+	super testEventsFromClickSelectionChangePermitted!
 
 testNewSelectionsCtrlShiftClickAdditive
 	| event |
@@ -57,11 +33,11 @@ testNewSelectionsCtrlShiftClickAdditive
 		selectionsByIndex: #(1 3);
 		anchorIndex: 3.
 	event := self mouseDownEventOnItem: 7 buttons: #(#left #control #shift).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1 3 4 5 6 7).
+	self verifyNewSelectionsFromEvent: event equals: #(1 3 4 5 6 7).
 	presenter selectionsByIndex: #(1 3 5 7).
 	"Programatically changing selection does not change the anchor."
 	self assert: presenter anchorIndex equals: 3.
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1 3 4 5 6 7)!
+	self verifyNewSelectionsFromEvent: event equals: #(1 3 4 5 6 7)!
 
 testNewSelectionsCtrlShiftClickSubtractive
 	| event |
@@ -73,136 +49,27 @@ testNewSelectionsCtrlShiftClickSubtractive
 	"In Windows Explorer and other applications that use ListView or a similar control,
 	(2) would not be selected at this point. Why is it in Dolphin?
 	(See comment at the end of #newSelectionsFromEvent:.)"
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1 2 7).
+	self verifyNewSelectionsFromEvent: event equals: #(1 2 7).
 	presenter selectionsByIndex: #(1 3 5 7).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1 2 7)!
-
-testNewSelectionsInitialShiftClick
-	| event |
-	self setUpForSelectionTesting.
-	event := self mouseDownEventOnItem: 1 buttons: #(#left #shift).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1).
-	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(3)!
-
-testNewSelectionsNonLeftClicksWithModifiers
-	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(1 3 5).
-	"Right or middle clicks with any modifiers will never modify the selection. Just cover a few example cases."
-	OrderedCollection new
-		add: 1 -> #(#right #control);
-		add: 2 -> #(#middle #shift);
-		add: 3 -> #(#right #control #shift);
-		add: 0 -> #(#middle #control);
-		do: 
-				[:assoc |
-				| event |
-				event := self mouseDownEventOnItem: assoc key buttons: assoc value.
-				self assert: (presenter newSelectionsFromEvent: event) equals: #(1 3 5)]!
-
-testNewSelectionsRightClickOutsideSelection
-	| event |
-	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(1 3 5).
-	event := self mouseDownEventOnItem: 2 buttons: #(#right).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(2)!
-
-testNewSelectionsRightClickWithinSelection
-	| event |
-	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(1 3 5).
-	event := self mouseDownEventOnItem: 3 buttons: #(#right).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(1 3 5)!
+	self verifyNewSelectionsFromEvent: event equals: #(1 2 7)!
 
 testNewSelectionsShiftClickWithSelectionMark
 	| event |
 	self setUpForSelectionTesting.
 	presenter anchorIndex: 3.
 	event := self mouseDownEventOnItem: 5 buttons: #(#left #shift).
-	"It does not really matter what is currently selected, only what is marked and what is clicked"
-	OrderedCollection new
-		add: #();
-		add: #(3);
-		add: #(1 2 3);
-		add: #(3 4 5 6);
-		do: 
-				[:oldSelections |
-				presenter selectionsByIndex: oldSelections.
-				self assert: (presenter newSelectionsFromEvent: event) equals: #(3 4 5)].
+	"In a ListView it does not really matter what is currently selected, only what is marked and what is clicked. The anchor is not expected to be part of the existing selection, and does not move on programmatic selection either."
+	#(#() #(3) #(1 2 3) #(3 4 5 6)) do: 
+			[:oldSelections |
+			presenter selectionsByIndex: oldSelections.
+			self verifyNewSelectionsFromEvent: event equals: #(3 4 5)].
 	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
-	self assert: (presenter newSelectionsFromEvent: event) equals: #(3)!
-
-testSelectionEventsFromLeftClick
-	"Fails because of duplicated selectionChanging: event. To be deleted when that bug is fixed."
-
-	self skipIfCiBuild.
-	super testSelectionEventsFromLeftClick!
-
-testSelectionsByIndex
-	| objects sel |
-	objects := self objectsToTest.
-	presenter view isMultiSelect: true.
-	presenter model addAll: objects.
-	"Select a single object"
-	sel := Array with: objects size.
-	self
-		should: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting same element should be a no-op"
-	self
-		shouldnt: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting a pair including the existing selection"
-	sel := Array with: 1 with: objects size.
-	self
-		should: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting same pair should be a no-op"
-	self
-		shouldnt: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting single item from existing selection should remove other selections"
-	sel := #(1).
-	self
-		should: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"Selecting a different pair not including the existing single selection"
-	sel := Array with: 2 with: objects size - 1.
-	self
-		should: [presenter selectionsByIndex: sel]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel.
-	"#selectionByIndex: should also clear other selections"
-	sel := sel copyFrom: 2.
-	self
-		should: [presenter selectionByIndex: sel first]
-		trigger: #selectionChanged
-		against: presenter.
-	self assert: presenter selectionsByIndex equals: sel! !
+	self verifyNewSelectionsFromEvent: event equals: #(3)! !
 !MultiSelectListViewTest categoriesFor: #expectedSelectionsForSendShiftClickTests!constants!private! !
 !MultiSelectListViewTest categoriesFor: #initializePresenter!public!Running! !
 !MultiSelectListViewTest categoriesFor: #sortSelections!private!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlClickOnSelectedItem!public!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlClickOnUnselectedItem!public!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testEventsFromClickSelectionChangePermitted!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickAdditive!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickSubtractive!public!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testNewSelectionsInitialShiftClick!public!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testNewSelectionsNonLeftClicksWithModifiers!public!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testNewSelectionsRightClickOutsideSelection!public!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testNewSelectionsRightClickWithinSelection!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsShiftClickWithSelectionMark!public!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testSelectionEventsFromLeftClick!public!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testSelectionsByIndex!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/MVP/MultipleSelectionListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultipleSelectionListBoxTest.cls
@@ -105,13 +105,13 @@ testSelectionCacheUpdated
 	box model list: (1 to: 6) asOrderedCollection.
 	box selections: #(1 3 5).
 	box model remove: 2.
-	self assert: (box instVarNamed: 'lastSelIndices') equals: box selectionsByIndex.
+	self assert: box lastSelIndices equals: box selectionsByIndex.
 	box model addFirst: 0.
-	self assert: (box instVarNamed: 'lastSelIndices') equals: box selectionsByIndex.
+	self assert: box lastSelIndices equals: box selectionsByIndex.
 	box model add: 4.5 afterIndex: 4.
-	self assert: (box instVarNamed: 'lastSelIndices') equals: box selectionsByIndex.
+	self assert: box lastSelIndices equals: box selectionsByIndex.
 	box model remove: 1.
-	self assert: (box instVarNamed: 'lastSelIndices') equals: box selectionsByIndex!
+	self assert: box lastSelIndices equals: box selectionsByIndex!
 
 testSelectionIfAbsent
 	"Test legacy selection behaviour is maintained (even though it is incorrect)"

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/BasicListAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/BasicListAbstract.cls
@@ -124,14 +124,14 @@ onSelChanging
 	change be denied."
 
 	| curSel |
-	(curSel := self selectionsByIndex) = lastSelIndices 
+	(curSel := self getSelectionsByIndex) = lastSelIndices 
 		ifFalse: 
 			[(self onSelChanging: curSel cause: #unknown) 
 				ifFalse: 
 					["Attempt to revert to previous selection"
 
 					self basicSelectionsByIndex: lastSelIndices.
-					(curSel := self selectionsByIndex) = lastSelIndices 
+					(curSel := self getSelectionsByIndex) = lastSelIndices 
 						ifTrue: 
 							["Successfully prevented selection change"
 
@@ -174,6 +174,11 @@ refreshContents
 	self basicRefreshContents.
 	self onSelChanged!
 
+selectionByIndex
+	"Answer the 1-based <integer> index of the selected item in the view, or zero if there is not exactly one selection."
+
+	^lastSelIndices size == 1 ifTrue: [lastSelIndices at: 1] ifFalse: [0]!
+
 selections: aCollection ifAbsent: aNiladicOrMonadicValuable
 	"Select the first occurrences of the specified collection of <Object>s in the receiver and
 	answer the new selection. If any of the elements of the collection are not present in the
@@ -186,6 +191,13 @@ selections: aCollection ifAbsent: aNiladicOrMonadicValuable
 	indices := self handlesFromObjects: aCollection whenAbsent: [:e | missing addLast: e].
 	self setSelectionsByIndex: indices.
 	^missing isEmpty ifTrue: [aCollection] ifFalse: [aNiladicOrMonadicValuable cull: missing]!
+
+selectionsByIndex
+	"Answer an <Array> of the <integer> the indices of the selected items 
+	in the receiver in ascending order. The array will be empty if there is
+	no selection."
+
+	^lastSelIndices!
 
 selectionsByIndex: aCollection ifAbsent: exceptionHandler
 	"Select the objects identified by the <collection> of <integer> indices, indices, in the
@@ -212,8 +224,7 @@ selectionState
 setSelectionsByIndex: indices 
 	(indices noDifference: lastSelIndices) ifTrue: [^self].
 	self basicSelectionsByIndex: indices.
-	"Note: We have to check again whether the selection has changed because of the single-select
-	case"
+	"Note: We have to check again whether the selection has changed because of the single-select case"
 	self onSelChanged!
 
 updateItem: anObject atIndex: anInteger 
@@ -233,7 +244,7 @@ updateItem: anObject atIndex: anInteger
 updateSelectionCache
 	"Private - If there is a cached selection, update it."
 
-	lastSelIndices notEmpty ifTrue: [lastSelIndices := self selectionsByIndex]! !
+	lastSelIndices notEmpty ifTrue: [lastSelIndices := self getSelectionsByIndex]! !
 !BasicListAbstract categoriesFor: #basicAdd:!adding!private! !
 !BasicListAbstract categoriesFor: #basicRefreshContents!private!updating! !
 !BasicListAbstract categoriesFor: #basicResetSelection!private!selection! !
@@ -254,10 +265,12 @@ updateSelectionCache
 !BasicListAbstract categoriesFor: #onSelChanging:cause:!event handling!private! !
 !BasicListAbstract categoriesFor: #onViewCreated!event handling!public! !
 !BasicListAbstract categoriesFor: #refreshContents!public!updating! !
+!BasicListAbstract categoriesFor: #selectionByIndex!public!selection! !
 !BasicListAbstract categoriesFor: #selections:ifAbsent:!public!selection! !
+!BasicListAbstract categoriesFor: #selectionsByIndex!public!selection! !
 !BasicListAbstract categoriesFor: #selectionsByIndex:ifAbsent:!public!selection! !
 !BasicListAbstract categoriesFor: #selectionState!accessing!private! !
-!BasicListAbstract categoriesFor: #setSelectionsByIndex:!public!selection! !
+!BasicListAbstract categoriesFor: #setSelectionsByIndex:!private!selection! !
 !BasicListAbstract categoriesFor: #updateItem:atIndex:!event handling!public! !
 !BasicListAbstract categoriesFor: #updateSelectionCache!helpers!private!selection! !
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ComboBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ComboBox.cls
@@ -225,6 +225,13 @@ extent: aPoint
 	super 
 		extent: (self mode == #simple ifTrue: [aPoint] ifFalse: [aPoint x @ self actualHeight])!
 
+getSelectionsByIndex
+	"Private - Query the current selections from the control"
+
+	| index |
+	index := (self sendMessage: CB_GETCURSEL) + 1.
+	^index == 0 ifTrue: [#()] ifFalse: [{index}]!
+
 getSingleSelection
 	"Private - Answer the one-based <integer> 'index' of the selected object in the receiver or
 	zero if there is none."
@@ -307,6 +314,11 @@ placement: aWINDOWPLACEMENT
 			placement rcNormalPosition: rect].
 	super placement: placement!
 
+selectionByIndex
+	"Answer the one-based <integer> 'index' of the selected object in the receiver or zero if there is none."
+
+	^(self sendMessage: CB_GETCURSEL) + 1!
+
 setSingleSelection: anInteger 
 	"Private - Set the selection to the item with the specified index (1-based), scrolling it
 	into view if necessary."
@@ -359,6 +371,7 @@ wmSetFocus: message wParam: wParam lParam: lParam
 !ComboBox categoriesFor: #editHwnd!accessing!private! !
 !ComboBox categoriesFor: #editView!accessing!public! !
 !ComboBox categoriesFor: #extent:!geometry!public! !
+!ComboBox categoriesFor: #getSelectionsByIndex!private!selection! !
 !ComboBox categoriesFor: #getSingleSelection!helpers!private!selection! !
 !ComboBox categoriesFor: #initialize!initializing!private! !
 !ComboBox categoriesFor: #itemCount!accessing!public! !
@@ -367,6 +380,7 @@ wmSetFocus: message wParam: wParam lParam: lParam
 !ComboBox categoriesFor: #mode:!accessing-styles!public! !
 !ComboBox categoriesFor: #onPositionChanged:!event handling!public! !
 !ComboBox categoriesFor: #placement:!geometry!private! !
+!ComboBox categoriesFor: #selectionByIndex!helpers!private!selection! !
 !ComboBox categoriesFor: #setSingleSelection:!private!selection! !
 !ComboBox categoriesFor: #textLimit:!accessing!public! !
 !ComboBox categoriesFor: #wmKillFocus:wParam:lParam:!event handling-win32!private! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
@@ -201,20 +201,30 @@ getMultipleSelections
 	the receiver, in ascending order. This will fail if the ListBox is not in multi-select mode."
 
 	| count buffer |
-	count := self getSelCount.
+	count := self getSelectedCount.
 	count <= 0 ifTrue: [^#()].
 	buffer := DWORDArray new: count.
-	(self 
+	(self
 		sendMessage: LB_GETSELITEMS
 		wParam: count
-		lpParam: buffer asParameter) = LB_ERR 
+		lpParam: buffer asParameter) = LB_ERR
 		ifTrue: [self errorNotMultiSelect].
 	^buffer collect: [:each | each + 1]!
 
-getSelCount
+getSelectedCount
 	| count |
 	count := self sendMessage: LB_GETSELCOUNT.
 	^count == LB_ERR ifTrue: [self getSingleSelection == 0 ifTrue: [0] ifFalse: [1]] ifFalse: [count]!
+
+getSelectionsByIndex
+	"Private - Query the current selections from the control."
+
+	^self isMultiSelect
+		ifTrue: [self getMultipleSelections]
+		ifFalse: 
+			[| index |
+			index := self getSingleSelection.
+			index == 0 ifTrue: [#()] ifFalse: [{index}]]!
 
 getSingleSelection
 	"Private - Answer the one-based <integer> 'index' of the selected object in the receiver or
@@ -365,6 +375,17 @@ lbnSelChange
 	self onSelChanging.
 	^nil!
 
+onRightButtonPressed: aMouseEvent
+	| indices |
+	self presenter trigger: #rightButtonPressed: with: aMouseEvent.
+	indices := self newSelectionsFromEvent: aMouseEvent.
+	(indices ~= lastSelIndices and: [self onSelChanging: indices cause: #mouse])
+		ifTrue: 
+			["Selection change permitted"
+			self selectionsByIndex: indices.
+			self onSelChanged: indices].
+	^aMouseEvent defaultWindowProcessing!
+
 positionForKeyboardContextMenu
 	"Answer the desired position for a context menu requested from the keyboard.
 	This should be based on the 'current selection', whatever that means in the context of the
@@ -376,17 +397,6 @@ positionForKeyboardContextMenu
 		ifTrue: [super positionForKeyboardContextMenu]
 		ifFalse: [self mapPoint: (self itemRect: caret) bottomLeft to: self class desktop]
 !
-
-primarySelectionIndex
-	"Answer the index of the selected item with focus, or zero if there is no selection."
-
-	| caret selected |
-	selected := self selectionsByIndex.
-	^selected isEmpty
-		ifTrue: [0]
-		ifFalse: 
-			[caret := self caretIndex.
-			(selected includes: caret) ifTrue: [caret] ifFalse: [selected first]]!
 
 selectAll
 	| size |
@@ -401,7 +411,7 @@ selectedCount
 	process. Thus we have to make this work for a list box which claims to be multiple
 	selection, but which is in fact single selection."
 
-	^self isMultiSelect ifTrue: [self getSelCount] ifFalse: [super selectedCount]!
+	^self isMultiSelect ifTrue: [self getSelectedCount] ifFalse: [super selectedCount]!
 
 selectIndex: anInteger set: aBoolean 
 	"Private - Set/reset the selection state of the object at the specified one-based <integer>
@@ -418,14 +428,6 @@ selectIndex: anInteger set: aBoolean
 					self errorSubscriptBounds: anInteger]
 				ifFalse: [self errorNotMultiSelect]]!
 
-selectionFromPoint: pos
-	"Private - Answer the selection that would occur if a mouse click at the
-	<Point>, pos, was passed to the control."
-
-	| item |
-	item := self itemFromPoint: pos.
-	^self isMultiSelect ifTrue: [item isNil ifTrue: [#()] ifFalse: [{item}]] ifFalse: [item]!
-
 selectionMode
 	^SelectionModes keyAtValue: (self baseStyle bitAnd: SelectionModeMask)!
 
@@ -440,7 +442,7 @@ selectionMode: aSymbol
 	mode := self selectionMode.
 	mode == aSymbol ifTrue: [^self].
 	self baseStyle: (SelectionModes at: aSymbol) maskedBy: SelectionModeMask.
-	(mode == #single eqv: aSymbol == #single) ifFalse: [self onSelChanged: self selectionsByIndex]!
+	(mode == #single eqv: aSymbol == #single) ifFalse: [self onSelChanged: self getSelectionsByIndex]!
 
 setSingleSelection: anInteger 
 	"Private - Set the selection to the item with the specified index (1-based), scrolling it
@@ -468,19 +470,7 @@ state
 	^super state
 		add: (MessageSend receiver: self selector: #horizontalExtent: argument: self horizontalExtent);
 		yourself
-!
-
-wmRButtonDown: message wParam: wParam lParam: lParam 
-	"Handle a WM_RBUTTONDOWN. We select the item under the mouse before
-	passing control on."
-
-	| sel |
-	sel := self selectionFromPoint: lParam lowPartSigned @ lParam highPartSigned.
-	sel notNil ifTrue: [self selectionByIndex: sel].
-	^super 
-		wmRButtonDown: message
-		wParam: wParam
-		lParam: lParam! !
+! !
 !ListBox categoriesFor: #anchorIndex!public!selection! !
 !ListBox categoriesFor: #anchorIndex:!public!selection! !
 !ListBox categoriesFor: #basicAdd:!adding!private! !
@@ -502,7 +492,8 @@ wmRButtonDown: message wParam: wParam lParam: lParam
 !ListBox categoriesFor: #dropHighlight!drag & drop!private! !
 !ListBox categoriesFor: #ensureSelectionVisible!public!selection! !
 !ListBox categoriesFor: #getMultipleSelections!private!selection! !
-!ListBox categoriesFor: #getSelCount!public!selection! !
+!ListBox categoriesFor: #getSelectedCount!private!selection! !
+!ListBox categoriesFor: #getSelectionsByIndex!private!selection! !
 !ListBox categoriesFor: #getSingleSelection!helpers!private!selection! !
 !ListBox categoriesFor: #hasPermanentScrollbars!public!testing! !
 !ListBox categoriesFor: #hasPermanentScrollbars:!accessing-styles!public! !
@@ -523,18 +514,16 @@ wmRButtonDown: message wParam: wParam lParam: lParam
 !ListBox categoriesFor: #lbnErrSpace!event handling-win32!private! !
 !ListBox categoriesFor: #lbnSelCancel!event handling-win32!private!selection! !
 !ListBox categoriesFor: #lbnSelChange!event handling-win32!private!selection! !
+!ListBox categoriesFor: #onRightButtonPressed:!event handling!public! !
 !ListBox categoriesFor: #positionForKeyboardContextMenu!enquiries!public! !
-!ListBox categoriesFor: #primarySelectionIndex!public!selection! !
 !ListBox categoriesFor: #selectAll!public!selection! !
 !ListBox categoriesFor: #selectedCount!public!selection! !
 !ListBox categoriesFor: #selectIndex:set:!private!selection! !
-!ListBox categoriesFor: #selectionFromPoint:!event handling!private! !
 !ListBox categoriesFor: #selectionMode!accessing-styles!public! !
 !ListBox categoriesFor: #selectionMode:!accessing-styles!public! !
 !ListBox categoriesFor: #setSingleSelection:!private!selection! !
 !ListBox categoriesFor: #showDropHighlight:!drag & drop!private! !
 !ListBox categoriesFor: #state!accessing!private! !
-!ListBox categoriesFor: #wmRButtonDown:wParam:lParam:!event handling-win32!public! !
 
 ListBox methodProtocol: #multipleIndexSelectableItems attributes: #(#readOnly) selectors: #(#addSelectionsByIndex: #clearSelectionsByIndex: #selectionsByIndex #selectionsByIndex: #selectionsByIndex:ifAbsent:)!
 ListBox methodProtocol: #multipleSelectableItems attributes: #(#readOnly) selectors: #(#addSelections: #addSelections:ifAbsent: #hasSelection #selectAll #selections #selections: #selections:ifAbsent:)!

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
@@ -148,18 +148,8 @@ getInfoTipBlock: monad
 	over. At present basic lists do not support bubble help, so this message is a no-op."
 !
 
-getMultipleSelections
-	"Private - Answer an <Array> of the one based <integer> indices of the selected items in 
-	the receiver, in ascending order."
-
-	"Subclasses which support multiple selections must override this method"
-
-	^self errorNotMultiSelect!
-
-getSingleSelection
-	"Private - Answer the 'index' of the selected object in the receiver or zero/nil if there is
-	none. The 'index' could be an <integer> or some kind of handle, whatever representation is
-	used by the control to communicate selections."
+getSelectionsByIndex
+	"Private - Query the current selections from the control."
 
 	^self subclassResponsibility!
 
@@ -264,6 +254,62 @@ list: aSequenceableCollection
 
 	self model list: aSequenceableCollection!
 
+newSelectionsFromEvent: aMouseEvent
+	"Private - Answer a collection of the <integer> selections that would occur if the `MouseEvent` argument was was passed to the control.
+	This method encodes the selection behaviour of `ListView` in response to mouse clicks, and is used there to predict what it will do in order to generate `selectionChanging:` events that the control itself does not provide (or at least not in virtual mode). The method is also used to implement right-click selection for `ListBox`, but note that it does not precisely replicate the listbox control's native left-click selection behaviour."
+
+	| itemClicked anyKeysDown newSelections anchorIndex shiftRange anchorIsSelected |
+	itemClicked := self itemFromPoint: aMouseEvent position.
+	"In single-select mode, the new selection is always the item clicked, or nothing if the click is outside all items."
+	self isMultiSelect
+		ifFalse: 
+			[^aMouseEvent isSelectionButtonDown
+				ifTrue: [itemClicked ifNil: [#()] ifNotNil: [:item | {item}]]
+				ifFalse: 
+					["Other buttons have no effect on the selection"
+					self selectionsByIndex]].
+	newSelections := self getSelectionsByIndex.
+	anyKeysDown := aMouseEvent isShiftDown or: [aMouseEvent isCtrlDown].
+	"If the click is outside all items, and ctrl or shift is down, nothing changes."
+	(itemClicked isNil and: [anyKeysDown]) ifTrue: [^newSelections].
+	"A right or middle click on an already-selected item also does not change the selection,
+	otherwise it would be very frustrating to open the context menu with multiple items selected.
+	The control also chooses to leave the selection alone if modifiers are held during a right/middle click."
+	(aMouseEvent button ~= #left and: [anyKeysDown or: [newSelections includes: itemClicked]])
+		ifTrue: [^newSelections].
+	"Having taken care of the above edge cases, if no keys are down, the behavior is equivalent to the single-select case."
+	anyKeysDown ifFalse: [^itemClicked ifNil: [#()] ifNotNil: [:item | {item}]].
+	"Only Ctrl is down, so we flip the selection state of the clicked item."
+	aMouseEvent isShiftDown
+		ifFalse: 
+			[newSelections := newSelections asSortedCollection.
+			newSelections remove: itemClicked ifAbsent: [newSelections add: itemClicked].
+			^newSelections asArray].
+	"At least Shift is down, so we must start examining the 'anchor'. This is the last item
+	that was clicked with no modifiers, only ctrl, or ctrl + shift (shift-clicks do *not* move the
+	anchor). It acts as the 'start point' for operations where shift is held--they affect
+	the range of items from the anchor to the click point, inclusive. Initially it is zero,
+	i.e. out-of-bounds, in which case holding shift essentially has no effect, and we act only on
+	the item actually clicked."
+	anchorIndex := self anchorIndex.
+	shiftRange := anchorIndex == 0
+				ifTrue: [itemClicked to: itemClicked]
+				ifFalse: [(anchorIndex min: itemClicked) to: (anchorIndex max: itemClicked)].
+	"Only shift is down, not ctrl, so the current selection will be entirely replaced by the marked range."
+	aMouseEvent isCtrlDown ifFalse: [^shiftRange asArray].
+	"Both ctrl and shift are down, so we set the selection state of the affected range to that of the
+	anchor itself. Note that this ignores the selection state of the item actually clicked
+	and everything in between it and the anchor."
+	newSelections := newSelections asSet.
+	anchorIsSelected := newSelections includes: anchorIndex.
+	shiftRange do: (anchorIsSelected
+				ifTrue: [[:i | newSelections add: i]]
+				ifFalse: [[:i | newSelections remove: i ifAbsent: []]]).
+	"For some reason, the item clicked is always left selected, even if we are deselecting the rest
+	of the marked range. This is not true in e.g. Windows Explorer--why is it in Dolphin?"
+	newSelections add: itemClicked.
+	^newSelections asSortedCollection asArray!
+
 noSelection
 	"Private - Answer the receiver's representation of no selection."
 
@@ -312,7 +358,7 @@ onSelChanged
 	"Private - Handle a selection change event by forwarding to the presenter."
 
 	| selections |
-	selections := self selectionsByIndex.
+	selections := self getSelectionsByIndex.
 	selections = self lastSelIndices ifFalse: [self onSelChanged: selections]!
 
 onSelChanged: anArray 
@@ -336,6 +382,17 @@ onSelectionChanging: aSelectionChangingEvent
 	false. The default is to trigger an #selectionChanging: event off the presenter"
 
 	self presenter trigger: #selectionChanging: with: aSelectionChangingEvent!
+
+primarySelectionIndex
+	"Answer the index of the selected item with focus, or zero if there is no selection."
+
+	| caret selected |
+	selected := self selectionsByIndex.
+	^selected isEmpty
+		ifTrue: [0]
+		ifFalse: 
+			[caret := self caretIndex.
+			(selected includes: caret) ifTrue: [caret] ifFalse: [selected first]]!
 
 refreshContents
 	"Refresh the receiver's contents to match the contents collection"
@@ -491,16 +548,9 @@ selections: newSelection ifAbsent: exceptionHandler
 		ifFalse: [self selection: newSelection first ifAbsent: exceptionHandler]!
 
 selectionsByIndex
-	"Answer an <Array> of the <integer> the indices of the selected items 
-	in the receiver in ascending order. The array will be empty if there is
-	no selection."
+	"Answer an <Array> of the <integer> the indices of the selected items in the receiver in ascending order. The array will be empty if there is no selection."
 
-	^self isMultiSelect
-		ifTrue: [self getMultipleSelections]
-		ifFalse: 
-			[| index |
-			index := self getSingleSelection.
-			index == 0 ifTrue: [#()] ifFalse: [{index}]]!
+	^self getSelectionsByIndex!
 
 selectionsByIndex: aCollectionOfIntegers
 	^self selectionsByIndex: aCollectionOfIntegers
@@ -604,8 +654,7 @@ updateSelectionCache
 !ListControlView categoriesFor: #errorNotMultiSelect!private!selection! !
 !ListControlView categoriesFor: #getInfoTipBlock!accessing!public! !
 !ListControlView categoriesFor: #getInfoTipBlock:!accessing!public! !
-!ListControlView categoriesFor: #getMultipleSelections!private!selection! !
-!ListControlView categoriesFor: #getSingleSelection!private!selection! !
+!ListControlView categoriesFor: #getSelectionsByIndex!private!selection! !
 !ListControlView categoriesFor: #getTextBlock!adapters!public! !
 !ListControlView categoriesFor: #getTextBlock:!adapters!public! !
 !ListControlView categoriesFor: #handleFromObject:!accessing!private! !
@@ -621,6 +670,7 @@ updateSelectionCache
 !ListControlView categoriesFor: #lastSelIndices!private! !
 !ListControlView categoriesFor: #list!accessing!public! !
 !ListControlView categoriesFor: #list:!accessing!public! !
+!ListControlView categoriesFor: #newSelectionsFromEvent:!event handling!private! !
 !ListControlView categoriesFor: #noSelection!constants!private! !
 !ListControlView categoriesFor: #objectFromHandle:!accessing!private! !
 !ListControlView categoriesFor: #objectFromHandle:ifAbsent:!accessing!private! !
@@ -633,6 +683,7 @@ updateSelectionCache
 !ListControlView categoriesFor: #onSelChanged:!event handling!private! !
 !ListControlView categoriesFor: #onSelectionChanged!event handling!public! !
 !ListControlView categoriesFor: #onSelectionChanging:!event handling!public! !
+!ListControlView categoriesFor: #primarySelectionIndex!public!selection! !
 !ListControlView categoriesFor: #refreshContents!public!updating! !
 !ListControlView categoriesFor: #requestDragObjects:!drag & drop!public! !
 !ListControlView categoriesFor: #resetSelection!public!selection! !

--- a/Core/Object Arts/Dolphin/MVP/SingleSelectListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/SingleSelectListBoxTest.cls
@@ -12,7 +12,7 @@ SingleSelectListBoxTest comment: ''!
 
 testSelectionModeChange
 	| objects |
-	self deny: presenter view isMultiSelect.
+	self deny: self isMultiSelect.
 	objects := self objectsToTest.
 	presenter model addAll: objects.
 	self assert: presenter hasSelection not.

--- a/Core/Object Arts/Dolphin/MVP/SingleSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/SingleSelectListViewTest.cls
@@ -18,7 +18,7 @@ sortSelections
 
 testSelectionModeChange
 	| objects caret |
-	self deny: presenter view isMultiSelect.
+	self deny: self isMultiSelect.
 	objects := self objectsToTest.
 	presenter model addAll: objects.
 	presenter selectionByIndex: 1.
@@ -26,7 +26,7 @@ testSelectionModeChange
 		shouldnt: [presenter view isMultiSelect: true]
 		trigger: #selectionChanged
 		against: presenter.
-	self assert: presenter view isMultiSelect.
+	self assert: self isMultiSelect.
 	self assert: presenter selectionsByIndex equals: #(1).
 	presenter selectionsByIndex: #(2 3).
 	caret := presenter view caretIndex.

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
@@ -244,11 +244,11 @@ ensureItemVisible: anObject
 
 ensureSelectionVisible
 	"Ensure the selected item is visible, scrolling it into view if necessary.
-	Raise an error if there is no selection."
+	Do nothing if there is no selection."
 
-	| selections |
-	selections := self selectionsByIndex.
-	selections notEmpty ifTrue: [self ensureVisible: selections first]!
+	| index |
+	index := self primarySelectionIndex.
+	index == 0 ifFalse: [self ensureVisible: index]!
 
 ensureVisible: anIntegerOrHandle 
 	"Ensure the item with the specified index is visible, scrolling it into view if necessary."
@@ -487,7 +487,7 @@ nmSelChanged: anExternalAddress
 	"Private - Default handler for the ??N_SELCHANGED notification message.
 	N.B. This notification is not necessarily sent by all subclasses."
 
-	^self onSelChanged: self selectionsByIndex!
+	^self onSelChanged: self getSelectionsByIndex!
 
 nmSetDispInfoW: pNMHDR
 	"Private - Default handler for the ?VN_SETDISPINFO notification message.

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -630,19 +630,6 @@ getItemText: anInteger
 	self lvmGetItem: item.
 	^item pszText!
 
-getMultipleSelections
-	"Private - Answer an <Array> of the <integer> the indices of the selected items in the
-	receiver in ascending order. The array will be empty if there is no selection."
-
-	^self withOldWndProc: 
-			[| count index answer |
-			count := self getSelectedCount.
-			answer := Array new: count.
-			index := -1.
-			1 to: count
-				do: [:i | answer at: i put: (index := self lvmGetNextItem: index flags: LVNI_SELECTED) + 1].
-			answer]!
-
 getSelectedCount
 	"Private - Query the total number of items selected from the control."
 
@@ -651,12 +638,16 @@ getSelectedCount
 getSelectionsByIndex
 	"Private - Query the actual current selections from the control."
 
-	^self isMultiSelect
-		ifTrue: [self getMultipleSelections]
-		ifFalse: 
-			[| index |
-			index := self getSingleSelection.
-			index == 0 ifTrue: [#()] ifFalse: [{index}]]!
+	| selections index |
+	selections := Array writeStream.
+	index := -1.
+	
+	[(index := self
+				sendMessage: LVM_GETNEXTITEM
+				wParam: index
+				lParam: LVNI_SELECTED) == -1]
+			whileFalse: [selections nextPut: index + 1].
+	^selections contents!
 
 getSingleSelection
 	"Private - Answer the one-based <integer> index of the selected object in the receiver or
@@ -1532,56 +1523,6 @@ maybeSelChanging: aSymbol
 			^self].
 	self onSelChanged: curSel!
 
-newSelectionsFromEvent: event
-	"Private - Answer a collection of the <integer> selections that would occur if the <MouseEvent>,
-	event, was was passed to the control."
-
-	| itemClicked anyKeysDown newSelections anchorIndex shiftRange anchorIsSelected |
-	itemClicked := self itemFromPoint: event position.
-	"In single-select mode, the new selection is always the item clicked, or nothing if the click is outside all items."
-	self isMultiSelect ifFalse: [^itemClicked ifNil: [#()] ifNotNil: [:item | {item}]].
-	newSelections := self getSelectionsByIndex.
-	anyKeysDown := event isShiftDown or: [event isCtrlDown].
-	"If the click is outside all items, and ctrl or shift is down, nothing changes."
-	(itemClicked isNil and: [anyKeysDown]) ifTrue: [^newSelections].
-	"A right or middle click on an already-selected item also does not change the selection,
-	otherwise it would be very frustrating to open the context menu with multiple items selected.
-	The control also chooses to leave the selection alone if modifiers are held during a right/middle click."
-	(event button ~= #left and: [anyKeysDown or: [newSelections includes: itemClicked]])
-		ifTrue: [^newSelections].
-	"Having taken care of the above edge cases, if no keys are down, the behavior is equivalent to the single-select case."
-	anyKeysDown ifFalse: [^itemClicked ifNil: [#()] ifNotNil: [:item | {item}]].
-	"Only Ctrl is down, so we flip the selection state of the clicked item."
-	event isShiftDown
-		ifFalse: 
-			[newSelections := newSelections asSortedCollection.
-			newSelections remove: itemClicked ifAbsent: [newSelections add: itemClicked].
-			^newSelections asArray].
-	"At least Shift is down, so we must start examining the 'anchor'. This is the last item
-	that was clicked with no modifiers, only ctrl, or ctrl + shift (shift-clicks do *not* move the
-	anchor). It acts as the 'start point' for operations where shift is held--they affect
-	the range of items from the anchor to the click point, inclusive. Initially it is zero,
-	i.e. out-of-bounds, in which case holding shift essentially has no effect, and we act only on
-	the item actually clicked."
-	anchorIndex := self anchorIndex.
-	shiftRange := anchorIndex == 0
-				ifTrue: [itemClicked to: itemClicked]
-				ifFalse: [(anchorIndex min: itemClicked) to: (anchorIndex max: itemClicked)].
-	"Only shift is down, not ctrl, so the current selection will be entirely replaced by the marked range."
-	event isCtrlDown ifFalse: [^shiftRange asArray].
-	"Both ctrl and shift are down, so we set the selection state of the affected range to that of the
-	anchor itself. Note that this ignores the selection state of the item actually clicked
-	and everything in between it and the anchor."
-	newSelections := newSelections asSet.
-	anchorIsSelected := newSelections includes: anchorIndex.
-	shiftRange do: (anchorIsSelected
-				ifTrue: [[:i | newSelections add: i]]
-				ifFalse: [[:i | newSelections remove: i ifAbsent: []]]).
-	"For some reason, the item clicked is always left selected, even if we are deselecting the rest
-	of the marked range. This is not true in e.g. Windows Explorer--why is it in Dolphin?"
-	newSelections add: itemClicked.
-	^newSelections asSortedCollection asArray!
-
 nmClick: pNMHDR 
 	"Private - Handler for a NM_CLICK notification message.
 	We intercept this to catch potential selection changes resulting from a drag-select
@@ -1657,6 +1598,12 @@ onButtonPressed: aMouseEvent
 				ifTrue: 
 					[| answer |
 					"Selection change permitted"
+					(Keyboard default isButtonDown: aMouseEvent button)
+						ifFalse: 
+							[self
+								postMessage: WM_MOUSEMOVE
+								wParam: (aMouseEvent wParam maskClear: aMouseEvent buttonFlag)
+								lParam: aMouseEvent lParam].
 					answer := aMouseEvent defaultWindowProcessing.
 					self onSelChanged.	"Selection may have changed"
 					answer]
@@ -1878,17 +1825,6 @@ primaryColumn
 
 	^self allColumns first!
 
-primarySelectionIndex
-	"Answer the index of the selected item with focus, or zero if there is no selection."
-
-	| caret selected |
-	selected := self selectionsByIndex.
-	^selected isEmpty
-		ifTrue: [0]
-		ifFalse: 
-			[caret := self caretIndex.
-			(selected includes: caret) ifTrue: [caret] ifFalse: [selected first]]!
-
 queryCommand: aCommandQuery
 	"Update aCommandQuery to indicates how a command would be processed.
 	if sent to the receiver. Answers whether the receiver recognised the command
@@ -1998,6 +1934,11 @@ selectIndex: anInteger set: aBoolean
 	aBoolean ifTrue: [anLvItem dwState: SelectionStateMask].
 	self lvmSetItem: anInteger - 1 state: anLvItem!
 
+selectionByIndex
+	"Answer the 1-based <integer> index of the selected item in the view, or zero if there is not exactly one selection."
+
+	^lastSelIndices size == 1 ifTrue: [lastSelIndices at: 1] ifFalse: [0]!
+
 selections: aCollection ifAbsent: aNiladicOrMonadicValuable
 	"Select the first occurrences of the specified collection of <Object>s in the receiver and
 	answer the new selection. If any of the elements of the collection are not present in the
@@ -2061,10 +2002,12 @@ setSelectionsByIndex: indices
 	| selections |
 	(indices noDifference: lastSelIndices) ifTrue: [^self].
 	self basicSelectionsByIndex: indices.
-	"Use the actual selections that resulted"
+	"Use the actual selections that resulted - we need to check these again against the last selections, as in the single selection case the actual selection may not have changed if multiple selections were requested and the first is still the same as the previous single selection."
 	selections := self getSelectionsByIndex.
-	self ensureItemsVisible: selections.
-	self onSelChanged: selections!
+	selections = lastSelIndices
+		ifFalse: 
+			[self ensureItemsVisible: selections.
+			self onSelChanged: selections]!
 
 setSingleSelection: anInteger 
 	self selectIndex: anInteger set: anInteger ~~ 0!
@@ -2361,7 +2304,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #forecolor:!accessing!public! !
 !ListView categoriesFor: #forgetLastClickedColumn!helpers!private! !
 !ListView categoriesFor: #getItemText:!accessing!private! !
-!ListView categoriesFor: #getMultipleSelections!private!selection! !
 !ListView categoriesFor: #getSelectedCount!private!selection! !
 !ListView categoriesFor: #getSelectionsByIndex!private!selection! !
 !ListView categoriesFor: #getSingleSelection!private!selection! !
@@ -2484,7 +2426,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #lvnMarqueeBegin:!event handling-win32!private! !
 !ListView categoriesFor: #lvnODStateChanged:!event handling-win32!private! !
 !ListView categoriesFor: #maybeSelChanging:!event handling!private! !
-!ListView categoriesFor: #newSelectionsFromEvent:!event handling!private! !
 !ListView categoriesFor: #nmClick:!event handling-win32!private! !
 !ListView categoriesFor: #nmNotify:!event handling-win32!private! !
 !ListView categoriesFor: #nmRClick:!event handling-win32!private! !
@@ -2507,7 +2448,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #onSelRemoved!public!selection! !
 !ListView categoriesFor: #onViewCreated!event handling!public! !
 !ListView categoriesFor: #primaryColumn!columns!private! !
-!ListView categoriesFor: #primarySelectionIndex!public!selection! !
 !ListView categoriesFor: #queryCommand:!commands!public! !
 !ListView categoriesFor: #refreshContents!public!updating! !
 !ListView categoriesFor: #refreshNonVirtual!private!updating! !
@@ -2520,6 +2460,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #selectAll!public!selection! !
 !ListView categoriesFor: #selectedCount!private!selection! !
 !ListView categoriesFor: #selectIndex:set:!private!selection!wine fix! !
+!ListView categoriesFor: #selectionByIndex!public!selection! !
 !ListView categoriesFor: #selections:ifAbsent:!public!selection! !
 !ListView categoriesFor: #selectionsByIndex!public!selection! !
 !ListView categoriesFor: #selectionsByIndex:ifAbsent:!public!selection! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TabView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TabView.cls
@@ -147,6 +147,13 @@ getItem: anInteger
 		lpParam: tcItem asParameter.
 	^tcItem!
 
+getSelectionsByIndex
+	"Private - Query the current selections from the control"
+
+	| index |
+	index := self getSingleSelection.
+	^index == 0 ifTrue: [#()] ifFalse: [{index}]!
+
 getSingleSelection
 	"Private - Answers the handle of the selected object in the receiver or zero if
 	there is none."
@@ -322,7 +329,7 @@ onMouseHovering: aMouseEvent
 		ifTrue: 
 			[| hit |
 			hit := self basicItemFromPoint: aMouseEvent position.
-			(hit isItemHit and: [self getSingleSelection ~= hit handle]) 
+			(hit isItemHit and: [self selectionByIndex ~= hit handle]) 
 				ifTrue: 
 					[| event |
 					event := SelectionChangingEvent forSource: self.
@@ -388,6 +395,11 @@ rows
 	"Answer the number of tab rows in the receiver."
 
 	^self sendMessage: TCM_GETROWCOUNT!
+
+selectionByIndex
+	"Answers the handle of the selected object in the receiver or zero if there is none."
+
+	^(self sendMessage: TCM_GETCURSEL) + 1!
 
 selectionByIndex: anInteger ifAbsent: exceptionHandler 
 	"Selects the object identified by the specified one-based <integer> index in the receiver.
@@ -595,6 +607,7 @@ viewModeChanged
 !TabView categoriesFor: #ensureVisible:!public! !
 !TabView categoriesFor: #fontChanged!public!updating! !
 !TabView categoriesFor: #getItem:!helpers!private! !
+!TabView categoriesFor: #getSelectionsByIndex!private!selection! !
 !TabView categoriesFor: #getSingleSelection!public!selection! !
 !TabView categoriesFor: #hasButtons!accessing-styles!public! !
 !TabView categoriesFor: #hasButtons:!accessing-styles!public! !
@@ -626,6 +639,7 @@ viewModeChanged
 !TabView categoriesFor: #queryCommand:!private! !
 !TabView categoriesFor: #refreshContents!public!updating! !
 !TabView categoriesFor: #rows!geometry!public! !
+!TabView categoriesFor: #selectionByIndex!public!selection! !
 !TabView categoriesFor: #selectionByIndex:ifAbsent:!public!selection! !
 !TabView categoriesFor: #setSingleSelection:!public!selection! !
 !TabView categoriesFor: #setViewMode:!accessing!private! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TabViewXP.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TabViewXP.cls
@@ -166,7 +166,7 @@ paintTabLabelsOn: aCanvas
 	itemCount < 1 ifTrue: [^self].
 	nOldMode := aCanvas backgroundMode: TRANSPARENT.
 	oldFont := aCanvas font: self actualFont.
-	selectedIndex := self getSingleSelection.
+	selectedIndex := self selectionByIndex.
 	1 to: selectedIndex - 1
 		do: 
 			[:i |
@@ -215,7 +215,7 @@ paintThemedTabsOn: aCanvas offset: aMonadicValuable
 	numItems <= 0 ifTrue: [^self].
 	"Paint all the tabs except for the selected one (assuming there is one; in very unusual circumstances there may not be)"
 	hot := self itemFromPoint: self cursorPosition.
-	selected := self getSingleSelection.
+	selected := self selectionByIndex.
 	themeLib := ThemeLibrary default.
 	dc := aCanvas asParameter.
 	hTheme := self theme.
@@ -325,7 +325,7 @@ paintVerticalTabLabelsOn: aCanvas
 	itemCount < 1 ifTrue: [^self].
 	oldFont := aCanvas font: self createVerticalFont.
 	nOldMode := aCanvas backgroundMode: TRANSPARENT.
-	selectedIndex := self getSingleSelection.
+	selectedIndex := self selectionByIndex .
 	1 to: selectedIndex - 1
 		do: 
 			[:i | 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TreeView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/TreeView.cls
@@ -357,6 +357,13 @@ getItemText: itemHandle
 	self tvmGetItem: tvItem.
 	^tvItem pszText!
 
+getSelectionsByIndex
+	"Private - Query the control for the current selection"
+
+	| selection |
+	selection := self tvmGetNextItem: nil code: TVGN_CARET.
+	^selection == 0 ifTrue: [#()] ifFalse: [{selection}]!
+
 getSingleSelection
 	"Private - Answer the 'index' (or in the case of the receiver, the handle) of the selected object in 
 	the receiver, or nil if there is no selection."
@@ -930,13 +937,18 @@ selection: anObject ifAbsent: exceptionHandler
 		ifNil: [exceptionHandler cull: anObject]
 		ifNotNil: [anObject]!
 
+selectionByIndex
+	"Answer the 'index' (or in the case of the receiver, the handle) of the selected object in the receiver, or 0 if there is no selection."
+
+	^self tvmGetNextItem: nil code: TVGN_CARET!
+
 selectionByIndex: itemHandle ifAbsent: exceptionHandler
 	"Select the object identified by the 'handle', itemHandle, in the receiver.
 	Answer the 'handle' of the resulting selection (the selection might not
 	change if the selection changing request is denied)."
 
 	| oldSel |
-	(oldSel := self getSingleSelection) = itemHandle
+	(oldSel := self selectionByIndex) = itemHandle
 		ifFalse: 
 			[(self setSingleSelection: itemHandle)
 				ifTrue: [(self objectFromHandle: itemHandle ifAbsent: []) ifNil: [^exceptionHandler value]]
@@ -1236,6 +1248,7 @@ wmKeyDown: message wParam: wParam lParam: lParam
 !TreeView categoriesFor: #getIndent!accessing!private! !
 !TreeView categoriesFor: #getItemState:!helpers!private! !
 !TreeView categoriesFor: #getItemText:!accessing!private! !
+!TreeView categoriesFor: #getSelectionsByIndex!private!selection! !
 !TreeView categoriesFor: #getSingleSelection!private!selection! !
 !TreeView categoriesFor: #handleFromObject:ifAbsent:!accessing!private! !
 !TreeView categoriesFor: #hasButtons!accessing-styles!public! !
@@ -1296,6 +1309,7 @@ wmKeyDown: message wParam: wParam lParam: lParam
 !TreeView categoriesFor: #resolutionScaledBy:!geometry!private! !
 !TreeView categoriesFor: #restoreSelection:!binary filing!private!selection! !
 !TreeView categoriesFor: #selection:ifAbsent:!public!selection! !
+!TreeView categoriesFor: #selectionByIndex!private!selection! !
 !TreeView categoriesFor: #selectionByIndex:ifAbsent:!public!selection! !
 !TreeView categoriesFor: #selectionFromPoint:!event handling!private! !
 !TreeView categoriesFor: #selectionIfNone:!public!selection! !


### PR DESCRIPTION
Only ListView and ListBox subclasses of ListControlView actually support
multiple selections, and of these only ListBox has an irregular API for
querying selections based on whether in single or multi-select mode.
Therefore we can push the complexity of selectionsByIndex down into ListBox
and simplify everything else.
The ListView tests are abstracted to provide coverage for ListBox as well.