### PR TITLE
Add SetTest>>testAllHealthy; verifies all sets in image hashed correctly

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Set.cls
+++ b/Core/Object Arts/Dolphin/Base/Set.cls
@@ -265,6 +265,18 @@ initialize
 	tally := 0
 !
 
+isHealthy
+	"Test that object hashes match their positions stored in set's array,
+	answer true if everything ok, false otherwise
+	
+	Set allSubInstances select: [:badSet |
+		badSet isHealthy not ]
+	"
+
+	1 to: self basicSize
+		do: [:i | (self basicAt: i) ifNotNil: [:element | (self findElementOrNil: element) == i ifFalse: [^false]]].
+	^true!
+
 moveFrom: fromIndex to: toIndex
 	"Private - Destructively move the element at index, fromIndex, over
 	the element (normally nil) at index, toIndex. Must be overridden by subclasses
@@ -415,6 +427,7 @@ uncheckedAdd: newObject
 !Set categoriesFor: #identityIncludes:!public!searching! !
 !Set categoriesFor: #includes:!public!searching! !
 !Set categoriesFor: #initialize!initializing!private! !
+!Set categoriesFor: #isHealthy!public! !
 !Set categoriesFor: #moveFrom:to:!private!removing! !
 !Set categoriesFor: #occurrencesOf:!public!searching! !
 !Set categoriesFor: #postResize:!adding!private! !

--- a/Core/Object Arts/Dolphin/Base/SetTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SetTest.cls
@@ -64,6 +64,13 @@ setSizes
 	^((Set preferredSizesFrom: (Integer primesUpTo: lastSmall + 256))
 		select: [:each | each <= lastSmall]) , (Set.PrimeSizes select: [:each | each > lastSmall])!
 
+testAllHealthy
+	"Test whether all subinstances are correctly hashed."
+
+	| unhealthy |
+	unhealthy := Set allSubinstances reject: [:each | each isHealthy].
+	self assert: unhealthy asArray equals: #()!
+
 testAllInstancesValid
 	| invalid |
 	invalid := self collectionClass allSubinstances
@@ -209,6 +216,7 @@ testShallowCopy
 !SetTest categoriesFor: #newSet!private!unit tests! !
 !SetTest categoriesFor: #newSet:!private!unit tests! !
 !SetTest categoriesFor: #setSizes!public!unit tests! !
+!SetTest categoriesFor: #testAllHealthy!public! !
 !SetTest categoriesFor: #testAllInstancesValid!public!unit tests! !
 !SetTest categoriesFor: #testClassSizeFor!public!unit tests! !
 !SetTest categoriesFor: #testCopy!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/Base/GUISessionManager.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/GUISessionManager.cls
@@ -114,6 +114,7 @@ saveSessionState
 saveWindowState
 	"Private - Save the state of the top-level windows."
 
+	inputState purgeDeadWindows.
 	savedWindows := self topLevelWindowsInZOrder reverse collect: [ :w | ViewState recordStateOf: w forRecreate: false]
 
 !

--- a/Core/Object Arts/Dolphin/System/STON/Dolphin STON Tests.pax
+++ b/Core/Object Arts/Dolphin/System/STON/Dolphin STON Tests.pax
@@ -14,7 +14,6 @@ package methodNames
 	add: #SequenceableCollection -> #asIntegerArray;
 	add: #SequenceableCollection -> #atRandom;
 	add: #SequenceableCollection -> #doWithIndex:;
-	add: #Set -> #isHealthy;
 	add: #STONReaderTests -> #testSymbolMultiByte;
 	add: #STONWriteReadTests -> #testProcessor;
 	add: #STONWriteReadTests -> #testSystemDictionary;
@@ -85,24 +84,6 @@ doWithIndex: aDyadicValuable
 !SequenceableCollection categoriesFor: #asIntegerArray!public! !
 !SequenceableCollection categoriesFor: #atRandom!public! !
 !SequenceableCollection categoriesFor: #doWithIndex:!public! !
-
-!Set methodsFor!
-
-isHealthy
-	"Test that object hashes match their positions stored in set's array,
-	answer true if everything ok, false otherwise
-	
-	Set allSubInstances select: [:badSet |
-		badSet isHealthy not ]
-	"
-	| capacity |
-	capacity := self basicSize.
-	1 to: capacity do: [:i | 
-		(self basicAt: i) ifNotNil: [:element |
-			(self findElementOrNil: element) == i
-				ifFalse: [ ^ false ]]].
-	^ true! !
-!Set categoriesFor: #isHealthy!public! !
 
 !STONReaderTests methodsFor!
 


### PR DESCRIPTION
Set>>isHealthy is moved from the Dolphin STON Tests, as this is useful in verifying the state of a booted image.