### PR TITLE
MultipleFileOpenDialog showModal returns +1 entries than selected ones #921

### DIFF
--- a/Core/Contributions/IDB/IDB MultipleFileOpenDialog.pax
+++ b/Core/Contributions/IDB/IDB MultipleFileOpenDialog.pax
@@ -24,7 +24,6 @@ package globalAliases: (Set new
 	yourself).
 
 package setPrerequisites: #(
-	'..\..\Object Arts\Dolphin\Base\Dolphin'
 	'..\..\Object Arts\Dolphin\MVP\Dialogs\Common\Dolphin Common Dialogs').
 
 package!
@@ -32,7 +31,7 @@ package!
 "Class Definitions"!
 
 FileOpenDialog subclass: #MultipleFileOpenDialog
-	instanceVariableNames: 'buffer maxFileCount'
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Contributions/IDB/MultipleFileOpenDialog.cls
+++ b/Core/Contributions/IDB/MultipleFileOpenDialog.cls
@@ -1,93 +1,22 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 FileOpenDialog subclass: #MultipleFileOpenDialog
-	instanceVariableNames: 'buffer maxFileCount'
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 MultipleFileOpenDialog guid: (GUID fromString: '{6bf5baa9-0551-40bd-a72f-e1e38b778543}')!
-MultipleFileOpenDialog comment: 'See [DolphinImageFolder]/Idb/Documentation for details
+MultipleFileOpenDialog comment: 'MultipleFileOpenDialog is no longer required. To request multiple filenames just specify a maximum file count > 1, i.e. use the following pattern:
 
-(C) 2005 Ian Bartholomew
-ian@idb.me.uk
-Public Domain Freeware'!
+	FileOpenDialog new
+		maxFileCount: 30;
+		showModal'!
 !MultipleFileOpenDialog categoriesForClass!IDB Goodies! !
 !MultipleFileOpenDialog methodsFor!
 
 defaultMaxFileCount
 	"Answers the default number of selections that are expected  to fit into the buffer"
 
