### PR TITLE
 Fix ProcessTest>>testLargeAddress to work when MEM_TOP_DOWN is enabled

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/COM/COMObjectStub.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/COM/COMObjectStub.cls
@@ -335,7 +335,7 @@ initialize
 	"
 
 	self initializeRegistries.
-	VMLibrary default primRegistryAt: 70 put: #comCallback:id:subId:withArgumentsAt:cookie:.
+	VMLibrary default registryAtIndex: 70 put: #comCallback:id:subId:withArgumentsAt:cookie:
 
 	"See also OLE COM package post install script which sets up various method skips with the debugger"!
 
@@ -373,7 +373,7 @@ uninitialize
 	"Private - Uninitialize the receiver immediately prior to its removal from the system."
 
 	self initializeRegistries.
-	VMLibrary default primRegistryAt: 70 put: nil! !
+	VMLibrary default registryAtIndex: 70 put: nil! !
 !COMObjectStub class categoriesFor: #disconnectAll!accessing!public! !
 !COMObjectStub class categoriesFor: #initialize!development!initializing!private! !
 !COMObjectStub class categoriesFor: #initializeRegistries!initializing!private! !

--- a/Core/Object Arts/Dolphin/Base/Behavior.cls
+++ b/Core/Object Arts/Dolphin/Base/Behavior.cls
@@ -86,25 +86,15 @@ addSubclass: aClass
 	aClass superclass == self
 		ifFalse: [^self error: ('I am not <1p>''s superclass' expandMacrosWith: aClass)].
 	subs := self subclasses.
-	"Maintain the array in sorted order as saves sorting on access - speed is important to minimize class creation time"
 	count := subs size.
 	count == 0
 		ifTrue: 
 			[subclasses := {aClass}.
 			^self].
+	"Maintain the array in sorted order as saves sorting on access - speed is important to minimize class creation time"
 	index := subs binarySearchFor: aClass using: [:a :b | a name <=> b name <= 0].
 	(index > 1 and: [(subs at: index - 1) == aClass]) ifTrue: [^self].
-	subclasses := Array new: count + 1.
-	subclasses at: index put: aClass.
-	subs
-		replaceElementsOf: subclasses
-			from: 1
-			to: index - 1
-			startingAt: 1;
-		replaceElementsOf: subclasses
-			from: index + 1
-			to: count + 1
-			startingAt: index!
+	subclasses := subs copyWith: aClass atIndex: index!
 
 addToSuper
 	"Private - Add the receiver to its superclasses' subclass collection."

--- a/Core/Object Arts/Dolphin/Base/Behavior.cls
+++ b/Core/Object Arts/Dolphin/Base/Behavior.cls
@@ -94,7 +94,6 @@ addSubclass: aClass
 			^self].
 	index := subs binarySearchFor: aClass using: [:a :b | a name <=> b name <= 0].
 	(index > 1 and: [(subs at: index - 1) == aClass]) ifTrue: [^self].
-	self assert: [(subs identityIndexOf: aClass) == 0].
 	subclasses := Array new: count + 1.
 	subclasses at: index put: aClass.
 	subs

--- a/Core/Object Arts/Dolphin/Base/Class.cls
+++ b/Core/Object Arts/Dolphin/Base/Class.cls
@@ -179,7 +179,7 @@ classCategories: categoryCollection
 	"Private - Set the class categories of the receiver to categoryCollection."
 
 	classCategories := categoryCollection notEmpty 
-				ifTrue: [categoryCollection asSortedCollection asArray]!
+				ifTrue: [categoryCollection asArray sort]!
 
 classPool
 	"Answer the Dictionary of class variables belonging to the receiver.

--- a/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
@@ -483,10 +483,6 @@ mutateMetaclass: oldMetaclass toBeASubclassOf: newSuperclass
 
 	| newMetaclass |
 	newMetaclass := self newMetaclassLike: oldMetaclass superclass: newSuperclass.
-	self assert: 
-			[| instances |
-			instances := oldMetaclass primAllInstances.
-			instances size = 1 and: [instances first == oldMetaclass instanceClass]].
 	self
 		mutateInstances: {oldMetaclass instanceClass}
 		of: oldMetaclass

--- a/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
+++ b/Core/Object Arts/Dolphin/Base/ClassBuilder.cls
@@ -691,16 +691,17 @@ translateInstance: oldInstance intoANewInstanceOf: newClass via: mappingArray
 	^newInstance!
 
 updateVMRegistryWith: aClass
