### PR TITLE
Arrange to skip tests when the DB is not installed

### DIFF
--- a/Core/Contributions/Camp Smalltalk/SUnit/TestResource.cls
+++ b/Core/Contributions/Camp Smalltalk/SUnit/TestResource.cls
@@ -46,9 +46,6 @@ setUp
 	"Does nothing. Subclasses should override this
 	to initialize their resource"!
 
-signalInitializationError
-	^TestResult signalErrorWith: 'Resource ' , self name , ' could not be initialized'!
-
 tearDown
 	"Does nothing. Subclasses should override this
 	to tear down their resource"! !
@@ -62,7 +59,6 @@ tearDown
 !TestResource categoriesFor: #printOn:!Printing!public! !
 !TestResource categoriesFor: #resources!public! !
 !TestResource categoriesFor: #setUp!public!Running! !
-!TestResource categoriesFor: #signalInitializationError!public!Running! !
 !TestResource categoriesFor: #tearDown!public!Running! !
 
 !TestResource class methodsFor!
@@ -90,7 +86,10 @@ reset
 			current := nil]]!
 
 resources
-	^#()! !
+	^#()!
+
+signalInitializationError
+	^TestResult signalErrorWith: 'Resource ' , self name , ' could not be initialized'! !
 !TestResource class categoriesFor: #current!Accessing!public! !
 !TestResource class categoriesFor: #current:!Accessing!public! !
 !TestResource class categoriesFor: #isAvailable!public!Testing! !
@@ -98,4 +97,5 @@ resources
 !TestResource class categoriesFor: #new!Creation!public! !
 !TestResource class categoriesFor: #reset!Creation!public! !
 !TestResource class categoriesFor: #resources!public! !
+!TestResource class categoriesFor: #signalInitializationError!public!Running! !
 

--- a/Core/Contributions/Camp Smalltalk/SUnit/TestSuite.cls
+++ b/Core/Contributions/Camp Smalltalk/SUnit/TestSuite.cls
@@ -62,9 +62,6 @@ run: aResult
 			each run: aResult]]
 		ensure: [aResult duration: (Delay microsecondClockValue - start) microseconds]!
 
-signalResourceErrorFor: res
-	^res signalInitializationError!
-
 tests
 	tests isNil ifTrue: [tests := OrderedCollection new].
 	^tests! !
@@ -79,7 +76,6 @@ tests
 !TestSuite categoriesFor: #resources:!Accessing!public! !
 !TestSuite categoriesFor: #run!public!Running! !
 !TestSuite categoriesFor: #run:!public!Running! !
-!TestSuite categoriesFor: #signalResourceErrorFor:!public!Running! !
 !TestSuite categoriesFor: #tests!Accessing!public! !
 
 !TestSuite class methodsFor!

--- a/Core/Object Arts/Dolphin/Database/AccessNorthwindDB.cls
+++ b/Core/Object Arts/Dolphin/Database/AccessNorthwindDB.cls
@@ -17,11 +17,11 @@ connectString
 
 createDatabase
 	| source |
-	super createDatabase.
 	source := (PackageRelativeFileLocator package: self class owningPackage) localFileSpecFor: 'Northwind.mdb'.
 	filename := File composePath: File tempPath subPath: 'Northwind.mdb'.
 	File copy: source to: filename.
-	(File isWriteable: filename) ifFalse: [File isWriteable: filename set: true]!
+	(File isWriteable: filename) ifFalse: [File isWriteable: filename set: true].
+	^true!
 
 dropDatabase
 	super dropDatabase.

--- a/Core/Object Arts/Dolphin/Database/DBConnectionTest.cls
+++ b/Core/Object Arts/Dolphin/Database/DBConnectionTest.cls
@@ -6,6 +6,7 @@ DolphinTest subclass: #DBConnectionTest
 	poolDictionaries: 'ODBCConstants ODBCTypes'
 	classInstanceVariableNames: ''!
 DBConnectionTest guid: (GUID fromString: '{0a84fa8d-f7c4-4bbe-b459-da0409a391b9}')!
+DBConnectionTest isAbstract: true!
 DBConnectionTest comment: 'SUnitBrowser openOnTestCase: self.
 
 If these tests fail make sure that Tests\NWind.mdb is available and NOT write protected.'!