-	^25!
-
-defaultStyle
-	"Answers the style for the receiver."
-
-	^super defaultStyle bitOr: ##(OFN_ALLOWMULTISELECT | OFN_EXPLORER)!
-
-extractResult: result 
-	"Extract the result from the buffer. The possible outcomes are
-		result == false. 
-			The user cancelled. Don't change the model.
-		result == true.
-			If the user made one selection then the buffer contains a full path.
-			If the user made multiple selections then the first item in the buffer contains the
-				 path (minus any filename) and the subsequent entries contain the selected 
-				filenames.
-			In both cases we construct a collection of full paths to  set the receivers value.
-	Items are stored in the buffer separated by 0, the end of the buffer indicated by an empty
-	entry (double 0)"
-
-	result 
-		ifTrue: 
-			[| endIndex pathNames |
-			endIndex := buffer indexOfSubCollection: ##(String with: Character null with: Character null).
-			pathNames := (buffer copyFrom: 1 to: endIndex) subStrings: Character null.
-			pathNames size > 1 
-				ifTrue: 
-					[pathNames := (pathNames copyFrom: 2) 
-								collect: [:each | File composePath: pathNames first subPath: each]].
-			self value: pathNames.
-			self apply]!
-
-maxFileCount
-	"Answers the maximum number of selections that can be expected to fit into the buffer.
-	Maintain a minimum size of 10, just in case"
-
-	maxFileCount isNil ifTrue: [^self defaultMaxFileCount].
-	^maxFileCount max: 10!
-
-maxFileCount: anInteger 
-	"Sets the maximum number of paths that can be expected to fit into the buffer"
-
-	maxFileCount := anInteger!
-
-prepareStruct
-	"Prepare the structure expected by the dialog. The size of the buffer is set to the 
-	maximum size of a Windows path (the buffer will only ever contain one path) plus
-	maxFileCount instVar multiplied by 30 (i.e. 3 times the average file name size). 
-	If the buffer specified is too small then the Dialog just answers nil, no error is raised.
-	NB We keep a reference to the buffer in an instVar as we need to scan it later to 
-	extract multiple Strings (see #extractResult). If we try to use the winStruct reference
-	we can only recover the first String."
-
-	| filename |
-	buffer := Utf16String newFixed: self maxFileCount * 30 + File maxPath.
-	filename := self value.
-	filename notNil
-		ifTrue: 
-			[buffer
-				replaceFrom: 1
-				to: filename size
-				with: filename].
-	self winStruct
-		fileTypes: (self fileTypesStringFromSpecs: self fileTypes);
-		nMaxFile: buffer size;
-		fileName: buffer;
-		flags: self style! !
+	^25! !
 !MultipleFileOpenDialog categoriesFor: #defaultMaxFileCount!accessing!public! !
-!MultipleFileOpenDialog categoriesFor: #defaultStyle!constants!public! !
-!MultipleFileOpenDialog categoriesFor: #extractResult:!helpers!public! !
-!MultipleFileOpenDialog categoriesFor: #maxFileCount!accessing!public! !
-!MultipleFileOpenDialog categoriesFor: #maxFileCount:!accessing!public! !
-!MultipleFileOpenDialog categoriesFor: #prepareStruct!public!realizing/unrealizing! !
 

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/Dolphin Common Dialogs.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/Dolphin Common Dialogs.pax
@@ -119,7 +119,7 @@ CommonDialog subclass: #FontDialog
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 FileDialog subclass: #FileOpenDialog
-	instanceVariableNames: ''
+	instanceVariableNames: 'maxFileCount'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FileDialog.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FileDialog.cls
@@ -19,6 +19,9 @@ allFilesType
 
 	^self class allFilesType!
 
+averageFilenameLength
+	^30!
+
 basicShowModal
 	"Private - Show a Open File dialog for the receiver."
 
@@ -110,13 +113,36 @@ defaultStyle
 
 	^##(OFN_HIDEREADONLY | OFN_EXPLORER | OFN_ENABLESIZING)!
 
-extractResult: result 
-	"Private - Extract and apply the result from the parameter structure 
-	passed to the Win32 API associated with this common dialog, immediately 
+extractPathNames: aString
+	| multisz strings pathNames |
+	multisz := aString readStream.
+	strings := Array writeStream.
+	"The dialog populates the buffer with potentially multiple null-terminated strings, with an extra null terminator delimiting the list.
+	If there is only a single file selected, the full path of that file is the only entry. If more than one file is selected, then the first entry is the folder path, and subsequent entries the names of files in that folder."
+	[multisz atEnd or: [multisz peekFor: $\0]] whileFalse: [strings nextPut: (multisz upTo: $\0)].
+	strings := strings contents.
+	^strings size == 1
+		ifTrue: [strings]
+		ifFalse: 
+			[| folder count |
+			folder := strings first.
+			count := strings size.
+			pathNames := Array writeStream: count - 1.
+			strings
+				from: 2
+				to: count
+				do: [:each | pathNames nextPut: (File composePath: folder subPath: each)].
+			pathNames collection]!
+
+extractResult: result
+	"Private - Extract and apply the result from the parameter structure passed to the Win32 API associated with this common dialog, immediately 
 	after the call to that API."
 
+	| buffer |
 	result ifFalse: [^self].
-	self value: self winStruct lpstrFile.
+	buffer := self winStruct fileName.
+	self
+		value: (self maxFileCount > 1 ifTrue: [self extractPathNames: buffer] ifFalse: [buffer trimNulls]).
 	self apply!
 
 fileTypes
@@ -227,19 +253,25 @@ initialize
 	style := self defaultStyle.
 	validationBlock := [:path | true]!
 
-prepareStruct
-	"Private - Initialize the parameter structure to be passed to the Win32 API associated with
-	this common dialog, immediately prior to the call to that API."
+maxFileCount
+	"Answers the maximum number of selections that can be expected to fit into the buffer."
 
-	| buf filename defext |
-	buf := File pathBuffer.
-	filename := self value asUtf16String.
-	filename notNil
-		ifTrue: 
-			[buf
+	^1!
+
+prepareStruct
+	"Private - Initialize the parameter structure to be passed to the Win32 API associated with this common dialog, immediately prior to the call to that API."
+
+	| buf defext |
+	buf := Utf16String newFixed: self maxFileCount * self averageFilenameLength + File maxPath.
+	self value
+		ifNotNil: 
+			[:filename |
+			| utf16 |
+			utf16 := filename asUtf16String.
+			buf
 				replaceFrom: 1
-				to: filename size
-				with: filename].
+				to: utf16 size
+				with: utf16].
 	(self filterIndex = 0 and: [(defext := self defaultExtension) notNil])
 		ifTrue: [self filterIndex: (self fileTypes findFirst: [:pair | pair last contains: defext])].
 	self winStruct
@@ -303,6 +335,7 @@ wmNotify: msgInteger wParam: wParamInteger lParam: lParamInteger
 		ifNil: [0]
 		ifNotNil: [:action | self perform: action with: ptr]! !
 !FileDialog categoriesFor: #allFilesType!constants!private! !
+!FileDialog categoriesFor: #averageFilenameLength!constants!private! !
 !FileDialog categoriesFor: #basicShowModal!private!realizing/unrealizing! !
 !FileDialog categoriesFor: #caption:!accessing!public! !
 !FileDialog categoriesFor: #cdnFileOk:!event handling-win32!private! !
@@ -317,6 +350,7 @@ wmNotify: msgInteger wParam: wParamInteger lParam: lParamInteger
 !FileDialog categoriesFor: #defaultExtension!accessing!public! !
 !FileDialog categoriesFor: #defaultExtension:!accessing!public! !
 !FileDialog categoriesFor: #defaultStyle!constants!public! !
+!FileDialog categoriesFor: #extractPathNames:!helpers!private! !
 !FileDialog categoriesFor: #extractResult:!helpers!private! !
 !FileDialog categoriesFor: #fileTypes!accessing!public! !
 !FileDialog categoriesFor: #fileTypes:!accessing!public! !
@@ -327,6 +361,7 @@ wmNotify: msgInteger wParam: wParamInteger lParam: lParamInteger
 !FileDialog categoriesFor: #getFileSpec!operations!private! !
 !FileDialog categoriesFor: #initialDirectory:!accessing!public! !
 !FileDialog categoriesFor: #initialize!initializing!private! !
+!FileDialog categoriesFor: #maxFileCount!accessing!public! !
 !FileDialog categoriesFor: #prepareStruct!helpers!private! !
 !FileDialog categoriesFor: #style!accessing!public! !
 !FileDialog categoriesFor: #style:!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FileOpenDialog.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FileOpenDialog.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 FileDialog subclass: #FileOpenDialog
-	instanceVariableNames: ''
+	instanceVariableNames: 'maxFileCount'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -28,12 +28,35 @@ basicShowModal
 
 	^ComDlgLibrary default getOpenFileName: winStruct!
 
-defaultStyle
-	"Answers the style for the receiver."
+defaultMaxFileCount
+	"Private - Answers the default number of selections that are expected to fit into the buffer. If the maxFileCount is not set, then the FileOpenDialog is operated in single file mode."
 
-	^super defaultStyle bitOr: OFN_FILEMUSTEXIST! !
+	^1!
+
+defaultStyle
+	"Private - Answers the style for the receiver."
+
+	^super defaultStyle bitOr: OFN_FILEMUSTEXIST!
+
+maxFileCount
+	^maxFileCount ifNil: [self defaultMaxFileCount] ifNotNil: [maxFileCount max: 10]!
+
+maxFileCount: anInteger
+	"Set the maximum number of files to be selected. Note that this is not a hard limit - it mainly affects the buffer size, so a larger or smaller number of files may fit depending on the length of the folder path and the file names.
+	However, a maximum count of 1 is special in that it means the dialog will operate in single selection mode."
+
+	maxFileCount := anInteger!
+
+style
+	"Answers the style flags to be used when the receiver is opened."
+
+	^self maxFileCount > 1 ifTrue: [style | ##(OFN_ALLOWMULTISELECT | OFN_EXPLORER)] ifFalse: [style]! !
 !FileOpenDialog categoriesFor: #basicShowModal!private!realizing/unrealizing! !
-!FileOpenDialog categoriesFor: #defaultStyle!constants!public! !
+!FileOpenDialog categoriesFor: #defaultMaxFileCount!constants!private! !
+!FileOpenDialog categoriesFor: #defaultStyle!constants!private! !
+!FileOpenDialog categoriesFor: #maxFileCount!accessing!public! !
+!FileOpenDialog categoriesFor: #maxFileCount:!accessing!public! !
+!FileOpenDialog categoriesFor: #style!accessing!public! !
 
 !FileOpenDialog class methodsFor!
 

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/OPENFILENAMEW.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/OPENFILENAMEW.cls
@@ -60,6 +60,11 @@ dwSize: anInteger
 
 	bytes dwordAtOffset: _OffsetOf_dwSize put: anInteger!
 
+fileName
+	"Answer the file name buffer."
+
+	^fileName!
+
 fileName: aString
 	"Set the file name to be opened/saved.
 	We store down the String in an instance variable to prevent it being GC'd."
@@ -192,6 +197,7 @@ title: aString
 !OPENFILENAMEW categoriesFor: #defaultExtension!accessing!public! !
 !OPENFILENAMEW categoriesFor: #defaultExtension:!accessing!public! !
 !OPENFILENAMEW categoriesFor: #dwSize:!**compiled accessors**!public! !
+!OPENFILENAMEW categoriesFor: #fileName!accessing!public! !
 !OPENFILENAMEW categoriesFor: #fileName:!accessing!public! !
 !OPENFILENAMEW categoriesFor: #fileTypes:!accessing!public! !
 !OPENFILENAMEW categoriesFor: #flags!**compiled accessors**!public! !

--- a/Core/Object Arts/Dolphin/MVP/FileDialogTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/FileDialogTest.cls
@@ -10,6 +10,30 @@ FileDialogTest comment: ''!
 !FileDialogTest categoriesForClass!Unclassified! !
 !FileDialogTest methodsFor!
 
+testExtractPathnames
+	| subject |
+	subject := FileOpenDialog new.
+	subject maxFileCount: 5.
+	subject prepareStruct.
+	#(#(#('c:\dir1\file1') #('c:\dir1\file1')) #(#('c:\dir1\dir2' 'file1' 'file2') #('c:\dir1\dir2\file1' 'c:\dir1\dir2\file2')))
+		do: 
+			[:each |
+			| multisz buf pathNames |
+			multisz := ($\0 join: each first) asUtf16String , (Utf16String new: 2).
+			buf := subject winStruct fileName.
+			buf
+				replaceFrom: 1
+				to: multisz size
+				with: multisz.
+			pathNames := subject extractPathNames: buf.
+			self assert: pathNames equals: each second]!
+
+testPrepareStructWithNil
+	| subject |
+	subject := FileSaveDialog on: nil asValue.
+	subject prepareStruct.
+	self assert: subject winStruct lpstrFile isEmpty!
+
 testPrepareStructWithUtf8String
 	| subject utf8String lpstrFile |
 	utf8String := 'a 🐬 Utf8String' asUtf8String.
@@ -18,5 +42,7 @@ testPrepareStructWithUtf8String
 	lpstrFile := subject winStruct lpstrFile.
 	self assert: lpstrFile isKindOf: Utf16String.
 	self assert: lpstrFile equals: utf8String! !
+!FileDialogTest categoriesFor: #testExtractPathnames!public! !
+!FileDialogTest categoriesFor: #testPrepareStructWithNil!public! !
 !FileDialogTest categoriesFor: #testPrepareStructWithUtf8String!public! !
 


### PR DESCRIPTION
Fix #921, and consolidate MultipleFileOpenDialog into FileOpenDialog so that FileOpenDialog supports multiple file selections in the base.
MultipleFileOpenDialog is no longer required, but is temporarily retained. It will be deprecated in the next release, and eventually removed.