### PR TITLE
Revert master to pre-7.2 String>>subStrings: behaviour

### DIFF
--- a/Core/Contributions/Camp Smalltalk/ANSI/Tests/CS ANSI Tests.pax
+++ b/Core/Contributions/Camp Smalltalk/ANSI/Tests/CS ANSI Tests.pax
@@ -208,7 +208,7 @@ MainTestCase subclass: #CollectionTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 MainTestCase subclass: #DateAndTimeANSITest
-	instanceVariableNames: 'd19970426t8'
+	instanceVariableNames: 'd19970426t8 savedLocale'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Contributions/Camp Smalltalk/ANSI/Tests/DateAndTimeANSITest.cls
+++ b/Core/Contributions/Camp Smalltalk/ANSI/Tests/DateAndTimeANSITest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 MainTestCase subclass: #DateAndTimeANSITest
-	instanceVariableNames: 'd19970426t8'
+	instanceVariableNames: 'd19970426t8 savedLocale'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -18,9 +18,16 @@ protocol
 
 setUp
 	super setUp.
+	savedLocale := Locale userDefault.
+	"The tests of month and day names, etc, are expecting US English names and abbreviations"
+	Locale userDefault: (Locale lcid: 1033).
 	d19970426t8 := DateAndTime
 		year: 1997 month: 4 day: 26
 		hour: 8 minute: 0 second: 0.!
+
+tearDown
+	savedLocale ifNotNil: [Locale userDefault: savedLocale. savedLocale := nil].
+	super tearDown!
 
 testXaddOp
 	" <DateAndTime>#+ "
@@ -370,7 +377,8 @@ testXyear
 		conformTo: #'DateAndTime' selector: #'year'.! !
 !DateAndTimeANSITest categoriesFor: #canonicalObject!public! !
 !DateAndTimeANSITest categoriesFor: #protocol!public! !
-!DateAndTimeANSITest categoriesFor: #setUp!public! !
+!DateAndTimeANSITest categoriesFor: #setUp!private!running! !
+!DateAndTimeANSITest categoriesFor: #tearDown!private!running! !
 !DateAndTimeANSITest categoriesFor: #testXaddOp!public! !
 !DateAndTimeANSITest categoriesFor: #testXasLocal!public! !
 !DateAndTimeANSITest categoriesFor: #testXasUTC!public! !

--- a/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
@@ -289,11 +289,10 @@ skipIfWin32
 
 	self skipUnless: [KernelLibrary default isWow64]!
 
-skipUnless: aBooleanOrBlock
-	" If the assumption in aBooleanOrBlock is not true, abandon the running test
-	and mark it as passed. "
-
-	aBooleanOrBlock value ifFalse: [TestSkip signal: 'Assumption in #skipUnless: failed']! !
+skipUnless: aNiladicValuable
+	" If the assumption in the <niladicValuable> argument evaluates to false, abandon the running test and mark it as skipped."
+	
+	aNiladicValuable value ifFalse: [TestSkip signal: 'Assumption in #skipUnless: failed']! !
 !TestCase categoriesFor: #<=!comparing!public! !
 !TestCase categoriesFor: #=!comparing!public! !
 !TestCase categoriesFor: #assert:equals:description:!asserting!public! !

--- a/Core/Object Arts/Dolphin/Base/AnsiStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/AnsiStringTest.cls
@@ -1,6 +1,6 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-AbstractStringTest subclass: #AnsiStringTest
+StringTest subclass: #AnsiStringTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/Base/Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Character.cls
@@ -54,7 +54,7 @@ _beginsString: aString
 	^aString readStream peek = self!
 
 _separateSubStringsIn: tokens
-	| start answer size end |
+	| start answer size end codeUnits |
 	size := tokens size.
 	size == 0 ifTrue: [^{}].
 	end := tokens
@@ -64,9 +64,10 @@ _separateSubStringsIn: tokens
 	end == 0 ifTrue: [^{tokens}].
 	answer := Array writeStream: 5.
 	start := 1.
