### PR TITLE
Add package class/inst properties to govern class pre-declaration on load

### DIFF
--- a/Core/Contributions/Camp Smalltalk/ANSI/Tests/CS ANSI Tests.pax
+++ b/Core/Contributions/Camp Smalltalk/ANSI/Tests/CS ANSI Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'CS ANSI Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicScriptAt: #postinstall put: '| locator |

--- a/Core/Contributions/Camp Smalltalk/Refactoring Browser/Refactorings/CSRefactorings.pax
+++ b/Core/Contributions/Camp Smalltalk/Refactoring Browser/Refactorings/CSRefactorings.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'CSRefactorings'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Additional Refactorings developed by the Camp Smalltalk "Custom Refactorings and Rewrite Editor Usability" project: 
 
 http://wiki.cs.uiuc.edu/CampSmalltalk/Custom+Refactorings+and+Rewrite+Editor+Usability

--- a/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'OA SUnit Extensions'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Object Arts SUnit Extensions.
 Copyright (c) Object Arts Ltd, 2002.
 

--- a/Core/Contributions/Camp Smalltalk/SUnit/SUnit.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/SUnit.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'SUnit'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Contributions/Camp Smalltalk/SUnit/SUnitPreload.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/SUnitPreload.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'SUnitPreload'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Contributions/Camp Smalltalk/SUnit/SUnitTests.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/SUnitTests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'SUnitTests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Contributions/Camp Smalltalk/SUnit/SUnitUI.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/SUnitUI.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'SUnitUI'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Change Objects/RBChangeObjects.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Change Objects/RBChangeObjects.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RBChangeObjects'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Refactoring Browser Change Objects
 Copyright (c) John Brant & Don Roberts.
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Environments/RBEnvironments.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Environments/RBEnvironments.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RBEnvironments'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Refactoring Browser Environments
 Copyright (c) John Brant & Don Roberts.
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Formatters/RBFormatters.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Formatters/RBFormatters.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RBFormatters'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Smalltalk Code Reformatters
 Based on the Refactoring Browser formatter (RBFormatter) and configurable formatter (RBConfigurableFormatter), copyright (c) John Brant & Don Roberts.
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Parser/RBParser.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Parser/RBParser.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RBParser'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin RBParser Package
 Copyright John Brant and Don Roberts.
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBRefactorings.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBRefactorings.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RBRefactorings'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Refactoring Browser Refactorings
 Copyright (c) John Brant & Don Roberts.
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBReferenceFinder.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBReferenceFinder.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RBReferenceFinder'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Refactoring Browser Reference Finder
 Copyright (c) John Brant & Don Roberts.
 

