### PR TITLE
Running Database tests dirties the Northwind.mdb file

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Exception.cls
+++ b/Core/Object Arts/Dolphin/Base/Exception.cls
@@ -523,7 +523,7 @@ toTrace: anInteger
 	traceStream
 		nextPutAll: self description;
 		cr.
-	self raisingFrame printStackOn: traceStream depth: anInteger.
+	anInteger > 0 ifTrue: [self raisingFrame printStackOn: traceStream depth: anInteger].
 	traceStream flush! !
 !Exception categoriesFor: #_descriptionArguments!displaying!public! !
 !Exception categoriesFor: #_descriptionFormat!displaying!public! !

--- a/Core/Object Arts/Dolphin/Database/.gitattributes
+++ b/Core/Object Arts/Dolphin/Database/.gitattributes
@@ -1,0 +1,1 @@
+*.mdb filter=lfs diff=lfs merge=lfs -text

--- a/Core/Object Arts/Dolphin/Database/DBConnectionTest.cls
+++ b/Core/Object Arts/Dolphin/Database/DBConnectionTest.cls
@@ -85,9 +85,11 @@ connectString
 
 	"'DSN=MS Access Database;DBQ=C:\OBJECT ARTS\DEV\DOLPHIN6\OBJECT ARTS\DOLPHIN\Tests\Northwind.mdb;DefaultDir=C:\OBJECT ARTS\DEV\DOLPHIN6\OBJECT ARTS\DOLPHIN\Tests;DriverId=25;FIL=MS Access;MaxBufferSize=2048;PageTimeout=5;'"
 
-	| locator filename |
+	| locator filename source |
 	locator := PackageRelativeFileLocator package: self class owningPackage.
-	filename := locator localFileSpecFor: 'Northwind.mdb'.
+	source := locator localFileSpecFor: 'Northwind.mdb'.
+	filename :=File composePath: File tempPath subPath: 'Northwind.mdb'.
+	File copy: source to: filename.
 	(File isWriteable: filename) ifFalse: [File isWriteable: filename set: true].
 	^'DRIVER={Microsoft Access Driver (*.mdb)};DBQ=<1s>' expandMacrosWith: filename with: locator basePath!
 

--- a/Core/Object Arts/Dolphin/Database/Database Tests.pax
+++ b/Core/Object Arts/Dolphin/Database/Database Tests.pax
@@ -19,7 +19,7 @@ package setPrerequisites: #(
 	'Database Connection Base'
 	'..\IDE\Base\Development System'
 	'..\Base\Dolphin'
-	'..\..\..\..\..\Base Image\Core\Object Arts\Dolphin\Base\Dolphin Base Tests').
+	'..\Base\Dolphin Base Tests').
 
 package!
 


### PR DESCRIPTION
Copy the test resource Northwind.mdb to temp dir before running the tests
against it to avoid creating uncommitted changes in the git workspace