### PR TITLE
ClassBuilder does not need allInstances scan for single Metaclass instance

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/Automation/VARIANTTest.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/VARIANTTest.cls
@@ -151,7 +151,8 @@ testDISPATCHREF
 	self assert: obj referenceCount identicalTo: 1.
 	val free.
 	self assert: obj referenceCount identicalTo: 1.
-	self assert: var value value asExternalAddress equals: obj bytes!
+	self assert: var value value asExternalAddress equals: obj bytes.
+	obj free!
 
 testEMPTY
 	| var |

--- a/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
@@ -423,22 +423,6 @@ modifyProper
 	self superclassIsBeingChanged ifTrue: [self removeUnimplementedProtocols]
 !
 
-mutateAllInstancesOf: oldClass toBeInstancesOf: newClass 
-	"Private - Mutate all instances of oldClass to instances of newClass."
-
-	| mappingArray |
-	mappingArray := self generateMapFrom: oldClass to: newClass.
-	oldClass primAllInstances do: 
-			[:oldInst | 
-			| newInst |
-			newInst := self 
-						translateInstance: oldInst
-						intoANewInstanceOf: newClass
-						via: mappingArray.
-			"We need to manually move the special behavior as #become: does not"
-			newInst setSpecialBehavior: (oldInst setSpecialBehavior: 16rFF00).
-			oldInst become: newInst]!
-
 mutateClass: oldClass toBeASubclassOf: newSuperclass
 	"Private - Create a new class with the appropriate features and mutate
 	all instances of oldClass to new instances of the new class and then 
@@ -452,7 +436,10 @@ mutateClass: oldClass toBeASubclassOf: newSuperclass
 		ifTrue: 
 			[| newClass |
 			newClass := self newMetaclassLike: oldClass superclass: newSuperclass.
-			self mutateAllInstancesOf: oldClass toBeInstancesOf: newClass.	"Mutate the instance class."
+			self
+				mutateInstances: {oldClass instanceClass}
+				of: oldClass
+				toBeInstancesOf: newClass.	"Mutate the instance class."
 			self updateVMRegistryWith: newClass instanceClass.
 			oldClass subclasses do: [:cls | self mutateClass: cls toBeASubclassOf: newClass].
 			oldClass removeFromSuper.
@@ -463,7 +450,10 @@ mutateClass: oldClass toBeASubclassOf: newSuperclass
 			mutatingClassItself := oldClass == Class.
 			newClass := self newClassLike: oldClass superclass: newSuperclass.
 			self install: newClass.
-			self mutateAllInstancesOf: oldClass toBeInstancesOf: newClass.
+			self
+				mutateInstances: oldClass primAllInstances
+				of: oldClass
+				toBeInstancesOf: newClass.
 			mutatingClassItself
 				ifTrue: 
 					["In Dolphin Object class et al are not in the subclasses
@@ -486,6 +476,26 @@ mutateInSitu
 			currentClass setSuperclass: superclass.
 			self instanceVariablesAreBeingChanged ifTrue: [self setInstanceVariablesOf: currentClass].
 			self recompilationRequired: true].!
+
+mutateInstances: anArray of: oldClass toBeInstancesOf: newClass
+	"Private - Mutate the instances of oldClass in anArray to be instances of newClass."
+
+	| mappingArray count |
+	count := anArray size.
+	count == 0 ifTrue: [^self].
+	mappingArray := self generateMapFrom: oldClass to: newClass.
+	1 to: count
+		do: 
+			[:i |
+			| oldInst newInst |
+			oldInst := anArray at: i.
+			newInst := self
+						translateInstance: oldInst
+						intoANewInstanceOf: newClass
+						via: mappingArray.
+			"We need to manually move the special behavior as #become: does not"
+			newInst setSpecialBehavior: (oldInst setSpecialBehavior: 16rFF00).
+			oldInst become: newInst]!
 
 mutateToNewClass
 	"Private - Set currentClass to a mutation of itself based on the information
@@ -962,10 +972,10 @@ validateSuperclassIsSubclassable
 !ClassBuilder categoriesFor: #modifyExistingClass!operations!private! !
 !ClassBuilder categoriesFor: #modifyOrCreate!operations!public! !
 !ClassBuilder categoriesFor: #modifyPrivate!operations!private! !
-!ClassBuilder categoriesFor: #modifyProper!helpers!private! !
-!ClassBuilder categoriesFor: #mutateAllInstancesOf:toBeInstancesOf:!mutating!private! !
+!ClassBuilder categoriesFor: #modifyProper!private! !
 !ClassBuilder categoriesFor: #mutateClass:toBeASubclassOf:!mutating!private! !
 !ClassBuilder categoriesFor: #mutateInSitu!mutating!private! !
+!ClassBuilder categoriesFor: #mutateInstances:of:toBeInstancesOf:!mutating!private! !
 !ClassBuilder categoriesFor: #mutateToNewClass!mutating!private! !
 !ClassBuilder categoriesFor: #newClassLike:superclass:!mutating!private! !
 !ClassBuilder categoriesFor: #newMetaclassLike:superclass:!mutating!private! !

--- a/Core/Object Arts/Dolphin/Base/ClassDescriptionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescriptionTest.cls
@@ -1,0 +1,27 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #ClassDescriptionTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ClassDescriptionTest guid: (GUID fromString: '{2e47ba8b-6e05-41a9-87ce-ccfeabd45cb7}')!
+ClassDescriptionTest isAbstract: true!
+ClassDescriptionTest comment: ''!
+!ClassDescriptionTest categoriesForClass!Unclassified! !
+!ClassDescriptionTest methodsFor!
+
+allClassHierarchyInstancesDo: aMonadicValuable
+	self subclassResponsibility!
+
+testSubclasses
+	self allClassHierarchyInstancesDo: 
+			[:each |
+			each subclasses do: [:subclass | self assert: subclass superclass identicalTo: each].
+			"Dolphin's Class subclasses collections have historically been sorted arrays. This gives repeatable results when enumerating classes.
+			It does impose a cost when building classes, but I'm loathe to change it now for fear of what it will break."
+			self assert: each subclasses
+				equals: (each subclasses asSortedCollection: [:a :b | a name <= b name]) asArray]! !
+!ClassDescriptionTest categoriesFor: #allClassHierarchyInstancesDo:!helpers!private! !
+!ClassDescriptionTest categoriesFor: #testSubclasses!public! !
+

--- a/Core/Object Arts/Dolphin/Base/ClassTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassTest.cls
@@ -1,6 +1,6 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-DolphinTest subclass: #ClassTest
+ClassDescriptionTest subclass: #ClassTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -9,6 +9,9 @@ ClassTest guid: (GUID fromString: '{3c2fe318-ee64-4a1e-8b1a-8bf38c6d1803}')!
 ClassTest comment: ''!
 !ClassTest categoriesForClass!Unclassified! !
 !ClassTest methodsFor!
+
+allClassHierarchyInstancesDo: aMonadicValuable
+	Smalltalk allClasses do: aMonadicValuable!
 
 testClassPoolsWellFormed
 	"https://github.com/dolphinsmalltalk/Dolphin/issues/562"
@@ -19,5 +22,6 @@ testClassPoolsWellFormed
 					each classPool class == PoolDictionary
 						and: [each classPool associations allSatisfy: [:v | v class == VariableBinding]]].
 	self assert: badPools asArray equals: #()! !