-	"Private - Ensure that if aClass is a VM registered class then the VM's
-	entry is updated to the new class."
+	"Private - Ensure that if aClass is a VM registered class then the VM's entry is updated to the new class."
 
 	| name |
 	name := aClass name asSymbol.
-	((VMLibrary registryKeys includesKey: name) and: 
-			[| current |
-			current := VMLibrary default registryAt: name.
-			current isNil or: [current class isMetaclass]])
-		ifTrue: [VMLibrary default registryAt: name put: aClass]!
+	(VMLibrary.RegistryKeys lookup: name)
+		ifNotNil: 
+			[:index |
+			| current |
+			current := VMLibrary.Registry at: index.
+			(current isNil or: [current class isMetaclass])
+				ifTrue: [VMLibrary default registryAtIndex: index put: aClass]]!
 
 validateClass
 	"Private - Ensure that currentClass is a valid Behavior."

--- a/Core/Object Arts/Dolphin/Base/CompiledMethod.cls
+++ b/Core/Object Arts/Dolphin/Base/CompiledMethod.cls
@@ -78,21 +78,6 @@ hasChanged
 
 	^self changeManager hasMethodChanged: self!
 
-infoTip
-	"Private - Answer a suitable 'info tip' for the receiver."
-
-	| stream |
-	stream := String writeStream: 32.
-	stream
-		display: self;
-		nextPutAll: ' ('.
-	self realCategories asSortedCollection asArray 
-		, (self protocols asSortedCollection: [:a :b | a asSymbol < b asSymbol]) 
-			do: [:each | stream display: each]
-			separatedBy: [stream nextPutAll: ', '].
-	stream nextPut: $).
-	^stream contents!
-
 isChanged
 	"Private - Answer whether the receiver is 'changed' (i.e. its class has unsaved changes)."
 
@@ -212,7 +197,6 @@ storeSourceString: aString
 !CompiledMethod categoriesFor: #getDebugInfo!development!private! !
 !CompiledMethod categoriesFor: #getSource!accessing!development!public! !
 !CompiledMethod categoriesFor: #hasChanged!development!private!testing! !
-!CompiledMethod categoriesFor: #infoTip!accessing!development!private! !
 !CompiledMethod categoriesFor: #isChanged!development!private!testing! !
 !CompiledMethod categoriesFor: #isClassMethod!public!testing! !
 !CompiledMethod categoriesFor: #isExpression!private!testing! !

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -154,6 +154,7 @@ package setPrerequisites: #(
 	'Dolphin Legacy Date & Time'
 	'Dolphin Message Box'
 	'..\System\Random\Dolphin Random Stream'
+	'..\Registry\Dolphin Registry Access'
 	'..\System\Compiler\Smalltalk Parser'
 	'..\..\..\Contributions\Camp Smalltalk\SUnit\SUnit'
 	'..\ActiveX\Components\XML DOM\XML DOM').

--- a/Core/Object Arts/Dolphin/Base/ExternalCallback.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalCallback.cls
@@ -269,10 +269,9 @@ uninitializeBeforeRemove
 	remaining := ##(self) allSubclasses reject: [:each | each isNonInstantiable].
 	(remaining size = 1 and: [remaining first == self])
 		ifTrue: 
