### PR TITLE
Fix #898

### DIFF
--- a/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
@@ -10,6 +10,7 @@ Extensions to the basic SUnit unit testing packages, including the ability to te
 package methodNames
 	add: #TestCase -> #<=;
 	add: #TestCase -> #=;
+	add: #TestCase -> #assert:equals:description:;
 	add: #TestCase -> #assert:identicalTo:;
 	add: #TestCase -> #assert:isKindOf:;
 	add: #TestCase -> #assert:sameAs:;
@@ -72,6 +73,12 @@ package!
 	"Answer whether the argument, aTestCase, is considered exactly equivalent to the receiver."
 
 	^self class == aTestCase class and: [self selector == aTestCase selector]!
+
+assert: actualObject equals: expectedObject description: aStringOrValue
+	expectedObject = actualObject
+		ifFalse: 
+			[self fail: (self getDescription: aStringOrValue) , ': '
+						, (self comparingStringBetween: expectedObject and: actualObject)]!
 
 assert: actualObject identicalTo: expectedObject
 	expectedObject == actualObject
@@ -289,6 +296,7 @@ skipUnless: aBooleanOrBlock
 	aBooleanOrBlock value ifFalse: [TestSkip signal: 'Assumption in #skipUnless: failed']! !
 !TestCase categoriesFor: #<=!comparing!public! !
 !TestCase categoriesFor: #=!comparing!public! !
+!TestCase categoriesFor: #assert:equals:description:!asserting!public! !
 !TestCase categoriesFor: #assert:identicalTo:!asserting!public! !
 !TestCase categoriesFor: #assert:isKindOf:!asserting!public! !
 !TestCase categoriesFor: #assert:sameAs:!asserting!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/ResourceBrowser.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/ResourceBrowser.cls
@@ -160,7 +160,7 @@ showAsToolboxFor: aView at: aPoint
 
 	| toolbox toolboxView position |
 	toolboxView := (self loadViewResource: 'Toolbox' inContext: View desktop) bePopupFor: aView.
-	position := aView mapPoint: aPoint to: View desktop.
+	position := aView mapPointToScreen: aPoint.
 	toolboxView position: position.
 
 	toolbox := self new.

--- a/Core/Object Arts/Dolphin/IDE/Base/Splash/SeeingTheObjectsInside.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Splash/SeeingTheObjectsInside.cls
@@ -341,13 +341,13 @@ render
 
 showHintBubble
 	self hasHintBubble ifTrue: [^self].
-	hintBubble := (MessageBubble new)
+	hintBubble := MessageBubble new
 				caption: 'Hint';
 				maxWidth: 140;
 				willFade: true;
 				timeout: 5 seconds.
 	hintBubble
-		position: (self mapPoint: self sunPosition to: View desktop);
+		position: (self mapPointToScreen: self sunPosition);
 		notify: 'Find the dolphin inside and click to continue.'!
 
 startStepProcess

--- a/Core/Object Arts/Dolphin/MVP/Base/MouseEvent.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/MouseEvent.cls
@@ -26,6 +26,8 @@ buttonFlag
 	^self button ifNil: [0] ifNotNil: [:button | self class wParamFlags at: button]!
 
 isButtonDown
+	"Is the event associated with any mouse button being down?"
+
 	^wParam anyMask: ##(MK_LBUTTON | MK_RBUTTON | MK_MBUTTON | MK_XBUTTON1 | MK_XBUTTON2)!
 
 isCtrlDown
@@ -42,6 +44,11 @@ isMButtonDown
 	"Answer whether the middle mouse button is down."
 
 	^wParam anyMask: MK_MBUTTON!
+
+isModifierDown
+	"Answer whether the control or shift key is down."
+
+	^wParam anyMask: ##(MK_CONTROL | MK_SHIFT)!
 
 isRButtonDown
 	"Answer whether the right mouse button is down."
@@ -74,10 +81,11 @@ printWParamOn: aStream
 					aStream nextPutAll: each]]! !
 !MouseEvent categoriesFor: #button!accessing!public! !
 !MouseEvent categoriesFor: #buttonFlag!accessing!public! !
-!MouseEvent categoriesFor: #isButtonDown!helpers!private! !
+!MouseEvent categoriesFor: #isButtonDown!public!testing! !
 !MouseEvent categoriesFor: #isCtrlDown!public!testing! !
 !MouseEvent categoriesFor: #isLButtonDown!public!testing! !
 !MouseEvent categoriesFor: #isMButtonDown!public!testing! !
+!MouseEvent categoriesFor: #isModifierDown!public!testing! !
 !MouseEvent categoriesFor: #isRButtonDown!public!testing! !
 !MouseEvent categoriesFor: #isSelectionButtonDown!public!testing! !
 !MouseEvent categoriesFor: #isShiftDown!public!testing! !

--- a/Core/Object Arts/Dolphin/MVP/Base/MouseTracker.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/MouseTracker.cls
@@ -213,15 +213,13 @@ simulateMouseMouse: aKeyEvent
 	| pos event wParam |
 	pos := Cursor position.
 	wParam := 0.
-	##((OrderedCollection new)
-		add: VK_LBUTTON -> MK_LBUTTON;
-		add: VK_MBUTTON -> MK_MBUTTON;
-		add: VK_RBUTTON -> MK_RBUTTON;
-		add: VK_CONTROL -> MK_CONTROL;
-		add: VK_SHIFT -> MK_SHIFT;
-		add: VK_XBUTTON1 -> MK_XBUTTON1;
-		add: VK_XBUTTON2 -> MK_XBUTTON2;
-		asArray)
+	##({VK_LBUTTON -> MK_LBUTTON.
+		VK_MBUTTON -> MK_MBUTTON.
+		VK_RBUTTON -> MK_RBUTTON.
+		VK_CONTROL -> MK_CONTROL.
+		VK_SHIFT -> MK_SHIFT.
+		VK_XBUTTON1 -> MK_XBUTTON1.
+		VK_XBUTTON2 -> MK_XBUTTON2})
 			do: [:each | (Keyboard default isKeyDown: each key) ifTrue: [wParam := wParam bitOr: each value]].
 	event := MouseEvent
 				window: self view

--- a/Core/Object Arts/Dolphin/MVP/Base/PointEvent.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/PointEvent.cls
@@ -24,7 +24,7 @@ printLParamOn: aStream
 screenPosition
 	"Answer the point stored in the receiver's lParam mapped to screen coordinates"
 
-	^self window mapPoint: self position to: View desktop!
+	^self window mapPointToScreen: self position!
 
 x
 	"Answer the x-position of the pointer."

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -2127,6 +2127,14 @@ mapPoint: aPoint to: anotherView
 		cPoints: 1.
 	^pt asPoint!
 
+mapPointToScreen: aPoint
+	"Maps the `Point` argument from the coordinate system of the receiver to screen coordindates."
+
+	| pt |
+	pt := POINTL fromPoint: aPoint.
+	UserLibrary default clientToScreen: handle lpPoint: pt.
+	^pt asPoint!
+
 mapRectangle: aRectangle to: anotherView
 	"Maps aRectangle from the coordinate system of the receiver into that of anotherView."
 
@@ -4739,6 +4747,7 @@ zOrderTop
 !View categoriesFor: #managedSubViews!hierarchy!public!sub views! !
 !View categoriesFor: #managedSubViewsDo:!hierarchy!public!sub views! !
 !View categoriesFor: #mapPoint:to:!geometry!public! !
+!View categoriesFor: #mapPointToScreen:!geometry!public! !
 !View categoriesFor: #mapRectangle:to:!geometry!public! !
 !View categoriesFor: #maxExtent!accessing!public! !
 !View categoriesFor: #minExtent!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/WindowsEvent.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/WindowsEvent.cls
@@ -30,6 +30,9 @@ isHandled
 lParam
 	^lParam!
 
+lParam: anInteger 
+	lParam := anInteger!
+
 lParamX
 	"Answer the X-value signed integer packed into the low half of the receiver's lParam field.
 	Note that this could be a 16 or 32-bit value depending on whether the host OS is 32 or
@@ -104,6 +107,7 @@ wParam
 !WindowsEvent categoriesFor: #defaultWindowProcessing!event handling!public! !
 !WindowsEvent categoriesFor: #isHandled!public!testing! !
 !WindowsEvent categoriesFor: #lParam!accessing!public! !
+!WindowsEvent categoriesFor: #lParam:!accessing!public! !
 !WindowsEvent categoriesFor: #lParamX!accessing!public! !
 !WindowsEvent categoriesFor: #lParamY!accessing!public! !
 !WindowsEvent categoriesFor: #lResult!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -343,7 +343,7 @@ SelectableItemsTest subclass: #SelectableTreeItemsTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 SelectableListItemsTest subclass: #ListControlTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'selectionChanged selectionChanging timedout events clicks'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -358,12 +358,12 @@ SelectableListItemsTest subclass: #TabViewTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ListControlTest subclass: #ListBoxTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'lbnSelChange'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ListControlTest subclass: #ListViewTest
-	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks timedout'
+	instanceVariableNames: 'nmClick'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -364,7 +364,7 @@ ListControlTest subclass: #ListBoxTest
 	classInstanceVariableNames: ''!
 ListControlTest subclass: #ListViewTest
 	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks timedout'
-	classVariableNames: 'Test898'
+	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ListBoxTest subclass: #MultiSelectListBoxTest

--- a/Core/Object Arts/Dolphin/MVP/ListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListBoxTest.cls
@@ -45,7 +45,7 @@ testNewSelectionsClickOutsideListWithModifiers
 				presenter selectionsByIndex: selection.
 				event := self mouseDownEventOnItem: 0 buttons: (pair first copyWith: #left).
 				expected := self isMultiSelect ifTrue: [pair second] ifFalse: [selection].
-				self verifyNewSelectionsFromEvent: event equals: expected]!
+				self verifySelectionsFromMouseDown: event equals: expected]!
 
 verifyClicks: anArray
 	self assert: clicks size equals: anArray size! !

--- a/Core/Object Arts/Dolphin/MVP/ListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListBoxTest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 ListControlTest subclass: #ListBoxTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'lbnSelChange'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -17,20 +17,19 @@ classToTest
 newSelectionAfterLeftClickOutsideList: anArrayOfInteger 
 	^anArrayOfInteger!
 
-sendClickEvent: aMouseEvent
-	| keyState newKeyState |
-	"The ListBox control ignores the button/key state flags the mouse messages and uses the keyboard state, so unfortunately we have to set that.
-	We use an ensure: block to prevent keys appearing stuck down if there is an error, but stopping in the debugger after the key state is set, but before the ensure block is run, will leave the shift and/or control keys stuck down. Hitting the actual keys will clear this though."
-	keyState := Keyboard default getState.
-	newKeyState := keyState copy.
-	aMouseEvent isCtrlDown ifTrue: [newKeyState at: VK_CONTROL + 1 put: 128].
-	aMouseEvent isShiftDown ifTrue: [newKeyState at: VK_SHIFT + 1 put: 128].
-	self postClickEvent: aMouseEvent.
-	
-	[newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: newKeyState].
-	"Dispatch the posted messages to the control"
-	SessionManager inputState pumpMessages]
-			ensure: [newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: keyState]]!
+setupClickIntercept
+	| anonClass method |
+	"Convert the ListBox to an instance of an anonymous subclass with an override of lbnSelChange handler that allows us to intercept the notifications."
+	anonClass := ListBox newAnonymousSubclass.
+	presenter view becomeA: anonClass.
+	method := anonClass
+				compile: 'lbnSelChange
+		#placeholder value.
+		^super lbnSelChange'.
+	self assert: (method literalAt: 1) equals: #placeholder.
+	lbnSelChange := [clicks addLast: #()].
+	method whileMutableDo: 
+			[method literalAt: 1 put: [lbnSelChange value]]!
 
 testNewSelectionsClickOutsideListWithModifiers
 	| event selection expected |
@@ -46,9 +45,13 @@ testNewSelectionsClickOutsideListWithModifiers
 				presenter selectionsByIndex: selection.
 				event := self mouseDownEventOnItem: 0 buttons: (pair first copyWith: #left).
 				expected := self isMultiSelect ifTrue: [pair second] ifFalse: [selection].
-				self verifyNewSelectionsFromEvent: event equals: expected]! !
+				self verifyNewSelectionsFromEvent: event equals: expected]!
+
+verifyClicks: anArray
+	self assert: clicks size equals: anArray size! !
 !ListBoxTest categoriesFor: #classToTest!helpers!private! !
 !ListBoxTest categoriesFor: #newSelectionAfterLeftClickOutsideList:!helpers!private! !
-!ListBoxTest categoriesFor: #sendClickEvent:!helpers!private! !
+!ListBoxTest categoriesFor: #setupClickIntercept!private! !
 !ListBoxTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !
+!ListBoxTest categoriesFor: #verifyClicks:!helpers!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 SelectableListItemsTest subclass: #ListControlTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'selectionChanged selectionChanging timedout events clicks'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -16,6 +16,9 @@ assertCaretVisible
 	view := presenter view.
 	pos := (view itemRect: view caretIndex) origin.
 	self assert: (view rectangle containsPoint: pos)!
+
+expectedSelectionsForSendShiftClickTests
+	^self isMultiSelect ifTrue: [#(2 3 4)] ifFalse: [#(4)]!
 
 isMultiSelect
 	"Private - Is this a test of a list control in multi-select mode?"
@@ -44,6 +47,19 @@ mouseDownEventOnItem: itemIndex buttons: anArray
 newSelectionAfterLeftClickOutsideList: anArrayOfInteger 
 	^self subclassResponsibility!
 
+onSelectionChanged
+	selectionChanged value!
+
+onSelectionChanging: aSelectionChangingEvent 
+	selectionChanging value: aSelectionChangingEvent!
+
+onTimerTick: wParam
+	wParam = self timeoutId ifTrue: [
+		timedout := true.
+		presenter view killTimer: self timeoutId.
+		"Post a mouse move so that the ListView control returns from its WM_?BUTTONDOWN handler"
+		presenter view postMessage: WM_LBUTTONUP wParam: 0 lParam: 0]!
+
 postClickEvent: aMouseEvent
 	self assert: aMouseEvent isButtonDown.
 	"Clear the message queue"
@@ -58,10 +74,119 @@ postClickEvent: aMouseEvent
 			lParam: aMouseEvent lParam!
 
 sendClickEvent: aMouseEvent
-	self subclassResponsibility!
+	| keyState newKeyState pos |
+	"The ListBox control ignores the button/key state flags the mouse messages and uses the keyboard state, so unfortunately we have to set that.
+	We use an ensure: block to prevent keys appearing stuck down if there is an error, but stopping in the debugger after the key state is set, but before the ensure block is run, will leave the shift and/or control keys stuck down. Hitting the actual keys will clear this though."
+	keyState := Keyboard default getState.
+	newKeyState := keyState copy.
+	aMouseEvent isCtrlDown ifTrue: [newKeyState at: VK_CONTROL + 1 put: 128].
+	aMouseEvent isShiftDown ifTrue: [newKeyState at: VK_SHIFT + 1 put: 128].
+
+	"The mouse needs to be outside any Dolphin window in order to cause the control's WM_?BUTTONDOWN handler to block in the way described in #898"
+	pos := POINTL new.
+	UserLibrary default
+		getCursorPos: pos;
+		setCursorPosX: 0 y: 0.
+	self postClickEvent: aMouseEvent.
+	"Schedule a WM_TIMER so that we can detect the control's WM_?BUTTONDOWN handler not returning"
+	timedout := false.
+	presenter view setTimer: self timeoutId interval: 500.
+	"Dispatch the posted mouse down/up messages to the control"
+	
+	[newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: newKeyState].
+	"Dispatch the posted messages to the control"
+	SessionManager inputState pumpMessages]
+			ensure: [newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: keyState]].
+	presenter view killTimer: self timeoutId.
+	UserLibrary default setCursorPosX: pos x y: pos y.
+	"If this fires, it means the control did not return from the call to its window proc to handle the button down event in ListView>>onButtonPressed:"
+	self deny: timedout description: 'Control blocked in mouse down handler'!
+
+setupClickIntercept
+	^self subclassResponsibility!
+
+setUpForSelectionEventTesting
+	self setUpForSelectionTesting.
+	events := OrderedCollection new.
+	presenter view
+		when: #selectionChanging:
+			send: #onSelectionChanging:
+			to: self;
+		when: #selectionChanged
+			send: #onSelectionChanged
+			to: self.
+	selectionChanging := [:event | events addLast: event].
+	"The ListView (and other selectable item views) should really be generating a #selectionChanged: event with a SelectionChangedEvent parameter, but at present they don't"
+	selectionChanged := 
+			[events addLast: ((SelectionChangedEvent forSource: presenter)
+						newSelections: presenter view selectionsByIndex;
+						yourself)].
+	presenter view
+		when: #timerTick:
+		send: #onTimerTick:
+		to: self.
+	timedout := false.
+	clicks := OrderedCollection new.
+	self setupClickIntercept!
 
 setUpForSelectionTesting
 	presenter list: (1 to: 10) asOrderedCollection!