@@ -30,7 +31,8 @@ queryColumns
 	self subclassResponsibility!
 
 setUp
-	connection := self databaseResource newConnection!
+	connection := self databaseResource newConnection.
+	self skipUnless: [connection notNil]!
 
 shouldRaiseNotSupported: block 
 	self 
@@ -39,7 +41,7 @@ shouldRaiseNotSupported: block
 		matching: [:e | e tag errors anySatisfy: [:x | x sqlState = 'IM001']]!
 
 tearDown
-	connection close!
+	connection ifNotNil: [:cnxn | cnxn close]!
 
 testAsArray
 	| results array |
@@ -302,10 +304,4 @@ testTracing
 !DBConnectionTest categoriesFor: #testSpecialColumnsQuery!public!unit tests! !
 !DBConnectionTest categoriesFor: #testStatisticsQuery!public!unit tests! !
 !DBConnectionTest categoriesFor: #testTracing!public!unit tests! !
-
-!DBConnectionTest class methodsFor!
-
-isAbstract
-	^self == ##(self)! !
-!DBConnectionTest class categoriesFor: #isAbstract!public! !
 

--- a/Core/Object Arts/Dolphin/Database/DBConnectionTestResource.cls
+++ b/Core/Object Arts/Dolphin/Database/DBConnectionTestResource.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 TestResource subclass: #DBConnectionTestResource
-	instanceVariableNames: 'connection'
+	instanceVariableNames: 'connection isAvailable'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -22,23 +22,23 @@ connectString
 createDatabase
 	"Private - Override in subclasses"
 
-	!
+	^self subclassResponsibility!
 
 dropDatabase
-	connection close.
-	connection := nil
-
-	!
+	connection
+		ifNotNil: 
+			[connection close.
+			connection := nil]!
 
 newConnection
-	^(DBConnection new connectString: self connectString)
-		open;
-		yourself!
+	^isAvailable
+		ifTrue: 
+			[(DBConnection new connectString: self connectString)
+				open;
+				yourself]!
 
 setUp
-	self
-		createDatabase;
-		connect!
+	(isAvailable := self createDatabase) ifTrue: [self connect]!
 
 tearDown
 	self dropDatabase! !

--- a/Core/Object Arts/Dolphin/Database/Database Tests.pax
+++ b/Core/Object Arts/Dolphin/Database/Database Tests.pax
@@ -47,7 +47,7 @@ DBConnectionTest subclass: #SQLServerDBTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 TestResource subclass: #DBConnectionTestResource
-	instanceVariableNames: 'connection'
+	instanceVariableNames: 'connection isAvailable'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Database/SQLServerNorthwindDB.cls
+++ b/Core/Object Arts/Dolphin/Database/SQLServerNorthwindDB.cls
@@ -20,7 +20,6 @@ connectString
 
 createDatabase
 	| sql cmd process |
-	super createDatabase.
 	sql := (PackageRelativeFileLocator package: self class owningPackage)
 				localFileSpecFor: 'Northwind.sql'.
 	cmd := 'sqlcmd -S <1d> -U <2d> -P <3d> -i "<4d>"'
@@ -30,17 +29,26 @@ createDatabase
 				with: sql.
 	process := ExternalProcess new.
 	process commandLine: cmd.
-	process executeSync!
+	^
+	[process executeSync.
+	true] on: ExternalProcessExecuteError do: [:ex | false]!
 
 dropDatabase
-	self connection exec: 'USE [master]'.
-	self connection exec: 'DROP DATABASE [Northwind]'.
+	self connection
+		ifNotNil: 
+			[:cnxn |
+			cnxn
+				exec: 'USE [master]';
+				exec: 'DROP DATABASE [Northwind]'].
 	super dropDatabase!
 
 newConnection
 	^super newConnection
-		exec: 'USE [Northwind]';
-		yourself!
+		ifNotNil: 
+			[:cnxn |
+			cnxn
+				exec: 'USE [Northwind]';
+				yourself]!
 
 pwd
 	^'Password12!!'!


### PR DESCRIPTION
This change to the DB tests to prevent them failing on a machine that does not have SQLLocalDB installed did not make it into the eventual PR.