--- a/Core/Contributions/Refactory/Refactoring Browser/SmallLint/RBSmallLint.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/SmallLint/RBSmallLint.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RBSmallLint'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Refactoring Browser SmallLint
 Copyright (c) John Brant & Don Roberts.'.
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Tests/RBTestMethods.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Tests/RBTestMethods.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RBTestMethods'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Tests/RBTests.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Tests/RBTests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RBTests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Contributions/svenc/STON/STON-Core.pax
+++ b/Core/Contributions/svenc/STON/STON-Core.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'STON-Core'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: '# STON - Smalltalk Object Notation
 
 [!![Build Status](https://travis-ci.org/svenvc/ston.svg?branch=master)](https://travis-ci.org/svenvc/ston)

--- a/Core/Contributions/svenc/STON/STON-Tests.pax
+++ b/Core/Contributions/svenc/STON/STON-Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'STON-Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/ActiveX/Automation/ActiveX Automation Tests.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/ActiveX Automation Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX Automation Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/ActiveX/Automation/ActiveX Automation.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/ActiveX Automation.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX Automation'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk ActiveX Automation Support.
 Copyright (c) Object Arts Ltd, 2000-2003.
 

--- a/Core/Object Arts/Dolphin/ActiveX/COM/OLE COM.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/COM/OLE COM.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'OLE COM'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk OLE COM Support. 
 Copyright (c) Object Arts Ltd 1997-2006. Portions copyright (c) CGI Group (Europe) Ltd, 1997.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Categories/ActiveX Categories.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Categories/ActiveX Categories.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX Categories'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Active-X Categories Package. 
 Copyright (c) Object Arts Ltd, 2000-2001.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Components/ADO/ADODB.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/ADO/ADODB.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ADODB'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk ADODB 2.5 Package. 
 Copyright (c) Object Arts Ltd, 2000-2002
 

--- a/Core/Object Arts/Dolphin/ActiveX/Components/CDO/CDO.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/CDO/CDO.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'CDO'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk CDO Package. 
 Copyright (c) Object Arts Ltd, 2000-2002
 

--- a/Core/Object Arts/Dolphin/ActiveX/Components/Font/OLE Font.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/Font/OLE Font.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'OLE Font'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk OLE Font component. 
 Copyright (c) Object Arts Ltd 1997-2001.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Components/Picture/OLE Picture.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/Picture/OLE Picture.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'OLE Picture'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk OLE Picture component. 
 Copyright (c) Object Arts Ltd 2000-2002.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Components/Scripting/ActiveX Scripting.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/Scripting/ActiveX Scripting.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX Scripting'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk ActiveX Script Control Support. 
 Copyright (c) Object Arts Ltd, 2000.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Components/ShDocVw/Internet Explorer.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/ShDocVw/Internet Explorer.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Internet Explorer'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Internet Explorer* Package.
 Copyright (c) Object Arts Ltd, 2000.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Components/VBScript/VBScript Regular Expressions.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/VBScript/VBScript Regular Expressions.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'VBScript Regular Expressions'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk VBScript Regular Expressions Package
 Copyright (c) Object Arts Ltd, 2004.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Components/WinHttp/WinHttp.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/WinHttp/WinHttp.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'WinHttp'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk WinHttp Package. 
 
 This package implements a Smalltalk mapping for the Microsoft WinHttp component, which provides a simple and high performance HTTP client.'.

--- a/Core/Object Arts/Dolphin/ActiveX/Components/XML DOM/XML DOM Visitor.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/XML DOM/XML DOM Visitor.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'XML DOM Visitor'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk XML DOM Visitor Package. 
 Copyright (c) Object Arts Ltd, 2000-2006
 

--- a/Core/Object Arts/Dolphin/ActiveX/Components/XML DOM/XML DOM.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/XML DOM/XML DOM.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'XML DOM'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk XML DOM Package. 
 Copyright (c) Object Arts Ltd, 2000-2006
 

--- a/Core/Object Arts/Dolphin/ActiveX/Connection Points/ActiveX Connection Points.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Connection Points/ActiveX Connection Points.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX Connection Points'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Active-X Connection Points Package. 
 Copyright (c) Object Arts Ltd, 2000.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Deprecated/ActiveX (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Deprecated/ActiveX (Deprecated).pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX (Deprecated)'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Active-X Support (Deprecated Classes and Methods)
 
 This package includes legacy classes and methods from Dolphin''s Active-X framework that have been deprecated. If you have no requirement to use code imported from pre-5.0 versions of Dolphin, then this package can be safely uninstalled.'.

--- a/Core/Object Arts/Dolphin/ActiveX/OCX/ActiveX Control Hosting.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/OCX/ActiveX Control Hosting.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX Control Hosting'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk ActiveX Visual Control (OCX) Hosting. 
 Copyright (c) Object Arts Ltd, 2000-2006.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Persist/OLE Persistence Base.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Persist/OLE Persistence Base.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'OLE Persistence Base'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk OLE Persistence Support. 
 Copyright (c) Object Arts Ltd 2000.
 

--- a/Core/Object Arts/Dolphin/ActiveX/Property Bags/ActiveX Property Bags.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Property Bags/ActiveX Property Bags.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX Property Bags'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Active-X Property Bags package.
 Copyright (c) Object Arts Ltd, 2000-2001.
 '.

--- a/Core/Object Arts/Dolphin/ActiveX/Shell/Windows Shell Namespace.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Shell/Windows Shell Namespace.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Windows Shell Namespace'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Windows Shell Namespace Support
 Copyright (c) Object Arts Ltd, 1998-2000. 
 

--- a/Core/Object Arts/Dolphin/ActiveX/Shell/Windows Shell.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Shell/Windows Shell.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Windows Shell'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Windows Shell Basics
 Copyright (c) Object Arts Ltd, 1998-2000. 
 

--- a/Core/Object Arts/Dolphin/ActiveX/Structured Storage/OLE Structured Storage.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Structured Storage/OLE Structured Storage.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'OLE Structured Storage'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk OLE Structured Storage Support. 
 Copyright (c) Object Arts Ltd 1997-2003. Portions copyright (c) CGI Group (Europe) Ltd, 1997.
 

--- a/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Base (Deprecated)'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Base System (Deprecated Classes and Methods)
 Copyright (c) Object Arts Ltd 1997-2002. Portions copyright (c) CGI Group (Europe) Ltd, 1997.
 

--- a/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Legacy Package Support.pax
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Legacy Package Support.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Legacy Package Support'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Legacy Package Support.
 Copyright (c) Object Arts Ltd. 1997-2006. 
 

--- a/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Legacy Resource Framework.pax
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Legacy Resource Framework.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Legacy Resource Framework'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Legacy Resource Framework.
 Copyright (c) Object Arts Ltd. 1997-2006. 
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Additional Sort Algorithms.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Additional Sort Algorithms.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Additional Sort Algorithms'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Additional Sort Algorithms.
 Copyright (c) Object Arts Ltd. 2005.
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Anonymous Classes.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Anonymous Classes.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Anonymous Classes'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Anonymous Classes
 Copyright (c) Object Arts Ltd. 2019.'.
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Base Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Collection Arithmetic.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Collection Arithmetic.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Collection Arithmetic'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Command-line Parser.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Command-line Parser.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Command-line Parser'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Conformant Array Fields.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Conformant Array Fields.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Conformant Array Fields'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Conformant Array Fields Package.
 
 Contains support for conformant array fields in structures. Conformant array fields are those where the size of the array is variable and defined by another field in the structure.'.

--- a/Core/Object Arts/Dolphin/Base/Dolphin Legacy Date & Time.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Legacy Date & Time.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Legacy Date & Time'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk legacy Date and Time.
 Copyright (c) Object Arts Ltd. 1997-2019
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Message Box.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Message Box.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Message Box'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin MessageBox
 Copyright (c) Object Arts Ltd. 1997-2016'.
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin SizeIs Fields.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin SizeIs Fields.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin SizeIs Fields'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin SizeIs Fields Package.
 
 Contains support for sophisticated conformant field types that can interpret a MIDL size_is expression involving simple arithmetic.'.

--- a/Core/Object Arts/Dolphin/Base/Dolphin Source Fileout.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Source Fileout.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Source Fileout'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicScriptAt: #postinstall put: '(MethodProtocol name: #sourceObject)
@@ -979,13 +980,12 @@ savePAXNamesOn: target
 						cr;
 						cr]]!
 
-savePAXPackageOn: stream
-	"Private - Save the basic details of the receiver in the PAX source file 
-	representation onto the <puttableStream>, target."
+savePAXPackageOn: aPuttableStream
+	"Private - Save the basic details of the receiver in the PAX source file representation onto the <puttableStream> argument."
 
 	"Create package and set some basic attributes"
 
-	stream
+	aPuttableStream
 		nextPutAll: '| package |';
 		cr;
 		nextPutAll: 'package := ';
@@ -1001,14 +1001,22 @@ savePAXPackageOn: stream
 		space;
 		print: self paxVersion;
 		nextPut: $;;
-		crtab;
+		crtab.
+	preDeclareClassesOnLoad
+		ifNotNil: 
+			[aPuttableStream
+				nextPutAll: #preDeclareClassesOnLoad:;
+				space;
+				print: preDeclareClassesOnLoad;
+				nextPut: $;;
+				crtab].
+	aPuttableStream
 		nextPutAll: #basicComment:;
 		space;
 		print: self comment;
 		nextPut: $.;
 		cr;
-		cr.
-!
+		cr!
 
 savePAXPackageVersionOn: aStream 
 	"Private - Save Package Version - this is the version of the package, not the file out format"

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -231,8 +231,8 @@ Object subclass: #ObjectRegistry
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Object subclass: #Package
-	instanceVariableNames: 'name packagePathname comment classNames methodNames globalNames prerequisiteNames events scripts doNotReuse imageStripperBytes aboutBlock packageVersion manualPrerequisites timestamp untracedGlobals changeIndex properties'
-	classVariableNames: '_Uncommitted BinaryPacLoader ChangedIcon CheckTimestamps ClashSignal SourcePackageIcon UnsaveableSignal'
+	instanceVariableNames: 'name packagePathname comment classNames methodNames globalNames prerequisiteNames events scripts doNotReuse imageStripperBytes aboutBlock packageVersion manualPrerequisites timestamp untracedGlobals changeIndex properties preDeclareClassesOnLoad'
+	classVariableNames: '_Uncommitted BinaryPacLoader ChangedIcon CheckTimestamps ClashSignal PreDeclareClassesOnLoad SourcePackageIcon UnsaveableSignal'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Object subclass: #PackageManager

--- a/Core/Object Arts/Dolphin/Base/Package.cls
+++ b/Core/Object Arts/Dolphin/Base/Package.cls
@@ -1,8 +1,8 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #Package
-	instanceVariableNames: 'name packagePathname comment classNames methodNames globalNames prerequisiteNames events scripts doNotReuse imageStripperBytes aboutBlock packageVersion manualPrerequisites timestamp untracedGlobals changeIndex properties'
-	classVariableNames: '_Uncommitted BinaryPacLoader ChangedIcon CheckTimestamps ClashSignal SourcePackageIcon UnsaveableSignal'
+	instanceVariableNames: 'name packagePathname comment classNames methodNames globalNames prerequisiteNames events scripts doNotReuse imageStripperBytes aboutBlock packageVersion manualPrerequisites timestamp untracedGlobals changeIndex properties preDeclareClassesOnLoad'
+	classVariableNames: '_Uncommitted BinaryPacLoader ChangedIcon CheckTimestamps ClashSignal PreDeclareClassesOnLoad SourcePackageIcon UnsaveableSignal'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Package guid: (GUID fromString: '{87b4c4a6-026e-11d3-9fd7-00a0cc3e4a32}')!
@@ -802,21 +802,17 @@ loadPAX
 	timestamp := stream file lastWriteTime asInteger.
 	filer := ChunkSourceFiler on: stream.
 	
-	[| sourceGlobals |
-	filer nextChunk.	"Skip the first chunk since it represents the receiver."
+	[filer nextChunk.	"Skip the first chunk since it represents the receiver."
 	self fileInScript: #preinstall.
 
-	"Define any globals that might be referenced from source code, but don't load them as yet as they
-		 may be instances of one of the classes in the package."
+	"Define any globals that might be referenced from source code, but don't load them as yet as they may be instances of one of the classes in the package."
 	self declareGlobals.
-	sourceGlobals := self globalNames - (self propertyAt: #binaryGlobalNames ifAbsent: [#()])
-				- (self propertyAt: #globalAliases ifAbsent: [#()]).
-	sourceGlobals isEmpty
-		ifFalse: 
-			["Forward reference any classes just in case they are required by the source globals that are just about to be loaded"
-			self declareClasses.
-			"Load source globals"
-			sourceGlobals do: [:each | self sourceManager fileIn: (self fileNameForSourceGlobal: each)]].
+	"Optionally declare all classes in the package for the case where classes are referenced by source globals or other class definitions (other than the class hierarchy relationship)"
+	self preDeclareClassesOnLoad ifTrue: [self declareClasses].
+	"Load source globals"
+	self globalNames - (self propertyAt: #binaryGlobalNames ifAbsent: [#()])
+		- (self propertyAt: #globalAliases ifAbsent: [#()])
+			do: [:each | self sourceManager fileIn: (self fileNameForSourceGlobal: each)].
 
 	"Load class definitions, aliases, and loose methods from the remainder of the PAX file"
 	filer fileIn.
@@ -1133,6 +1129,17 @@ paxVersion: anInteger
 	was saved. This may be used for loading old format source packages in future."
 
 	self propertyAt: #paxVersion put: anInteger!
+
+preDeclareClassesOnLoad
+	"Answer whether Package loading from a .pax should, by default, declare classes before loading any code. See the class side implementation of this message for further details."
+
+	^preDeclareClassesOnLoad ifNil: [self class preDeclareClassesOnLoad]!
+
+preDeclareClassesOnLoad: aBoolean
+	preDeclareClassesOnLoad == aBoolean
+		ifFalse: 
+			[preDeclareClassesOnLoad := aBoolean.
+			self isChanged: true]!
 
 prerequisiteNames
 	"Private - Answer the <readableString> names of the receiver's prerequisite packages, i.e.
@@ -1849,6 +1856,8 @@ If you experience subsequent problems please contact the package supplier for an
 !Package categoriesFor: #path!accessing!public! !
 !Package categoriesFor: #paxVersion!accessing!private! !
 !Package categoriesFor: #paxVersion:!accessing!private! !
+!Package categoriesFor: #preDeclareClassesOnLoad!accessing!public! !
+!Package categoriesFor: #preDeclareClassesOnLoad:!accessing!public! !
 !Package categoriesFor: #prerequisiteNames!accessing!private! !
 !Package categoriesFor: #prerequisites!enumerating!public! !
 !Package categoriesFor: #printOn:!printing!public! !
@@ -2038,6 +2047,14 @@ paxVersion
 	1 - D6.0 format with implicit literal (i.e. not embedded binary) resources"
 
 	^1!
+
+preDeclareClassesOnLoad
+	"Answer whether Package loading from a .pax should, by default, declare classes before loading any code. This is generally not necessary except in circumstances where one or more of the source globals in the package as dependencies on classes in the package, or where classes in the package are being used in the role of pool dictionaries by other classes in the package. However, the historic behaviour was to declare classes, so for the time being this is still on by default. The setting can either be changed globally (i.e. `Package declareClassesOnLoad: false`) or for individual packages using the `preDeclareClassesOnLoad` property on the instance side. If the property is set, then it will be persisted to the package file and respected by future loads. In the next major release of Dolphin, this property will default to 'false'. The reason for this is that pre-declaration is relatively expensive (causing a class mutation when the actual class declaration is subsequently loaded), and so worth avoiding when not required."
+
+	^PreDeclareClassesOnLoad ?? true!
+
+preDeclareClassesOnLoad: aBoolean
+	PreDeclareClassesOnLoad := aBoolean!
 
 readFrom: pacStream
 	"Private - Answer a new instance of the receiver created from the .PAX (source 
@@ -2268,6 +2285,8 @@ unsaveableSignal
 !Package class categoriesFor: #packageExtension!constants!private! !
 !Package class categoriesFor: #packageFileVersion!constants!public! !
 !Package class categoriesFor: #paxVersion!constants!private! !
+!Package class categoriesFor: #preDeclareClassesOnLoad!accessing!public! !
+!Package class categoriesFor: #preDeclareClassesOnLoad:!accessing!public! !
 !Package class categoriesFor: #readFrom:!instance creation!private! !
 !Package class categoriesFor: #sourceGlobalExtension!constants!private! !
 !Package class categoriesFor: #sourcePackageExtension!constants!private! !

--- a/Core/Object Arts/Dolphin/Base/PackageManager.cls
+++ b/Core/Object Arts/Dolphin/Base/PackageManager.cls
@@ -1346,6 +1346,7 @@ newSystemPackage
 	dolphin timestamp: ((File lastWriteTime: dolphin classDefinitionsFileName)
 				ifNil: [0]
 				ifNotNil: [:filetime | filetime asInteger]).
+	dolphin preDeclareClassesOnLoad: false.
 	dolphin isChanged: false.
 	^dolphin!
 

--- a/Core/Object Arts/Dolphin/Database/Database Connection (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/Database/Database Connection (Deprecated).pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Database Connection (Deprecated)'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicPackageVersion: '6.0'.

--- a/Core/Object Arts/Dolphin/Database/Database Connection Base.pax
+++ b/Core/Object Arts/Dolphin/Database/Database Connection Base.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Database Connection Base'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk ODBC Database Connection Base (run time).
 Copyright (c) Object Arts Ltd, 1997-2003. Portions copyright CGI Group (Europe) Ltd, 1997.
 

--- a/Core/Object Arts/Dolphin/Database/Database Connection.pax
+++ b/Core/Object Arts/Dolphin/Database/Database Connection.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Database Connection'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk ODBC Database Connection Development Extensions
 Copyright (c) Object Arts Ltd, 1997-2003. Portions copyright CGI Group (Europe) Ltd, 1997.
 

--- a/Core/Object Arts/Dolphin/Database/Database Tests.pax
+++ b/Core/Object Arts/Dolphin/Database/Database Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Database Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/DolphinSure/DolphinSure Tests.pax
+++ b/Core/Object Arts/Dolphin/DolphinSure/DolphinSure Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'DolphinSure Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/DolphinSure/DolphinSure UI.pax
+++ b/Core/Object Arts/Dolphin/DolphinSure/DolphinSure UI.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'DolphinSure UI'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk "DolphinSure" user interface.
 Copyright (c) Object Arts Ltd, 1999-2001.
 

--- a/Core/Object Arts/Dolphin/DolphinSure/DolphinSure.pax
+++ b/Core/Object Arts/Dolphin/DolphinSure/DolphinSure.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'DolphinSure'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk "DolphinSure" encryption and signature support.
 Copyright (c) Object Arts Ltd, 1999-2000.
 

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System Tests.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Development System Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Development System'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Development System.
     Copyright (c) Object Arts Ltd, 1997-2007. Portions Copyright (c) CGI Group (Europe) Ltd, 1997.
     

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -4599,6 +4599,7 @@ publishedAspectsOfInstances
 				add: (Aspect fileSave: #packageFileName);
 				add: (Aspect sequenceableCollection: #manualPrerequisites
 							addFrom: self manager packageNames asSortedCollection);
+				add: (Aspect boolean: #preDeclareClassesOnLoad);
 				yourself.
 	"If the image has the ADK loaded, then include the image stripper"
 	self environment at: #ImageStripper

--- a/Core/Object Arts/Dolphin/IDE/Base/Dolphin Transcript.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Dolphin Transcript.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Transcript'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicPackageVersion: '6.2'.

--- a/Core/Object Arts/Dolphin/IDE/Base/Splash/Seeing the Objects Inside.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Splash/Seeing the Objects Inside.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Seeing the Objects Inside'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicScriptAt: #postinstall put: 'Smalltalk developmentSystem aboutBoxClass: DolphinSplash'.

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/ActiveX Automation Development.pax
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/ActiveX Automation Development.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX Automation Development'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk ActiveX Automation Development Tools.
 Copyright (c) Object Arts Ltd, 2000-2006.
 

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Community Edition Tools'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Community Edition Additional Tools.
 Copyright (c) Object Arts Ltd, 1999-2005
 

--- a/Core/Object Arts/Dolphin/IDE/Dolphin IDE Tests.pax
+++ b/Core/Object Arts/Dolphin/IDE/Dolphin IDE Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin IDE Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Professional Tools'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Professional Additional Tools.
 Copyright (c) Object Arts Ltd, 2001-2006.
 

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Refactoring Browser'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Refactoring Browser Native UI Integration
 Copyright (c) Object Arts Ltd, 2001-2009.
 

--- a/Core/Object Arts/Dolphin/Installation Manager/Dolphin Products.pax
+++ b/Core/Object Arts/Dolphin/Installation Manager/Dolphin Products.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Products'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Product Descriptions'.
 
 package basicPackageVersion: '6.1.27'.

--- a/Core/Object Arts/Dolphin/Lagoon/ActiveX DLL Server Kit.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/ActiveX DLL Server Kit.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'ActiveX DLL Server Kit'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Active-X In-Process Server Deployment Kit 
 Copyright (c) Object Arts Ltd, 2001-2002.
 

--- a/Core/Object Arts/Dolphin/Lagoon/Application Deployment Kit.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/Application Deployment Kit.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Application Deployment Kit'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Application Deployment Kit. 
 Copyright (c) Object Arts Ltd, 1998-2006.
 

--- a/Core/Object Arts/Dolphin/Lagoon/Lagoon Image Stripper.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/Lagoon Image Stripper.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Lagoon Image Stripper'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Lagoon Image Stripper.
 Copyright (c) Object Arts Ltd, 1998-2006.
 

--- a/Core/Object Arts/Dolphin/Lagoon/Lagoon Tests.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/Lagoon Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Lagoon Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/Lagoon/Product Protection Base.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/Product Protection Base.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Product Protection Base'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicPackageVersion: 'OA 6 CU 1'.

--- a/Core/Object Arts/Dolphin/Lagoon/Product Protection.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/Product Protection.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Product Protection'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Product Protection Package.
 Copyright (c) Object Arts Ltd, 2002-2005.
 

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin Basic Geometry.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin Basic Geometry.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Basic Geometry'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Basic Geometry.
 Copyright (c) Object Arts Ltd. 1997-2018. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 '.

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin MVP Base'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Graphical User Interface framework.
 Copyright (c) Object Arts Ltd. 1997-2018. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 '.

--- a/Core/Object Arts/Dolphin/MVP/Deprecated/Dolphin MVP (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/MVP/Deprecated/Dolphin MVP (Deprecated).pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin MVP (Deprecated)'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Graphical User Interface framework (Deprecated Classes and Methods).
 
 This package includes legacy classes and methods from Dolphin''s base package that have been deprecated. If you have no requirement to use code imported from pre-5.0 versions of Dolphin, then this package can be safely uninstalled.

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/Dolphin Common Dialogs.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/Dolphin Common Dialogs.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Common Dialogs'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Windows Common Dialogs.
 Copyright (c) Object Arts Ltd. 1997-2018. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/Dolphin Common Print Dialog.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/Dolphin Common Print Dialog.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Common Print Dialog'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Windows Common Print Dialog.
 Copyright (c) Object Arts Ltd. 1997-2005. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Find/Dolphin Find Dialog.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Find/Dolphin Find Dialog.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Find Dialog'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Find Dialog
 Copyright (c) Object Arts Ltd. 2004.
 

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Progress/Dolphin Progress Dialog.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Progress/Dolphin Progress Dialog.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Progress Dialog'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Progress Dialog.
 Copyright (c) Object Arts Ltd. 1997-2003. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin MVP Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/MVP/Gdiplus/Gdiplus ImageView.pax
+++ b/Core/Object Arts/Dolphin/MVP/Gdiplus/Gdiplus ImageView.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Gdiplus ImageView'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'See the "Gdiplus ImageView Sample" package'.
 
 package basicPackageVersion: '6.1'.

--- a/Core/Object Arts/Dolphin/MVP/Gdiplus/Gdiplus.pax
+++ b/Core/Object Arts/Dolphin/MVP/Gdiplus/Gdiplus.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Gdiplus'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk GDI+ Binding
 Copyright (c) Dan Antion, Object Arts Ltd, Louis Sumberg, Chris Uppal, and Steve Waring, 2003-2004.
 

--- a/Core/Object Arts/Dolphin/MVP/Gdiplus/Samples/Gdiplus ImageView Sample.pax
+++ b/Core/Object Arts/Dolphin/MVP/Gdiplus/Samples/Gdiplus ImageView Sample.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Gdiplus ImageView Sample'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Evaluate
 	GdiplusImageViewSampleShell show'.
 

--- a/Core/Object Arts/Dolphin/MVP/Gdiplus/Tests/Gdiplus Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Gdiplus/Tests/Gdiplus Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Gdiplus Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk GDI+ Binding tests
 
 '.

--- a/Core/Object Arts/Dolphin/MVP/Icons/Dolphin Base Icons.pax
+++ b/Core/Object Arts/Dolphin/MVP/Icons/Dolphin Base Icons.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Base Icons'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Base Icons
 Copyright (c) Object Arts Ltd, 2018.
 

--- a/Core/Object Arts/Dolphin/MVP/Icons/Dolphin Text Tile Icons.pax
+++ b/Core/Object Arts/Dolphin/MVP/Icons/Dolphin Text Tile Icons.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Text Tile Icons'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Text Tile Icons
 Copyright (c) Object Arts Ltd. 2018.
 '.

--- a/Core/Object Arts/Dolphin/MVP/Icons/Internal Bitmaps and Icons.pax
+++ b/Core/Object Arts/Dolphin/MVP/Icons/Internal Bitmaps and Icons.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Internal Bitmaps and Icons'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'One of the most common reasons why Dolphin applications need to use external files is to make use of icon and bitmap resources. These may be required solely to present your Dolphin classes with an icon inside the browsers or for more functional reasons such as toolbar buttons etc. 
 
 This package makes use of GDI+ to load in external image files and hold them as GdiplusBitmap byte array initializers within the image. Hence the appropriate bitmap can be created at anytime without reference to the external file. Typically, the external file will be a PNG file, which can contain transparency information and is therefore capable of replacing most functionality of standard Windows ICO files. Other files, such as BMP and JPG, may also be used if alpha transparency is not required. Note, however, that currently ICO files are not allowed due to an inability to easily load the correct (large) resource from the icon file (anyone care to fix this?)

--- a/Core/Object Arts/Dolphin/MVP/Metafiles/Dolphin Metafile Records.pax
+++ b/Core/Object Arts/Dolphin/MVP/Metafiles/Dolphin Metafile Records.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Metafile Records'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk metafile extensions for handling individual metafile records. Allows diagnostic tracing, and also manipulation of the individual records.
 Copyright (c) Object Arts Ltd. 2010.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Metafiles/Dolphin Metafiles.pax
+++ b/Core/Object Arts/Dolphin/MVP/Metafiles/Dolphin Metafiles.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Metafiles'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Image class wrapper for Windows Enhanced Metafiles.
 Copyright (c) Object Arts Ltd. 2010.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Models/List/Dolphin List Models.pax
+++ b/Core/Object Arts/Dolphin/MVP/Models/List/Dolphin List Models.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin List Models'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk MVP framework List Models.
 Copyright (c) Object Arts Ltd. 1997-2005. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Models/Tree/Dolphin Tree Models.pax
+++ b/Core/Object Arts/Dolphin/MVP/Models/Tree/Dolphin Tree Models.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Tree Models'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Tree Models.
 Copyright (c) Object Arts Ltd. 1997-2001. Portions Copyright (c) CGI Group (Europe) Ltd. 1996.
 

--- a/Core/Object Arts/Dolphin/MVP/Models/Value/Dolphin Value Models.pax
+++ b/Core/Object Arts/Dolphin/MVP/Models/Value/Dolphin Value Models.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Value Models'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk MVP framework Value Models.
 Copyright (c) Object Arts Ltd. 1997-2001. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Accelerator/Dolphin Accelerator Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Accelerator/Dolphin Accelerator Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Accelerator Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Accelerator Presenter.
 Copyright (c) Object Arts Ltd, 1997-2002, and CGI Group (Europe) Ltd, 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Boolean/Dolphin Boolean Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Boolean/Dolphin Boolean Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Boolean Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Boolean Presenter
 Copyright (c) Object Arts Ltd. 1997-2003. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Choice/Dolphin Choice Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Choice/Dolphin Choice Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Choice Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Choice Presenters.
 Copyright (c) Object Arts Ltd. 1997-2003. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Collection/Dolphin Collection Presenters.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Collection/Dolphin Collection Presenters.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Collection Presenters'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Collection Presenters.
 Copyright (c) Object Arts Ltd. 2002.
 '.

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Color/Dolphin Color Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Color/Dolphin Color Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Color Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Color Presenter
 Copyright (c) Object Arts Ltd. 1997-2005. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/Dolphin Date Time Presenters.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/Dolphin Date Time Presenters.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Date Time Presenters'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Date & Time Presenters
 Copyright (c) Object Arts Ltd. 1997-2003. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Difference/Diff Algorithm.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Difference/Diff Algorithm.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Diff Algorithm'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Diff Algorithm Package
 Copyright (c) Mario Wolczko, 1993, portions copyright (c) Ian Bartholomew 2002.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Difference/Dolphin Differences Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Difference/Dolphin Differences Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Differences Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Differences Presenter.
 Copyright (c) Ian Bartholomew and Object Arts Ltd. 2002.
 '.

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Folder/Dolphin Folder Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Folder/Dolphin Folder Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Folder Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Folder Presenter.
 Copyright (c) Object Arts Ltd. 2002.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Font/Dolphin Font Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Font/Dolphin Font Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Font Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Font Presenter.
 Copyright (c) Object Arts Ltd. 1997-2003. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Image/Dolphin Image Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Image/Dolphin Image Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Image Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Image Presenter and Views.
 Copyright (c) Object Arts Ltd. 1997-2005. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/Dolphin List Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/Dolphin List Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin List Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk List Presenter.
 Copyright (c) Object Arts Ltd. 1997-2018. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/ListTree/Dolphin List Tree Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/ListTree/Dolphin List Tree Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin List Tree Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Copyright © Chris Uppal, 2002 - 2004.
 chris.uppal@metagnostic.org
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Number/Dolphin Number Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Number/Dolphin Number Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Number Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Number Presenter
 Copyright (c) Object Arts Ltd. 1997-2003. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin Choice Prompter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin Choice Prompter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Choice Prompter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Generic Choice Dialog
 Copyright (c) Object Arts Ltd. 1997-2003. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 '.

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin In-place Text Editor.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin In-place Text Editor.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin In-place Text Editor'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Generic In-place Text Editor.
 Copyright (c) Object Arts Ltd. 2009
 '.

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin Integer Prompter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin Integer Prompter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Integer Prompter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Generic Integer Prompter.
 Copyright (c) Object Arts Ltd. 2003.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin Key-Value Prompter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin Key-Value Prompter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Key-Value Prompter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Generic Key-Value Pair Prompter.
 Copyright (c) Object Arts Ltd. 2005.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin Prompter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Prompters/Dolphin Prompter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Prompter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Generic Prompter.
 Copyright (c) Object Arts Ltd. 1997-2003. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 '.

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Radio/Dolphin Radio Buttons.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Radio/Dolphin Radio Buttons.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Radio Buttons'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Radio Buttons.
 Copyright (c) Object Arts Ltd. 1997-2003. Portions Copyright (c) Ian Bartholomew.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Shell/Dolphin Document Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Shell/Dolphin Document Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Document Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Document Presenter
 Copyright (c) Object Arts Ltd. 1997-2018. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Shell/Dolphin Legacy Document Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Shell/Dolphin Legacy Document Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Legacy Document Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Legacy Document Shell Presenter
 Copyright (c) Object Arts Ltd. 1997-2018. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/Dolphin Rich Text Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/Dolphin Rich Text Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Rich Text Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk RichTextEdit View.
 Copyright (c) Object Arts Ltd. 1997-2018. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/Dolphin Text Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/Dolphin Text Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Text Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Text Presenter
 Copyright (c) Object Arts Ltd. 1997-2006. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Tree/Dolphin Tree List Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Tree/Dolphin Tree List Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Tree List Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Tree List Presenter.
 Copyright (c) Object Arts Ltd. 2002.
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Tree/Dolphin Tree Presenter.pax
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Tree/Dolphin Tree Presenter.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Tree Presenter'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Tree Presenter.
 Copyright (c) Object Arts Ltd. 1997-2003. Portions copyright CGI Group (Europe) Ltd, 1997.
 

--- a/Core/Object Arts/Dolphin/MVP/Type Converters/Dolphin Type Converters.pax
+++ b/Core/Object Arts/Dolphin/MVP/Type Converters/Dolphin Type Converters.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Type Converters'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk MVP framework Type Converters.
 Copyright (c) Object Arts Ltd. 1997-2001. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Cards/Dolphin Card Containers.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Cards/Dolphin Card Containers.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Card Containers'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Card Containers.
 Copyright (c) Object Arts Ltd. 1997-2005. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Common Controls'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Common Controls.
 Copyright (c) Object Arts Ltd, 1997-2018. Portions Copyright (c) CGI Group (Europe) Ltd, 1996.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Dolphin Control Bars.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Dolphin Control Bars.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Control Bars'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Control Bars.
 Copyright (c) Object Arts Ltd, 1997-2002. Portions Copyright (c) CGI Group (Europe) Ltd, 1996.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Date Time/Dolphin Date Time Controls.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Date Time/Dolphin Date Time Controls.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Date Time Controls'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Date & Time Common Controls.
 Copyright (c) Object Arts Ltd, 1997-2003.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/MoenTree/Dolphin MoenTree View.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/MoenTree/Dolphin MoenTree View.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin MoenTree View'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Moen Tree View.
 Copyright (c) Object Arts Ltd, 1997-2001. Portions Copyright (c) CGI Group (Europe) Ltd, 1996.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/Dolphin Scintilla View.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/Dolphin Scintilla View.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Scintilla View'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Scintilla Control Wrapper
 Copyright (c) Object Arts Ltd, 2002-2020.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Scrollbars/Dolphin Scrollbars.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scrollbars/Dolphin Scrollbars.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Scrollbars'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Scrollbars
 Copyright (c) Object Arts Ltd. 1997-2005. Portions Copyright (c) CGI Group (Europe) Ltd. 1997.'.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Slider/Dolphin Slider Control.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Slider/Dolphin Slider Control.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Slider Control'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk SpinButton Common Control.
 Copyright (c) Ian Bartholomew, 2002, and Object Arts Ltd, 2002-2005.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/Dolphin Slidey-Inney-Outey Thing.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/Dolphin Slidey-Inney-Outey Thing.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Slidey-Inney-Outey Thing'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicPackageVersion: '6.1'.

--- a/Core/Object Arts/Dolphin/MVP/Views/SpinButton/Dolphin SpinButton Control.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/SpinButton/Dolphin SpinButton Control.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin SpinButton Control'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk SpinButton Common Control.
 Copyright (c) Object Arts Ltd 2005.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Styled Views/Dolphin Styled Views.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Styled Views/Dolphin Styled Views.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Styled Views'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicPackageVersion: '0.003'.

--- a/Core/Object Arts/Dolphin/MVP/Views/SysLink/Dolphin SysLink Control.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/SysLink/Dolphin SysLink Control.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin SysLink Control'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk SysLink Common Control.
 Copyright (c) Object Arts Ltd, 2005.
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Tooltips/Dolphin Tooltips.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Tooltips/Dolphin Tooltips.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Tooltips'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Tooltips
 Copyright (c) Object Arts Ltd 2003-2018.
 

--- a/Core/Object Arts/Dolphin/Registry/Dolphin Registry Access.pax
+++ b/Core/Object Arts/Dolphin/Registry/Dolphin Registry Access.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Registry Access'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Windows Registry Access.
 Copyright (c) Object Arts Ltd, 1998-2018.
 

--- a/Core/Object Arts/Dolphin/Registry/Dolphin Registry Serialisation.pax
+++ b/Core/Object Arts/Dolphin/Registry/Dolphin Registry Serialisation.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Registry Serialisation'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Windows Registry Serialisation.
 Copyright (c) Object Arts Ltd, 2004.
 

--- a/Core/Object Arts/Dolphin/Sockets/Dolphin Sockets Tests.pax
+++ b/Core/Object Arts/Dolphin/Sockets/Dolphin Sockets Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Sockets Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/Sockets/Dolphin Sockets.pax
+++ b/Core/Object Arts/Dolphin/Sockets/Dolphin Sockets.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Sockets'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk TCP/IP Sockets Support
 Copyright (c) Object Arts Ltd, 2002-2003
 

--- a/Core/Object Arts/Dolphin/Sockets/Sockets Connection.pax
+++ b/Core/Object Arts/Dolphin/Sockets/Sockets Connection.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Sockets Connection'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk TCP/IP Sockets Connection Support
 Copyright (c) Object Arts Ltd, 1997-2003. Portions copyright CGI Group (Europe) Ltd, 1997.
 

--- a/Core/Object Arts/Dolphin/Sockets/WinInet.pax
+++ b/Core/Object Arts/Dolphin/Sockets/WinInet.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'WinInet'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk WinInet Library Wrapper
 Copyright (c) Object Arts Ltd, 1997-2006.'.
 

--- a/Core/Object Arts/Dolphin/System/Announcements/Dolphin Announcements Tests.pax
+++ b/Core/Object Arts/Dolphin/System/Announcements/Dolphin Announcements Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Announcements Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/System/Announcements/Dolphin Announcements.pax
+++ b/Core/Object Arts/Dolphin/System/Announcements/Dolphin Announcements.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Announcements'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/System/Base64/Dolphin Base64 Tests.pax
+++ b/Core/Object Arts/Dolphin/System/Base64/Dolphin Base64 Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Base64 Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/System/Base64/Dolphin Base64.pax
+++ b/Core/Object Arts/Dolphin/System/Base64/Dolphin Base64.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Base64'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Base64 Codec
 Copyright (c) Object Arts Ltd, 2004.
 

--- a/Core/Object Arts/Dolphin/System/Compiler/Smalltalk Compiler.pax
+++ b/Core/Object Arts/Dolphin/System/Compiler/Smalltalk Compiler.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Smalltalk Compiler'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/System/Compiler/Smalltalk Parser.pax
+++ b/Core/Object Arts/Dolphin/System/Compiler/Smalltalk Parser.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Smalltalk Parser'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Parser
 Based on the Refactoring Browser parser (RBParser), copyright (c) John Brant & Don Roberts. 
 

--- a/Core/Object Arts/Dolphin/System/Continuations/Continuation Tests.pax
+++ b/Core/Object Arts/Dolphin/System/Continuations/Continuation Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Continuation Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicPackageVersion: '6.1'.

--- a/Core/Object Arts/Dolphin/System/Continuations/Dolphin Continuations.pax
+++ b/Core/Object Arts/Dolphin/System/Continuations/Dolphin Continuations.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Continuations'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Call Continuations.
 Copyright (c) Object Arts Ltd, 2002.
 

--- a/Core/Object Arts/Dolphin/System/Filer/Dolphin Literal Filer Tests.pax
+++ b/Core/Object Arts/Dolphin/System/Filer/Dolphin Literal Filer Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Literal Filer Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/System/Filer/Dolphin Literal Filer.pax
+++ b/Core/Object Arts/Dolphin/System/Filer/Dolphin Literal Filer.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Literal Filer'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicPackageVersion: '6.1'.

--- a/Core/Object Arts/Dolphin/System/Random/Dolphin CRT Random Stream.pax
+++ b/Core/Object Arts/Dolphin/System/Random/Dolphin CRT Random Stream.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin CRT Random Stream'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Simple, fast, but low quality Random stream implemented on the C-runtime library rand() function. Note that this has only 16 bits of randomness.'.
 
 

--- a/Core/Object Arts/Dolphin/System/Random/Dolphin Random Stream Tests.pax
+++ b/Core/Object Arts/Dolphin/System/Random/Dolphin Random Stream Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Random Stream Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/System/Random/Dolphin Random Stream.pax
+++ b/Core/Object Arts/Dolphin/System/Random/Dolphin Random Stream.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Random Stream'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/System/Recent/Dolphin Recent Menu.pax
+++ b/Core/Object Arts/Dolphin/System/Recent/Dolphin Recent Menu.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Recent Menu'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 package basicPackageVersion: '6.2.2'.

--- a/Core/Object Arts/Dolphin/System/STON/Dolphin STON Tests.pax
+++ b/Core/Object Arts/Dolphin/System/STON/Dolphin STON Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin STON Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin STON SUnit tests
 Copyright (c) Object Arts Ltd, 2019
 

--- a/Core/Object Arts/Dolphin/System/STON/Dolphin STON.pax
+++ b/Core/Object Arts/Dolphin/System/STON/Dolphin STON.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin STON'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin STON support
 Copyright (c) Object Arts Ltd, 2019'.
 

--- a/Core/Object Arts/Dolphin/System/Trace/Debug Trace Stream.pax
+++ b/Core/Object Arts/Dolphin/System/Trace/Debug Trace Stream.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Debug Trace Stream'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Debug Trace Stream.
 Copyright (c) Object Arts Ltd, 2002.
 

--- a/Core/Object Arts/Dolphin/System/Win32/Dolphin File System Watcher.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Dolphin File System Watcher.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin File System Watcher'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk File System Watcher
 Copyright (c) Object Arts Ltd, 2005
 

--- a/Core/Object Arts/Dolphin/System/Win32/Dolphin MMF Tests.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Dolphin MMF Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin MMF Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Tests for the Dolphin Memory-Mapped Files Package
 Copyright (c) Object Arts Ltd, 2004.
 '.

--- a/Core/Object Arts/Dolphin/System/Win32/Dolphin Memory-Mapped Files.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Dolphin Memory-Mapped Files.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Memory-Mapped Files'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Memory-Mapped Files
 Copyright (c) Object Arts Ltd, 2004.
 

--- a/Core/Object Arts/Dolphin/System/Win32/Dolphin Overlapped IO.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Dolphin Overlapped IO.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin Overlapped IO'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Win32 Overlapped I/O
 Copyright (c) Object Arts Ltd, 2004
 

--- a/Core/Object Arts/Dolphin/System/Win32/Windows Data Protection API Tests.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Windows Data Protection API Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Windows Data Protection API Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/System/Win32/Windows Data Protection API.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Windows Data Protection API.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Windows Data Protection API'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Win32 Data Protection API
 
 This package contains classes and methods for using the Windows Data Protection API (aka DP API).

--- a/Core/Object Arts/Dolphin/System/Win32/Windows HTTP Server.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Windows HTTP Server.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Windows HTTP Server'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Win32 HTTP Server
 Copyright (c) Object Arts Ltd, 2017
 

--- a/Core/Object Arts/Dolphin/System/Win32/Windows Ini Files Tests.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Windows Ini Files Tests.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Windows Ini Files Tests'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Tests for Dolphin Smalltalk Windows Ini Files
 Copyright (c) Object Arts Ltd, 2017-18'.
 

--- a/Core/Object Arts/Dolphin/System/Win32/Windows Ini Files.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Windows Ini Files.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Windows Ini Files'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Windows Ini Files
 Copyright (c) Object Arts Ltd, 2017
 

--- a/Core/Object Arts/Dolphin/Utilities/IPHelp/IP Help API.pax
+++ b/Core/Object Arts/Dolphin/Utilities/IPHelp/IP Help API.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'IP Help API'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk IP Helper Library Package
 Copyright (c) Object Arts Ltd, 2004
 

--- a/Core/Object Arts/Dolphin/Utilities/Tutorials/Learn Smalltalk.pax
+++ b/Core/Object Arts/Dolphin/Utilities/Tutorials/Learn Smalltalk.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Learn Smalltalk'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Dolphin/Utilities/Tutorials/Tutorial Player.pax
+++ b/Core/Object Arts/Dolphin/Utilities/Tutorials/Tutorial Player.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Tutorial Player'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Samples/ActiveX/EnumRECT/EnumRect.pax
+++ b/Core/Object Arts/Samples/ActiveX/EnumRECT/EnumRect.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'EnumRECT'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk EnumRect COM Sample.
 Copyright (c) Object Arts Ltd, 1997-2000.
 

--- a/Core/Object Arts/Samples/ActiveX/Random/COM Random Stream.pax
+++ b/Core/Object Arts/Samples/ActiveX/Random/COM Random Stream.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'COM Random Stream'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Random Stream COM Server Sample
 Copyright (c) Object Arts Ltd, 1997-2000. Portions copyright CGI Group (Europe) Ltd, 1997.
 

--- a/Core/Object Arts/Samples/ActiveX/Web Browser/Simple Web Browser.pax
+++ b/Core/Object Arts/Samples/ActiveX/Web Browser/Simple Web Browser.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Simple Web Browser'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Simple Web Browser Sample.
 Copyright (c) Object Arts Ltd, 2000.
 

--- a/Core/Object Arts/Samples/Console/Calculator/Calculator (Console).pax
+++ b/Core/Object Arts/Samples/Console/Calculator/Calculator (Console).pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Calculator (Console)'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Console Calculator Sample. 
 Copyright (c) Object Arts Ltd, 2000-2002.
 

--- a/Core/Object Arts/Samples/Console/Catenate/Catenate.pax
+++ b/Core/Object Arts/Samples/Console/Catenate/Catenate.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Catenate'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Catenate Sample. 
 Copyright (c) Object Arts Ltd, 2000-2004.
 

--- a/Core/Object Arts/Samples/Console/Hello World/Hello World (Console).pax
+++ b/Core/Object Arts/Samples/Console/Hello World/Hello World (Console).pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Hello World (Console)'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Command-line Hello World Sample.
 Copyright (c) Object Arts Ltd, 2000-2002.
 

--- a/Core/Object Arts/Samples/DolphinSure Example Authority/DolphinSure Example Authority.pax
+++ b/Core/Object Arts/Samples/DolphinSure Example Authority/DolphinSure Example Authority.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'DolphinSure Example Authority'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Example Authority for DolphinSure Sample
 Copyright (c) Object Arts Ltd, 2006.
 

--- a/Core/Object Arts/Samples/IDE/Dolphin IDE Extension Example.pax
+++ b/Core/Object Arts/Samples/IDE/Dolphin IDE Extension Example.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Dolphin IDE Extension Example'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk IDE Extension Sample. 
 Copyright (c) Object Arts Ltd, 2002.
 

--- a/Core/Object Arts/Samples/Lagoon/Autoplay/Autoplay.pax
+++ b/Core/Object Arts/Samples/Lagoon/Autoplay/Autoplay.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Autoplay'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Autoplay Sample. 
 Copyright (c) Object Arts Ltd, 2001-2002.
 

--- a/Core/Object Arts/Samples/Lagoon/Protected Product/Protected Notepad.pax
+++ b/Core/Object Arts/Samples/Lagoon/Protected Product/Protected Notepad.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Protected Notepad'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'This is a version of the Notebook sample which uses non-default cryptography to encrypt the unlock key.  It uses the example class ElgamalSerialNumberProtector to use private/public encryption to protect the key.
 
 Note that this is intended to be an EXAMPLE of how to replace the default cryptography.  The Elgamal implementation has some issues (see the class comment) which may make it unsuitable for production use.'.

--- a/Core/Object Arts/Samples/Lagoon/Protected Product/Protected Scribble.pax
+++ b/Core/Object Arts/Samples/Lagoon/Protected Product/Protected Scribble.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Protected Scribble'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'This is a version of the standard Scribble application that is protected by serial number. Try deploying this application and then entering the following serial number on startup:
 
 	CWDH-UA9B-VS9Q-TAVQ-FP0C-YBSY-NZ5G-DB'.

--- a/Core/Object Arts/Samples/MVP/Animal Game/Animals.pax
+++ b/Core/Object Arts/Samples/MVP/Animal Game/Animals.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Animals'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'This is a simple animal guessing game designed as a tutorial for the Dolphin Beginner''s Guide. The computer will attempt to guess the name of an animal that you are thinking of. It does this by asking questions to which you must answer yes or no. It might be that you think of an animal that the computer does not know. In this case the game can learn by asking you to enter the name of the new animal and also a question which will distinguish this animal from another in the knowledge base. Next time you play the game will know about the new animal. 
 
 The game starts off by knowing about only one animal; a dog. You can play the game by evaluating: 

--- a/Core/Object Arts/Samples/MVP/Better Hello World/Better Hello World.pax
+++ b/Core/Object Arts/Samples/MVP/Better Hello World/Better Hello World.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Better Hello World'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'The standard “Hello World” sample application that comes pre-loaded the Dolphin Samples folder is not ideal because it doesn’t show how to build Hello World in the normal Dolphin Model-View-Presenter framework. Whilst this makes it quick and easy do to, it’s educational value is limited and some users have found it rather confusing.
 
 This example shows an Hello World Model-View-Presenter component consisting of a ValueModel, a composite ShellView (drawn with the ViewComposer) and a BetterHelloWorld presenter class that ties these pieces together. You can follow a tutorial video at: https://youtu.be/u3I3AYeeIec and then an explanation of what makes MVP a good idea at: https://youtu.be/1LOR2tg8YOg. If you follow the tutorial directly then you''ll need to uninstall this package first.

--- a/Core/Object Arts/Samples/MVP/Bouncing Balls/Bouncing Balls.pax
+++ b/Core/Object Arts/Samples/MVP/Bouncing Balls/Bouncing Balls.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Bouncing Balls'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Bouncing Balls Animation Sample. 
 Copyright (c) Object Arts Ltd, 2001.
 

--- a/Core/Object Arts/Samples/MVP/Calculator/Calculator.pax
+++ b/Core/Object Arts/Samples/MVP/Calculator/Calculator.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Calculator'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk GUI Calculator Sample. 
 Copyright (c) Object Arts Ltd, 2000.
 

--- a/Core/Object Arts/Samples/MVP/Etch-a-Sketch/Etch-a-Sketch.pax
+++ b/Core/Object Arts/Samples/MVP/Etch-a-Sketch/Etch-a-Sketch.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Etch-a-Sketch'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Etch-A-Sketch(tm) Sample. 
 Copyright (c) Object Arts Ltd, 1998-2000.
 

--- a/Core/Object Arts/Samples/MVP/Generative Music/Midi.pax
+++ b/Core/Object Arts/Samples/MVP/Generative Music/Midi.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Midi'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: ''.
 
 

--- a/Core/Object Arts/Samples/MVP/Generative Music/Plimbole.pax
+++ b/Core/Object Arts/Samples/MVP/Generative Music/Plimbole.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Plimbole'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Plimbole is a Generative Music Sequencer based on Otomata (http://www.earslap.com/page/otomata.html). It uses the same cellular automata logic as Otomata but adds a few features that, hopefully, make the results more compelling. Things like different grid sizes and the ability to play through MIDI with separate voices for the tenor (low) and alto (high) parts.
 
 In order to get started, just click in the central grid area and place cells. Each cell has a direction that it is travelling in and, as it collides with the boundary walls, it will create a note. The pitch of the note will be dependent on which part of the boundary is hit; pitches increase from left to right and from top to bottom. Clicking again on a cell will alter the starting direction by 90 degrees. Start the "music" with the Play button and the cells are stepped in their current directions. Cells that hit each other are rotated a quarter turn and those that hit the boundaries bounce back after having generated their notes. You can stop the player at any time and add more cells, or you can just add them while it is running. 

--- a/Core/Object Arts/Samples/MVP/Hello World/Hello World.pax
+++ b/Core/Object Arts/Samples/MVP/Hello World/Hello World.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Hello World'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Hello World Sample. 
 Copyright (c) Object Arts Ltd, 1998-2000.
 

--- a/Core/Object Arts/Samples/MVP/Notepad/Notepad.pax
+++ b/Core/Object Arts/Samples/MVP/Notepad/Notepad.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Notepad'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Notepad Sample. 
 Copyright (c) Object Arts Ltd, 2000-2001.
 

--- a/Core/Object Arts/Samples/MVP/Personal Money/PersonalMoney.pax
+++ b/Core/Object Arts/Samples/MVP/Personal Money/PersonalMoney.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'PersonalMoney'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Personal Accounts Sample.
 Copyright (c) Object Arts Ltd, 1998-2005
 

--- a/Core/Object Arts/Samples/MVP/Playground/Playground.pax
+++ b/Core/Object Arts/Samples/MVP/Playground/Playground.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Playground'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Playground Tutorial Sample. 
 Copyright (c) Object Arts Ltd, 1998-2000.
 

--- a/Core/Object Arts/Samples/MVP/RegEdit/RegEdit.pax
+++ b/Core/Object Arts/Samples/MVP/RegEdit/RegEdit.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'RegEdit'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk RegEdit Sample.
 Copyright (c) Object Arts Ltd, 1998-2002.
 

--- a/Core/Object Arts/Samples/MVP/Scribble/Scribble.pax
+++ b/Core/Object Arts/Samples/MVP/Scribble/Scribble.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Scribble'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Scribble Sample
 Copyright (c) Object Arts Ltd, 1997-2000.
 

--- a/Core/Object Arts/Samples/MVP/Sliding Ball Demo/SlidingBallDemo.pax
+++ b/Core/Object Arts/Samples/MVP/Sliding Ball Demo/SlidingBallDemo.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'SlidingBallDemo'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'I would like the example to have two rectangles connected by a line.
 One button (called "start") that when presssed will show a small
 circle travel along the line from one rectangle to the other. Upon

--- a/Core/Object Arts/Samples/MVP/Video Library/Video Library.pax
+++ b/Core/Object Arts/Samples/MVP/Video Library/Video Library.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Video Library'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Video Library Sample. 
 Copyright (c) Object Arts Ltd, 2001.
 

--- a/Core/Object Arts/Samples/MVP/Wordpad/Wordpad.pax
+++ b/Core/Object Arts/Samples/MVP/Wordpad/Wordpad.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Wordpad'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Wordpad Sample. 
 Copyright (c) Object Arts Ltd, 2005.
 

--- a/Core/Object Arts/Samples/MVP/XmlPad/XmlPad.pax
+++ b/Core/Object Arts/Samples/MVP/XmlPad/XmlPad.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'XmlPad'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk XmlPad Sample. 
 Copyright (c) Object Arts Ltd, 2005
 

--- a/Core/Object Arts/Samples/Sockets/Chat/Chat.pax
+++ b/Core/Object Arts/Samples/Sockets/Chat/Chat.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'Chat'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk Chat Sample. 
 Copyright (c) Object Arts Ltd, 1998-2000.
 

--- a/Core/Object Arts/Samples/Utilities/File System Monitor.pax
+++ b/Core/Object Arts/Samples/Utilities/File System Monitor.pax
@@ -1,6 +1,7 @@
 ﻿| package |
 package := Package name: 'File System Monitor'.
 package paxVersion: 1;
+	preDeclareClassesOnLoad: false;
 	basicComment: 'Dolphin Smalltalk File System Monitor Sample
 Copyright (c) Object Arts Ltd, 2005.
 


### PR DESCRIPTION
Forward declaration of classes has a significant effect on package load times, but is historically what Dolphin has done. I recently disabled this unless packages contained source globals (e.g. pool constants dictionaries) but the effect is to break loading of code ported from Pharo that uses the idiom of representing pool dictionaries as classes. Classes as pools may be referenced before they are defined, and the hierarchy ordering of classes does not help. In order to re-enable scenarios that worked
previously, but which now do not, but still provide options to disable pre-declaration when it is known not to be required, this commit adds properties on the class and instance sides of Package. The class side setting controls the default choice when there is no per-package setting.
The default for this default is true, to behave as before (this may be changed in future). The setting can also be applied to individual packages and once set is persisted in the .pax file and respected regardless of the overall setting.
A 2nd commit sets the property to false (do not pre-declare) on all of the system packages, and some of the contributed packages. This isn't an indication that the other contributed packages need pre-declaration, they are just packages I try to avoid changing on the whole, perhaps because they are actively owned by the contributor. 