+
+testEventsFromClickSelectChangeConfirmed
+	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is confirmed with a prompt so the control does not receive the mouse up associated with the actual click.
+	Regression test for #898."
+
+	self setUpForSelectionEventTesting.
+	selectionChanging := 
+			[:selChanging |
+			| msg |
+			events addLast: selChanging.
+			"Consume the mouse up so the control does not receive it."
+			msg := MSG new.
+			UserLibrary default
+				getMessage: msg
+				hWnd: presenter view handle
+				wMsgFilterMin: WM_LBUTTONUP
+				wMsgFilterMax: WM_LBUTTONUP.
+			"Allow the selection change to proceed"
+			selChanging value: true].
+	self verifyEventsFromClickSelectionChangeAccepted: #left!
+
+testEventsFromClickSelectChangeRefused
+	"Test that the expected sequence of selection events are raised for left-click selection, simulating the selectionChanging: event being refused by user in response to a prompt so the control does not receive the mouse up associated with the actual click."
+
+	self setUpForSelectionEventTesting.
+	selectionChanging := 
+			[:selChanging |
+			| msg |
+			events addLast: selChanging.
+			"Snaffle the mouse up as the control will lose focus/activation as soon as the prompt is opened"
+			msg := MSG new.
+			UserLibrary default
+				getMessage: msg
+				hWnd: presenter view handle
+				wMsgFilterMin: WM_LBUTTONUP
+				wMsgFilterMax: WM_LBUTTONUP.
+			"Prevent the selection change from proceeding"
+			selChanging value: false].
+	self verifyEventsFromClickSelectionChangeRejected: #left!
+
+testEventsFromClickSelectionChangePermitted
+	"Test that the expected sequence of selectionChanging: and selectionChanged events are raised for left-click selection with the selection change permitted without a prompt.
+	The test sends simulated mouse clicks to the control to try and test the actual control integration."
+
+	self setUpForSelectionEventTesting.
+	self verifyEventsFromClickSelectionChangeAccepted: #left!
+
+testEventsFromClickSelectionChangeRejected
+	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is rejected but without a prompt so the control still receives the mouse up."
+
+	self setUpForSelectionEventTesting.
+	selectionChanging := 
+			[:selChanging |
+			events addLast: selChanging.
+			selChanging value: false].
+	self verifyEventsFromClickSelectionChangeRejected: #left!
 
 testLastSelectionCacheUpdatedOnRemove
 	"#717"
@@ -203,6 +328,64 @@ testSelectionsByIndex
 		ifTrue: [self verifyMultiSelectionsByIndex]
 		ifFalse: [self verifySingleSelectionsByIndex]!
 
+timeoutId
+	^171717!
+
+verifyClicks: anArray
+	self subclassResponsibility!
+
+verifyEventsFromClickSelectionChangeAccepted: aSymbol
+	| changed changing click event |
+	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
+	self sendClickEvent: event.
+	self assert: events size equals: 2.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #().
+	self assert: changing newSelections equals: #(2).
+	changed := events last.
+	self assert: changed isKindOf: SelectionChangedEvent.
+	self assert: changed newSelections equals: #(2).
+	self verifyClicks: {{2. event position}}.
+	"Send a shift-left-click event over a subsequent item."
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
+	event := self mouseDownEventOnItem: 4 buttons: {aSymbol. #shift}.
+	self sendClickEvent: event.
+	self assert: events size equals: 2.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #(2).
+	self assert: changing newSelections equals: self expectedSelectionsForSendShiftClickTests.
+	changed := events last.
+	self assert: changed isKindOf: SelectionChangedEvent.
+	self assert: changed newSelections equals: self expectedSelectionsForSendShiftClickTests.
+	self verifyClicks: {{4. event position}}!
+
+verifyEventsFromClickSelectionChangeRejected: aSymbol
+	| event changing |
+	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
+	self sendClickEvent: event.
+	self assert: events size equals: 1.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #().
+	self assert: changing newSelections equals: #(2).
+	"Because we didn't forward the button down event to the control, there should be no click notification."
+	self assert: clicks size equals: 0.
+	"Ensure there is a selection and then send a shift-left-click event over a subsequent item."
+	presenter view selectionByIndex: 2.
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
+	event := self mouseDownEventOnItem: 4 buttons: {aSymbol. #shift}.
+	self sendClickEvent: event.
+	self assert: events size equals: 1.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #(2).
+	self assert: changing newSelections equals: self expectedSelectionsForSendShiftClickTests.
+	self assert: clicks size equals: 0!
+
 verifyMultiSelectionsByIndex
 	| objects sel |
 	objects := self objectsToTest.
@@ -319,12 +502,22 @@ verifySingleSelectionsByIndex
 		against: presenter.
 	self assert: presenter selectionsByIndex equals: #()! !
 !ListControlTest categoriesFor: #assertCaretVisible!helpers!private! !
+!ListControlTest categoriesFor: #expectedSelectionsForSendShiftClickTests!constants!private! !
 !ListControlTest categoriesFor: #isMultiSelect!private!testing! !
 !ListControlTest categoriesFor: #mouseDownEventOnItem:buttons:!helpers!private! !
 !ListControlTest categoriesFor: #newSelectionAfterLeftClickOutsideList:!constants!private! !
+!ListControlTest categoriesFor: #onSelectionChanged!helpers!private! !
+!ListControlTest categoriesFor: #onSelectionChanging:!public! !
+!ListControlTest categoriesFor: #onTimerTick:!event handling!private! !
 !ListControlTest categoriesFor: #postClickEvent:!helpers!private! !
 !ListControlTest categoriesFor: #sendClickEvent:!helpers!private! !
+!ListControlTest categoriesFor: #setupClickIntercept!helpers!private! !
+!ListControlTest categoriesFor: #setUpForSelectionEventTesting!helpers!private! !
 !ListControlTest categoriesFor: #setUpForSelectionTesting!helpers!private! !
+!ListControlTest categoriesFor: #testEventsFromClickSelectChangeConfirmed!public!unit tests! !
+!ListControlTest categoriesFor: #testEventsFromClickSelectChangeRefused!public!unit tests! !
+!ListControlTest categoriesFor: #testEventsFromClickSelectionChangePermitted!public!unit tests! !
+!ListControlTest categoriesFor: #testEventsFromClickSelectionChangeRejected!public!unit tests! !
 !ListControlTest categoriesFor: #testLastSelectionCacheUpdatedOnRemove!public!unit tests! !
 !ListControlTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !
 !ListControlTest categoriesFor: #testNewSelectionsCtrlClickOnSelectedItem!public!unit tests! !
@@ -337,6 +530,10 @@ verifySingleSelectionsByIndex
 !ListControlTest categoriesFor: #testNewSelectionsSimpleLeftClick!public!unit tests! !
 !ListControlTest categoriesFor: #testProgrammaticSelectionVisible!public!unit tests! !
 !ListControlTest categoriesFor: #testSelectionsByIndex!public!unit tests! !
+!ListControlTest categoriesFor: #timeoutId!constants!private! !
+!ListControlTest categoriesFor: #verifyClicks:!helpers!private! !
+!ListControlTest categoriesFor: #verifyEventsFromClickSelectionChangeAccepted:!helpers!private! !
+!ListControlTest categoriesFor: #verifyEventsFromClickSelectionChangeRejected:!private! !
 !ListControlTest categoriesFor: #verifyMultiSelectionsByIndex!helpers!private! !
 !ListControlTest categoriesFor: #verifyNewSelectionsFromEvent:equals:!helpers!private! !
 !ListControlTest categoriesFor: #verifySingleSelectionsByIndex!helpers!private! !

--- a/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
@@ -32,8 +32,8 @@ mouseDownEventOnItem: itemIndex buttons: anArray
 	mouseButton := mouseButton anyOne.
 	keys := (anArray collect: [:each | MouseEvent wParamFlags at: each]) fold: [:a :b | a bitOr: b].
 	position := itemIndex == 0
-				ifTrue: [presenter clientExtent - (1 @ 1)]
-				ifFalse: [(presenter itemRect: itemIndex) origin + (1 @ 1)].
+				ifTrue: [presenter clientRectangle corner - 1]
+				ifFalse: [(presenter itemRect: itemIndex) origin + 1].
 	^MouseEvent
 		window: presenter
 		message: (##(IdentityDictionary
@@ -41,6 +41,15 @@ mouseDownEventOnItem: itemIndex buttons: anArray
 					at: mouseButton)
 		wParam: keys
 		lParam: position asDword!
+
+mouseUpForMouseDown: aMouseEvent
+	| upEvent |
+	upEvent := MouseEvent
+				window: presenter
+				message: aMouseEvent message + 1
+				wParam: (aMouseEvent wParam maskClear: aMouseEvent buttonFlag)
+				lParam: aMouseEvent lParam.
+	^upEvent!
 
 newSelectionAfterLeftClickOutsideList: anArrayOfInteger 
 	^self subclassResponsibility!
@@ -57,36 +66,41 @@ onTimerTick: wParam
 			[timedout := true.
 			presenter killTimer: wParam.
 			"Post a mouse up so that the ListView control returns from its WM_?BUTTONDOWN handler"
-			presenter postMessage: wParam + 1]!
+			presenter postMessage: wParam + 1 wParam: 0 lParam: 0]!
 
-postClickEvent: aMouseEvent
-	self assert: aMouseEvent isButtonDown.
+postMouseEvents: aSequencedReadableCollection
+	self assert: aSequencedReadableCollection first isButtonDown.
 	"Clear the message queue"
 	SessionManager inputState pumpMessages.
-	"Post a matched mouse down/up pair to the control"
-	presenter view
-		postMessage: aMouseEvent message
-			wParam: aMouseEvent wParam
-			lParam: aMouseEvent lParam;
-		postMessage: aMouseEvent message + 1
-			wParam: (aMouseEvent wParam maskClear: aMouseEvent buttonFlag)
-			lParam: aMouseEvent lParam!
+	aSequencedReadableCollection do: 
+			[:each |
+			presenter
+				postMessage: each message
+				wParam: each wParam
+				lParam: each lParam]!
 
 sendClickEvent: aMouseEvent
-	| keyState newKeyState pos |
-	"The ListBox control ignores the button/key state flags the mouse messages and uses the keyboard state, so unfortunately we have to set that.
-	We use an ensure: block to prevent keys appearing stuck down if there is an error, but stopping in the debugger after the key state is set, but before the ensure block is run, will leave the shift and/or control keys stuck down. Hitting the actual keys will clear this though."
-	keyState := Keyboard default getState.
-	newKeyState := keyState copy.
-	aMouseEvent isCtrlDown ifTrue: [newKeyState at: VK_CONTROL + 1 put: 128].
-	aMouseEvent isShiftDown ifTrue: [newKeyState at: VK_SHIFT + 1 put: 128].
-
+	| pos |
 	"The mouse needs to be outside any Dolphin window in order to cause the control's WM_?BUTTONDOWN handler to block in the way described in #898"
 	pos := POINTL new.
 	UserLibrary default
 		getCursorPos: pos;
 		setCursorPosX: 0 y: 0.
-	self postClickEvent: aMouseEvent.
+	self sendMouseEvents: {aMouseEvent. self mouseUpForMouseDown: aMouseEvent}.
+	UserLibrary default setCursorPosX: pos x y: pos y.
+!
+
+sendMouseEvents: aSequencedReadableCollection
+	| keyState newKeyState aMouseEvent |
+	"The ListBox control ignores the button/key state flags the mouse messages and uses the keyboard state, so unfortunately we have to set that.
+	We use an ensure: block to prevent keys appearing stuck down if there is an error, but stopping in the debugger after the key state is set, but before the ensure block is run, will leave the shift and/or control keys stuck down. Hitting the actual keys will clear this though."
+	keyState := Keyboard default getState.
+	newKeyState := keyState copy.
+	aMouseEvent := aSequencedReadableCollection first.
+	aMouseEvent isCtrlDown ifTrue: [newKeyState at: VK_CONTROL + 1 put: 128].
+	aMouseEvent isShiftDown ifTrue: [newKeyState at: VK_SHIFT + 1 put: 128].
+	self postMouseEvents: aSequencedReadableCollection.
+
 	"Schedule a WM_TIMER so that we can detect the control's WM_?BUTTONDOWN handler not returning"
 	timedout := false.
 	presenter view setTimer: aMouseEvent message interval: 500.
@@ -94,10 +108,16 @@ sendClickEvent: aMouseEvent
 	
 	[newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: newKeyState].
 	"Dispatch the posted messages to the control"
-	SessionManager inputState pumpMessages]
+	false
+		ifTrue: 
+			[| i |
+			i := aSequencedReadableCollection size.
+			SessionManager inputState loopWhile: 
+					[Sound bell.
+					(i := i - 1) > 0]]
+		ifFalse: [SessionManager inputState pumpMessages]]
 			ensure: [newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: keyState]].
 	presenter view killTimer: aMouseEvent message.
-	UserLibrary default setCursorPosX: pos x y: pos y.
 	"If this fires, it means the control did not return from the call to its window proc to handle the button down event in ListView>>onButtonPressed:"
 	self deny: timedout description: 'Control blocked in mouse down handler'!
 
@@ -474,12 +494,14 @@ verifySingleSelectionsByIndex
 !ListControlTest categoriesFor: #expectedSelectionsForSendShiftClickTests!constants!private! !
 !ListControlTest categoriesFor: #isMultiSelect!private!testing! !
 !ListControlTest categoriesFor: #mouseDownEventOnItem:buttons:!helpers!private! !
+!ListControlTest categoriesFor: #mouseUpForMouseDown:!helpers!private! !
 !ListControlTest categoriesFor: #newSelectionAfterLeftClickOutsideList:!constants!private! !
 !ListControlTest categoriesFor: #onSelectionChanged!helpers!private! !
 !ListControlTest categoriesFor: #onSelectionChanging:!public! !
 !ListControlTest categoriesFor: #onTimerTick:!event handling!private! !
-!ListControlTest categoriesFor: #postClickEvent:!helpers!private! !
+!ListControlTest categoriesFor: #postMouseEvents:!helpers!private! !
 !ListControlTest categoriesFor: #sendClickEvent:!helpers!private! !
+!ListControlTest categoriesFor: #sendMouseEvents:!helpers!private! !
 !ListControlTest categoriesFor: #setupClickIntercept!helpers!private! !
 !ListControlTest categoriesFor: #setUpForSelectionEventTesting!helpers!private! !
 !ListControlTest categoriesFor: #setUpForSelectionTesting!helpers!private! !

--- a/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
@@ -36,11 +36,9 @@ mouseDownEventOnItem: itemIndex buttons: anArray
 				ifFalse: [(presenter itemRect: itemIndex) origin + (1 @ 1)].
 	^MouseEvent
 		window: presenter