-			[
-			Notification signal: 'Uninstalling VM callback entry point'.
+			[Notification signal: 'Uninstalling VM callback entry point'.
 			ProcessorScheduler removeSelector: #callback:withArgumentsAt:cookie:.
-			VMLibrary default primRegistryAt: (VMLibrary.Registry indexOf: #callback:withArgumentsAt:cookie:)
+			VMLibrary default registryAtIndex: (VMLibrary.Registry indexOf: #callback:withArgumentsAt:cookie:)
 				put: nil]!
 
 unitializeSubclass: anExternalCallbackClass

--- a/Core/Object Arts/Dolphin/Base/OrderedCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/OrderedCollection.cls
@@ -169,6 +169,25 @@ copyWithout: oldElement
 	self do: [:element | element = oldElement ifFalse: [answer add: element]].
 	^answer!
 
+copyWithoutIndex: anInteger
+	"Answer a <SequenceableCollection> which is a copy of the receiver but without the element with the specified index.
+	Implementation Note: This implementation is more efficient for OrderedCollection, and necessary for SortedCollection."
+
+	| size copy |
+	size := self size - 1.
+	copy := self copyLikeOfSize: size.
+	self
+		basicReplaceElementsOf: copy
+		from: 1
+		to: anInteger - 1
+		startingAt: firstIndex.
+	self
+		basicReplaceElementsOf: copy
+		from: anInteger
+		to: size
+		startingAt: firstIndex + anInteger.
+	^copy!
+
 detect: discriminator ifNone: exceptionHandler
 	"Evaluate the <monadicValuable> argument, discriminator, for each of the receiver's 
 	elements.  Answer the first element (in the #do: order) for which discriminator evaluates 
@@ -500,6 +519,7 @@ uncheckedFrom: startInteger to: stopInteger keysAndValuesDo: aDyadicValuable
 !OrderedCollection categoriesFor: #basicReplaceElementsOf:from:to:startingAt:!private!replacing! !
 !OrderedCollection categoriesFor: #copyWith:!copying!public! !
 !OrderedCollection categoriesFor: #copyWithout:!copying!public! !
+!OrderedCollection categoriesFor: #copyWithoutIndex:!copying!public! !
 !OrderedCollection categoriesFor: #detect:ifNone:!public!searching! !
 !OrderedCollection categoriesFor: #do:!enumerating!public! !
 !OrderedCollection categoriesFor: #findFirst:!public!searching! !

--- a/Core/Object Arts/Dolphin/Base/Package.cls
+++ b/Core/Object Arts/Dolphin/Base/Package.cls
@@ -1998,9 +1998,7 @@ initialize
 	BinaryPacLoader := nil!
 
 manager
-	"Answer the object responsible for managing the collection of installed packages.
-	N.B. This should be the only reference to PackageManager in the entire system,
-	as the class may be removed from a future release."
+	"Answer the object responsible for managing the collection of installed packages."
 
 	^PackageManager current!
 

--- a/Core/Object Arts/Dolphin/Base/PackageManager.cls
+++ b/Core/Object Arts/Dolphin/Base/PackageManager.cls
@@ -763,6 +763,12 @@ onClassAdded: aClass
 	#todo.	"This event needs an additional parameter which should be the desired package, or nil for default"
 	self isProcessingEvents ifTrue: [self addClass: aClass to: self defaultPackage]!
 
+onClassDirtied: aClass
+	"Sent by a class when it detects that it has been made dirty."
+
+	self isProcessingEvents ifFalse: [^self].
+	aClass owningPackage ifNotNil: [:package | package isChanged: true]!
+
 onClassRemoved: aClass 
 	"Private - React to aClass being removed from the Smalltalk system. Ensure that none of the
 	packages held by the receiver refer to aClass or its methods now it has departed."
@@ -1243,6 +1249,7 @@ youShouldBeProcessingEvents
 !PackageManager categoriesFor: #noEventsDo:!helpers!private! !
 !PackageManager categoriesFor: #observePackage:!private!updating! !
 !PackageManager categoriesFor: #onClassAdded:!event handling!private! !
+!PackageManager categoriesFor: #onClassDirtied:!helpers!private! !
 !PackageManager categoriesFor: #onClassRemoved:!event handling!private! !
 !PackageManager categoriesFor: #onClassRenamed:from:to:!event handling!private! !
 !PackageManager categoriesFor: #onClassUpdated:!event handling!private! !
@@ -1290,16 +1297,16 @@ buildSingletonInstance
 	Notification signal: 'Creating new PackageManager'.
 	Current := self basicNew initialize.
 	dolphin := self systemPackage.
-	Current
+	^Current
 		basicAddPackage: dolphin;
 		observePackage: dolphin;
-		buildGlobalsMap!
+		buildGlobalsMap;
+		yourself!
 
 current
 	"Answer the singleton instance of the receiver."
 
-	Current isNil ifTrue: [self buildSingletonInstance].
-	^Current!
+	^Current ifNil: [self buildSingletonInstance]!
 
 initialize
 	"Private - Initialize the receiver's class variables.

--- a/Core/Object Arts/Dolphin/Base/ProcessTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ProcessTest.cls
@@ -286,6 +286,17 @@ forkWaiterOn: s sharing: anIdentityDictionary
 	anIdentityDictionary at: #state put: (anIdentityDictionary at: #state) + 1] 
 			forkAt: Processor userInterruptPriority!
 
+isMemTopDown
+	"It is possible to configure Windows so that memory for 32-bit processes is allocated top-down. This is really a debugging mode to help detect issues in 32-bit apps when run large address aware.
+	If this mode is enabled, then we don't need to try and push process allocations over the 2Gb boundary, as actually we may end up doing the reverse."
+
+	| allocationPreference |
+	allocationPreference := (RegKey localMachineRoot
+				at: 'System\CurrentControlSet\Control\Session Manager\Memory Management')
+				mode: #read;
+				valueAt: 'AllocationPreference' ifAbsent: [0].
+	^allocationPreference allMask: Win32Constants.MEM_TOP_DOWN!
+
 testAsStackPointer
 	{0 -> 0.
 		-1 -> -1.
@@ -414,23 +425,27 @@ testForkedBlockHomeFrame
 	Processor sleep: 10 milliseconds!
 
 testLargeAddress
-	| blocks sem1 sem2 result proc value copy1 copy2 frame expected |
+	| blocks sem1 sem2 result proc value copy1 copy2 frame expected isTopDown |
 	self skipIfWin32.
-	blocks := OrderedCollection new: 3000.
-	"Start by blocking out a few large chunks (mainly just to speed up the test a bit)"
-	
-	[
-	[blocks addLast: (Array new: 1 max: 1024 * 1024 * 128).
-	true] on: OutOfMemoryError
-			do: [:ex | false]]
-			whileTrue.
-	"Reserve enough Process sized blocks of virtual memory to start pushing allocations beyond the 2Gb boundary"
-	
-	[| block |
-	block := Process new: 1 max: Process.DefaultMaxStack.
-	blocks addLast: block.
-	block yourAddress <= 16r7FFFFFFF]
-			whileTrue.
+	isTopDown := self isMemTopDown.
+	isTopDown
+		ifTrue: [self assert: Processor activeProcess yourAddress > SmallInteger maximum]
+		ifFalse: 
+			[blocks := OrderedCollection new: 3000.
+			"Start by blocking out a few large chunks (mainly just to speed up the test a bit)"
+			
+			[
+			[blocks addLast: (Array new: 1 max: 1024 * 1024 * 128).
+			true] on: OutOfMemoryError
+					do: [:ex | false]]
+					whileTrue.
+			"Reserve enough Process sized blocks of virtual memory to start pushing allocations beyond the 2Gb boundary"
+			
+			[| block |
+			block := Process new: 1 max: Process.DefaultMaxStack.
+			blocks addLast: block.
+			block yourAddress <= 16r7FFFFFFF]
+					whileTrue].
 	"Now fork a process in large address space"
 	sem1 := Semaphore new.
 	sem2 := Semaphore new.
@@ -445,7 +460,9 @@ testLargeAddress
 	self assert: proc yourAddress >= 16r7FFFFFFF.
 	self assert: proc basicSuspendedFrame class equals: SmallInteger.
 	copy1 := proc copy.
-	self assert: copy1 yourAddress > proc yourAddress.
+	isTopDown
+		ifTrue: [self assert: copy1 yourAddress < proc yourAddress]
+		ifFalse: [self assert: copy1 yourAddress > proc yourAddress].
 	self assert: copy1 basicSuspendedFrame class equals: SmallInteger.
 	frame := copy1 topFrame.
 	self assert: frame basicSP class equals: SmallInteger.
@@ -573,6 +590,7 @@ testUnwindFromForeignProcess
 !ProcessTest categoriesFor: #assertStackFrame:isCopyOf:visited:!helpers!private! !
 !ProcessTest categoriesFor: #forkNested:!helpers!private! !
 !ProcessTest categoriesFor: #forkWaiterOn:sharing:!helpers!private! !
+!ProcessTest categoriesFor: #isMemTopDown!helpers!private! !
 !ProcessTest categoriesFor: #testAsStackPointer!public!unit tests! !
 !ProcessTest categoriesFor: #testCopy!public!unit tests! !
 !ProcessTest categoriesFor: #testCopyExceptionHandlers!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
@@ -256,7 +256,7 @@ beginsWith: aCollection
 	^self basicBeginsWith: aCollection!
 
 binarySearchFor: anObject using: searchBlock 
-	"Answer the index at which anObject is located using a binary chop search based on searchBlock"
+	"Answer the index at which anObject would have to be inserted into this collection in order to maintain its sort order. The <dyadicValuble> search block must express the same ordering."
 
 	^self class 
 		binarySearch: self
@@ -465,6 +465,23 @@ copyWith: newElement
 			with: self
 			startingAt: 1!
 
+copyWith: anObject atIndex: anInteger
+	"Answer a <SequenceableCollection> which is a copy of the receiver that has anObject inserted at the index, anInteger."
+
+	| size |
+	size := self size + 1.
+	^(self copyLikeOfSize: size)
+		replaceFrom: 1
+			to: anInteger - 1
+			with: self
+			startingAt: 1;
+		at: anInteger put: anObject;
+		replaceFrom: anInteger + 1
+			to: size
+			with: self
+			startingAt: anInteger;
+		yourself!
+
 copyWithout: oldElement
 	"Answer a <sequencedReadableCollection> which is a copy of the receiver, but in
 	which all occurrences of the <Object> oldElement have been removed."
@@ -484,6 +501,22 @@ copyWithoutAll: oldElements
 	self 
 		do: [:element | (oldElements includes: element) ifFalse: [aStream nextPut: element]].
 	^aStream contents!
+
+copyWithoutIndex: anInteger
+	"Answer a <SequenceableCollection> which is a copy of the receiver but without the element with the specified index."
+
+	| size |
+	size := self size - 1.
+	^(self copyLikeOfSize: size)
+		replaceFrom: 1
+			to: anInteger - 1
+			with: self
+			startingAt: 1;
+		replaceFrom: anInteger
+			to: size
+			with: self
+			startingAt: anInteger + 1;
+		yourself!
 
 decodeFrom: aReadStream upTo: anObject
 	"Private - Answer the future sequence values of the <ReadStream>, aReadStream, up to but not including, the <Object>, anObject.
@@ -1274,8 +1307,10 @@ writeStream
 !SequenceableCollection categoriesFor: #copyReplaceFrom:to:withObject:!copying!public! !
 !SequenceableCollection categoriesFor: #copyReplacing:withObject:!copying!public! !
 !SequenceableCollection categoriesFor: #copyWith:!copying!public! !
+!SequenceableCollection categoriesFor: #copyWith:atIndex:!copying!public! !
 !SequenceableCollection categoriesFor: #copyWithout:!copying!public! !
 !SequenceableCollection categoriesFor: #copyWithoutAll:!copying!public! !
+!SequenceableCollection categoriesFor: #copyWithoutIndex:!copying!public! !
 !SequenceableCollection categoriesFor: #decodeFrom:upTo:!encode/decode!private! !
 !SequenceableCollection categoriesFor: #decodeNextAvailable:from:!encode/decode!private! !
 !SequenceableCollection categoriesFor: #decodeNextFrom:!encode/decode!private! !
@@ -1365,8 +1400,7 @@ SequenceableCollection methodProtocol: #sequencedReadableCollection attributes: 
 !SequenceableCollection class methodsFor!
 
 binarySearch: aSequenceableCollection for: anObject using: searchBlock 
-	"Private - Answer the index at which anObject is located within aSequenceableCollection using a binary chop
-	search based on searchBlock"
+	"Search aSequenceableCollection, which must be sorted, for anObject using a binary chop search based on the <dyadicValuable>, searchBlock. The search block needs to express the same sort order as that used to sort the collection or the result will be incorrect. If the collection is ordered in ascending order, then use #<= comparison, or #>= for descending order. If anObject is in the collection, then the answer will be the index of the last occurrence of anObject + 1. If anObject is not in the collection, then the answer will be 1. This is most useful to find an insertion point."
 
 	| index low high |
 	low := 1.

--- a/Core/Object Arts/Dolphin/Base/SequenceableCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollectionTest.cls
@@ -114,16 +114,22 @@ testBeginsWith
 	self assert: (sequence beginsWith: (self newUnsortedCollection: #($1 $2 $3 $4 $5 $6))) not!
 
 testBinarySearch
-	| searchee lessThan |
+	| searchee lessThan lessOrEqual |
 	lessThan := [:x :y | x < y].
-	searchee := self newCollection: 'abcdefghijklmnopqrstuvwxyz'.
-	(searchee respondsTo: #binarySearchFor:using:)
-		ifFalse: 
-			["Binary search method introduced in D6"
-			^self].
-	self assert: (searchee binarySearchFor: (searchee at: 1) using: lessThan) equals: 1.
-	self assert: (searchee binarySearchFor: (searchee at: 8) using: lessThan) equals: 8.
-	self assert: (searchee binarySearchFor: (searchee at: 26) using: lessThan) equals: 26!
+	searchee := self newCollection: 'bcdefghijklmnopqrstuvwxy'.
+	self assert: (searchee binarySearchFor: (self assimilate: $a) using: lessThan) equals: 1.
+	self assert: (searchee binarySearchFor: (self assimilate: $b) using: lessThan) equals: 1.
+	self assert: (searchee binarySearchFor: (self assimilate: $e) using: lessThan) equals: 4.
+	self assert: (searchee binarySearchFor: (self assimilate: $y) using: lessThan) equals: 24.
+	self assert: (searchee binarySearchFor: (self assimilate: $z) using: lessThan) equals: 25.
+	lessOrEqual := [:x :y | x <= y].
+	self assert: (searchee binarySearchFor: (self assimilate: $a) using: lessOrEqual) equals: 1.
+	self assert: (searchee binarySearchFor: (self assimilate: $b) using: lessOrEqual) equals: 2.
+	self assert: (searchee binarySearchFor: (self assimilate: $e) using: lessOrEqual) equals: 5.
+	self assert: (searchee binarySearchFor: (self assimilate: $y) using: lessOrEqual) equals: 25.
+	self assert: (searchee binarySearchFor: (self assimilate: $z) using: lessOrEqual) equals: 25.
+	self assert: ((self newCollection: #()) binarySearchFor: (self assimilate: $a) using: lessOrEqual) equals: 1.
+!
 
 testConcatenation
 	| a b |
@@ -272,6 +278,26 @@ testCopyReplaceAllWith
 			actual := subject copyReplaceAll: (self newCollection: eachCase second)
 						with: (self newCollection: eachCase third).
 			self assert: actual equals: expected]!
+
+testCopyWithAtIndex
+	#(#(#() 1 #($1)) #(#($2) 1 #($1 $2)) #(#($2) 2 #($2 $1)) #(#($2 $3) 1 #($1 $2 $3)) #(#($2 $3) 2 #($2 $1 $3)) #(#($2 $3) 3 #($2 $3 $1)))
+		do: 
+			[:each |
+			self assert: ((self newCollection: each first) copyWith: (self assimilate: $1) atIndex: each second)
+				equals: (self newCollection: each third)].
+	#(#() 2 #() 0 #($1) 3 #($1 $2) 4) pairsDo: 
+			[:each :index |
+			self should: [(self newCollection: each) copyWith: (self assimilate: $1) atIndex: index]
+				raise: BoundsError]!
+
+testCopyWithoutIndex
+	#(#(#($1) 1 #()) #(#($1 $2) 1 #($2)) #(#($1 $2) 2 #($1)) #(#($1 $2 $3) 1 #($2 $3)) #(#($1 $2 $3) 2 #($1 $3)) #(#($1 $2 $3) 3 #($1 $2)))
+		do: 
+			[:each |
+			self assert: ((self newCollection: each first) copyWithoutIndex: each second)
+				equals: (self newCollection: each third)].
+	#(#() 1 #() 0 #($1) 2 #($1 $2) 3)
+		pairsDo: [:each :index | self should: [(self newCollection: each) copyWithoutIndex: index] raise: Error]!
 
 testEndsWith
 	"Test SequenceableCollection>>endsWith:"
@@ -785,6 +811,8 @@ verifyIndexOfAnyOf: searchFor startingAt: startInteger in: searchee is: foundInt
 !SequenceableCollectionTest categoriesFor: #testConcatenation!public!unit tests! !
 !SequenceableCollectionTest categoriesFor: #testCopyFromTo!public!unit tests! !
 !SequenceableCollectionTest categoriesFor: #testCopyReplaceAllWith!public!unit tests! !
+!SequenceableCollectionTest categoriesFor: #testCopyWithAtIndex!public!unit tests! !
+!SequenceableCollectionTest categoriesFor: #testCopyWithoutIndex!public!unit tests! !
 !SequenceableCollectionTest categoriesFor: #testEndsWith!public!unit tests! !
 !SequenceableCollectionTest categoriesFor: #testFindFirst!public!unit tests! !
 !SequenceableCollectionTest categoriesFor: #testFirst!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/SequencedGrowableCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SequencedGrowableCollectionTest.cls
@@ -149,9 +149,21 @@ testAddFirst
 	interval := 1 to: 30.
 	"Collection may have to grow a few times"
 	interval do: [:each | subject addFirst: each].
-	self assert: subject asArray equals: interval reverse! !
+	self assert: subject asArray equals: interval reverse!
+
+testCopyWithoutIndex
+	super testCopyWithoutIndex.
+	"Also test that the copying works if there is some space up front."
+	#(#(#($a $b) 1 #()) #(#($a $b $c) 1 #($c)) #(#($a $b $c) 2 #($b))) do: 
+			[:each |
+			| subject |
+			subject := (self newCollection: each first)
+						removeFirst;
+						yourself.
+			self assert: (subject copyWithoutIndex: each second) equals: (self newCollection: each third)]! !
 !SequencedGrowableCollectionTest categoriesFor: #testAddAllFirst!public!unit tests! !
 !SequencedGrowableCollectionTest categoriesFor: #testAddAllFirst2!public!unit tests! !
 !SequencedGrowableCollectionTest categoriesFor: #testAddAllLast!public!unit tests! !
 !SequencedGrowableCollectionTest categoriesFor: #testAddFirst!public!unit tests! !
+!SequencedGrowableCollectionTest categoriesFor: #testCopyWithoutIndex!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/SortedCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SortedCollectionTest.cls
@@ -38,6 +38,9 @@ testBinaryIncludes
 testCopyReplaceAllWith
 	self shouldnt: [super testCopyReplaceAllWith] implement: #replaceFrom:to:with:startingAt:!
 
+testCopyWithAtIndex
+	self shouldnt: [super testCopyWithAtIndex] implement: #replaceFrom:to:with:startingAt:!
+
 testReplaceFromToWithStartingAt
 	self shouldnt: [super testReplaceFromToWithStartingAt] implement: #replaceFrom:to:with:startingAt:!
 
@@ -73,6 +76,7 @@ verifyConcatenation: b with: a
 !SortedCollectionTest categoriesFor: #testAddFirst!public!unit tests! !
 !SortedCollectionTest categoriesFor: #testBinaryIncludes!public!unit tests! !
 !SortedCollectionTest categoriesFor: #testCopyReplaceAllWith!public!unit tests! !
+!SortedCollectionTest categoriesFor: #testCopyWithAtIndex!public!unit tests! !
 !SortedCollectionTest categoriesFor: #testReplaceFromToWithStartingAt!public!unit tests! !
 !SortedCollectionTest categoriesFor: #testResize!public!unit tests! !
 !SortedCollectionTest categoriesFor: #testStrongTalkTests!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/VMLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/VMLibrary.cls
@@ -451,21 +451,6 @@ onStartup
 	wndProc := dlgProc := vtable := genericCallback := nil.
 	WinVerOrGreaterMask := nil!
 
-primRegistryAt: anInteger put: anObject
-	"Private - Generic VM object registering primitive. Used to register cookies, Semaphores,
-	the Corpse object, etc.
-
-	Equivalent to 'Registry at: anInteger put: anObject', but allows the VM to reload any
-	information it caches.
-
-	Primitive failure reasons:
-		InvalidParameter1	- anInteger is not a SmallInteger
-		OutOfBounds		- anInteger is out of the bounds of the registry
-		InvalidParameter2	- anObject is not of the appropriate class for the object being registered."
-
-	<primitive: 93>
-	^self primitiveFailed: _failureCode!
-
 productName
 	"Answer the localised name for Dolphin."
 
@@ -486,12 +471,27 @@ registryAt: aSymbol
 
 	^Registry at: (RegistryKeys at: aSymbol)!
 
-registryAt: aSymbol put: anObject 
+registryAt: aSymbol put: anObject
 	"Private - Register the argument, anObject, as the VM registered object with the name,
 	aSymbol."
 
-	self primRegistryAt: (RegistryKeys at: aSymbol) put: anObject.
+	self registryAtIndex: (RegistryKeys at: aSymbol) put: anObject.
 	^anObject!
+
+registryAtIndex: anInteger put: anObject
+	"Private - Generic VM object registering primitive. Used to register cookies, Semaphores,
+	the Corpse object, etc.
+
+	Equivalent to 'Registry at: anInteger put: anObject', but allows the VM to reload any
+	information it caches.
+
+	Primitive failure reasons:
+		InvalidParameter1	- anInteger is not a SmallInteger
+		OutOfBounds		- anInteger is out of the bounds of the registry
+		InvalidParameter2	- anObject is not of the appropriate class for the object being registered."
+
+	<primitive: 93>
+	^self primitiveFailed: _failureCode!
 
 selectorOfSpecialSend: anInteger
 	^Registry at: specialSelectorStart + anInteger!
@@ -556,12 +556,12 @@ stringFromAddress: pointer
 	len := addr indexOf: 0.
 	^addr copyStringFrom: 1 to: len - 1!
 
-unregisterObject: anObject 
+unregisterObject: anObject
 	| i |
 	i := self registry identityIndexOf: anObject.
 	i > 0 ifFalse: [^self].
 	Notification signal: 'Unregistering VM ref ' , anObject printString.
-	self primRegistryAt: i put: nil!
+	self registryAtIndex: i put: nil!
 
 unsignedFromSigned: anInteger
 	"Private - Answer a 32-bit unsigned integer value instantiated from the signed 32-bit integer
@@ -627,12 +627,12 @@ versionFormatString
 !VMLibrary categoriesFor: #makeLargeUnsigned:!helpers!private! !
 !VMLibrary categoriesFor: #makeLargeUnsigned:highPart:!helpers!private! !
 !VMLibrary categoriesFor: #onStartup!event handling!public! !
-!VMLibrary categoriesFor: #primRegistryAt:put:!accessing-registry!private! !
 !VMLibrary categoriesFor: #productName!accessing!public! !
 !VMLibrary categoriesFor: #registerEventSource:!arithmetic!public! !
 !VMLibrary categoriesFor: #registry!accessing!private! !
 !VMLibrary categoriesFor: #registryAt:!accessing-registry!private! !
 !VMLibrary categoriesFor: #registryAt:put:!accessing-registry!private! !
+!VMLibrary categoriesFor: #registryAtIndex:put:!accessing-registry!private! !
 !VMLibrary categoriesFor: #selectorOfSpecialSend:!enquiries!private! !
 !VMLibrary categoriesFor: #selectorOfSpecialSendEx:!enquiries!private! !
 !VMLibrary categoriesFor: #shortName!accessing!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Debugger.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Debugger.cls
@@ -2083,11 +2083,10 @@ initialize
 	self interrupts do: [:each | ProcessorScheduler interruptSelectors at: each first put: each second].
 	self initializeSkipTable.
 	"Set up the debug empty block"
-	VMLibrary default primRegistryAt: 8 put: nil.
+	VMLibrary default registryAtIndex: 8 put: nil.
 	debugEmptyBlock := VMLibrary default emptyBlock method asDebugMethod value.
 	debugEmptyBlock method isImmutable: true.
-	VMLibrary default primRegistryAt: 8 put: debugEmptyBlock.
-!
+	VMLibrary default registryAtIndex: 8 put: debugEmptyBlock!
 
 initializeSkipTable
 	"Initialize the table of methods to be skipped (in one way or another) when debugging.

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -233,6 +233,7 @@ package methodNames
 	add: #CompiledMethod -> #asDebugMethod;
 	add: #CompiledMethod -> #browse;
 	add: #CompiledMethod -> #icon;
+	add: #CompiledMethod -> #infoTip;
 	add: #CompiledMethod -> #searchForInTool:;
 	add: #CompiledMethod -> #stylerClass;
 	add: #CompileFailedMethod -> #asDebugMethod;
@@ -2094,7 +2095,7 @@ methodChanged: aCompiledMethod
 	self notifyPackageOfChange!
 
 notifyPackageOfChange
-	self owningPackage ifNotNil: [:package | package isChanged: true]!
+	PackageManager current onClassDirtied: self!
 
 renameClassVar: oldString to: newString
 	"Private - Rename the class variable of the receiver named by the <readableString>, oldString, to be
@@ -2647,6 +2648,21 @@ icon
 
 	^Smalltalk developmentSystem iconForMethod: self!
 
+infoTip
+	"Private - Answer a suitable 'info tip' for the receiver."
+
+	| stream |
+	stream := String writeStream: 32.
+	stream
+		display: self;
+		nextPutAll: ' ('.
+	self realCategories asSortedCollection asArray 
+		, (self protocols asSortedCollection: [:a :b | a asSymbol < b asSymbol]) 
+			do: [:each | stream display: each]
+			separatedBy: [stream nextPutAll: ', '].
+	stream nextPut: $).
+	^stream contents!
+
 searchForInTool: aSmalltalkToolShell 
 	aSmalltalkToolShell searchForMethod: self!
 
@@ -2655,6 +2671,7 @@ stylerClass
 !CompiledMethod categoriesFor: #asDebugMethod!private! !
 !CompiledMethod categoriesFor: #browse!public! !
 !CompiledMethod categoriesFor: #icon!constants!public! !
+!CompiledMethod categoriesFor: #infoTip!accessing!development!private! !
 !CompiledMethod categoriesFor: #searchForInTool:!public! !
 !CompiledMethod categoriesFor: #stylerClass!constants!public! !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -5366,7 +5366,7 @@ initialize
 			[MessageMap := self buildMessageMap
 						isImmutable: true;
 						yourself].
-	VMLibrary default primRegistryAt: 54 put: #subclassWindow:!
+	VMLibrary default registryAtIndex: 54 put: #subclassWindow:!
 
 mapRectangle: aRectangle from: aSourceView to: aDestinationView
 	"Answers a RECT like aRectangle mapped from the coordinate system of aSourceView 


### PR DESCRIPTION
The Windows OS debugging memory configuration of allocating memory top down rather than bottom up help detects 32-bit application issues with high (>2Gb) addresses. Having enabled this for testing I found that Process>>largeAddressTest (ironically intended to do a similar job for Dolphin Process objects) broke due to some assumptions about ordering.

Also a number of small modifications from recent loading time tweaks.