-	
+	codeUnits := tokens encodedSizeOf: self.
+
 	[answer nextPut: (tokens copyFrom: start to: end - 1).
-	start := end + 1.
+	start := end + codeUnits.
 	end := tokens
 				nextIndexOf: self
 				from: start

--- a/Core/Object Arts/Dolphin/Base/Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Character.cls
@@ -53,6 +53,30 @@ At present only byte characters (that are not control characters) have a printab
 _beginsString: aString
 	^aString readStream peek = self!
 
+_separateSubStringsIn: tokens
+	| start answer size end |
+	size := tokens size.
+	size == 0 ifTrue: [^{}].
+	end := tokens
+				nextIndexOf: self
+				from: 1
+				to: size.
+	end == 0 ifTrue: [^{tokens}].
+	answer := Array writeStream: 5.
+	start := 1.
+	
+	[answer nextPut: (tokens copyFrom: start to: end - 1).
+	start := end + 1.
+	end := tokens
+				nextIndexOf: self
+				from: start
+				to: size.
+	end == 0]
+			whileFalse.
+	"Copy any remaining chars after the last separator"
+	start <= size ifTrue: [answer nextPut: (tokens copyFrom: start to: size)].
+	^answer contents!
+
 < aCharacter
 	"Answer whether the receiver is less than the parameter aCharacter."
 
@@ -475,6 +499,7 @@ to: aCharacter
 
 	^(self codePoint to: aCharacter codePoint) collect: [:each | Character codePoint: each]! !
 !Character categoriesFor: #_beginsString:!comparing!double dispatch!private! !
+!Character categoriesFor: #_separateSubStringsIn:!private!tokenizing! !
 !Character categoriesFor: #<!comparing!public! !
 !Character categoriesFor: #=!comparing!public! !
 !Character categoriesFor: #>!comparing!public! !

--- a/Core/Object Arts/Dolphin/Base/CharacterTest.cls
+++ b/Core/Object Arts/Dolphin/Base/CharacterTest.cls
@@ -446,6 +446,36 @@ testSize
 	self assert: $a size equals: 0.
 	self assert: Character dolphin size equals: 0!
 
+testSplit
+	"Test single character delimiter"
+
+	| empty |
+	empty := ''.
+	self assert: ($- split: empty) equals: #().
+	self assert: ($- split: '-') equals: {empty. empty}.
+	self assert: ($- split: 'a') equals: #('a').
+	self assert: ($- split: '-a') equals: #('' 'a').
+	self assert: ($- split: 'a-') equals: #('a' '').
+	self assert: ($- split: '--a') equals: #('' '' 'a').
+	self assert: ($- split: 'a--') equals: #('a' '' '').
+	self assert: ($- split: 'ab') equals: #('ab').
+	self assert: ($- split: '-ab') equals: #('' 'ab').
+	self assert: ($- split: 'ab-') equals: #('ab' '').
+	self assert: ($- split: 'ab---') equals: #('ab' '' '' '').
+	self assert: ($- split: '--ab') equals: #('' '' 'ab').
+	self assert: ($- split: 'a-b') equals: #('a' 'b').
+	self assert: ($- split: 'a--b') equals: #('a' '' 'b').
+	self assert: ($- split: 'ab-c-') equals: #('ab' 'c' '').
+	self assert: ($- split: 'a-b--c') equals: #('a' 'b' '' 'c').
+
+	"Note that if the string consists only of separators, then we get N+1 empty strings if there are N chars"
+	1 to: 3
+		do: 
+			[:i |
+			| subject |
+			subject := String new: i withAll: $a.
+			self assert: ($a split: subject) equals: (Array new: i + 1 withAll: empty)]!
+
 testStb
 	| bytes rehydrated |
 	bytes := Character dolphin binaryStoreBytes.
@@ -474,5 +504,6 @@ testStb
 !CharacterTest categoriesFor: #testIsUtf8SurrogateTests!public!unit tests! !
 !CharacterTest categoriesFor: #testPrintString!public!unit tests! !
 !CharacterTest categoriesFor: #testSize!public!unit tests! !
+!CharacterTest categoriesFor: #testSplit!public!unit tests! !
 !CharacterTest categoriesFor: #testStb!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/CommandLine.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLine.cls
@@ -171,7 +171,7 @@ parseLongOption: aString
 		key := aString.
 	] ifTrue: [		"option=value format"
 		| pieces |
-		pieces := aString subStrings: $=.
+		pieces := $= split: aString.
 		key := pieces at: 1.
 		argument := pieces at: 2.
 	].

--- a/Core/Object Arts/Dolphin/Base/CommandLineTest.cls
+++ b/Core/Object Arts/Dolphin/Base/CommandLineTest.cls
@@ -319,6 +319,18 @@ testLongOptionalArgumentPresent
 		assert: arguments equals: #('DPRO.img7');
 		yourself!
 