-		message: (##(IdentityDictionary new
-				at: #left put: WM_LBUTTONDOWN;
-				at: #right put: WM_RBUTTONDOWN;
-				at: #middle put: WM_MBUTTONDOWN;
-				yourself) at: mouseButton)
+		message: (##(IdentityDictionary
+				withAll: {#left -> WM_LBUTTONDOWN. #right -> WM_RBUTTONDOWN. #middle -> WM_MBUTTONDOWN})
+					at: mouseButton)
 		wParam: keys
 		lParam: position asDword!
 
@@ -54,11 +52,12 @@ onSelectionChanging: aSelectionChangingEvent
 	selectionChanging value: aSelectionChangingEvent!
 
 onTimerTick: wParam
-	wParam = self timeoutId ifTrue: [
-		timedout := true.
-		presenter view killTimer: self timeoutId.
-		"Post a mouse move so that the ListView control returns from its WM_?BUTTONDOWN handler"
-		presenter view postMessage: WM_LBUTTONUP wParam: 0 lParam: 0]!
+	(wParam == WM_LBUTTONDOWN or: [wParam == WM_RBUTTONDOWN])
+		ifTrue: 
+			[timedout := true.
+			presenter killTimer: wParam.
+			"Post a mouse up so that the ListView control returns from its WM_?BUTTONDOWN handler"
+			presenter postMessage: wParam + 1]!
 
 postClickEvent: aMouseEvent
 	self assert: aMouseEvent isButtonDown.
@@ -90,14 +89,14 @@ sendClickEvent: aMouseEvent
 	self postClickEvent: aMouseEvent.
 	"Schedule a WM_TIMER so that we can detect the control's WM_?BUTTONDOWN handler not returning"
 	timedout := false.
-	presenter view setTimer: self timeoutId interval: 500.
+	presenter view setTimer: aMouseEvent message interval: 500.
 	"Dispatch the posted mouse down/up messages to the control"
 	
 	[newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: newKeyState].
 	"Dispatch the posted messages to the control"
 	SessionManager inputState pumpMessages]
 			ensure: [newKeyState = keyState ifFalse: [UserLibrary default setKeyboardState: keyState]].
-	presenter view killTimer: self timeoutId.
+	presenter view killTimer: aMouseEvent message.
 	UserLibrary default setCursorPosX: pos x y: pos y.
 	"If this fires, it means the control did not return from the call to its window proc to handle the button down event in ListView>>onButtonPressed:"
 	self deny: timedout description: 'Control blocked in mouse down handler'!
@@ -209,11 +208,11 @@ testNewSelectionNonLeftClicks
 	self setUpForSelectionTesting.
 	presenter selectionsByIndex: #(1 3 5).
 	event := self mouseDownEventOnItem: 2 buttons: #(#right).
-	self verifyNewSelectionsFromEvent: event equals: #(2).
+	self verifySelectionsFromMouseDown: event equals: #(2).
 	presenter selectionsByIndex: #(3 5).
 	selections := presenter selectionsByIndex.
 	event := self mouseDownEventOnItem: 3 buttons: #(#right).
-	self verifyNewSelectionsFromEvent: event equals: selections.
+	self verifySelectionsFromMouseDown: event equals: selections.
 	presenter selectionsByIndex: #(1 3 5).
 	selections := presenter selectionsByIndex.
 	"Right or middle clicks with any modifiers will never modify the selection. Just cover a few example cases."
@@ -225,7 +224,7 @@ testNewSelectionNonLeftClicks
 			expected := (mouseDown isRButtonDown and: [self isMultiSelect not])
 						ifTrue: [{pair first}]
 						ifFalse: [selections].
-			self verifyNewSelectionsFromEvent: mouseDown equals: expected.
+			self verifySelectionsFromMouseDown: mouseDown equals: expected.
 			selections := expected]!
 
 testNewSelectionsBasicLeftClicks
@@ -234,12 +233,12 @@ testNewSelectionsBasicLeftClicks
 	| event inNoMansLand |
 	self setUpForSelectionTesting.
 	inNoMansLand := self mouseDownEventOnItem: 0 buttons: #(#left).
-	self verifyNewSelectionsFromEvent: inNoMansLand equals: #().
+	self verifySelectionsFromMouseDown: inNoMansLand equals: #().
 	event := self mouseDownEventOnItem: 1 buttons: #(#left).
-	self verifyNewSelectionsFromEvent: event equals: #(1).
+	self verifySelectionsFromMouseDown: event equals: #(1).
 	presenter selectionsByIndex: #(3).
