### PR TITLE
Optimize the maintenance of the 'subclasses' sorted arrays when defining classes

### DIFF
--- a/Core/DolphinVM/Compiler/compiler.cpp
+++ b/Core/DolphinVM/Compiler/compiler.cpp
@@ -3337,8 +3337,8 @@ void Compiler::AssertValidIpForTextMapEntry(ip_t ip, bool bFinal)
 		_ASSERTE(ip > ip_t::zero);
 		const BYTECODE& prev = m_bytecodes[ip-1];
 		_ASSERTE(prev.IsOpCode);
-		_ASSERTE((bc.Opcode == OpCode::PopStoreTemp && (prev.Opcode == OpCode::IncrementTemp || prev.Opcode == OpCode::DecrementTemp))
-			|| (bc.Opcode == OpCode::StoreTemp && (prev.Opcode == OpCode::IncrementPushTemp || prev.Opcode == OpCode::DecrementPushTemp)));
+		_ASSERTE((static_cast<OpCode>(bc.byte) == OpCode::PopStoreTemp && (prev.Opcode == OpCode::IncrementTemp || prev.Opcode == OpCode::DecrementTemp))
+			|| (static_cast<OpCode>(bc.byte) == OpCode::StoreTemp && (prev.Opcode == OpCode::IncrementPushTemp || prev.Opcode == OpCode::DecrementPushTemp)));
 	}
 	else
 	{

--- a/Core/DolphinVM/objmem.cpp
+++ b/Core/DolphinVM/objmem.cpp
@@ -71,6 +71,7 @@ constexpr int OTPagesAllocatedPerOverflow = 16;	// i.e. 64Kb per overflow, 4096 
 void __fastcall ObjectMemory::oneWayBecome(OTE* ote1, OTE* ote2)
 {
 	Interpreter::resizeActiveProcess();
+	ReconcileZct();
 
 	CHECKREFERENCES
 
@@ -159,6 +160,8 @@ typedef std::pair<OTEVector*, size_t> Batch;
 // To measure the performance of scans, be sure to use primAllInstances and primAllSubinstances, as allInstances/allSubinstances trigger a GC first.
 template<typename Partitioner, typename Predicate> ArrayOTE* ObjectMemory::selectObjects(const Partitioner&& part, const Predicate& pred)
 {
+	ReconcileZct();
+
 	combinable<OTEVector> selected;
 
 	// Parallel scan of the object table

--- a/Core/DolphinVM/zct.cpp
+++ b/Core/DolphinVM/zct.cpp
@@ -114,7 +114,7 @@ Oop* ObjectMemory::ReconcileZct()
 		//Interpreter::DumpOTEPoolStats();
 		TRACESTREAM << L"..." << std::endl;
 	}
-	dwLastReconcileTicks = dwTicksNow;
+	dwLastReconcileTicks = timeGetTime();
 	const auto nOldZctEntries = m_nZctEntries;
 #endif
 

--- a/Core/Object Arts/Dolphin/Base/Behavior.cls
+++ b/Core/Object Arts/Dolphin/Base/Behavior.cls
@@ -82,14 +82,30 @@ addSelector: aSymbol withMethod: aCompiledMethod
 addSubclass: aClass
 	"Private - Include the argument, aClass, as a subclass of the receiver."
 
-	| subs |
+	| subs count index |
 	aClass superclass == self
 		ifFalse: [^self error: ('I am not <1p>''s superclass' expandMacrosWith: aClass)].
 	subs := self subclasses.
-	(subs identityIndexOf: aClass) == 0
+	"Maintain the array in sorted order as saves sorting on access - speed is important to minimize class creation time"
+	count := subs size.
+	count == 0
 		ifTrue: 
-			["Maintain the array in sorted order as saves sorting on access"
-			subclasses := (subs copyWith: aClass) sort]!
+			[subclasses := {aClass}.
+			^self].
+	index := subs binarySearchFor: aClass using: [:a :b | a name <=> b name <= 0].
+	(index > 1 and: [(subs at: index - 1) == aClass]) ifTrue: [^self].
+	self assert: [(subs identityIndexOf: aClass) == 0].
+	subclasses := Array new: count + 1.
+	subclasses at: index put: aClass.
+	subs
+		replaceElementsOf: subclasses
+			from: 1
+			to: index - 1
+			startingAt: 1;
+		replaceElementsOf: subclasses
+			from: index + 1
+			to: count + 1
+			startingAt: index!
 
 addToSuper
 	"Private - Add the receiver to its superclasses' subclass collection."

--- a/Core/Object Arts/Dolphin/Base/Class.cls
+++ b/Core/Object Arts/Dolphin/Base/Class.cls
@@ -792,7 +792,7 @@ allRoots
 	| roots i |
 	roots := self basicAllRoots select: [:each | (self environment lookup: each name) == each].
 	i := roots identityIndexOf: Object.
-	i ~~ 1
+	i == 1
 		ifFalse: 
 			[roots at: i put: (roots at: 1).
 			roots at: 1 put: Object].

--- a/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
@@ -424,47 +424,27 @@ modifyProper
 !
 
 mutateClass: oldClass toBeASubclassOf: newSuperclass
-	"Private - Create a new class with the appropriate features and mutate
-	all instances of oldClass to new instances of the new class and then 
-	recursively make the same change to the subclasses of aClass. Finally,
-	remove the oldClass and if appropriate its metaclass from their
-	respective superclasses and do a #oneWayBeome: on oldClass to newClass.
-	Implementation Note: We must not access any instance variables after mutation, in case
-	the receiver is being mutated and the inst. var offsets change."
+	"Private - Create a new class with the appropriate features and mutate	all instances of oldClass to new instances of the new class and then recursively make the same change to the subclasses of aClass. Finally, remove the oldClass and if appropriate its metaclass from their respective superclasses and do a #oneWayBeome: on oldClass to newClass.
+	Implementation Note: We must not access any instance variables after mutation, in case the receiver is being mutated and the inst. var offsets change."
 
-	oldClass isMeta
+	| newClass mutatingClassItself |
+	mutatingClassItself := oldClass == Class.
+	newClass := self newClassLike: oldClass superclass: newSuperclass.
+	self install: newClass.
+	self
+		mutateInstances: oldClass primAllInstances
+		of: oldClass
+		toBeInstancesOf: newClass.
+	mutatingClassItself
 		ifTrue: 
-			[| newClass |
-			newClass := self newMetaclassLike: oldClass superclass: newSuperclass.
-			self
-				mutateInstances: {oldClass instanceClass}
-				of: oldClass
-				toBeInstancesOf: newClass.	"Mutate the instance class."
-			self updateVMRegistryWith: newClass instanceClass.
-			oldClass subclasses do: [:cls | self mutateClass: cls toBeASubclassOf: newClass].
-			oldClass removeFromSuper.
-			oldClass become: newClass.
-			newClass oneWayBecome: oldClass]
-		ifFalse: 
-			[| newClass mutatingClassItself |
-			mutatingClassItself := oldClass == Class.
-			newClass := self newClassLike: oldClass superclass: newSuperclass.
-			self install: newClass.
-			self
-				mutateInstances: oldClass primAllInstances
-				of: oldClass
-				toBeInstancesOf: newClass.
-			mutatingClassItself
-				ifTrue: 
-					["In Dolphin Object class et al are not in the subclasses
-					collection of Class, so need special case handling"
-					Smalltalk allRoots do: [:each | self mutateClass: each class toBeASubclassOf: newClass]]
-				ifFalse: [oldClass subclasses do: [:cls | self mutateClass: cls toBeASubclassOf: newClass]].
-			oldClass class removeFromSuper.
-			oldClass removeFromSuper.
-			oldClass become: newClass.
-			newClass oneWayBecome: oldClass.
-			self updateVMRegistryWith: newClass]!
+			["In Dolphin Object class et al are not in the subclasses collection of Class, so need special case handling"
+			Smalltalk allRoots do: [:each | self mutateClass: each class toBeASubclassOf: newClass]]
+		ifFalse: [oldClass subclasses do: [:cls | self mutateClass: cls toBeASubclassOf: newClass]].
+	oldClass class removeFromSuper.
+	oldClass removeFromSuper.
+	oldClass become: newClass.
+	newClass oneWayBecome: oldClass.
+	self updateVMRegistryWith: newClass!
 
 mutateInSitu
 	"Private - Mutate the class being modified without mutating its instances.
@@ -497,12 +477,34 @@ mutateInstances: anArray of: oldClass toBeInstancesOf: newClass
 			newInst setSpecialBehavior: (oldInst setSpecialBehavior: 16rFF00).
 			oldInst become: newInst]!
 
+mutateMetaclass: oldMetaclass toBeASubclassOf: newSuperclass
+	"Private - Create a new Metaclass with the appropriate features and mutate all instances of oldClass to new instances of the new class and then recursively make the same change to the subclasses of aClass. Finally, remove the oldClass and if appropriate its metaclass from their respective superclasses and do a #oneWayBeome: on oldClass to newClass.
+	Implementation Note: We must not access any instance variables after mutation, in case the receiver is being mutated and the inst. var offsets change."
+
+	| newMetaclass |
+	newMetaclass := self newMetaclassLike: oldMetaclass superclass: newSuperclass.
+	self assert: 
+			[| instances |
+			instances := oldMetaclass primAllInstances.
+			instances size = 1 and: [instances first == oldMetaclass instanceClass]].
+	self
+		mutateInstances: {oldMetaclass instanceClass}
+		of: oldMetaclass
+		toBeInstancesOf: newMetaclass.	"Mutate the instance class."
+	self updateVMRegistryWith: newMetaclass instanceClass.
+	oldMetaclass subclasses do: [:metaclass | self mutateClass: metaclass toBeASubclassOf: newMetaclass].
+	oldMetaclass removeFromSuper.
+	oldMetaclass become: newMetaclass.
+	newMetaclass oneWayBecome: oldMetaclass!
+
 mutateToNewClass
 	"Private - Set currentClass to a mutation of itself based on the information
 	in the receiver. The instances of the new currentClass are mutations of the
 	instances of the old currentClass."
 
-	self mutateClass: currentClass toBeASubclassOf: superclass!
+	currentClass isMeta
+		ifTrue: [self mutateMetaclass: currentClass toBeASubclassOf: superclass]
+		ifFalse: [self mutateClass: currentClass toBeASubclassOf: superclass]!
 
 newClassLike: aClass superclass: aSuperclass
 	"Private - Answer a new class based on aClass with superclass aSuperclass.
@@ -976,6 +978,7 @@ validateSuperclassIsSubclassable
 !ClassBuilder categoriesFor: #mutateClass:toBeASubclassOf:!mutating!private! !
 !ClassBuilder categoriesFor: #mutateInSitu!mutating!private! !
 !ClassBuilder categoriesFor: #mutateInstances:of:toBeInstancesOf:!mutating!private! !
+!ClassBuilder categoriesFor: #mutateMetaclass:toBeASubclassOf:!mutating!private! !
 !ClassBuilder categoriesFor: #mutateToNewClass!mutating!private! !
 !ClassBuilder categoriesFor: #newClassLike:superclass:!mutating!private! !
 !ClassBuilder categoriesFor: #newMetaclassLike:superclass:!mutating!private! !

--- a/Core/Object Arts/Dolphin/Base/ClassDescription.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescription.cls
@@ -19,7 +19,7 @@ Instance Variables:
 <= aClassDescription
 	"Answer whether the receiver should sort before the argument, e.g. in a SortedCollection using the default sort block."
 
-	^self name <= aClassDescription name!
+	^self name <=> aClassDescription name <= 0!
 
 >> aSymbol
 	^self compiledMethodAt: aSymbol!

--- a/Core/Object Arts/Dolphin/Base/ClassDescription.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescription.cls
@@ -17,9 +17,7 @@ Instance Variables:
 !ClassDescription methodsFor!
 
 <= aClassDescription
-	"Answer whether the receiver is 'less than' aClassDescription.
-	By implementing this method, we enable Class objects to be stored
-	in a SortedCollection with the default sort block."
+	"Answer whether the receiver should sort before the argument, e.g. in a SortedCollection using the default sort block."
 
 	^self name <= aClassDescription name!
 

--- a/Core/Object Arts/Dolphin/Base/ClassDescriptionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescriptionTest.cls
@@ -14,6 +14,9 @@ ClassDescriptionTest comment: ''!
 allClassHierarchyInstancesDo: aMonadicValuable
 	self subclassResponsibility!
 
+testLessOrEqual
+	self subclassResponsibility!
+
 testSubclasses
 	self allClassHierarchyInstancesDo: 
 			[:each |
@@ -23,5 +26,6 @@ testSubclasses
 			self assert: each subclasses
 				equals: (each subclasses asSortedCollection: [:a :b | a name <= b name]) asArray]! !
 !ClassDescriptionTest categoriesFor: #allClassHierarchyInstancesDo:!helpers!private! !
-!ClassDescriptionTest categoriesFor: #testSubclasses!public! !
+!ClassDescriptionTest categoriesFor: #testLessOrEqual!public!unit tests! !
+!ClassDescriptionTest categoriesFor: #testSubclasses!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/ClassDescriptionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassDescriptionTest.cls
@@ -21,6 +21,7 @@ testSubclasses
 	self allClassHierarchyInstancesDo: 
 			[:each |
 			each subclasses do: [:subclass | self assert: subclass superclass identicalTo: each].
+			self assert: each subclasses asSet size equals: each subclasses size.
 			"Dolphin's Class subclasses collections have historically been sorted arrays. This gives repeatable results when enumerating classes.
 			It does impose a cost when building classes, but I'm loathe to change it now for fear of what it will break."
 			self assert: each subclasses

--- a/Core/Object Arts/Dolphin/Base/ClassTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassTest.cls
@@ -13,6 +13,12 @@ ClassTest comment: ''!
 allClassHierarchyInstancesDo: aMonadicValuable
 	Smalltalk allClasses do: aMonadicValuable!
 
+testAllRoots
+	| roots |
+	roots := Class allRoots.
+	self assert: roots first identicalTo: Object.
+	roots do: [:each | self assertIsNil: each superclass]!
+
 testClassPoolsWellFormed
 	"https://github.com/dolphinsmalltalk/Dolphin/issues/562"
 
@@ -31,6 +37,7 @@ testLessOrEqual
 	self deny: ArithmeticValue <= ArithmeticError.
 	self deny: ArithmeticValue <= ArithmeticError class.! !
 !ClassTest categoriesFor: #allClassHierarchyInstancesDo:!helpers!private! !
+!ClassTest categoriesFor: #testAllRoots!public!unit tests! !
 !ClassTest categoriesFor: #testClassPoolsWellFormed!public!unit tests! !
 !ClassTest categoriesFor: #testLessOrEqual!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/ClassTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassTest.cls
@@ -21,7 +21,16 @@ testClassPoolsWellFormed
 					[:each |
 					each classPool class == PoolDictionary
 						and: [each classPool associations allSatisfy: [:v | v class == VariableBinding]]].
-	self assert: badPools asArray equals: #()! !
+	self assert: badPools asArray equals: #()!
+
+testLessOrEqual
+	self assert: ArithmeticError <= ArithmeticError description: 'Classes must be <= to themselves'.
+	self assert: ArithmeticError <= ArithmeticError class description: 'Classes must be <= their Metaclass'.
+	self assert: ArithmeticError <= ArithmeticValue.
+	self assert: ArithmeticError <= ArithmeticValue class.
+	self deny: ArithmeticValue <= ArithmeticError.
+	self deny: ArithmeticValue <= ArithmeticError class.! !
 !ClassTest categoriesFor: #allClassHierarchyInstancesDo:!helpers!private! !
-!ClassTest categoriesFor: #testClassPoolsWellFormed!public! !
+!ClassTest categoriesFor: #testClassPoolsWellFormed!public!unit tests! !
+!ClassTest categoriesFor: #testLessOrEqual!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/MetaclassTest.cls
+++ b/Core/Object Arts/Dolphin/Base/MetaclassTest.cls
@@ -59,6 +59,14 @@ testInstances
 					each isAnonymous not and: [each instanceClass environment includesKey: each instanceClass name]].
 	self assert: shadows asArray equals: #()!
 
+testLessOrEqual
+	self assert: ArithmeticError class <= ArithmeticError class description: 'Metaclasses must be <= to themselves'.
+	self deny: ArithmeticError class <= ArithmeticError description: 'Metaclasses should sort after their instance classes'.
+	self assert: ArithmeticError class <= ArithmeticValue class .
+	self assert: ArithmeticError class <= ArithmeticValue.
+	self deny: ArithmeticValue class <= ArithmeticError.
+	self deny: ArithmeticValue class <= ArithmeticError class.!
+
 testName
 	Smalltalk allRoots do: 
 			[:root |
@@ -66,5 +74,6 @@ testName
 				allSubclassesDo: [:each | self assert: each name equals: each instanceClass name , ' class']]! !
 !MetaclassTest categoriesFor: #allClassHierarchyInstancesDo:!helpers!private! !
 !MetaclassTest categoriesFor: #testInstances!public!unit tests! !
+!MetaclassTest categoriesFor: #testLessOrEqual!public!unit tests! !
 !MetaclassTest categoriesFor: #testName!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/IDE/PackageManagerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/PackageManagerTest.cls
@@ -15,7 +15,7 @@ testAllClassesPackaged
 	or patched correctly. This is to avoid embarassments like Base64Codec being unpackaged in
 	5.1 PL4."
 
-	self assert: Package manager unpackagedClasses isEmpty!
+	self assert: Package manager unpackagedClasses asArray equals: #()!
 
 testLooseMethodCacheUpToDate
 	| allNames loose |

--- a/PreBoot.st
+++ b/PreBoot.st
@@ -47,4 +47,4 @@ split: aReadableString
 	answer nextPut: (aReadableString copyFrom: start to: size).
 	^answer contents! !
 
-Metaclass allInstances do: [:each | each  subclasses sort]!
+Metaclass allInstances do: [:each | each subclasses sort. each instanceClass subclasses sort]!


### PR DESCRIPTION
Profiling shows that when loading code that quite a high percentage of the time required to define classes is consumed by the cost of maintaining the sort order of the subclasses collection of the superclass. This is because the code appended the new class and then sorted the already mostly sorted collection, which is an expensive case for quicksort even with the introsort modifications.
Since we are only adding one new element to an already sorted collection we can do the work much more efficiently by finding the insertion point with a binary search.