+!ClassTest categoriesFor: #allClassHierarchyInstancesDo:!helpers!private! !
 !ClassTest categoriesFor: #testClassPoolsWellFormed!public! !
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Anonymous Classes.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Anonymous Classes.pax
@@ -10,7 +10,10 @@ package classNames
 	yourself.
 
 package methodNames
+	add: #Class -> #isAnonymous;
 	add: #Class -> #newAnonymousSubclass;
+	add: #ClassDescription -> #isAnonymous;
+	add: #Metaclass -> #isAnonymous;
 	add: 'ClassBuilder class' -> #forAnonymousSubclassOf:;
 	yourself.
 
@@ -40,9 +43,15 @@ ClassBuilder subclass: #AnonymousClassBuilder
 
 !Class methodsFor!
 
+isAnonymous
+	"Answer whether this is an anonymous (unbound) class."
+
+	^name isNil!
+
 newAnonymousSubclass
 	^(ClassBuilder forAnonymousSubclassOf: self)
 		createNewClass! !
+!Class categoriesFor: #isAnonymous!public!testing! !
 !Class categoriesFor: #newAnonymousSubclass!public! !
 
 !ClassBuilder class methodsFor!
@@ -52,6 +61,22 @@ forAnonymousSubclassOf: aClass
 		superclass: aClass;
 		yourself! !
 !ClassBuilder class categoriesFor: #forAnonymousSubclassOf:!instance creation!public! !
+
+!ClassDescription methodsFor!
+
+isAnonymous
+	"Answer whether this is an anonymous (unbound) class."
+
+	^self subclassResponsibility! !
+!ClassDescription categoriesFor: #isAnonymous!public!testing! !
+
+!Metaclass methodsFor!
+
+isAnonymous
+	"Answer whether this is an anonymous (unbound) class."
+
+	^self instanceClass isAnonymous! !
+!Metaclass categoriesFor: #isAnonymous!public!testing! !
 
 "End of package definition"!
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -22,6 +22,7 @@ package classNames
 	add: #CharacterTest;
 	add: #ClassBuilderTestClasses;
 	add: #ClassBuilderTests;
+	add: #ClassDescriptionTest;
 	add: #ClassTest;
 	add: #CollectionCombinator;
 	add: #CommandLineTest;
