### PR TITLE
Fix Keyboard class>>default does not track current Windows Keyboard choice

### DIFF
--- a/Core/Object Arts/Dolphin/Base/SessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SessionManager.cls
@@ -422,6 +422,7 @@ initializeFromSessionManager: oldSessionManager
 	imagePath := oldSessionManager imagePath.
 	stdioStreams := oldSessionManager basicStdioStreams.
 	startupArgs := oldSessionManager startupArgs.
+	events := oldSessionManager events.
 	^self!
 
 inputState


### PR DESCRIPTION
Keyboard and Locale classes register event subscriptions against the session manager to receiver settings change events, but as they do this during boot the initial registrations are against the BootSessionManager instance. These event subscriptions were not being preserved when the new DevelopmentSessionManager instance is installed.

Fixes #931