-	self verifyNewSelectionsFromEvent: event equals: #(1).
-	self verifyNewSelectionsFromEvent: inNoMansLand
+	self verifySelectionsFromMouseDown: event equals: #(1).
+	self verifySelectionsFromMouseDown: inNoMansLand
 		equals: (self newSelectionAfterLeftClickOutsideList: #(1))!
 
 testNewSelectionsClickOutsideListWithModifiers
@@ -251,27 +250,27 @@ testNewSelectionsCtrlLeftClick
 	| event expected |
 	self setUpForSelectionTesting.
 	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
-	self verifyNewSelectionsFromEvent: event equals: #(1).
+	self verifySelectionsFromMouseDown: event equals: #(1).
 	presenter selectionsByIndex: #(3).
 	expected := self isMultiSelect ifTrue: [#(1 3)] ifFalse: [#(1)].
-	self verifyNewSelectionsFromEvent: event equals: expected.
+	self verifySelectionsFromMouseDown: event equals: expected.
 	"Ctrl-click over selected item makes no different in single-select mode"
 	expected := {self isMultiSelect ifTrue: [3] ifFalse: [1]}.
-	self verifyNewSelectionsFromEvent: event equals: expected.
+	self verifySelectionsFromMouseDown: event equals: expected.
 	presenter selectionsByIndex: #(1).
 	self isMultiSelect ifTrue: [expected := #()].
-	self verifyNewSelectionsFromEvent: event equals: expected!
+	self verifySelectionsFromMouseDown: event equals: expected!
 
 testNewSelectionsInitialShiftClick
 	| event |
 	self setUpForSelectionTesting.
 	event := self mouseDownEventOnItem: 1 buttons: #(#left #shift).
-	self verifyNewSelectionsFromEvent: event equals: #(1).
+	self verifySelectionsFromMouseDown: event equals: #(1).
 	"Note that we have to clear the anchorIndex to reset to 'initial' state where a shift-click in a multi-select list will only select the clicked item and not a range. Unfortunately the only way to remove an existing anchor in a traditional ListBox is to delete the item. LB_SETANCHORINDEX returns LB_ERR when passed 0. The equivalent ListView operation to clear the anchor does work and is necessary because deleting the item does not remove the anchor. So we do both."
 	presenter model removeAtIndex: 1.
 	presenter view anchorIndex: 0.
 	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
-	self verifyNewSelectionsFromEvent: event equals: #(3)!
+	self verifySelectionsFromMouseDown: event equals: #(3)!
 
 testProgrammaticSelectionVisible
 	"#1381"
@@ -290,9 +289,6 @@ testSelectionsByIndex
 	self isMultiSelect
 		ifTrue: [self verifyMultiSelectionsByIndex]
 		ifFalse: [self verifySingleSelectionsByIndex]!
-
-timeoutId
-	^171717!
 
 verifyClicks: anArray
 	self subclassResponsibility!
@@ -313,7 +309,7 @@ verifyEventsFromClickSelectionChangeAccepted: aSymbol
 	self assert: changed isKindOf: SelectionChangedEvent.
 	self assert: changed newSelections equals: #(2).
 	self verifyClicks: {{2. event position}}.
-	"Send a shift-left-click event over a subsequent item."
+	"Send a shift-<button>-click event over a subsequent item."
 	events := OrderedCollection new.
 	clicks := OrderedCollection new.
 	event := self mouseDownEventOnItem: 4 buttons: {aSymbol. #shift}.
@@ -341,7 +337,7 @@ verifyEventsFromClickSelectionChangeRejected: aSymbol
 	self assert: changing newSelections equals: #(2).
 	"Because we didn't forward the button down event to the control, there should be no click notification."
 	self assert: clicks size equals: 0.
-	"Ensure there is a selection and then send a shift-left-click event over a subsequent item."
+	"Ensure there is a selection and then send a shift-<button>-click event over a subsequent item."
 	presenter view selectionByIndex: 2.
 	events := OrderedCollection new.
 	clicks := OrderedCollection new.
@@ -406,9 +402,14 @@ verifyMultiSelectionsByIndex
 		against: presenter.
 	self assert: presenter selectionsByIndex equals: sel!
 
-verifyNewSelectionsFromEvent: aMouseEvent equals: anArray
+verifySelectionsFromMouseDown: aMouseEvent equals: anArray
+	"Test the predicted selection..."
+	self assert: (presenter newSelectionsFromEvent: aMouseEvent) equals: anArray description: 'Predicted selections mismatch'.
 	self sendClickEvent: aMouseEvent.
-	self assert: presenter view selectionsByIndex equals: anArray!
+	"... and that the control did actually select the expected item(s)"
+	self assert: presenter getSelectionsByIndex equals: anArray description: 'Actual selections mismatch'.
+	"... and the selection cache was updated"
+	self assert: presenter selectionsByIndex equals: anArray description: 'Cached selections mismatch'!
 
 verifySingleSelectionsByIndex
 	| objects sel |
@@ -492,11 +493,10 @@ verifySingleSelectionsByIndex
 !ListControlTest categoriesFor: #testNewSelectionsInitialShiftClick!public!unit tests! !
 !ListControlTest categoriesFor: #testProgrammaticSelectionVisible!public!unit tests! !
 !ListControlTest categoriesFor: #testSelectionsByIndex!public!unit tests! !
-!ListControlTest categoriesFor: #timeoutId!constants!private! !
 !ListControlTest categoriesFor: #verifyClicks:!helpers!private! !
 !ListControlTest categoriesFor: #verifyEventsFromClickSelectionChangeAccepted:!helpers!private! !
 !ListControlTest categoriesFor: #verifyEventsFromClickSelectionChangeRejected:!private! !
 !ListControlTest categoriesFor: #verifyMultiSelectionsByIndex!helpers!private! !
-!ListControlTest categoriesFor: #verifyNewSelectionsFromEvent:equals:!helpers!private! !
+!ListControlTest categoriesFor: #verifySelectionsFromMouseDown:equals:!helpers!private! !
 !ListControlTest categoriesFor: #verifySingleSelectionsByIndex!helpers!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListControlTest.cls
@@ -132,30 +132,26 @@ setUpForSelectionEventTesting
 setUpForSelectionTesting
 	presenter list: (1 to: 10) asOrderedCollection!
 
-testEventsFromClickSelectChangeConfirmed
-	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is confirmed with a prompt so the control does not receive the mouse up associated with the actual click.
-	Regression test for #898."
+testEventsFromClickSelectionChange
+	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is rejected but without a prompt so the control still receives the mouse up."
 
+	| decision |
 	self setUpForSelectionEventTesting.
+	decision := false.
 	selectionChanging := 
 			[:selChanging |
-			| msg |
 			events addLast: selChanging.
-			"Consume the mouse up so the control does not receive it."
-			msg := MSG new.
-			UserLibrary default
-				getMessage: msg
-				hWnd: presenter view handle
-				wMsgFilterMin: WM_LBUTTONUP
-				wMsgFilterMax: WM_LBUTTONUP.
-			"Allow the selection change to proceed"
-			selChanging value: true].
+			selChanging value: decision].
+	self verifyEventsFromClickSelectionChangeRejected: #left.
+	decision := true.
 	self verifyEventsFromClickSelectionChangeAccepted: #left!
 
-testEventsFromClickSelectChangeRefused
+testEventsFromClickSelectionChangePrompted
 	"Test that the expected sequence of selection events are raised for left-click selection, simulating the selectionChanging: event being refused by user in response to a prompt so the control does not receive the mouse up associated with the actual click."
 
+	| decision |
 	self setUpForSelectionEventTesting.
+	decision := false.
 	selectionChanging := 
 			[:selChanging |
 			| msg |
@@ -167,26 +163,11 @@ testEventsFromClickSelectChangeRefused
 				hWnd: presenter view handle
 				wMsgFilterMin: WM_LBUTTONUP
 				wMsgFilterMax: WM_LBUTTONUP.
-			"Prevent the selection change from proceeding"
-			selChanging value: false].
-	self verifyEventsFromClickSelectionChangeRejected: #left!
-
-testEventsFromClickSelectionChangePermitted
-	"Test that the expected sequence of selectionChanging: and selectionChanged events are raised for left-click selection with the selection change permitted without a prompt.
-	The test sends simulated mouse clicks to the control to try and test the actual control integration."
-
-	self setUpForSelectionEventTesting.
+			"Confirm or refuse the selection change"
+			selChanging value: decision].
+	self verifyEventsFromClickSelectionChangeRejected: #left.
+	decision := true.
 	self verifyEventsFromClickSelectionChangeAccepted: #left!
-
-testEventsFromClickSelectionChangeRejected
-	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is rejected but without a prompt so the control still receives the mouse up."
-
-	self setUpForSelectionEventTesting.
-	selectionChanging := 
-			[:selChanging |
-			events addLast: selChanging.
-			selChanging value: false].
-	self verifyEventsFromClickSelectionChangeRejected: #left!
 
 testLastSelectionCacheUpdatedOnRemove
 	"#717"
@@ -223,30 +204,62 @@ testLastSelectionCacheUpdatedOnRemove
 		against: presenter.
 	self assert: presenter lastSelIndices equals: #(1 3)!
 
+testNewSelectionNonLeftClicks
+	| event selections |
+	self setUpForSelectionTesting.
+	presenter selectionsByIndex: #(1 3 5).
+	event := self mouseDownEventOnItem: 2 buttons: #(#right).
+	self verifyNewSelectionsFromEvent: event equals: #(2).
+	presenter selectionsByIndex: #(3 5).
+	selections := presenter selectionsByIndex.
+	event := self mouseDownEventOnItem: 3 buttons: #(#right).
+	self verifyNewSelectionsFromEvent: event equals: selections.
+	presenter selectionsByIndex: #(1 3 5).
+	selections := presenter selectionsByIndex.
+	"Right or middle clicks with any modifiers will never modify the selection. Just cover a few example cases."
+	#(#(4 #(#right #control)) #(2 #(#middle #shift)) #(3 #(#right #control #shift)) #(0 #(#middle #control)))
+		do: 
+			[:pair |
+			| mouseDown expected |
+			mouseDown := self mouseDownEventOnItem: pair first buttons: pair second.
+			expected := (mouseDown isRButtonDown and: [self isMultiSelect not])
+						ifTrue: [{pair first}]
+						ifFalse: [selections].
+			self verifyNewSelectionsFromEvent: mouseDown equals: expected.
+			selections := expected]!
+
+testNewSelectionsBasicLeftClicks
+	"Tests left-click on an item changes selection, and left-click in no-mans land."
+
+	| event inNoMansLand |
+	self setUpForSelectionTesting.
+	inNoMansLand := self mouseDownEventOnItem: 0 buttons: #(#left).
+	self verifyNewSelectionsFromEvent: inNoMansLand equals: #().
+	event := self mouseDownEventOnItem: 1 buttons: #(#left).
+	self verifyNewSelectionsFromEvent: event equals: #(1).
+	presenter selectionsByIndex: #(3).
+	self verifyNewSelectionsFromEvent: event equals: #(1).
+	self verifyNewSelectionsFromEvent: inNoMansLand
+		equals: (self newSelectionAfterLeftClickOutsideList: #(1))!
+
 testNewSelectionsClickOutsideListWithModifiers
 	"ListView and ListBox behaviour differs"
 
 	self subclassResponsibility!
 
-testNewSelectionsCtrlClickOnSelectedItem
-	| event expected |
-	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(1 3).
-	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
-	"Ctrl-click over selected item makes no different in single-select mode"
-	expected := {self isMultiSelect ifTrue: [3] ifFalse: [1]}.
-	self verifyNewSelectionsFromEvent: event equals: expected.
-	presenter selectionsByIndex: #(1).
-	self isMultiSelect ifTrue: [expected := #()].
-	self verifyNewSelectionsFromEvent: event equals: expected!
-
-testNewSelectionsCtrlClickOnUnselectedItem
+testNewSelectionsCtrlLeftClick
 	| event expected |
 	self setUpForSelectionTesting.
 	event := self mouseDownEventOnItem: 1 buttons: #(#left #control).
 	self verifyNewSelectionsFromEvent: event equals: #(1).
 	presenter selectionsByIndex: #(3).
 	expected := self isMultiSelect ifTrue: [#(1 3)] ifFalse: [#(1)].
+	self verifyNewSelectionsFromEvent: event equals: expected.
+	"Ctrl-click over selected item makes no different in single-select mode"
+	expected := {self isMultiSelect ifTrue: [3] ifFalse: [1]}.
+	self verifyNewSelectionsFromEvent: event equals: expected.
+	presenter selectionsByIndex: #(1).
+	self isMultiSelect ifTrue: [expected := #()].
 	self verifyNewSelectionsFromEvent: event equals: expected!
 
 testNewSelectionsInitialShiftClick
@@ -260,56 +273,6 @@ testNewSelectionsInitialShiftClick
 	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
 	self verifyNewSelectionsFromEvent: event equals: #(3)!
 
-testNewSelectionsLeftClickOutsideList
-	| event |
-	self setUpForSelectionTesting.
-	event := self mouseDownEventOnItem: 0 buttons: #(#left).
-	self verifyNewSelectionsFromEvent: event equals: #().
-	presenter selectionsByIndex: #(3).
-	self verifyNewSelectionsFromEvent: event equals: (self newSelectionAfterLeftClickOutsideList: #(3))!
-
-testNewSelectionsNonLeftClicksWithModifiers
-	"Single selection ListView will always change the selection for right button clicks, regardless of modifiers"
-
-	| selections |
-	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(1 3 5).
-	selections := presenter selectionsByIndex.
-	"Right or middle clicks with any modifiers will never modify the selection. Just cover a few example cases."
-	#(#(4 #(#right #control)) #(2 #(#middle #shift)) #(3 #(#right #control #shift)) #(0 #(#middle #control)))
-		do: 
-			[:pair |
-			| event expected |
-			event := self mouseDownEventOnItem: pair first buttons: pair second.
-			expected := (event isRButtonDown and: [self isMultiSelect not])
-						ifTrue: [{pair first}]
-						ifFalse: [selections].
-			self verifyNewSelectionsFromEvent: event equals: expected.
-			selections := expected]!
-
-testNewSelectionsRightClickOutsideSelection
-	| event |
-	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(1 3 5).
-	event := self mouseDownEventOnItem: 2 buttons: #(#right).
-	self verifyNewSelectionsFromEvent: event equals: #(2)!
-
-testNewSelectionsRightClickWithinSelection
-	| event selections |
-	self setUpForSelectionTesting.
-	presenter selectionsByIndex: #(3 5).
-	selections := presenter selectionsByIndex.
-	event := self mouseDownEventOnItem: 3 buttons: #(#right).
-	self verifyNewSelectionsFromEvent: event equals: selections!
-
-testNewSelectionsSimpleLeftClick
-	| event |
-	self setUpForSelectionTesting.
-	event := self mouseDownEventOnItem: 1 buttons: #(#left).
-	self verifyNewSelectionsFromEvent: event equals: #(1).
-	presenter selectionsByIndex: #(3).
-	self verifyNewSelectionsFromEvent: event equals: #(1)!
-
 testProgrammaticSelectionVisible
 	"#1381"
 
@@ -317,7 +280,7 @@ testProgrammaticSelectionVisible
 
 	| view |
 	view := presenter view.
-	view list: (0 to: 100) asOrderedCollection.
+	view list: (0 to: 100).
 	#(#(100) #(50 100) #(100 50) #(1)) do: 
 			[:each | 
 			view selections: each.
@@ -335,7 +298,10 @@ verifyClicks: anArray
 	self subclassResponsibility!
 
 verifyEventsFromClickSelectionChangeAccepted: aSymbol
-	| changed changing click event |
+	| changed changing event |
+	presenter view selectionsByIndex: #().
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
 	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
 	self sendClickEvent: event.
 	self assert: events size equals: 2.
@@ -364,6 +330,8 @@ verifyEventsFromClickSelectionChangeAccepted: aSymbol
 
 verifyEventsFromClickSelectionChangeRejected: aSymbol
 	| event changing |
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
 	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
 	self sendClickEvent: event.
 	self assert: events size equals: 1.
@@ -514,20 +482,14 @@ verifySingleSelectionsByIndex
 !ListControlTest categoriesFor: #setupClickIntercept!helpers!private! !
 !ListControlTest categoriesFor: #setUpForSelectionEventTesting!helpers!private! !
 !ListControlTest categoriesFor: #setUpForSelectionTesting!helpers!private! !
-!ListControlTest categoriesFor: #testEventsFromClickSelectChangeConfirmed!public!unit tests! !
-!ListControlTest categoriesFor: #testEventsFromClickSelectChangeRefused!public!unit tests! !
-!ListControlTest categoriesFor: #testEventsFromClickSelectionChangePermitted!public!unit tests! !
-!ListControlTest categoriesFor: #testEventsFromClickSelectionChangeRejected!public!unit tests! !
+!ListControlTest categoriesFor: #testEventsFromClickSelectionChange!public!unit tests! !
+!ListControlTest categoriesFor: #testEventsFromClickSelectionChangePrompted!public!unit tests! !
 !ListControlTest categoriesFor: #testLastSelectionCacheUpdatedOnRemove!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionNonLeftClicks!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsBasicLeftClicks!public!unit tests! !
 !ListControlTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !
-!ListControlTest categoriesFor: #testNewSelectionsCtrlClickOnSelectedItem!public!unit tests! !
-!ListControlTest categoriesFor: #testNewSelectionsCtrlClickOnUnselectedItem!public!unit tests! !
+!ListControlTest categoriesFor: #testNewSelectionsCtrlLeftClick!public!unit tests! !
 !ListControlTest categoriesFor: #testNewSelectionsInitialShiftClick!public!unit tests! !
-!ListControlTest categoriesFor: #testNewSelectionsLeftClickOutsideList!public!unit tests! !
-!ListControlTest categoriesFor: #testNewSelectionsNonLeftClicksWithModifiers!public!unit tests! !
-!ListControlTest categoriesFor: #testNewSelectionsRightClickOutsideSelection!public!unit tests! !
-!ListControlTest categoriesFor: #testNewSelectionsRightClickWithinSelection!public!unit tests! !
-!ListControlTest categoriesFor: #testNewSelectionsSimpleLeftClick!public!unit tests! !
 !ListControlTest categoriesFor: #testProgrammaticSelectionVisible!public!unit tests! !
 !ListControlTest categoriesFor: #testSelectionsByIndex!public!unit tests! !
 !ListControlTest categoriesFor: #timeoutId!constants!private! !

--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -183,7 +183,7 @@ testNewSelectionsClickOutsideListWithModifiers
 				[:modifiers |
 				presenter selectionsByIndex: selection.
 				event := self mouseDownEventOnItem: 0 buttons: (modifiers copyWith: #left).
-				self verifyNewSelectionsFromEvent: event equals: expected]!
+				self verifySelectionsFromMouseDown: event equals: expected]!
 
 testNilRow
 	"#2157"
@@ -245,11 +245,7 @@ verifyClicks: anArray
 		do: 
 			[:click :expected |
 			self assert: click iItem equals: expected first - 1.
-			self assert: click position equals: expected second]!
-
-verifyNewSelectionsFromEvent: aMouseEvent equals: anArray
-	self assert: (presenter view newSelectionsFromEvent: aMouseEvent) equals: anArray.
-	super verifyNewSelectionsFromEvent: aMouseEvent equals: anArray! !
+			self assert: click position equals: expected second]! !
 !ListViewTest categoriesFor: #classToTest!helpers!private! !
 !ListViewTest categoriesFor: #getColumns!helpers!private! !
 !ListViewTest categoriesFor: #getItem:!helpers!private! !
@@ -268,5 +264,4 @@ verifyNewSelectionsFromEvent: aMouseEvent equals: anArray
 !ListViewTest categoriesFor: #testSetTextBlockDoesNotAffectSelection!public!unit tests! !
 !ListViewTest categoriesFor: #testSetTextImageDoesNotAffectSelection!public!unit tests! !
 !ListViewTest categoriesFor: #verifyClicks:!helpers!private! !
-!ListViewTest categoriesFor: #verifyNewSelectionsFromEvent:equals:!helpers!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -2,12 +2,11 @@
 
 ListControlTest subclass: #ListViewTest
 	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks timedout'
-	classVariableNames: 'Test898'
+	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ListViewTest guid: (GUID fromString: '{bce10a8d-244e-4377-846c-bcbef9d853a1}')!
 ListViewTest isAbstract: true!
-ListViewTest addClassConstant: 'Test898' value: false!
 ListViewTest comment: ''!
 !ListViewTest categoriesForClass!Unclassified! !
 !ListViewTest methodsFor!
@@ -127,9 +126,6 @@ setUpForSelectionTesting
 	super setUpForSelectionTesting.
 	presenter view viewMode: #list!
 
-skip898
-	self skipUnless: [Test898]!
-
 sortSelections
 	^self subclassResponsibility!
 
@@ -230,9 +226,6 @@ testEventsFromClickSelectChangeConfirmed
 	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is confirmed with a prompt so the control does not receive the mouse up associated with the actual click.
 	Regression test for #898."
 
-	"Test fails because the listview blocks in a modal message loop in its WM_LBUTTONDOWN handler"
-
-	self skip898.
 	self setUpForSelectionEventTesting.
 	selectionChanging := 
 			[:selChanging |
@@ -433,7 +426,6 @@ verifyNewSelectionsFromEvent: aMouseEvent equals: anArray
 !ListViewTest categoriesFor: #setColumns:!helpers!private! !
 !ListViewTest categoriesFor: #setUpForSelectionEventTesting!helpers!private! !
 !ListViewTest categoriesFor: #setUpForSelectionTesting!helpers!private! !
-!ListViewTest categoriesFor: #skip898!private!unit tests! !
 !ListViewTest categoriesFor: #sortSelections!helpers!public! !
 !ListViewTest categoriesFor: #testBackImage!public!unit tests! !
 !ListViewTest categoriesFor: #testChangeViewMode!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 ListControlTest subclass: #ListViewTest
-	instanceVariableNames: 'selectionChanging events selectionChanged nmClick clicks timedout'
+	instanceVariableNames: 'nmClick'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -13,9 +13,6 @@ ListViewTest comment: ''!
 
 classToTest
 	^ListView!
-
-expectedSelectionsForSendShiftClickTests
-	^self subclassResponsibility!
 
 getColumns
 	| answer |
@@ -51,37 +48,6 @@ newSelectionAfterLeftClickOutsideList: anArrayOfInteger
 newSelectionsFromEvent: aMouseEvent
 	^presenter view newSelectionsFromEvent: aMouseEvent!
 
-onSelectionChanged
-	selectionChanged value!
-
-onSelectionChanging: aSelectionChangingEvent 
-	selectionChanging value: aSelectionChangingEvent!
-
-onTimerTick: wParam
-	wParam = self timeoutId ifTrue: [
-		timedout := true.
-		presenter view killTimer: self timeoutId.
-		"Post a mouse move so that the ListView control returns from its WM_?BUTTONDOWN handler"
-		presenter view postMessage: WM_MOUSEMOVE wParam: 0 lParam: 0]!
-
-sendClickEvent: aMouseEvent
-	| pos |
-	"The mouse needs to be outside any Dolphin window in order to cause the control's WM_?BUTTONDOWN handler to block in the way described in #898"
-	pos := POINTL new.
-	UserLibrary default
-		getCursorPos: pos;
-		setCursorPosX: 0 y: 0.
-	self postClickEvent: aMouseEvent.
-	"Schedule a WM_TIMER so that we can detect the control's WM_?BUTTONDOWN handler not returning"
-	timedout := false.
-	presenter view setTimer: self timeoutId interval: 500.
-	"Dispatch the posted mouse down/up messages to the control"
-	SessionManager inputState pumpMessages.
-	presenter view killTimer: self timeoutId.
-	UserLibrary default setCursorPosX: pos x y: pos y.
-	"If this fires, it means the control did not return from the call to its window proc to handle the button down event in ListView>>onButtonPressed:"
-	self deny: timedout description: 'Control blocked in mouse down handler'!
-
 setColumns: cols
 	| list |
 	presenter view columnsList: cols.
@@ -91,36 +57,18 @@ setColumns: cols
 	self assert: presenter view columnOrder equals: (1 to: cols size).
 	^list!
 
-setUpForSelectionEventTesting
+setupClickIntercept
 	| anonClass method |
-	self setUpForSelectionTesting.
-	anonClass := ListView newAnonymousSubclass.
+	anonClass := ListView newAnonymousSubclass.	"Convert the ListView to an instance of an anonymous subclass with an override of nmClick handler that allows us to intercept the notifications."
 	presenter view becomeA: anonClass.
 	method := anonClass
 				compile: 'nmClick: pNMHDR
 		#placeholder value: pNMHDR.
 		^super nmClick: pNMHDR'.
 	self assert: (method literalAt: 1) equals: #placeholder.
-	clicks := OrderedCollection new.
 	nmClick := [:itemactivate | clicks addLast: itemactivate copy].
 	method whileMutableDo: 
-			[method literalAt: 1 put: [:pNMHDR | nmClick value: (NMITEMACTIVATE fromAddress: pNMHDR)]].
-	events := OrderedCollection new.
-	presenter
-		when: #selectionChanging:
-			send: #onSelectionChanging:
-			to: self;
-		when: #selectionChanged
-			send: #onSelectionChanged
-			to: self.
-	selectionChanging := [:event | events addLast: event].
-	"The ListView (and other selectable item views) should really be generating a #selectionChanged: event with a SelectionChangedEvent parameter, but at present they don't"
-	selectionChanged := 
-			[events addLast: ((SelectionChangedEvent forSource: presenter)
-						newSelections: presenter view selectionsByIndex;
-						yourself)].
-	presenter when: #timerTick: send: #onTimerTick: to: self.
-	timedout := false!
+			[method literalAt: 1 put: [:pNMHDR | nmClick value: (NMITEMACTIVATE fromAddress: pNMHDR)]]!
 
 setUpForSelectionTesting
 	super setUpForSelectionTesting.
@@ -222,62 +170,6 @@ testColumnsList
 	"Remove them all"
 	self setColumns: #()!
 
-testEventsFromClickSelectChangeConfirmed
-	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is confirmed with a prompt so the control does not receive the mouse up associated with the actual click.
-	Regression test for #898."
-
-	self setUpForSelectionEventTesting.
-	selectionChanging := 
-			[:selChanging |
-			| msg |
-			events addLast: selChanging.
-			"Consume the mouse up so the control does not receive it."
-			msg := MSG new.
-			UserLibrary default
-				getMessage: msg
-				hWnd: presenter view handle
-				wMsgFilterMin: WM_LBUTTONUP
-				wMsgFilterMax: WM_LBUTTONUP.
-			"Allow the selection change to proceed"
-			selChanging value: true].
-	self verifyEventsFromClickSelectionChangeAccepted: #left!
-
-testEventsFromClickSelectChangeRefused
-	"Test that the expected sequence of selection events are raised for left-click selection, simulating the selectionChanging: event being refused by user in response to a prompt so the control does not receive the mouse up associated with the actual click."
-
-	self setUpForSelectionEventTesting.
-	selectionChanging := 
-			[:selChanging |
-			| msg |
-			events addLast: selChanging.
-			"Snaffle the mouse up as the control will lose focus/activation as soon as the prompt is opened"
-			msg := MSG new.
-			UserLibrary default
-				getMessage: msg
-				hWnd: presenter view handle
-				wMsgFilterMin: WM_LBUTTONUP
-				wMsgFilterMax: WM_LBUTTONUP.
-			"Prevent the selection change from proceeding"
-			selChanging value: false].
-	self verifyEventsFromClickSelectionChangeRejected: #left!
-
-testEventsFromClickSelectionChangePermitted
-	"Test that the expected sequence of selectionChanging: and selectionChanged events are raised for left-click selection with the selection change permitted without a prompt.
-	The test sends simulated mouse clicks to the control to try and test the actual control integration."
-
-	self setUpForSelectionEventTesting.
-	self verifyEventsFromClickSelectionChangeAccepted: #left!
-
-testEventsFromClickSelectionChangeRejected
-	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is rejected but without a prompt so the control still receives the mouse up."
-
-	self setUpForSelectionEventTesting.
-	selectionChanging := 
-			[:selChanging |
-			events addLast: selChanging.
-			selChanging value: false].
-	self verifyEventsFromClickSelectionChangeRejected: #left!
-
 testNewSelectionsClickOutsideListWithModifiers
 	| event selection expected |
 	self setUpForSelectionTesting.
@@ -348,99 +240,33 @@ testSetTextImageDoesNotAffectSelection
 				trigger: #selectionChanging:
 				against: presenter]!
 
-timeoutId
-	^171717!
-
-verifyEventsFromClickSelectionChangeAccepted: aSymbol
-	| changed changing click event |
-	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
-	self sendClickEvent: event.
-	self assert: events size equals: 2.
-	changing := events first.
-	self assert: changing isKindOf: SelectionChangingEvent.
-	self assert: changing oldSelections equals: #().
-	self assert: changing newSelections equals: #(2).
-	changed := events last.
-	self assert: changed isKindOf: SelectionChangedEvent.
-	self assert: changed newSelections equals: #(2).
-	self assert: clicks size equals: 1.
-	click := clicks first.
-	self assert: click iItem equals: 2 - 1.
-	self assert: click position equals: event lParamX @ event lParamY.
-	"Send a shift-left-click event over a subsequent item."
-	events := OrderedCollection new.
-	clicks := OrderedCollection new.
-	event := self mouseDownEventOnItem: 4 buttons: {aSymbol. #shift}.
-	self sendClickEvent: event.
-	self assert: events size equals: 2.
-	changing := events first.
-	self assert: changing isKindOf: SelectionChangingEvent.
-	self assert: changing oldSelections equals: #(2).
-	self assert: changing newSelections equals: self expectedSelectionsForSendShiftClickTests.
-	changed := events last.
-	self assert: changed isKindOf: SelectionChangedEvent.
-	self assert: changed newSelections equals: self expectedSelectionsForSendShiftClickTests.
-	self assert: clicks size equals: 1.
-	self assert: clicks size equals: 1.
-	click := clicks first.
-	self assert: click iItem equals: 4 - 1.
-	self assert: click position equals: event lParamX @ event lParamY!
-
-verifyEventsFromClickSelectionChangeRejected: aSymbol
-	| event changing |
-	event := self mouseDownEventOnItem: 2 buttons: {aSymbol}.
-	self sendClickEvent: event.
-	self assert: events size equals: 1.
-	changing := events first.
-	self assert: changing isKindOf: SelectionChangingEvent.
-	self assert: changing oldSelections equals: #().
-	self assert: changing newSelections equals: #(2).
-	"Because we didn't forward the button down event to the control, there should be no click notification."
-	self assert: clicks size equals: 0.
-	"Ensure there is a selection and then send a shift-left-click event over a subsequent item."
-	presenter view selectionByIndex: 2.
-	events := OrderedCollection new.
-	clicks := OrderedCollection new.
-	event := self mouseDownEventOnItem: 4 buttons: {aSymbol. #shift}.
-	self sendClickEvent: event.
-	self assert: events size equals: 1.
-	changing := events first.
-	self assert: changing isKindOf: SelectionChangingEvent.
-	self assert: changing oldSelections equals: #(2).
-	self assert: changing newSelections equals: self expectedSelectionsForSendShiftClickTests.
-	self assert: clicks size equals: 0!
+verifyClicks: anArray
+	clicks with: anArray
+		do: 
+			[:click :expected |
+			self assert: click iItem equals: expected first - 1.
+			self assert: click position equals: expected second]!
 
 verifyNewSelectionsFromEvent: aMouseEvent equals: anArray
 	self assert: (presenter view newSelectionsFromEvent: aMouseEvent) equals: anArray.
 	super verifyNewSelectionsFromEvent: aMouseEvent equals: anArray! !
 !ListViewTest categoriesFor: #classToTest!helpers!private! !
-!ListViewTest categoriesFor: #expectedSelectionsForSendShiftClickTests!constants!private! !
 !ListViewTest categoriesFor: #getColumns!helpers!private! !
 !ListViewTest categoriesFor: #getItem:!helpers!private! !
 !ListViewTest categoriesFor: #newSelectionAfterLeftClickOutsideList:!constants!private! !
 !ListViewTest categoriesFor: #newSelectionsFromEvent:!helpers!private! !
-!ListViewTest categoriesFor: #onSelectionChanged!event handling!private! !
-!ListViewTest categoriesFor: #onSelectionChanging:!event handling!private! !
-!ListViewTest categoriesFor: #onTimerTick:!event handling!private! !
-!ListViewTest categoriesFor: #sendClickEvent:!helpers!private! !
 !ListViewTest categoriesFor: #setColumns:!helpers!private! !
-!ListViewTest categoriesFor: #setUpForSelectionEventTesting!helpers!private! !
+!ListViewTest categoriesFor: #setupClickIntercept!private! !
 !ListViewTest categoriesFor: #setUpForSelectionTesting!helpers!private! !
 !ListViewTest categoriesFor: #sortSelections!helpers!public! !
 !ListViewTest categoriesFor: #testBackImage!public!unit tests! !
 !ListViewTest categoriesFor: #testChangeViewMode!public!unit tests! !
 !ListViewTest categoriesFor: #testColumnsList!public!unit tests! !
-!ListViewTest categoriesFor: #testEventsFromClickSelectChangeConfirmed!public!unit tests! !
-!ListViewTest categoriesFor: #testEventsFromClickSelectChangeRefused!public!unit tests! !
-!ListViewTest categoriesFor: #testEventsFromClickSelectionChangePermitted!public!unit tests! !
-!ListViewTest categoriesFor: #testEventsFromClickSelectionChangeRejected!public!unit tests! !
 !ListViewTest categoriesFor: #testNewSelectionsClickOutsideListWithModifiers!public!unit tests! !
 !ListViewTest categoriesFor: #testNilRow!public!unit tests! !
 !ListViewTest categoriesFor: #testSelectionRemainsVisibleOnSort!public!unit tests! !
 !ListViewTest categoriesFor: #testSetTextBlockDoesNotAffectSelection!public!unit tests! !
 !ListViewTest categoriesFor: #testSetTextImageDoesNotAffectSelection!public!unit tests! !
-!ListViewTest categoriesFor: #timeoutId!constants!private! !
-!ListViewTest categoriesFor: #verifyEventsFromClickSelectionChangeAccepted:!helpers!private! !
-!ListViewTest categoriesFor: #verifyEventsFromClickSelectionChangeRejected:!helpers!private! !
+!ListViewTest categoriesFor: #verifyClicks:!helpers!private! !
 !ListViewTest categoriesFor: #verifyNewSelectionsFromEvent:equals:!helpers!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListBoxTest.cls
@@ -21,12 +21,12 @@ testNewSelectionsCtrlShiftClickAdditive
 		selectionsByIndex: #(1 3);
 		anchorIndex: 3.
 	event := self mouseDownEventOnItem: 7 buttons: #(#left #control #shift).
-	self verifyNewSelectionsFromEvent: event equals: #(1 3 4 5 6 7).
+	self verifySelectionsFromMouseDown: event equals: #(1 3 4 5 6 7).
 	presenter selectionsByIndex: #(1 3 5 7).
 	"Programatically changing selection in a ListBox does change the anchor (because it expects that the anchor is part of the selection, unsually the last selected item), unlike a ListView."
 	self assert: presenter anchorIndex equals: 7.
 	presenter anchorIndex: 3.
-	self verifyNewSelectionsFromEvent: event equals: #(1 3 4 5 6 7)!
+	self verifySelectionsFromMouseDown: event equals: #(1 3 4 5 6 7)!
 
 testNewSelectionsCtrlShiftClickSubtractive
 	| event |
@@ -36,12 +36,12 @@ testNewSelectionsCtrlShiftClickSubtractive
 		anchorIndex: 6.
 	event := self mouseDownEventOnItem: 2 buttons: #(#left #control #shift).
 	"ListBox does not seem to have the issue that we have with ListView where the ctrl-shift-left-clicked item is retained in the selection when it should not be"
-	self verifyNewSelectionsFromEvent: event equals: #(1 7).
+	self verifySelectionsFromMouseDown: event equals: #(1 7).
 	self assert: presenter caretIndex equals: 2.
 	presenter selectionsByIndex: #(1 3 5 7).
 	"Unlike ListView, programmatically changing the selection moves the anchor, so we must reset it."
 	presenter anchorIndex: 6.
-	self verifyNewSelectionsFromEvent: event equals: #(1 7)!
+	self verifySelectionsFromMouseDown: event equals: #(1 7)!
 
 testNewSelectionsShiftClickWithSelectionMark
 	| event |
@@ -56,11 +56,44 @@ testNewSelectionsShiftClickWithSelectionMark
 			self assert: presenter anchorIndex equals: 3.
 			"In a ListBox, unlike a ListView, the current selection does matter. If the anchor is set to an item in the selection, then that item will still be selected on a Shift-Click. If the anchor is not a selected item, then the selection will on Shift-Click will not include it."
 			expected := (oldSelections includes: 3) ifTrue: [#(3 4 5)] ifFalse: [#(4 5)].
-			self verifyNewSelectionsFromEvent: event equals: expected].
+			self verifySelectionsFromMouseDown: event equals: expected].
 	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
-	self verifyNewSelectionsFromEvent: event equals: #(3)! !
+	self verifySelectionsFromMouseDown: event equals: #(3)!
+
+testNewSelectionsToggleMode
+	| event i |
+	self setUpForSelectionTesting.
+	presenter selectionMode: #toggle.
+	event := self mouseDownEventOnItem: 5 buttons: #(#left).
+	"Toggle on, no selection"
+	self verifySelectionsFromMouseDown: event equals: #(5).
+	"Toggle on, existing selection"
+	self verifySelectionsFromMouseDown: (self mouseDownEventOnItem: 3 buttons: #(#left)) equals: #(3 5).
+	"Right click on existing selection, no change."
+	self verifySelectionsFromMouseDown: (self mouseDownEventOnItem: 3 buttons: #(#right)) equals: #(3 5).
+	"Right click on new selection, adds to selection..."
+	self verifySelectionsFromMouseDown: (self mouseDownEventOnItem: 1 buttons: #(#right))
+		equals: #(1 3 5).
+	"... but not with modifiers"
+	#(#(#control #right) #(#shift #right) #(#control #shift #right))
+		do: [:each | self verifySelectionsFromMouseDown: (self mouseDownEventOnItem: 2 buttons: each) equals: #(1 3 5)].
+	self assert: presenter caretIndex equals: 5.
+	"Click past end same as clicking on last selected"
+	self verifySelectionsFromMouseDown: (self mouseDownEventOnItem: 0 buttons: #(#left)) equals: #(1 3).
+	"The control has an odd behaviour that clicking past the end moves the caret that it reports to the last item, but internally it remembers a separate focused item and toggles that.
+	This seems like a bug, but means that we can't correctly determine the effect of clicks past the end in a toggle mode multi-select list box. It looks like this will require tracking the last selected item"
+	false
+		ifTrue: 
+			[self verifySelectionsFromMouseDown: (self mouseDownEventOnItem: 0 buttons: #(#left))
+				equals: #(1 3 5)].
+	"Toggle off with left click"
+	self verifySelectionsFromMouseDown: event equals: #(1 3 5).
+	"Modifiers disable right clicks"
+	#(#(#control #right) #(#shift #right) #(#control #shift #right))
+		do: [:each | self verifySelectionsFromMouseDown: (self mouseDownEventOnItem: 7 buttons: each) equals: #(1 3 5)]! !
 !MultiSelectListBoxTest categoriesFor: #initializePresenter!private!Running! !
 !MultiSelectListBoxTest categoriesFor: #testNewSelectionsCtrlShiftClickAdditive!public!unit tests! !
 !MultiSelectListBoxTest categoriesFor: #testNewSelectionsCtrlShiftClickSubtractive!public!unit tests! !
 !MultiSelectListBoxTest categoriesFor: #testNewSelectionsShiftClickWithSelectionMark!public!unit tests! !
+!MultiSelectListBoxTest categoriesFor: #testNewSelectionsToggleMode!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListBoxTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListBoxTest.cls
@@ -61,7 +61,7 @@ testNewSelectionsShiftClickWithSelectionMark
 	self verifySelectionsFromMouseDown: event equals: #(3)!
 
 testNewSelectionsToggleMode
-	| event i |
+	| event |
 	self setUpForSelectionTesting.
 	presenter selectionMode: #toggle.
 	event := self mouseDownEventOnItem: 5 buttons: #(#left).

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -20,12 +20,6 @@ initializePresenter
 sortSelections
 	^#(49 50)!
 
-testEventsFromClickSelectionChangePermitted
-	"Fails because of duplicated selectionChanging: event. To be deleted when that bug is fixed."
-
-	self skip898.
-	super testEventsFromClickSelectionChangePermitted!
-
 testNewSelectionsCtrlShiftClickAdditive
 	| event |
 	self setUpForSelectionTesting.
@@ -68,7 +62,6 @@ testNewSelectionsShiftClickWithSelectionMark
 !MultiSelectListViewTest categoriesFor: #expectedSelectionsForSendShiftClickTests!constants!private! !
 !MultiSelectListViewTest categoriesFor: #initializePresenter!public!Running! !
 !MultiSelectListViewTest categoriesFor: #sortSelections!private!unit tests! !
-!MultiSelectListViewTest categoriesFor: #testEventsFromClickSelectionChangePermitted!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickAdditive!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickSubtractive!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsShiftClickWithSelectionMark!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -10,9 +10,6 @@ MultiSelectListViewTest comment: ''!
 !MultiSelectListViewTest categoriesForClass!Unclassified! !
 !MultiSelectListViewTest methodsFor!
 
-expectedSelectionsForSendShiftClickTests
-	^#(2 3 4)!
-
 initializePresenter
 	super initializePresenter.
 	presenter view isMultiSelect: true!
@@ -59,7 +56,6 @@ testNewSelectionsShiftClickWithSelectionMark
 			self verifyNewSelectionsFromEvent: event equals: #(3 4 5)].
 	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
 	self verifyNewSelectionsFromEvent: event equals: #(3)! !
-!MultiSelectListViewTest categoriesFor: #expectedSelectionsForSendShiftClickTests!constants!private! !
 !MultiSelectListViewTest categoriesFor: #initializePresenter!public!Running! !
 !MultiSelectListViewTest categoriesFor: #sortSelections!private!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickAdditive!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -24,11 +24,11 @@ testNewSelectionsCtrlShiftClickAdditive
 		selectionsByIndex: #(1 3);
 		anchorIndex: 3.
 	event := self mouseDownEventOnItem: 7 buttons: #(#left #control #shift).
-	self verifyNewSelectionsFromEvent: event equals: #(1 3 4 5 6 7).
+	self verifySelectionsFromMouseDown: event equals: #(1 3 4 5 6 7).
 	presenter selectionsByIndex: #(1 3 5 7).
 	"Programatically changing selection does not change the anchor."
 	self assert: presenter anchorIndex equals: 3.
-	self verifyNewSelectionsFromEvent: event equals: #(1 3 4 5 6 7)!
+	self verifySelectionsFromMouseDown: event equals: #(1 3 4 5 6 7)!
 
 testNewSelectionsCtrlShiftClickSubtractive
 	| event |
@@ -40,9 +40,9 @@ testNewSelectionsCtrlShiftClickSubtractive
 	"In Windows Explorer and other applications that use ListView or a similar control,
 	(2) would not be selected at this point. Why is it in Dolphin?
 	(See comment at the end of #newSelectionsFromEvent:.)"
-	self verifyNewSelectionsFromEvent: event equals: #(1 2 7).
+	self verifySelectionsFromMouseDown: event equals: #(1 2 7).
 	presenter selectionsByIndex: #(1 3 5 7).
-	self verifyNewSelectionsFromEvent: event equals: #(1 2 7)!
+	self verifySelectionsFromMouseDown: event equals: #(1 2 7)!
 
 testNewSelectionsShiftClickWithSelectionMark
 	| event |
@@ -53,9 +53,9 @@ testNewSelectionsShiftClickWithSelectionMark
 	#(#() #(3) #(1 2 3) #(3 4 5 6)) do: 
 			[:oldSelections |
 			presenter selectionsByIndex: oldSelections.
-			self verifyNewSelectionsFromEvent: event equals: #(3 4 5)].
+			self verifySelectionsFromMouseDown: event equals: #(3 4 5)].
 	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
-	self verifyNewSelectionsFromEvent: event equals: #(3)! !
+	self verifySelectionsFromMouseDown: event equals: #(3)! !
 !MultiSelectListViewTest categoriesFor: #initializePresenter!public!Running! !
 !MultiSelectListViewTest categoriesFor: #sortSelections!private!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickAdditive!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/MultiSelectListViewTest.cls
@@ -14,8 +14,114 @@ initializePresenter
 	super initializePresenter.
 	presenter view isMultiSelect: true!
 
+marqueeSelectionEventsToItem: anInteger
+	| downEvent targetPos mouseEvents x |
+	downEvent := self mouseDownEventOnItem: 0 buttons: {#left}.
+	targetPos := (presenter itemRect: anInteger) origin + 5.
+	mouseEvents := Array writeStream.
+	mouseEvents nextPut: downEvent.
+	"It seems the minimum number of WM_MOUSEMOVEs we can get away with is two; one a small distance away from the start point, and another at the target position.
+	Note that for mouse moves Windows updates the posted event to convert the co-ords to client co-ords, so we must supply them as screen co-ords)"
+	mouseEvents nextPut: (MouseEvent
+						window: presenter
+						message: WM_MOUSEMOVE
+						wParam: downEvent wParam
+						lParam: (presenter mapPointToScreen: downEvent position - 5) asDword).
+	mouseEvents nextPut: (MouseEvent
+						window: presenter
+						message: WM_MOUSEMOVE
+						wParam: downEvent wParam
+						lParam: (presenter mapPointToScreen: targetPos) asDword).
+	mouseEvents nextPut: ((self mouseUpForMouseDown: downEvent)
+				lParam: targetPos asDword;
+				yourself).
+	^mouseEvents contents!
+
 sortSelections
 	^#(49 50)!
+
+testEventsFromMarqueeSelectionChange
+	"Test that the expected sequence of selection events are raised for left-click selection when the selectionChanging: event is rejected but without a prompt so the control still receives the mouse up."
+
+	| decision changing mouseEvents changed |
+	self setUpForSelectionEventTesting.
+	decision := true.
+	selectionChanging := 
+			[:selChanging |
+			events addLast: selChanging.
+			selChanging value: decision].
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
+	mouseEvents := self marqueeSelectionEventsToItem: 9.
+	self sendMouseEvents: mouseEvents.
+	"We allowed the selection change to proceed, so expect 2 events (as the initial selection was empty)"
+	self assert: presenter selectionsByIndex equals: (9 to: 10).
+	self assert: events size equals: 2.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #().
+	self assert: changing newSelections equals: #(9 10).
+	changed := events second.
+	self assert: changed isKindOf: SelectionChangedEvent.
+	self assert: clicks size equals: 1.
+
+	"Now test marquee selection when there is an initial selection - in this case we get two selection changing events, one for the initial mouse down in no-mans land to clear all selections, and another for the eventual marquee selection."
+	presenter view selectionByIndex: 8.
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
+	self sendMouseEvents: mouseEvents.
+	"We allowed the selection change to proceed, so expect 3 events (as the initial selection was not empty)"
+	self assert: presenter selectionsByIndex equals: (9 to: 10).
+	self assert: events size equals: 3.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #(8).
+	self assert: changing newSelections equals: #().
+	changing := events second.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #(8).
+	self assert: changing newSelections equals: #(9 10).
+	changed := events third.
+	self assert: changed isKindOf: SelectionChangedEvent.
+	self assert: clicks size equals: 1.
+
+	"Now try refusing the change"
+	presenter view selectionByIndex: 8.
+	decision := false.
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
+	self sendMouseEvents: mouseEvents.
+	"We allowed the selection change to proceed, so expect 3 events (as the initial selection was not empty)"
+	self assert: presenter selectionsByIndex equals: #(8).
+	self assert: events size equals: 1.
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #(8).
+	self assert: changing newSelections equals: #().
+	self assert: clicks size equals: 0.
+
+	"Accept the 1st change, but not the 2nd"
+	decision := true.
+	selectionChanging := 
+			[:selChanging |
+			events addLast: selChanging.
+			selChanging value: decision.
+			decision := decision not].
+	events := OrderedCollection new.
+	clicks := OrderedCollection new.
+	self sendMouseEvents: mouseEvents.
+	"We prevented the selection change on 2nd asking, so expect 2 events"
+	self assert: presenter selectionsByIndex equals: #(8).
+	changing := events first.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #(8).
+	self assert: changing newSelections equals: #().
+	changing := events second.
+	self assert: changing isKindOf: SelectionChangingEvent.
+	self assert: changing oldSelections equals: #(8).
+	self assert: changing newSelections equals: #(9 10).
+
+!
 
 testNewSelectionsCtrlShiftClickAdditive
 	| event |
@@ -57,7 +163,9 @@ testNewSelectionsShiftClickWithSelectionMark
 	event := self mouseDownEventOnItem: 3 buttons: #(#left #shift).
 	self verifySelectionsFromMouseDown: event equals: #(3)! !
 !MultiSelectListViewTest categoriesFor: #initializePresenter!public!Running! !
+!MultiSelectListViewTest categoriesFor: #marqueeSelectionEventsToItem:!helpers!private! !
 !MultiSelectListViewTest categoriesFor: #sortSelections!private!unit tests! !
+!MultiSelectListViewTest categoriesFor: #testEventsFromMarqueeSelectionChange!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickAdditive!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsCtrlShiftClickSubtractive!public!unit tests! !
 !MultiSelectListViewTest categoriesFor: #testNewSelectionsShiftClickWithSelectionMark!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/Dolphin List Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/Dolphin List Presenter.pax
@@ -53,7 +53,7 @@ SelectableItemsPresenter subclass: #ListPresenter
 	classInstanceVariableNames: ''!
 ControlView subclass: #ListControlView
 	instanceVariableNames: 'getTextBlock'
-	classVariableNames: ''
+	classVariableNames: 'RevertSelMessage'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ListControlView subclass: #BasicListAbstract
@@ -67,7 +67,7 @@ BasicListAbstract subclass: #ComboBox
 	poolDictionaries: 'ComboBoxConstants'
 	classInstanceVariableNames: ''!
 BasicListAbstract subclass: #ListBox
-	instanceVariableNames: '_reserved'
+	instanceVariableNames: 'approvedSelIndices'
 	classVariableNames: 'SelectionModeMask SelectionModes'
 	poolDictionaries: 'ListBoxConstants'
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
@@ -543,8 +543,7 @@ positionForKeyboardContextMenu
 	caret := self caretIndex.
 	^caret == 0
 		ifTrue: [super positionForKeyboardContextMenu]
-		ifFalse: [self mapPoint: (self itemRect: caret) bottomLeft to: self class desktop]
-!
+		ifFalse: [self mapPointToScreen: (self itemRect: caret) bottomLeft]!
 
 selectAll
 	| count |

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 BasicListAbstract subclass: #ListBox
-	instanceVariableNames: '_reserved'
+	instanceVariableNames: 'approvedSelIndices'
 	classVariableNames: 'SelectionModeMask SelectionModes'
 	poolDictionaries: 'ListBoxConstants'
 	classInstanceVariableNames: ''!
@@ -366,16 +366,142 @@ lbnErrSpace
 lbnSelCancel
 	"Private - A LBN_SELCANCEL has been received by our parent window."
 
-	self onSelChanging.
+	self maybeSelChanging: #mouse.
 	^nil!
 
 lbnSelChange
 	"Private - A LBN_SELCHANGE has been received by our parent window."
 
-	self onSelChanging.
+	self maybeSelChanging: #mouse.
 	^nil!
 
+maybeSelChanging: aSymbol
+	"Private - The selection may be changing as a result of a user action (e.g. due to a keypress). 
+	The argument is either #mouse, or #keyboard, indicating the source of the user input that
+	is initiating the selection change. Give the presenter/view a chance to change their mind."
+
+	"See if the change is acceptable, and if not revert to original selection if there was one"
+
+	| curSel |
+	curSel := self getSelectionsByIndex.
+	curSel = lastSelIndices ifTrue: [^self].
+	(self onSelChanging: curSel cause: aSymbol)
+		ifFalse: 
+			[self
+				postMessage: RevertSelMessage
+				wParam: 0
+				lParam: 0.
+			^self].
+	self onSelChanged: curSel!
+
+newMultiSelectionsFromEvent: aMouseEvent
+	"Private - Answer a collection of the <integer> selections that would occur if the `MouseEvent` argument was was passed to the list box control.
+	The behaviour is quite complicated, and different from the equally complicated behaviour of the later ListView control."
+
+	| itemClicked modified anchorIndex shiftRange button |
+	itemClicked := self itemFromPoint: aMouseEvent position.
+	modified := aMouseEvent isModifierDown.
+	button := aMouseEvent button.
+	"We follow the ListView behavior for right button clicks as the control itself does not actually change selection on right click natively:
+		- A right or middle click on an already-selected item should not change the selection
+		- If there are any modifiers then the click has no effect on selection"
+	(button ~~ #left and: [modified or: [lastSelIndices includes: itemClicked]])
+		ifTrue: [^lastSelIndices].
+	"Having taken care of the above edge cases, if no modifier keys are down, the behavior is equivalent to the single-select case."
+	modified ifFalse: [^itemClicked ifNil: [lastSelIndices] ifNotNil: [{itemClicked}]].
+	"The ListBox has a different with respect to the ListView in that clicking out of bounds is as if clicking on the last item"
+	itemClicked isNil ifTrue: [itemClicked := self itemCount].
+	aMouseEvent isShiftDown
+		ifFalse: 
+			[| newSelections |
+			"Only Ctrl is down, so we flip the selection state of the clicked item."
+			newSelections := lastSelIndices asSortedCollection.
+			newSelections remove: itemClicked ifAbsent: [newSelections add: itemClicked].
+			^newSelections asArray].
+	"At least Shift is down, so we must start examining the 'anchor'. This is the last item that was clicked with no modifiers, only ctrl, or ctrl + shift (shift-clicks do *not* move the 	anchor). It acts as the 'start point' for operations where shift is held--they affect the range of items from the anchor to the click point, inclusive. Initially it is zero, i.e. out-of-bounds, in which case holding shift essentially has no effect, and we act only on the item actually clicked."
+	anchorIndex := self anchorIndex.
+	shiftRange := anchorIndex == 0
+				ifTrue: [itemClicked to: itemClicked]
+				ifFalse: [(anchorIndex min: itemClicked) to: (anchorIndex max: itemClicked)].
+	"If only shift is down, not ctrl, the current selection will be replaced by the marked range between the anchor and the selection, although inclusive of the anchor only if currently selected."
+	^aMouseEvent isCtrlDown
+		ifTrue: 
+			["Both ctrl and shift are down, so we set the selection state of the affected range to that of the anchor itself. Note that this ignores the selection state of the item actually clicked and everything in between it and the anchor."
+			((lastSelIndices includes: anchorIndex)
+				ifTrue: [lastSelIndices union: shiftRange]
+				ifFalse: [lastSelIndices difference: shiftRange]) asSortedCollection
+				asArray]
+		ifFalse: 
+			[((lastSelIndices includes: anchorIndex) or: [anchorIndex == 0])
+				ifTrue: [shiftRange asArray]
+				ifFalse: [shiftRange copyWithout: anchorIndex]]!
+
+newSelectionsFromEvent: aMouseEvent
+	"Private - Answer a collection of the <integer> selections that would occur if the `MouseEvent` argument was was passed to the list box control.
+	The behaviour is quite complicated, and different from the similarly complicated behaviour of the later ListView control."
+
+	| mode |
+	mode := self selectionMode.
+	mode == #single ifTrue: [^self newSingleSelectionsFromEvent: aMouseEvent].
+	mode == #multi ifTrue: [^self newMultiSelectionsFromEvent: aMouseEvent].
+	^self newToggleSelectionsFromEvent: aMouseEvent!
+
+newSingleSelectionsFromEvent: aMouseEvent
+	"Private - Answer a single element `Array` of <integer> being the selections that result if the `MouseEvent` argument was was passed to a list box control in single-select mode.
+	Single select mode is very simple:
+		- clicking an item selects it
+		- clicking outside any item has no effect on selection (although the caret moves)
+		- modifier keys are irrelevant"
+
+	^(self itemFromPoint: aMouseEvent position)
+		ifNil: [lastSelIndices]
+		ifNotNil: [:itemClicked | {itemClicked}]!
+
+newToggleSelectionsFromEvent: aMouseEvent
+	"Private - Answer a single element `Array` of <integer> being the selections that result if the `MouseEvent` argument was was passed to a list box control in toggle-select mode.
+	Toggle select mode is relatively simple:
+		- clicking an item toggles its previous selection state
+		- clicking outside any item has no effect on selection (although the caret moves)
+		- modifier keys are ignored for left clicks, and cause right clicks to be ignored
+		- right clicks can only add to the selection (not toggle off items).
+	Note that the right click actions are not native behaviour of the control, but rather added here in Dolphin following the general principles of the way right clicks work in the ListView."
+
+	| itemClicked newSelections |
+	itemClicked := (self itemFromPoint: aMouseEvent position) ifNil: [self itemCount].
+	newSelections := lastSelIndices asSet.
+	aMouseEvent button == #left
+		ifTrue: [newSelections remove: itemClicked ifAbsent: [newSelections add: itemClicked]]
+		ifFalse: [aMouseEvent isModifierDown ifFalse: [newSelections add: itemClicked]].
+	^newSelections asArray
+		sort;
+		yourself!
+
+onLeftButtonPressed: aMouseEvent
+	"Handle a left button down mouse event. We intercede here in order to detect selection change events, and, if the view/presenter don't want the selection changed, then the message is absorbed without passing it to the control. Otherwise accept the default window processing."
+
+	| indices |
+	self presenter trigger: #leftButtonPressed: with: aMouseEvent.
+	indices := self newSelectionsFromEvent: aMouseEvent.
+	^indices = lastSelIndices
+		ifTrue: [aMouseEvent defaultWindowProcessing]
+		ifFalse: 
+			[(self onSelChanging: indices cause: #mouse)
+				ifTrue: 
+					["Selection change permitted"
+					(Keyboard default isButtonDown: aMouseEvent button)
+						ifFalse: 
+							[self
+								postMessage: aMouseEvent message + 1
+								wParam: (aMouseEvent wParam maskClear: aMouseEvent buttonFlag)
+								lParam: aMouseEvent lParam].
+					aMouseEvent defaultWindowProcessing]
+				ifFalse: 
+					["Suppress the mouse down so not received by control"
+					0]]!
+
 onRightButtonPressed: aMouseEvent
+	"Handle a left button down mouse event. We intercede here in order to implement selection changes on right clicks, which the control does not do natively."
+
 	| indices |
 	self presenter trigger: #rightButtonPressed: with: aMouseEvent.
 	indices := self newSelectionsFromEvent: aMouseEvent.
@@ -385,6 +511,26 @@ onRightButtonPressed: aMouseEvent
 			self selectionsByIndex: indices.
 			self onSelChanged: indices].
 	^aMouseEvent defaultWindowProcessing!
+
+onSelChanged: anArray
+	approvedSelIndices := nil.
+	super onSelChanged: anArray!
+
+onSelChanging: anArray cause: aSymbol
+	"Private - Selection is changing in the receiver to the item in the receiver's model identified by the specified <Collection> of <integer> indices. Answer whether to allow the selection change to proceed.
+	Note that #selectionChanging: events are only fired as a direct consequence of  user initiated actions, not in response to selection changes that occur as direct  or indirect results of programmatic actions."
+
+	^self isStateRestoring or: 
+			[anArray = approvedSelIndices or: 
+					[| event |
+					event := SelectionChangingEvent forSource: self.
+					event
+						newSelections: (anArray collect: [:each | self objectFromHandle: each]);
+						oldSelections: (lastSelIndices collect: [:each | self objectFromHandle: each]);
+						cause: aSymbol.
+					self presenter onSelectionChanging: event.
+					event value ifTrue: [approvedSelIndices := anArray].
+					event value]]!
 
 positionForKeyboardContextMenu
 	"Answer the desired position for a context menu requested from the keyboard.
@@ -399,9 +545,9 @@ positionForKeyboardContextMenu
 !
 
 selectAll
-	| size |
-	size := self size.
-	self selectedCount ~= size ifTrue: [self selectionsByIndex: (1 to: size)]!
+	| count |
+	count := self itemCount.
+	self selectedCount ~= count ifTrue: [self selectionsByIndex: (1 to: count)]!
 
 selectedCount
 	"Answer the total number of items selected in the receiver."
@@ -413,16 +559,15 @@ selectedCount
 
 	^self isMultiSelect ifTrue: [self getSelectedCount] ifFalse: [super selectedCount]!
 
-selectIndex: anInteger set: aBoolean 
-	"Private - Set/reset the selection state of the object at the specified one-based <integer>
-	index within the receiver according to the <boolean> argument."
+selectIndex: anInteger set: aBoolean
+	"Private - Set/reset the selection state of the object at the specified one-based <integer> index within the receiver according to the <boolean> argument."
 
-	(self 
+	(self
 		sendMessage: LB_SETSEL
 		wParam: aBoolean asParameter
-		lParam: anInteger - 1) == LB_ERR 
+		lParam: anInteger - 1) == LB_ERR
 		ifTrue: 
-			[self isMultiSelect 
+			[self isMultiSelect
 				ifTrue: 
 					["Assume its a bounds error"
 					self errorSubscriptBounds: anInteger]
@@ -514,7 +659,15 @@ state
 !ListBox categoriesFor: #lbnErrSpace!event handling-win32!private! !
 !ListBox categoriesFor: #lbnSelCancel!event handling-win32!private!selection! !
 !ListBox categoriesFor: #lbnSelChange!event handling-win32!private!selection! !
+!ListBox categoriesFor: #maybeSelChanging:!event handling!private! !
+!ListBox categoriesFor: #newMultiSelectionsFromEvent:!private!selection! !
+!ListBox categoriesFor: #newSelectionsFromEvent:!event handling!private! !
+!ListBox categoriesFor: #newSingleSelectionsFromEvent:!event handling!private! !
+!ListBox categoriesFor: #newToggleSelectionsFromEvent:!event handling!private! !
+!ListBox categoriesFor: #onLeftButtonPressed:!public! !
 !ListBox categoriesFor: #onRightButtonPressed:!event handling!public! !
+!ListBox categoriesFor: #onSelChanged:!event handling!private! !
+!ListBox categoriesFor: #onSelChanging:cause:!event handling!private! !
 !ListBox categoriesFor: #positionForKeyboardContextMenu!enquiries!public! !
 !ListBox categoriesFor: #selectAll!public!selection! !
 !ListBox categoriesFor: #selectedCount!public!selection! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListBox.cls
@@ -453,21 +453,23 @@ newSingleSelectionsFromEvent: aMouseEvent
 		- clicking outside any item has no effect on selection (although the caret moves)
 		- modifier keys are irrelevant"
 
-	^(self itemFromPoint: aMouseEvent position)
-		ifNil: [lastSelIndices]
-		ifNotNil: [:itemClicked | {itemClicked}]!
+	| itemClicked |
+	^(aMouseEvent isSelectionButtonDown
+		and: [(itemClicked := self itemFromPoint: aMouseEvent position) notNil])
+			ifTrue: [{itemClicked}]
+			ifFalse: [lastSelIndices]!
 
 newToggleSelectionsFromEvent: aMouseEvent
 	"Private - Answer a single element `Array` of <integer> being the selections that result if the `MouseEvent` argument was was passed to a list box control in toggle-select mode.
 	Toggle select mode is relatively simple:
 		- clicking an item toggles its previous selection state
-		- clicking outside any item has no effect on selection (although the caret moves)
+		- clicking outside any item toggles the last selected item
 		- modifier keys are ignored for left clicks, and cause right clicks to be ignored
 		- right clicks can only add to the selection (not toggle off items).
 	Note that the right click actions are not native behaviour of the control, but rather added here in Dolphin following the general principles of the way right clicks work in the ListView."
 
 	| itemClicked newSelections |
-	itemClicked := (self itemFromPoint: aMouseEvent position) ifNil: [self itemCount].
+	itemClicked := (self itemFromPoint: aMouseEvent position) ifNil: [self caretIndex].
 	newSelections := lastSelIndices asSet.
 	aMouseEvent button == #left
 		ifTrue: [newSelections remove: itemClicked ifAbsent: [newSelections add: itemClicked]]

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
@@ -269,7 +269,7 @@ newSelectionsFromEvent: aMouseEvent
 					["Other buttons have no effect on the selection"
 					self selectionsByIndex]].
 	newSelections := self getSelectionsByIndex.
-	anyKeysDown := aMouseEvent isShiftDown or: [aMouseEvent isCtrlDown].
+	anyKeysDown := aMouseEvent isModifierDown.
 	"If the click is outside all items, and ctrl or shift is down, nothing changes."
 	(itemClicked isNil and: [anyKeysDown]) ifTrue: [^newSelections].
 	"A right or middle click on an already-selected item also does not change the selection,

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
@@ -2,7 +2,7 @@
 
 ControlView subclass: #ListControlView
 	instanceVariableNames: 'getTextBlock'
-	classVariableNames: ''
+	classVariableNames: 'RevertSelMessage'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ListControlView guid: (GUID fromString: '{8db728e5-721c-4e56-b449-5fd43d00e1ba}')!
@@ -120,6 +120,13 @@ defaultGetTextBlock
 	for objects inserted into the receiver."
 
 	^[:item | item displayString]!
+
+dispatchRegistered: registeredId wParam: wParam lParam: lParam
+	"Private - Dispatch the registered message which was sent to the receiver."
+
+	^registeredId == RevertSelMessage
+		ifTrue: [self revertSelection. 0]
+		ifFalse: [super dispatchRegistered: registeredId wParam: wParam lParam: lParam]!
 
 ensureSelectionVisible
 	"Ensure the selected item is visible, scrolling it into view if necessary.
@@ -255,60 +262,9 @@ list: aSequenceableCollection
 	self model list: aSequenceableCollection!
 
 newSelectionsFromEvent: aMouseEvent
-	"Private - Answer a collection of the <integer> selections that would occur if the `MouseEvent` argument was was passed to the control.
-	This method encodes the selection behaviour of `ListView` in response to mouse clicks, and is used there to predict what it will do in order to generate `selectionChanging:` events that the control itself does not provide (or at least not in virtual mode). The method is also used to implement right-click selection for `ListBox`, but note that it does not precisely replicate the listbox control's native left-click selection behaviour."
+	"Private - Answer a collection of the <integer> selections that would occur if the `MouseEvent` argument was was passed to the control."
 
-	| itemClicked anyKeysDown newSelections anchorIndex shiftRange anchorIsSelected |
-	itemClicked := self itemFromPoint: aMouseEvent position.
-	"In single-select mode, the new selection is always the item clicked, or nothing if the click is outside all items."
-	self isMultiSelect
-		ifFalse: 
-			[^aMouseEvent isSelectionButtonDown
-				ifTrue: [itemClicked ifNil: [#()] ifNotNil: [:item | {item}]]
-				ifFalse: 
-					["Other buttons have no effect on the selection"
-					self selectionsByIndex]].
-	newSelections := self getSelectionsByIndex.
-	anyKeysDown := aMouseEvent isModifierDown.
-	"If the click is outside all items, and ctrl or shift is down, nothing changes."
-	(itemClicked isNil and: [anyKeysDown]) ifTrue: [^newSelections].
-	"A right or middle click on an already-selected item also does not change the selection,
-	otherwise it would be very frustrating to open the context menu with multiple items selected.
-	The control also chooses to leave the selection alone if modifiers are held during a right/middle click."
-	(aMouseEvent button ~= #left and: [anyKeysDown or: [newSelections includes: itemClicked]])
-		ifTrue: [^newSelections].
-	"Having taken care of the above edge cases, if no keys are down, the behavior is equivalent to the single-select case."
-	anyKeysDown ifFalse: [^itemClicked ifNil: [#()] ifNotNil: [:item | {item}]].
-	"Only Ctrl is down, so we flip the selection state of the clicked item."
-	aMouseEvent isShiftDown
-		ifFalse: 
-			[newSelections := newSelections asSortedCollection.
-			newSelections remove: itemClicked ifAbsent: [newSelections add: itemClicked].
-			^newSelections asArray].
-	"At least Shift is down, so we must start examining the 'anchor'. This is the last item
-	that was clicked with no modifiers, only ctrl, or ctrl + shift (shift-clicks do *not* move the
-	anchor). It acts as the 'start point' for operations where shift is held--they affect
-	the range of items from the anchor to the click point, inclusive. Initially it is zero,
-	i.e. out-of-bounds, in which case holding shift essentially has no effect, and we act only on
-	the item actually clicked."
-	anchorIndex := self anchorIndex.
-	shiftRange := anchorIndex == 0
-				ifTrue: [itemClicked to: itemClicked]
-				ifFalse: [(anchorIndex min: itemClicked) to: (anchorIndex max: itemClicked)].
-	"Only shift is down, not ctrl, so the current selection will be entirely replaced by the marked range."
-	aMouseEvent isCtrlDown ifFalse: [^shiftRange asArray].
-	"Both ctrl and shift are down, so we set the selection state of the affected range to that of the
-	anchor itself. Note that this ignores the selection state of the item actually clicked
-	and everything in between it and the anchor."
-	newSelections := newSelections asSet.
-	anchorIsSelected := newSelections includes: anchorIndex.
-	shiftRange do: (anchorIsSelected
-				ifTrue: [[:i | newSelections add: i]]
-				ifFalse: [[:i | newSelections remove: i ifAbsent: []]]).
-	"For some reason, the item clicked is always left selected, even if we are deselecting the rest
-	of the marked range. This is not true in e.g. Windows Explorer--why is it in Dolphin?"
-	newSelections add: itemClicked.
-	^newSelections asSortedCollection asArray!
+	^self subclassResponsibility!
 
 noSelection
 	"Private - Answer the receiver's representation of no selection."
@@ -417,6 +373,12 @@ resetSelection
 	"Set the receiver to have no selection."
 
 	self selectionsByIndex: #()!
+
+revertSelection
+	"Private - Revert to the last recorded selection (useful if the user indicated that he didn't want
+	to change selection after all when prompted)."
+
+	self basicSelectionsByIndex: self lastSelIndices!
 
 selectedCount
 	"Answer the total number of items selected in the receiver."
@@ -649,6 +611,7 @@ updateSelectionCache
 !ListControlView categoriesFor: #caretIndex!public!selection! !
 !ListControlView categoriesFor: #connectModel!models!public! !
 !ListControlView categoriesFor: #defaultGetTextBlock!constants!private! !
+!ListControlView categoriesFor: #dispatchRegistered:wParam:lParam:!operations!private! !
 !ListControlView categoriesFor: #ensureSelectionVisible!public!selection! !
 !ListControlView categoriesFor: #errorNoSelection!exceptions!private! !
 !ListControlView categoriesFor: #errorNotMultiSelect!private!selection! !
@@ -687,6 +650,7 @@ updateSelectionCache
 !ListControlView categoriesFor: #refreshContents!public!updating! !
 !ListControlView categoriesFor: #requestDragObjects:!drag & drop!public! !
 !ListControlView categoriesFor: #resetSelection!public!selection! !
+!ListControlView categoriesFor: #revertSelection!helpers!private!selection! !
 !ListControlView categoriesFor: #selectedCount!public!selection! !
 !ListControlView categoriesFor: #selectIndex:set:!private!selection! !
 !ListControlView categoriesFor: #selectIndices:set:!private!selection! !
@@ -730,7 +694,14 @@ defaultModel
 icon
 	"Answers an Icon that can be used to represent this class"
 
-	^##(self) defaultIcon! !
+	^##(self) defaultIcon!
+
+onStartup
+	"The system is starting: Register a message to be used for cancelling a selection after
+	the fact."
+
+	RevertSelMessage := self registerMessage: 'RevertSelection'! !
 !ListControlView class categoriesFor: #defaultModel!models!public! !
 !ListControlView class categoriesFor: #icon!constants!public! !
+!ListControlView class categoriesFor: #onStartup!events-session!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/TextEdit.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/TextEdit.cls
@@ -833,8 +833,7 @@ positionForKeyboardContextMenu
 	This should be based on the 'current selection', whatever that means in the context of the
 	receiver. Should be overridden by subclasses as appropriate."
 
-	^(self mapPoint: (self positionOfChar: self caretPosition) to: self class desktop) + (0@20)
-!
+	^(self mapPointToScreen: (self positionOfChar: self caretPosition)) + (0 @ 20)!
 
 positionOfChar: anInteger 
 	"Map the one-based index of a character in the receiver to its client co-ordinates

--- a/Core/Object Arts/Dolphin/MVP/SingleSelectListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/SingleSelectListViewTest.cls
@@ -10,9 +10,6 @@ SingleSelectListViewTest comment: ''!
 !SingleSelectListViewTest categoriesForClass!Unclassified! !
 !SingleSelectListViewTest methodsFor!
 
-expectedSelectionsForSendShiftClickTests
-	^#(4)!
-
 sortSelections
 	^#(50)!
 
@@ -38,7 +35,6 @@ testSelectionModeChange
 	self assert: presenter selectionByIndex equals: caret.
 	presenter view selectionsByIndex: #(1 2).
 	self assert: presenter selectionsByIndex equals: #(1)! !
-!SingleSelectListViewTest categoriesFor: #expectedSelectionsForSendShiftClickTests!constants!private! !
 !SingleSelectListViewTest categoriesFor: #sortSelections!private!unit tests! !
 !SingleSelectListViewTest categoriesFor: #testSelectionModeChange!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
@@ -212,7 +212,7 @@ ListControlView subclass: #IconicListAbstract
 	classInstanceVariableNames: ''!
 IconicListAbstract subclass: #ListView
 	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent lvFlags backImage backImageOffset backImageAlpha approvedSelIndices _unused35 _unused36 _unused37 _unused38 _unused39 _unused40 _unused41 _unused42 _unused43 _unused44 _unused45'
-	classVariableNames: 'BackImageIsTiledMask LvModes NoImageIndex RevertSelMessage SelectionStateMask UnknownItem'
+	classVariableNames: 'BackImageIsTiledMask LvModes NoImageIndex SelectionStateMask UnknownItem'
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!
 IconicListAbstract subclass: #TabView

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
@@ -211,7 +211,7 @@ ListControlView subclass: #IconicListAbstract
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 IconicListAbstract subclass: #ListView
-	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent lvFlags backImage backImageOffset backImageAlpha _unused34 _unused35 _unused36 _unused37 _unused38 _unused39 _unused40 _unused41 _unused42 _unused43 _unused44 _unused45'
+	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent lvFlags backImage backImageOffset backImageAlpha approvedSelIndices _unused35 _unused36 _unused37 _unused38 _unused39 _unused40 _unused41 _unused42 _unused43 _unused44 _unused45'
 	classVariableNames: 'BackImageIsTiledMask LvModes NoImageIndex RevertSelMessage SelectionStateMask UnknownItem'
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
@@ -389,6 +389,62 @@ largeIconExtent: aPointOrNil
 	self applyImageLists
 !
 
+newSelectionsFromEvent: aMouseEvent
+	"Private - Answer a collection of the <integer> selections that would occur if the `MouseEvent` argument was was passed to the control.
+	This method encodes the selection behaviour of `ListView` in response to mouse clicks, and is used there to predict what it will do in order to generate `selectionChanging:` events that the control itself does not provide (or at least not in virtual mode). The method is also used to implement right-click selection for `ListBox`, but note that it does not precisely replicate the listbox control's native left-click selection behaviour."
+
+	| itemClicked anyKeysDown newSelections anchorIndex shiftRange anchorIsSelected |
+	itemClicked := self itemFromPoint: aMouseEvent position.
+	"In single-select mode, the new selection is always the item clicked, or nothing if the click is outside all items."
+	self isMultiSelect
+		ifFalse: 
+			[^aMouseEvent isSelectionButtonDown
+				ifTrue: [itemClicked ifNil: [#()] ifNotNil: [:item | {item}]]
+				ifFalse: 
+					["Other buttons have no effect on the selection"
+					self selectionsByIndex]].
+	newSelections := self getSelectionsByIndex.
+	anyKeysDown := aMouseEvent isModifierDown.
+	"If the click is outside all items, and ctrl or shift is down, nothing changes."
+	(itemClicked isNil and: [anyKeysDown]) ifTrue: [^newSelections].
+	"A right or middle click on an already-selected item also does not change the selection,
+	otherwise it would be very frustrating to open the context menu with multiple items selected.
+	The control also chooses to leave the selection alone if modifiers are held during a right/middle click."
+	(aMouseEvent button ~= #left and: [anyKeysDown or: [newSelections includes: itemClicked]])
+		ifTrue: [^newSelections].
+	"Having taken care of the above edge cases, if no keys are down, the behavior is equivalent to the single-select case."
+	anyKeysDown ifFalse: [^itemClicked ifNil: [#()] ifNotNil: [:item | {item}]].
+	"Only Ctrl is down, so we flip the selection state of the clicked item."
+	aMouseEvent isShiftDown
+		ifFalse: 
+			[newSelections := newSelections asSortedCollection.
+			newSelections remove: itemClicked ifAbsent: [newSelections add: itemClicked].
+			^newSelections asArray].
+	"At least Shift is down, so we must start examining the 'anchor'. This is the last item
+	that was clicked with no modifiers, only ctrl, or ctrl + shift (shift-clicks do *not* move the
+	anchor). It acts as the 'start point' for operations where shift is held--they affect
+	the range of items from the anchor to the click point, inclusive. Initially it is zero,
+	i.e. out-of-bounds, in which case holding shift essentially has no effect, and we act only on
+	the item actually clicked."
+	anchorIndex := self anchorIndex.
+	shiftRange := anchorIndex == 0
+				ifTrue: [itemClicked to: itemClicked]
+				ifFalse: [(anchorIndex min: itemClicked) to: (anchorIndex max: itemClicked)].
+	"Only shift is down, not ctrl, so the current selection will be entirely replaced by the marked range."
+	aMouseEvent isCtrlDown ifFalse: [^shiftRange asArray].
+	"Both ctrl and shift are down, so we set the selection state of the affected range to that of the
+	anchor itself. Note that this ignores the selection state of the item actually clicked
+	and everything in between it and the anchor."
+	newSelections := newSelections asSet.
+	anchorIsSelected := newSelections includes: anchorIndex.
+	shiftRange do: (anchorIsSelected
+				ifTrue: [[:i | newSelections add: i]]
+				ifFalse: [[:i | newSelections remove: i ifAbsent: []]]).
+	"For some reason, the item clicked is always left selected, even if we are deselecting the rest
+	of the marked range. This is not true in e.g. Windows Explorer--why is it in Dolphin?"
+	newSelections add: itemClicked.
+	^newSelections asSortedCollection asArray!
+
 nmBeginDrag: pNMHDR
 	"Private - Default handler for the ?VN_BEGINDRAG notification message.
 	If the receiver is configured to be a drag source, then initiate a drag,
@@ -769,6 +825,7 @@ wmDestroy: message wParam: wParam lParam: lParam
 !IconicListAbstract categoriesFor: #itemRect:textOnly:!enquiries!public! !
 !IconicListAbstract categoriesFor: #largeIconExtent!constants!public! !
 !IconicListAbstract categoriesFor: #largeIconExtent:!constants!public! !
+!IconicListAbstract categoriesFor: #newSelectionsFromEvent:!event handling!private! !
 !IconicListAbstract categoriesFor: #nmBeginDrag:!event handling-win32!private! !
 !IconicListAbstract categoriesFor: #nmBeginLabelEdit:!event handling-win32!private! !
 !IconicListAbstract categoriesFor: #nmBeginRDrag:!event handling-win32!private! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/IconicListAbstract.cls
@@ -669,11 +669,9 @@ positionForKeyboardContextMenu
 
 	| selections |
 	selections := self selectionsByIndex.
-	^selections isEmpty 
+	^selections isEmpty
 		ifTrue: [super positionForKeyboardContextMenu]
-		ifFalse: 
-			[self mapPoint: (self itemRect: selections first textOnly: true) bottomLeft
-				to: self class desktop]!
+		ifFalse: [self mapPointToScreen: (self itemRect: selections first textOnly: true) bottomLeft]!
 
 queryCommand: aCommandQuery
 	"Update aCommandQuery to indicates how a command would be processed.

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -2,7 +2,7 @@
 
 IconicListAbstract subclass: #ListView
 	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent lvFlags backImage backImageOffset backImageAlpha approvedSelIndices _unused35 _unused36 _unused37 _unused38 _unused39 _unused40 _unused41 _unused42 _unused43 _unused44 _unused45'
-	classVariableNames: 'BackImageIsTiledMask LvModes NoImageIndex RevertSelMessage SelectionStateMask UnknownItem'
+	classVariableNames: 'BackImageIsTiledMask LvModes NoImageIndex SelectionStateMask UnknownItem'
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!
 ListView guid: (GUID fromString: '{87b4c730-026e-11d3-9fd7-00a0cc3e4a32}')!
@@ -521,13 +521,6 @@ defaultWindowStyle
 		##(LVS_ICON | LVS_SHAREIMAGELISTS | LVS_SHOWSELALWAYS | LVS_SINGLESEL| 
 			LVS_OWNERDATA	"This style is necessary for virtual list behaviour"
 			)!
-
-dispatchRegistered: registeredId wParam: wParam lParam: lParam
-	"Private - Dispatch the registered message which was sent to the receiver."
-
-	^registeredId == RevertSelMessage
-		ifTrue: [self revertSelection. 0]
-		ifFalse: [super dispatchRegistered: registeredId wParam: wParam lParam: lParam]!
 
 editLabelStyle
 	"Private - Answer the <integer> style mask used to control whether label editing is enabled
@@ -1523,6 +1516,14 @@ maybeSelChanging: aSymbol
 			^self].
 	self onSelChanged: curSel!
 
+nmBeginDrag: pNMHDR
+	self maybeSelChanging: #mouse.
+	^super nmBeginDrag: pNMHDR!
+
+nmBeginRDrag: pNMHDR
+	self maybeSelChanging: #mouse.
+	^super nmBeginRDrag: pNMHDR!
+
 nmClick: pNMHDR
 	"Private - Handler for a NM_CLICK notification message.
 	We intercept this to catch potential selection changes resulting from a drag-select
@@ -1765,13 +1766,6 @@ onRightButtonPressed: aMouseEvent
 	self presenter trigger: #rightButtonPressed: with: aMouseEvent.
 	^self onButtonPressed: aMouseEvent!
 
-onSelChanged
-	"Private - Handle a selection change event by forwarding to the presenter."
-
-	| selections |
-	selections := self getSelectionsByIndex.
-	selections = lastSelIndices ifFalse: [self onSelChanged: selections]!
-
 onSelChanged: anArray 
 	lastSelIndices := anArray.
 	approvedSelIndices := nil.
@@ -1905,12 +1899,6 @@ resolutionScaledBy: scale
 
 	self allColumns do: [:each | each resolutionScaledBy: scale].
 	iconSpacing ifNotNil: [self iconSpacing: (iconSpacing * scale) truncated]!
-
-revertSelection
-	"Private - Revert to the last recorded selection (useful if the user indicated that he didn't want
-	to change selection after all when prompted)."
-
-	self basicSelectionsByIndex: lastSelIndices!
 
 selectAll
 	| size |
@@ -2292,7 +2280,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #defaultListViewExStyle!accessing-styles!constants!private! !
 !ListView categoriesFor: #defaultThumbnailExtent!constants!private! !
 !ListView categoriesFor: #defaultWindowStyle!constants!private! !
-!ListView categoriesFor: #dispatchRegistered:wParam:lParam:!operations!private! !
 !ListView categoriesFor: #editLabelStyle!constants!private! !
 !ListView categoriesFor: #ensureItemsVisible:!helpers!private! !
 !ListView categoriesFor: #ensureSelectionVisible!public!selection! !
@@ -2425,12 +2412,14 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #lvnMarqueeBegin:!event handling-win32!private! !
 !ListView categoriesFor: #lvnODStateChanged:!event handling-win32!private! !
 !ListView categoriesFor: #maybeSelChanging:!event handling!private! !
+!ListView categoriesFor: #nmBeginDrag:!event handling-win32!private! !
+!ListView categoriesFor: #nmBeginRDrag:!event handling-win32!private! !
 !ListView categoriesFor: #nmClick:!event handling-win32!private! !
 !ListView categoriesFor: #nmNotify:!event handling-win32!private! !
 !ListView categoriesFor: #nmRClick:!event handling-win32!private! !
 !ListView categoriesFor: #nmSelChanged:!event handling-win32!private! !
 !ListView categoriesFor: #notificationClass!constants!private! !
-!ListView categoriesFor: #onButtonPressed:!event handling!private! !
+!ListView categoriesFor: #onButtonPressed:!private! !
 !ListView categoriesFor: #onDisplayDetailsRequired:!event handling!private! !
 !ListView categoriesFor: #onDropDown:!event handling!private! !
 !ListView categoriesFor: #onEraseRequired:!event handling!public! !
@@ -2441,7 +2430,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #onLeftButtonPressed:!event handling!public! !
 !ListView categoriesFor: #onPositionChanged:!event handling!public! !
 !ListView categoriesFor: #onRightButtonPressed:!event handling!public! !
-!ListView categoriesFor: #onSelChanged!private!selection! !
 !ListView categoriesFor: #onSelChanged:!event handling!private! !
 !ListView categoriesFor: #onSelChanging:cause:!event handling!private! !
 !ListView categoriesFor: #onSelRemoved!public!selection! !
@@ -2455,7 +2443,6 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #reportMode!commands!public! !
 !ListView categoriesFor: #resetSelection!public!selection! !
 !ListView categoriesFor: #resolutionScaledBy:!geometry!private! !
-!ListView categoriesFor: #revertSelection!helpers!private!selection! !
 !ListView categoriesFor: #selectAll!public!selection! !
 !ListView categoriesFor: #selectedCount!private!selection! !
 !ListView categoriesFor: #selectIndex:set:!private!selection!wine fix! !
@@ -2535,7 +2522,6 @@ onStartup
 	"The system is starting: Register a message to be used for cancelling a selection after
 	the fact."
 
-	RevertSelMessage := self registerMessage: 'RevertSelection'.
 	NTLibrary isWine
 		ifTrue: 
 			["Having autoSelectPackages option turned on in System  Browser gives unpleasant scrolling effect when many multiple packages are selected. This also happens in Package Browser. Problem under Wine traced to LVIS_FOCUSED option in ListView>>selectIndex:. Not sure what overall effect it will have turning this off."

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 IconicListAbstract subclass: #ListView
-	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent lvFlags backImage backImageOffset backImageAlpha _unused34 _unused35 _unused36 _unused37 _unused38 _unused39 _unused40 _unused41 _unused42 _unused43 _unused44 _unused45'
+	instanceVariableNames: 'lastClickedColIndex columns viewMode lastSelIndices iconSpacing lvStyle thumbnailExtent lvFlags backImage backImageOffset backImageAlpha approvedSelIndices _unused35 _unused36 _unused37 _unused38 _unused39 _unused40 _unused41 _unused42 _unused43 _unused44 _unused45'
 	classVariableNames: 'BackImageIsTiledMask LvModes NoImageIndex RevertSelMessage SelectionStateMask UnknownItem'
 	poolDictionaries: 'ListViewConstants'
 	classInstanceVariableNames: ''!
@@ -1523,12 +1523,12 @@ maybeSelChanging: aSymbol
 			^self].
 	self onSelChanged: curSel!
 
-nmClick: pNMHDR 
+nmClick: pNMHDR
 	"Private - Handler for a NM_CLICK notification message.
 	We intercept this to catch potential selection changes resulting from a drag-select
 	operation."
 
-	self isMultiSelect ifTrue: [self maybeSelChanging: #mouse].
+	self maybeSelChanging: #mouse.
 	^super nmClick: pNMHDR!
 
 nmNotify: pNMHDR
@@ -1566,12 +1566,12 @@ nmNotify: pNMHDR
 		ifNil: [super nmNotify: pNMHDR]
 		ifNotNil: [:action | self perform: action with: pNMHDR]!
 
-nmRClick: pNMHDR 
+nmRClick: pNMHDR
 	"Private - Handler for a NM_RCLICK notification message.
 	We intercept this to catch potential selection changes resulting from a drag-select
 	operation."
 
-	self isMultiSelect ifTrue: [self maybeSelChanging: #mouse].
+	self maybeSelChanging: #mouse.
 	^super nmRClick: pNMHDR!
 
 nmSelChanged: anExternalAddress 
@@ -1596,17 +1596,14 @@ onButtonPressed: aMouseEvent
 		ifFalse: 
 			[(self onSelChanging: indices cause: #mouse)
 				ifTrue: 
-					[| answer |
-					"Selection change permitted"
+					["Selection change permitted"
 					(Keyboard default isButtonDown: aMouseEvent button)
 						ifFalse: 
 							[self
-								postMessage: WM_MOUSEMOVE
+								postMessage: aMouseEvent message + 1
 								wParam: (aMouseEvent wParam maskClear: aMouseEvent buttonFlag)
 								lParam: aMouseEvent lParam].
-					answer := aMouseEvent defaultWindowProcessing.
-					self onSelChanged.	"Selection may have changed"
-					answer]
+					aMouseEvent defaultWindowProcessing]
 				ifFalse: 
 					["Suppress the mouse down so not received by control"
 					0]]!
@@ -1777,24 +1774,24 @@ onSelChanged
 
 onSelChanged: anArray 
 	lastSelIndices := anArray.
+	approvedSelIndices := nil.
 	super onSelChanged: anArray!
 
 onSelChanging: anArray cause: aSymbol
-	"Private - Selection is changing in the receiver to the item in the receiver's model 
-	identified by the specified <Collection> of <integer> indices. 
-	Note that #selectionChanging: events are only fired as a direct consequence of 
-	user initiated actions, not in response to selection changes that occur as direct 
-	or indirect results of programmatic actions."
+	"Private - Selection is changing in the receiver to the item in the receiver's model identified by the specified <Collection> of <integer> indices. Answer whether to allow the selection change to proceed.
+	Note that #selectionChanging: events are only fired as a direct consequence of  user initiated actions, not in response to selection changes that occur as direct  or indirect results of programmatic actions."
 
 	^self isStateRestoring or: 
-			[| event |
-			event := SelectionChangingEvent forSource: self.
-			event
-				newSelections: (anArray collect: [:each | self objectFromHandle: each]);
-				oldSelections: (lastSelIndices collect: [:each | self objectFromHandle: each]);
-				cause: aSymbol.
-			self presenter onSelectionChanging: event.
-			event value]!
+			[anArray = approvedSelIndices or: 
+					[| event |
+					event := SelectionChangingEvent forSource: self.
+					event
+						newSelections: (anArray collect: [:each | self objectFromHandle: each]);
+						oldSelections: (lastSelIndices collect: [:each | self objectFromHandle: each]);
+						cause: aSymbol.
+					self presenter onSelectionChanging: event.
+					event value ifTrue: [approvedSelIndices := anArray].
+					event value]]!
 
 onSelRemoved
 	"Private - A selected item has been removed. Update the receiver's selection state to
@@ -1810,6 +1807,7 @@ onViewCreated
 
 	super onViewCreated.
 	lastSelIndices := #().
+	approvedSelIndices := nil.
 	self setControlBackcolor.
 	self forecolor ifNotNil: [:fore | self forecolor: fore].
 	self allColumns
@@ -2200,7 +2198,8 @@ updateSelectionCache
 	"Private - The receiver's model is being modified, so we may need to account for selection changes caused by that.
 	Of course this can't add a selection if there is none."
 
-	lastSelIndices notEmpty ifTrue: [lastSelIndices := self getSelectionsByIndex]!
+	lastSelIndices notEmpty ifTrue: [lastSelIndices := self getSelectionsByIndex].
+	approvedSelIndices := nil!
 
 viewMode
 	"Answer the view mode of the receiver.

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
@@ -1151,7 +1151,7 @@ caretPosition: caretInteger
 				lParam: 0]!
 
 caretScreenCoordinates
-	^self mapPoint: (self positionOfChar: self caretPosition) to: View desktop!
+	^self mapPointToScreen: (self positionOfChar: self caretPosition)!
 
 caretStyle
 	"Answer the style of caret displayed in the receiver; one of #invisible (no caret), #line or


### PR DESCRIPTION
@daniels220, you may want to try this out to see if it fixes your scenario. The eventual fix is quite simple and is similar to what was discussed. It works for the new tests that reproduced the issues of blocking on the mouse down, and the duplicate selection changing events.

A test for marquee selection is still pending, but this will still fire two selection changing events - one for initial loss of any selection, and the 2nd for the eventual new selections.