+testLongOptionEmptyArgument
+	| commandLine options |
+	commandLine := (CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '--foo='))
+				addOptionRequiringArgument: 'foo';
+				yourself.
+	options := commandLine options.
+	self
+		assert: options class identicalTo: Dictionary;
+		assert: options keys asSortedCollection asArray equals: #('foo');
+		assert: (options at: 'foo') equals: '';
+		yourself!
+
 testLongRequiredArgumentPresent
 	| commandLine options arguments |
 	commandLine := (CommandLine argv: #('Dolphin7.exe' 'DPRO.img7' '--foo' 'bar'))
@@ -502,6 +514,7 @@ testUnrecognizedOption
 !CommandLineTest categoriesFor: #testLongNoArgument!long tests!public! !
 !CommandLineTest categoriesFor: #testLongOptionalArgumentAbsent!long tests!public! !
 !CommandLineTest categoriesFor: #testLongOptionalArgumentPresent!long tests!public! !
+!CommandLineTest categoriesFor: #testLongOptionEmptyArgument!errors!public! !
 !CommandLineTest categoriesFor: #testLongRequiredArgumentPresent!long tests!public! !
 !CommandLineTest categoriesFor: #testLongUnexpectedArgument!errors!public! !
 !CommandLineTest categoriesFor: #testLongUnexpectedOption!errors!public! !

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -8,7 +8,6 @@ package classNames
 	add: #AbstractDictionaryTest;
 	add: #AbstractFileStreamTest;
 	add: #AbstractKeyboardTest;
-	add: #AbstractStringTest;
 	add: #AlwaysSearchPolicyTest;
 	add: #AnsiStringTest;
 	add: #ArrayedCollectionTest;
@@ -108,6 +107,7 @@ package classNames
 	add: #STBTest;
 	add: #StdioFileStreamTest;
 	add: #StreamTest;
+	add: #StringTest;
 	add: #StructureArrayTest;
 	add: #SWORDArrayTest;
 	add: #SymbolTest;
@@ -494,11 +494,6 @@ SequenceableCollectionTest subclass: #SequencedGrowableCollectionTest
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-ArrayedCollectionTest subclass: #AbstractStringTest
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
 ArrayedCollectionTest subclass: #ArrayTest
 	instanceVariableNames: ''
 	classVariableNames: ''
@@ -514,17 +509,22 @@ ArrayedCollectionTest subclass: #RunArrayTest
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-AbstractStringTest subclass: #AnsiStringTest
+ArrayedCollectionTest subclass: #StringTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-AbstractStringTest subclass: #MultiByteStringTest
+StringTest subclass: #AnsiStringTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-AbstractStringTest subclass: #SymbolTest
+StringTest subclass: #MultiByteStringTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+StringTest subclass: #SymbolTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -335,7 +335,7 @@ DolphinTest subclass: #IntegerTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #LocaleTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'savedLocale'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -420,7 +420,7 @@ DolphinTest subclass: #TimeStampTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #TimeTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'savedLocale'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Base/LocaleTest.cls
+++ b/Core/Object Arts/Dolphin/Base/LocaleTest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 DolphinTest subclass: #LocaleTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'savedLocale'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -16,6 +16,15 @@ defaultSubject
 
 displayFloat: aFloat with: subject
 	^String streamContents: [:s | subject displayFloat: aFloat on: s]!
+
+setUp
+	super setUp.
+	savedLocale := Locale userDefault.
+	Locale userDefault: (Locale lcid: 1081)!
+
+tearDown
+	savedLocale ifNotNil: [Locale userDefault: savedLocale. savedLocale := nil].
+	super tearDown!
 
 testPrintDateTimeOnFormat
 	| subject now expected |
@@ -71,6 +80,8 @@ testPrintDurationOnFormat
 	self assert: actual equals: '-12:06'! !
 !LocaleTest categoriesFor: #defaultSubject!helpers!private! !
 !LocaleTest categoriesFor: #displayFloat:with:!helpers!private! !
+!LocaleTest categoriesFor: #setUp!private!running! !
+!LocaleTest categoriesFor: #tearDown!private!running! !
 !LocaleTest categoriesFor: #testPrintDateTimeOnFormat!public! !
 !LocaleTest categoriesFor: #testPrintDurationOnFormat!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/MultiByteStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/MultiByteStringTest.cls
@@ -1,6 +1,6 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-AbstractStringTest subclass: #MultiByteStringTest
+StringTest subclass: #MultiByteStringTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -81,6 +81,27 @@ _sameAsString: aString
 
 	^self == aString or: [aString <=> self == 0]!
 
+_separateSubStringsIn: aReadableString
+	| start size answer subSize |
+	(subSize := self size) == 0
+		ifTrue: [^self error: 'separator must consist of at least one character'].
+	subSize == 1 ifTrue: [^(self at: 1) _separateSubStringsIn: aReadableString].
+	start := 1.
+	size := aReadableString size.
+	answer := Array writeStream: 10.
+	
+	[| stop |
+	stop := aReadableString findString: self startingAt: start.
+	stop == 0
+		ifTrue: 
+			[^answer
+				nextPut: (aReadableString copyFrom: start to: size);
+				contents].
+	answer nextPut: (aReadableString copyFrom: start to: stop - 1).
+	(start := stop + subSize) > size]
+			whileFalse.
+	^answer contents!
+
 < aString
 	"Answer whether the receiver is lexically less than the <readableString> argument, ignoring case, according to the implementation defined collation sequence (see <=>)."
 
@@ -1061,13 +1082,8 @@ subStrings: separatorOrSeparators
 	"Answer an array containing the substrings of the receiver separated by occurrences of the <Character> or <readableString> argument, separator.
 	Repeated separators produce empty strings in the array (cf. #subStrings). The separators are removed."
 
-	#todo.	"This does not comply with the current ANSI definition, which expects that the
-		argument is a <sequencedReadableCollection> of separators, any one of which may
-		separate each token. For historical reasons the Dolphin implementation accepts also
-		accepts a single character as the separator, and furthermore when passed a <String>
-		it will use the entire string as a multi-character separator. A workaround is to
-		convert the separator string to an array of <Character>."
-	^separatorOrSeparators split: self!
+	#todo. "N.B. This does not comply with the current ANSI definition, which expects that the argument is a <sequencedReadableCollection> of separators, any one of which may separate each token. In the next major release (7.2) this behaviour will be changed to be ANSI compliant. Also the historic asymmetric behaviour of ignoring a terminating separator will be corrected so that the operation behaves in the same was as Character>>split:"
+	^separatorOrSeparators _separateSubStringsIn: self!
 
 subStringsAnsi: separators
 	"Answer an array containing the substrings of the receiver separated by occurrences
@@ -1076,6 +1092,7 @@ subStringsAnsi: separators
 	The separators are removed."
 
 	| start answer size end |
+	#deprecated. "Will be removed in 7.2"
 	size := self size.
 	size == 0 ifTrue: [^{}].
 	end := self indexOfAnyOf: separators startingAt: 1.
@@ -1175,6 +1192,7 @@ withNormalizedLineDelimiters
 !String categoriesFor: #_cmp:!comparing!private! !
 !String categoriesFor: #_indexOfAnyInString:startingAt:!double dispatch!private!searching! !
 !String categoriesFor: #_sameAsString:!comparing!private! !
+!String categoriesFor: #_separateSubStringsIn:!private!tokenizing! !
 !String categoriesFor: #<!comparing!public! !
 !String categoriesFor: #<=!comparing!public! !
 !String categoriesFor: #<==>!comparing!public! !
@@ -1265,8 +1283,8 @@ withNormalizedLineDelimiters
 !String categoriesFor: #storeOn:!printing!public! !
 !String categoriesFor: #strcspn:start:!private!searching! !
 !String categoriesFor: #strlen!accessing!private! !
-!String categoriesFor: #subStrings!copying!public! !
-!String categoriesFor: #subStrings:!copying!public! !
+!String categoriesFor: #subStrings!public!tokenizing! !
+!String categoriesFor: #subStrings:!public!tokenizing! !
 !String categoriesFor: #subStringsAnsi:!copying!public! !
 !String categoriesFor: #titleCased!converting!public! !
 !String categoriesFor: #trimBlanks!copying!public! !

--- a/Core/Object Arts/Dolphin/Base/StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StringTest.cls
@@ -1,15 +1,15 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-ArrayedCollectionTest subclass: #AbstractStringTest
+ArrayedCollectionTest subclass: #StringTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-AbstractStringTest guid: (GUID fromString: '{262b323f-d574-423e-8571-63b1fab0d021}')!
-AbstractStringTest isAbstract: true!
-AbstractStringTest comment: ''!
-!AbstractStringTest categoriesForClass!Unclassified! !
-!AbstractStringTest methodsFor!
+StringTest guid: (GUID fromString: '{262b323f-d574-423e-8571-63b1fab0d021}')!
+StringTest isAbstract: true!
+StringTest comment: ''!
+!StringTest categoriesForClass!Unclassified! !
+!StringTest methodsFor!
 
 assimilate: each 
 	^Character codePoint: each asInteger!
@@ -408,6 +408,77 @@ testReverse
 			actual := actual reverse.
 			self assert: actual equals: subject mutableCopy]!
 
+testSplitByString
+	"Test String>>split:, which tokenizes the argument string into sequences that are separated by the receiver string."
+
+	| sep empty |
+	empty := self newCollection: ''.
+	"The separator but must not be empty"
+	self should: [empty split: (self newCollection: 'abc')] raise: Error.
+
+	"And again but using a string argument of more than one character"
+	sep := self newCollection: String lineDelimiter.
+	self assert: (sep split: empty) equals: (#() collect: [:e | self newCollection: e]).
+	self assert: (sep split: (self newCollection: 'a'))
+		equals: (#('a') collect: [:e | self newCollection: e]).
+	self assert: (sep split: (self newCollection: sep , 'a'))
+		equals: (#('' 'a') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: 'a' , sep))
+		equals: (#('a' '') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: sep , sep , 'a'))
+		equals: (#('' '' 'a') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: 'a' , sep , sep))
+		equals: (#('a' '' '') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: 'ab'))
+		equals: (#('ab') collect: [:e | self newCollection: e]).
+	self assert: (sep split: (self newCollection: sep , 'ab'))
+		equals: (#('' 'ab') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: 'ab' , sep))
+		equals: (#('ab' '') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: 'ab' , sep , sep , sep))
+		equals: (#('ab' '' '' '') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: sep , sep , 'ab'))
+		equals: (#('' '' 'ab') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: 'a' , sep , 'b'))
+		equals: (#('a' 'b') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: 'a' , sep , sep , 'b'))
+		equals: (#('a' '' 'b') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: 'ab' , sep , 'c' , sep))
+		equals: (#('ab' 'c' '') collect: [:e | self newCopy: e]).
+	self assert: (sep split: (self newCollection: 'a' , sep , 'b' , sep , sep , 'c'))
+		equals: (#('a' 'b' '' 'c') collect: [:e | self newCopy: e]).
+	1 to: 3
+		do: 
+			[:i |
+			| subject |
+			subject := self
+						newCollection: (String streamContents: [:strm | i timesRepeat: [strm nextPutAll: 'ab']]).
+			self assert: ('ab' split: subject) equals: (Array new: i + 1 withAll: empty)]!
+
+testSplitSingle
+	"Test split by a single character string"
+
+	| empty sep |
+	empty := ''.
+	"And again but using a string argument of only one character"
+	sep := '-'.
+	self assert: (sep split: empty) equals: #().
+	self assert: (sep split: sep) equals: {empty. empty}.
+	self assert: (sep split: 'a') equals: #('a').
+	self assert: (sep split: '-a') equals: #('' 'a').
+	self assert: (sep split: 'a-') equals: #('a' '').
+	self assert: (sep split: '--a') equals: #('' '' 'a').
+	self assert: (sep split: 'a--') equals: #('a' '' '').
+	self assert: (sep split: 'ab') equals: #('ab').
+	self assert: (sep split: '-ab') equals: #('' 'ab').
+	self assert: (sep split: 'ab-') equals: #('ab' '').
+	self assert: (sep split: 'ab---') equals: #('ab' '' '' '').
+	self assert: (sep split: '--ab') equals: #('' '' 'ab').
+	self assert: (sep split: 'a-b') equals: #('a' 'b').
+	self assert: (sep split: 'a--b') equals: #('a' '' 'b').
+	self assert: (sep split: 'ab-c-') equals: #('ab' 'c' '').
+	self assert: (sep split: 'a-b--c') equals: #('a' 'b' '' 'c')!
+
 testStreamUtfRoundTrip
 	| expected actual |
 	self collectionClass == Symbol ifTrue: [^self].
@@ -431,30 +502,30 @@ testStreamUtfRoundTrip
 				self assert: (self assimilateString: actual) equals: expected]!
 
 testSubStringsByCharacter
-	"Test single character delimiter"
+	"Test legacy subStrings: behavior for single character delimiter. This will be changed in 7.2"
 
 	| empty sep |
 	empty := self newCollection: ''.
 	self assert: (empty subStrings: $-) equals: (#() collect: [:e | self newCollection: e]).
-	self assert: ('-' subStrings: $-) equals: {empty. empty}.
+	self assert: ('-' subStrings: $-) equals: {empty}.
 	self assert: ((self newCollection: 'a') subStrings: $-)
 		equals: (#('a') collect: [:e | self newCollection: e]).
 	self assert: ((self newCollection: '-a') subStrings: $-)
 		equals: (#('' 'a') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a-') subStrings: $-)
-		equals: (#('a' '') collect: [:e | self newCopy: e]).
+		equals: (#('a') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: '--a') subStrings: $-)
 		equals: (#('' '' 'a') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a--') subStrings: $-)
-		equals: (#('a' '' '') collect: [:e | self newCopy: e]).
+		equals: (#('a' '') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab') subStrings: $-)
 		equals: (#('ab') collect: [:e | self newCollection: e]).
 	self assert: ((self newCollection: '-ab') subStrings: $-)
 		equals: (#('' 'ab') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab-') subStrings: $-)
-		equals: (#('ab' '') collect: [:e | self newCopy: e]).
+		equals: (#('ab') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab---') subStrings: $-)
-		equals: (#('ab' '' '' '') collect: [:e | self newCopy: e]).
+		equals: (#('ab' '' '') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: '--ab') subStrings: $-)
 		equals: (#('' '' 'ab') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a-b') subStrings: $-)
@@ -462,32 +533,32 @@ testSubStringsByCharacter
 	self assert: ((self newCollection: 'a--b') subStrings: $-)
 		equals: (#('a' '' 'b') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab-c-') subStrings: $-)
-		equals: (#('ab' 'c' '') collect: [:e | self newCopy: e]).
+		equals: (#('ab' 'c') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a-b--c') subStrings: $-)
 		equals: (#('a' 'b' '' 'c') collect: [:e | self newCopy: e]).
 
 	"And again but using a string argument of only one character"
 	sep := self newCollection: '-'.
 	self assert: (empty subStrings: sep) equals: (#() collect: [:e | self newCollection: e]).
-	self assert: (sep subStrings: sep) equals: {empty. empty}.
+	self assert: (sep subStrings: sep) equals: {empty}.
 	self assert: ((self newCollection: 'a') subStrings: sep)
 		equals: (#('a') collect: [:e | self newCollection: e]).
 	self assert: ((self newCollection: '-a') subStrings: sep)
 		equals: (#('' 'a') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a-') subStrings: sep)
-		equals: (#('a' '') collect: [:e | self newCopy: e]).
+		equals: (#('a') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: '--a') subStrings: sep)
 		equals: (#('' '' 'a') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a--') subStrings: sep)
-		equals: (#('a' '' '') collect: [:e | self newCopy: e]).
+		equals: (#('a' '') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab') subStrings: sep)
 		equals: (#('ab') collect: [:e | self newCollection: e]).
 	self assert: ((self newCollection: '-ab') subStrings: sep)
 		equals: (#('' 'ab') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab-') subStrings: sep)
-		equals: (#('ab' '') collect: [:e | self newCopy: e]).
+		equals: (#('ab') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab---') subStrings: sep)
-		equals: (#('ab' '' '' '') collect: [:e | self newCopy: e]).
+		equals: (#('ab' '' '') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: '--ab') subStrings: sep)
 		equals: (#('' '' 'ab') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a-b') subStrings: sep)
@@ -495,20 +566,21 @@ testSubStringsByCharacter
 	self assert: ((self newCollection: 'a--b') subStrings: sep)
 		equals: (#('a' '' 'b') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab-c-') subStrings: sep)
-		equals: (#('ab' 'c' '') collect: [:e | self newCopy: e]).
+		equals: (#('ab' 'c') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a-b--c') subStrings: sep)
 		equals: (#('a' 'b' '' 'c') collect: [:e | self newCopy: e]).
 
-	"Note that if the string consists only of separators, then we get N+1 empty strings if there are N chars"
+	"Note that if the string consists only of separators, then we get N empty strings if there are N chars"
 	1 to: 3
 		do: 
 			[:i |
 			| subject |
 			subject := self newCollection: (String new: i withAll: $a).
-			self assert: (subject subStrings: $a) equals: (Array new: i + 1 withAll: empty)]!
+			self assert: (subject subStrings: $a) equals: (Array new: i withAll: empty)]!
 
 testSubStringsByString
-	"Test string delimiter"
+	"Test subStrings: with a multi-character string argument. This is the historic behaviour, which ignored a trailing terminator. This will be corrected in 7.2 which will also adopt the ANSI specified behaviour of splitting by any of the 
+	characters in the argument string. The String>>split: allows for splitting by all of a sequence of characters."
 
 	| sep empty |
 	empty := self newCollection: ''.
@@ -517,25 +589,29 @@ testSubStringsByString
 
 	"And again but using a string argument of more than one character"
 	sep := self newCollection: String lineDelimiter.
-	self assert: (empty subStrings: sep) equals: (#() collect: [:e | self newCollection: e]).
+
+	"Note historic incorrect behaviour that splitting an empty string by anything yields a result with one empty element. Corrected in 7.2."
+	self assert: (empty subStrings: sep) equals: (#('') collect: [:e | self newCollection: e]).
+
 	self assert: ((self newCollection: 'a') subStrings: sep)
 		equals: (#('a') collect: [:e | self newCollection: e]).
 	self assert: ((self newCollection: sep , 'a') subStrings: sep)
 		equals: (#('' 'a') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a' , sep) subStrings: sep)
-		equals: (#('a' '') collect: [:e | self newCopy: e]).
+		equals: (#('a') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: sep , sep , 'a') subStrings: sep)
 		equals: (#('' '' 'a') collect: [:e | self newCopy: e]).
+	"Note asymmetry - two leading separators and we get a 3 element result, two trailing separator and we get a 2 element result."
 	self assert: ((self newCollection: 'a' , sep , sep) subStrings: sep)
-		equals: (#('a' '' '') collect: [:e | self newCopy: e]).
+		equals: (#('a' '') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab') subStrings: sep)
 		equals: (#('ab') collect: [:e | self newCollection: e]).
 	self assert: ((self newCollection: sep , 'ab') subStrings: sep)
 		equals: (#('' 'ab') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab' , sep) subStrings: sep)
-		equals: (#('ab' '') collect: [:e | self newCopy: e]).
+		equals: (#('ab') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab' , sep , sep , sep) subStrings: sep)
-		equals: (#('ab' '' '' '') collect: [:e | self newCopy: e]).
+		equals: (#('ab' '' '') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: sep , sep , 'ab') subStrings: sep)
 		equals: (#('' '' 'ab') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a' , sep , 'b') subStrings: sep)
@@ -543,7 +619,7 @@ testSubStringsByString
 	self assert: ((self newCollection: 'a' , sep , sep , 'b') subStrings: sep)
 		equals: (#('a' '' 'b') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'ab' , sep , 'c' , sep) subStrings: sep)
-		equals: (#('ab' 'c' '') collect: [:e | self newCopy: e]).
+		equals: (#('ab' 'c') collect: [:e | self newCopy: e]).
 	self assert: ((self newCollection: 'a' , sep , 'b' , sep , sep , 'c') subStrings: sep)
 		equals: (#('a' 'b' '' 'c') collect: [:e | self newCopy: e]).
 	1 to: 3
@@ -552,7 +628,7 @@ testSubStringsByString
 			| subject |
 			subject := self
 						newCollection: (String streamContents: [:strm | i timesRepeat: [strm nextPutAll: 'ab']]).
-			self assert: (subject subStrings: 'ab') equals: (Array new: i + 1 withAll: empty)]!
+			self assert: (subject subStrings: 'ab') equals: (Array new: i  withAll: empty)]!
 
 testTrimNulls
 	"#1187"
@@ -684,35 +760,37 @@ verifyConcatenationResult: resultString of: receiverString with: argumentString
 
 withAllTestCases
 	^#('' 'a' 'abc' '£€')! !
-!AbstractStringTest categoriesFor: #assimilate:!helpers!private! !
-!AbstractStringTest categoriesFor: #assimilateString:!helpers!private! !
-!AbstractStringTest categoriesFor: #caseConversionCases!constants!private! !
-!AbstractStringTest categoriesFor: #equalityTestCases!constants!private! !
-!AbstractStringTest categoriesFor: #lengthTestCases!constants!private! !
-!AbstractStringTest categoriesFor: #newNumericArray:!helpers!private! !
-!AbstractStringTest categoriesFor: #reverseTestCases!constants!private! !
-!AbstractStringTest categoriesFor: #testAsByteArray!public!unit tests! !
-!AbstractStringTest categoriesFor: #testAt!public!unit tests! !
-!AbstractStringTest categoriesFor: #testCapitalized!public!unit tests! !
-!AbstractStringTest categoriesFor: #testCaseConversions!public!unit tests! !
-!AbstractStringTest categoriesFor: #testClassReadFrom!public!unit tests! !
-!AbstractStringTest categoriesFor: #testEmpty!public!testing / accessing! !
-!AbstractStringTest categoriesFor: #testEquals!public!unit tests! !
-!AbstractStringTest categoriesFor: #testFindStringStartingAt!public!unit tests! !
-!AbstractStringTest categoriesFor: #testFindStringStartingAtIgnoreCase!public!unit tests! !
-!AbstractStringTest categoriesFor: #testHash!public!unit tests! !
-!AbstractStringTest categoriesFor: #testInvalidComparisons!public!unit tests! !
-!AbstractStringTest categoriesFor: #testLength!public!unit tests! !
-!AbstractStringTest categoriesFor: #testLines!public!unit tests! !
-!AbstractStringTest categoriesFor: #testMutableCopy!public!unit tests! !
-!AbstractStringTest categoriesFor: #testReverse!public!unit tests! !
-!AbstractStringTest categoriesFor: #testStreamUtfRoundTrip!public!unit tests! !
-!AbstractStringTest categoriesFor: #testSubStringsByCharacter!public!unit tests! !
-!AbstractStringTest categoriesFor: #testSubStringsByString!public!unit tests! !
-!AbstractStringTest categoriesFor: #testTrimNulls!public!unit tests! !
-!AbstractStringTest categoriesFor: #testUnescapePercents!public!unit tests! !
-!AbstractStringTest categoriesFor: #testWithAll!public!unit tests! !
-!AbstractStringTest categoriesFor: #testWithNormalizedLineDelimiters!public!unit tests! !
-!AbstractStringTest categoriesFor: #verifyConcatenationResult:of:with:!helpers!private! !
-!AbstractStringTest categoriesFor: #withAllTestCases!constants!private! !
+!StringTest categoriesFor: #assimilate:!helpers!private! !
+!StringTest categoriesFor: #assimilateString:!helpers!private! !
+!StringTest categoriesFor: #caseConversionCases!constants!private! !
+!StringTest categoriesFor: #equalityTestCases!constants!private! !
+!StringTest categoriesFor: #lengthTestCases!constants!private! !
+!StringTest categoriesFor: #newNumericArray:!helpers!private! !
+!StringTest categoriesFor: #reverseTestCases!constants!private! !
+!StringTest categoriesFor: #testAsByteArray!public!unit tests! !
+!StringTest categoriesFor: #testAt!public!unit tests! !
+!StringTest categoriesFor: #testCapitalized!public!unit tests! !
+!StringTest categoriesFor: #testCaseConversions!public!unit tests! !
+!StringTest categoriesFor: #testClassReadFrom!public!unit tests! !
+!StringTest categoriesFor: #testEmpty!public!testing / accessing! !
+!StringTest categoriesFor: #testEquals!public!unit tests! !
+!StringTest categoriesFor: #testFindStringStartingAt!public!unit tests! !
+!StringTest categoriesFor: #testFindStringStartingAtIgnoreCase!public!unit tests! !
+!StringTest categoriesFor: #testHash!public!unit tests! !
+!StringTest categoriesFor: #testInvalidComparisons!public!unit tests! !
+!StringTest categoriesFor: #testLength!public!unit tests! !
+!StringTest categoriesFor: #testLines!public!unit tests! !
+!StringTest categoriesFor: #testMutableCopy!public!unit tests! !
+!StringTest categoriesFor: #testReverse!public!unit tests! !
+!StringTest categoriesFor: #testSplitByString!public!unit tests! !
+!StringTest categoriesFor: #testSplitSingle!public!unit tests! !
+!StringTest categoriesFor: #testStreamUtfRoundTrip!public!unit tests! !
+!StringTest categoriesFor: #testSubStringsByCharacter!public!unit tests! !
+!StringTest categoriesFor: #testSubStringsByString!public!unit tests! !
+!StringTest categoriesFor: #testTrimNulls!public!unit tests! !
+!StringTest categoriesFor: #testUnescapePercents!public!unit tests! !
+!StringTest categoriesFor: #testWithAll!public!unit tests! !
+!StringTest categoriesFor: #testWithNormalizedLineDelimiters!public!unit tests! !
+!StringTest categoriesFor: #verifyConcatenationResult:of:with:!helpers!private! !
+!StringTest categoriesFor: #withAllTestCases!constants!private! !
 

--- a/Core/Object Arts/Dolphin/Base/SymbolTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SymbolTest.cls
@@ -1,6 +1,6 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-AbstractStringTest subclass: #SymbolTest
+StringTest subclass: #SymbolTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/Base/TimeTest.cls
+++ b/Core/Object Arts/Dolphin/Base/TimeTest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 DolphinTest subclass: #TimeTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'savedLocale'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -31,6 +31,15 @@ minutesShould: expectedMinutes for: seconds
 
 secondsShould: expectedSeconds for: seconds
 	self assert: (Time fromSeconds: seconds) second equals: expectedSeconds!
+
+setUp
+	super setUp.
+	savedLocale := Locale userDefault.
+	Locale userDefault: (Locale lcid: 1033)!
+
+tearDown
+	savedLocale ifNotNil: [Locale userDefault: savedLocale. savedLocale := nil].
+	super tearDown!
 
 testAsSYSTEMTIME
 	| today now actual |
@@ -271,6 +280,8 @@ testStoreOn
 !TimeTest categoriesFor: #millisecondsShould:for:!comparing!private! !
 !TimeTest categoriesFor: #minutesShould:for:!comparing!private! !
 !TimeTest categoriesFor: #secondsShould:for:!comparing!private! !
+!TimeTest categoriesFor: #setUp!private!running! !
+!TimeTest categoriesFor: #tearDown!private!running! !
 !TimeTest categoriesFor: #testAsSYSTEMTIME!public!unit tests! !
 !TimeTest categoriesFor: #testClassReadFrom!public!unit tests! !
 !TimeTest categoriesFor: #testFromDuration!public!testing! !

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -414,7 +414,7 @@ TextEditTest subclass: #MultilineTextEditTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 MultilineTextEditTest subclass: #RichTextEditTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'savedLocale'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/RichTextEditTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/RichTextEditTest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 MultilineTextEditTest subclass: #RichTextEditTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'savedLocale'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -18,6 +18,15 @@ margins
 
 nonProportionalFont
 	^Font name: 'Consolas'!
+
+setUp
+	super setUp.
+	savedLocale := Locale userDefault.
+	Locale userDefault: (Locale lcid: 1033)!
+
+tearDown
+	savedLocale ifNotNil: [Locale userDefault: savedLocale. savedLocale := nil].
+	super tearDown!
 
 testCharNearestPosition
 	| text point char |
@@ -64,7 +73,7 @@ testStreamInAnsiText
 \uc1\pard\lang<2d>\f0\fs20 over the lazy dog}
 '
 				expandMacrosWith: Character.AnsiCodePage
-				with: Locale userDefault lcid.
+				with: Locale systemDefault lcid.
 	self assert: actual equals: rtf.
 
 	"Now stream in the ANSI RTF"
@@ -116,7 +125,7 @@ testStreamInUtfText
 \uc1\pard\lang<2d>\f0\fs20 ĉṓɲṩḙċ\f1 ť\f0 ᶒțûɾ ấɖḯƥĭṩ\f1 čį\f0 ɳġ ḝ\f1 łį\f0 ʈ}
 '
 				expandMacrosWith: Character.AnsiCodePage
-				with: Locale userDefault lcid.
+				with: Locale systemDefault lcid.
 	self assert: actual equals: rtf.
 
 	"Check round-trip as ANSI RTF (which has an escape syntax to preserve international characters)"
@@ -137,6 +146,8 @@ text
 !RichTextEditTest categoriesFor: #classToTest!helpers!private! !
 !RichTextEditTest categoriesFor: #margins!private!unit tests! !
 !RichTextEditTest categoriesFor: #nonProportionalFont!constants!private! !
+!RichTextEditTest categoriesFor: #setUp!private!unit tests! !
+!RichTextEditTest categoriesFor: #tearDown!private!running! !
 !RichTextEditTest categoriesFor: #testCharNearestPosition!public!unit tests! !
 !RichTextEditTest categoriesFor: #testStreamInAnsiText!public!unit tests! !
 !RichTextEditTest categoriesFor: #testStreamInUtfText!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/TypeConverterTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/TypeConverterTest.cls
@@ -12,6 +12,8 @@ TypeConverterTest comment: ''!
 
 setUp
 	savedLocale := Locale userDefault.
+	"Many formatting tests are Locale sensitive, so use a known Locale"
+	Locale userDefault: (Locale lcid: 1033).
 	edit := TextEdit show.
 !
 


### PR DESCRIPTION
This reverts the fix for #877 "String>>subStrings: not symmetric in
treatment of leading/trailing separators" as this was a breaking change
inappropriate for a minor release . The fix will be reinstated in the next
major release (7.2), when the behaviour will also be changed to follow the
ANSI NCITS 319-1998 standard so that it will only accept a String argument,
and will tokenize on any of the characters in the argument String.

Note that all uses in the base system have been replaced by uses of
#split:. The split: implementations in String and , which obeys the correct behaviour that removes the asymmetry of
the historic behaviour whereby it effectively ignored a trailing separator.