@@ -71,6 +72,7 @@ package classNames
 	add: #LookupTableTest;
 	add: #MemoryManagerTest;
 	add: #MergesortAlgorithmTest;
+	add: #MetaclassTest;
 	add: #MethodDictionaryTest;
 	add: #MultiByteStringTest;
 	add: #MustBeBooleanTestClasses;
@@ -223,7 +225,7 @@ DolphinTest subclass: #ClassBuilderTests
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-DolphinTest subclass: #ClassTest
+DolphinTest subclass: #ClassDescriptionTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -429,6 +431,16 @@ DolphinTest subclass: #UndefinedObjectTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 AbstractKeyboardTest subclass: #KeyboardTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ClassDescriptionTest subclass: #ClassTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ClassDescriptionTest subclass: #MetaclassTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/Base/MetaclassTest.cls
+++ b/Core/Object Arts/Dolphin/Base/MetaclassTest.cls
@@ -1,0 +1,70 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+ClassDescriptionTest subclass: #MetaclassTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+MetaclassTest guid: (GUID fromString: '{0643eed4-cf1f-4bfa-84f5-4af3a05fe655}')!
+MetaclassTest comment: ''!
+!MetaclassTest categoriesForClass!Unclassified! !
+!MetaclassTest methodsFor!
+
+allClassHierarchyInstancesDo: aMonadicValuable
+	Smalltalk allRoots do: [:root | root class withAllSubclassesDo: aMonadicValuable]!
+
+testInstances
+	"Verifies that 
+		- all metaclasses are correctly linked into the class hierarchy
+		- that they have exactly one instance, and it is the expected one
+		- that the superclass and subclasses or metaclass and instance are matching"
+
+	| all stats unbound shadows |
+	all := Array writeStream: Class allClasses size.
+	self allClassHierarchyInstancesDo: [:each | all nextPut: each].
+	all := all contents asIdentitySet.
+	"It is rather expensive to run a few thousand instance scans individually, so instead we use the VM's instance stats primitive to check that there is exactly one instance of each metaclass and then check that the stored instance is of the metaclass."
+	stats := MemoryManager current primInstanceStats: nil.
+	unbound := IdentitySet new.
+	1 to: stats size
+		by: 3
+		do: 
+			[:i |
+			| each |
+			each := stats at: i.
+			each isMeta
+				ifTrue: 
+					[| instClass |
+					(all includes: each)
+						ifTrue: 
+							[self
+								assert: (stats at: i + 1)
+								equals: 1
+								description: 'Metaclasses should have one instance'.
+							"Is the known instance actually an instance of this metaclass?"
+							self assert: each instanceClass class identicalTo: each.
+							"Does the instance have a matching superclass?"
+							instClass := each instanceClass.
+							instClass superclass
+								ifNil: [self assert: each superclass identicalTo: Class]
+								ifNotNil: [:superclass | self assert: superclass class identicalTo: each superclass].
+							"And matching subclasses too?"
+							self assert: each subclasses equals: (instClass subclasses collect: [:subbie | subbie class])]
+						ifFalse: [unbound add: each]]].
+	"Metaclasses not bound into the class hierarchy? It is all too easy to create these in tests and hang onto them in TestCase instance variables, so we can't reliably assert
+	that there are none. What we can do is to check that they aren't dead versions of bound classes"
+	"self assert: unbound asArray equals: #()"
+	shadows := unbound select: 
+					[:each |
+					each isAnonymous not and: [each instanceClass environment includesKey: each instanceClass name]].
+	self assert: shadows asArray equals: #()!
+
+testName
+	Smalltalk allRoots do: 
+			[:root |
+			root class
+				allSubclassesDo: [:each | self assert: each name equals: each instanceClass name , ' class']]! !
+!MetaclassTest categoriesFor: #allClassHierarchyInstancesDo:!helpers!private! !
+!MetaclassTest categoriesFor: #testInstances!public!unit tests! !
+!MetaclassTest categoriesFor: #testName!public!unit tests! !
+

--- a/PreBoot.st
+++ b/PreBoot.st
@@ -9,7 +9,9 @@ allRoots
 			[roots at: i put: (roots at: 1).
 			roots at: 1 put: Object].
 	^roots! !
-	
+
+Smalltalk clearCachedClasses!
+
 !Class class categoriesFor: #allRoots!class hierarchy-accessing!private! !
 ResourceIdentifier addClassVariable: 'SelectorPrefix' value: ('resource_' asUtf8String
 				isImmutable: true;
@@ -44,3 +46,5 @@ split: aReadableString
 	"Copy any remaining chars after the last separator"
 	answer nextPut: (aReadableString copyFrom: start to: size).
 	^answer contents! !
+
+Metaclass allInstances do: [:each | each  subclasses sort]!


### PR DESCRIPTION
Metaclasses can have only one instance, which is known and referred to by the instanceClass instance variable, so it is not necessary to scan the entire memory for instances to find it.