### PR TITLE
Add WriteStream>>grabContents

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Date.cls
+++ b/Core/Object Arts/Dolphin/Base/Date.cls
@@ -256,7 +256,7 @@ printStringFormat: aString
 	| stream |
 	stream := String writeStream: aString size.
 	self printOn: stream format: aString.
-	^stream contents!
+	^stream grabContents!
 
 seconds
 	"Answer the <number> of seconds past midnight in the local time of the receiver.
@@ -327,7 +327,7 @@ yyyymmdd
 		printDate: self
 		on: stream
 		format: 'yyyy-MM-dd'.
-	^stream contents! !
+	^stream grabContents! !
 !Date categoriesFor: #<!comparing!public! !
 !Date categoriesFor: #=!comparing!public! !
 !Date categoriesFor: #addDays:!arithmetic!public! !

--- a/Core/Object Arts/Dolphin/Base/ExternalDescriptor.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalDescriptor.cls
@@ -160,7 +160,7 @@ argumentTypes
 	| types |
 	types := Array writeStream: self argumentCount.
 	self argumentsDo: [:n :type | types nextPut: (self class nameOf: n type: type)].
-	^types contents!
+	^types grabContents!
 
 calleeCleans
 	"Answer whether the receiver describes a function which pops its own arguments

--- a/Core/Object Arts/Dolphin/Base/Locale.cls
+++ b/Core/Object Arts/Dolphin/Base/Locale.cls
@@ -518,11 +518,14 @@ printFloat: aFloat on: aStream format: aNUMBERFMT
 						ifFalse: [self infinity]).
 			^self].
 	"The Windows API takes a string as input in a canonical form"
-	invariant := ((classification anyMask: Float.FpClassZero)
-				ifTrue: [(classification anyMask: Float.FpClassNegative) ifTrue: ['-0.0'] ifFalse: ['0.0']]
+	invariant := (classification anyMask: Float.FpClassZero)
+				ifTrue: 
+					[(classification anyMask: Float.FpClassNegative)
+						ifTrue: [##('-0.0' asUtf16String)]
+						ifFalse: [##('0.0' asUtf16String)]]
 				ifFalse: 
 					[| stream |
-					stream := String writeStream: 30.
+					stream := Utf16String writeStream: 30.
 					((classification anyMask: Float.FpClassNegative)
 						ifTrue: 
 							[stream nextPut: $-.
@@ -532,8 +535,7 @@ printFloat: aFloat on: aStream format: aNUMBERFMT
 							base: 10
 							digitCount: 16
 							decimalExponents: ##(SmallInteger minimum to: SmallInteger maximum).
-					stream contents])
-					asUtf16String.
+					stream contents].
 	lib := KernelLibrary default.
 	size := lib
 				getNumberFormat: self lcid

--- a/Core/Object Arts/Dolphin/Base/STBIdentityDictionaryProxy.cls
+++ b/Core/Object Arts/Dolphin/Base/STBIdentityDictionaryProxy.cls
@@ -37,7 +37,7 @@ forCollection: anIdentityDictionary
 			nextPut: value].	
 	^self
 		class: anIdentityDictionary class
-		array: tempStream contents
+		array: tempStream grabContents
 ! !
 !STBIdentityDictionaryProxy class categoriesFor: #forCollection:!instance creation!public! !
 

--- a/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
@@ -1429,7 +1429,7 @@ new: anInteger streamContents: aMonadicValuable
 	| stream |
 	stream := self writeStream: anInteger.
 	aMonadicValuable value: stream.
-	^stream contents!
+	^stream grabContents!
 
 ofSize: anInteger
 	"Private - Answer a new instance of the receiver with anInteger nil elements.
@@ -1444,7 +1444,7 @@ ofSize: anInteger
 	^self new: anInteger!
 
 streamContents: aMonadicValuable
-	^self new: 100 streamContents: aMonadicValuable!
+	^self new: 64 streamContents: aMonadicValuable!
 
 writeStream
 	"Answer a WriteStream on the a new empty instance of the receiver."

--- a/Core/Object Arts/Dolphin/Base/StackFrame.cls
+++ b/Core/Object Arts/Dolphin/Base/StackFrame.cls
@@ -222,9 +222,9 @@ getFrames: anInteger
 	if anInteger < 0)."
 
 	| answer |
-	answer := Array writeStream: 40.
+	answer := Array writeStream: (anInteger < 0 ifTrue: [40] ifFalse: [anInteger]).
 	self callstackDo: [:frame | answer nextPut: frame] depth: anInteger.
-	^answer contents!
+	^answer grabContents!
 
 getOuter: anInteger 
 	| answer |

--- a/Core/Object Arts/Dolphin/Base/Stream.cls
+++ b/Core/Object Arts/Dolphin/Base/Stream.cls
@@ -55,19 +55,19 @@ basicNext: countInteger into: aSequenceableCollection startingAt: startInteger
 		do: [:i | aSequenceableCollection basicAt: i put: self basicNext].
 	^aSequenceableCollection!
 
-basicNextAvailable: anInteger 
+basicNextAvailable: anInteger
 	"Private - Answer up to anInteger undecoded elements of the receiver's collection. Generally, the
 	answer will be a collection of the same class as the one accessed by the receiver (though
 	this is determined by the receiver), and will contain anInteger undecoded elements, or as
 	many as are left in the receiver's collection."
 
-	| newStream count |
+	| writeStream count |
 	count := 0.
-	newStream := self basicContentsSpecies writeStream: anInteger.
+	writeStream := self basicContentsSpecies writeStream: anInteger.
 	[count == anInteger or: [self atEnd]] whileFalse: 
-			[newStream basicNextPut: self basicNext.
+			[writeStream basicNextPut: self basicNext.
 			count := count + 1].
-	^newStream contents!
+	^writeStream grabContents!
 
 close
 	"Relinquish any external resources associated with the receiver, and put the
@@ -148,10 +148,10 @@ next: anInteger
 	"Answer a <sequencedReadableCollection> containing the next anInteger number of objects
 	accessible by the receiver."
 
-	| newStream |
-	newStream := self contentsSpecies writeStream: anInteger.
-	anInteger timesRepeat: [newStream nextPut: self next].
-	^newStream contents!
+	| writeStream |
+	writeStream := self contentsSpecies writeStream: anInteger.
+	anInteger timesRepeat: [writeStream nextPut: self next].
+	^writeStream grabContents!
 
 next: countInteger into: aSequenceableCollection startingAt: startInteger
 	"Destructively replace the elements of the <sequenceableCollection> argument in the

--- a/Core/Object Arts/Dolphin/Base/Time.cls
+++ b/Core/Object Arts/Dolphin/Base/Time.cls
@@ -115,7 +115,7 @@ printStringFormat: aString
 	| stream |
 	stream := String writeStream: aString size.
 	self printOn: stream format: aString.
-	^stream contents!
+	^stream grabContents!
 
 second
 	"Answer a <rational> in the range [0, 60), representing the second of the minute of the local time of the receiver, including any fractional part."

--- a/Core/Object Arts/Dolphin/Base/WriteStream.cls
+++ b/Core/Object Arts/Dolphin/Base/WriteStream.cls
@@ -105,6 +105,17 @@ crtab: tabCount
 
 	self cr; tab: tabCount!
 
+grabContents
+	"Destructively answer the contents of the streamed over collection up to the current position. This may be the actual collection, or a copy of it up to the current position.
+	The stream is no longer usable after this, so the message should only be sent to owned streams that are going out of scope."
+
+	| answer |
+	answer := position == collection size 
+		ifTrue: [collection]
+		ifFalse: [collection copyFrom: 1 to: position].
+	collection := nil.
+	^answer!
+
 growCollection
 	"Private - Increase the size of the streamed over collection
 	to accomodate more elements."
@@ -261,6 +272,7 @@ tab: tabCount
 !WriteStream categoriesFor: #cr!accessing!public! !
 !WriteStream categoriesFor: #crtab!accessing!public! !
 !WriteStream categoriesFor: #crtab:!accessing!public! !
+!WriteStream categoriesFor: #grabContents!accessing!public! !
 !WriteStream categoriesFor: #growCollection!operations!private! !
 !WriteStream categoriesFor: #initialize!initializing!private! !
 !WriteStream categoriesFor: #isWriteable!public!testing! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Clipboard.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Clipboard.cls
@@ -36,7 +36,7 @@ availableFormatIds
 			[| fmt |
 			fmt := 0.
 			[(fmt := lib enumClipboardFormats: fmt) == 0] whileFalse: [answer nextPut: fmt]].
-	^answer contents!
+	^answer grabContents!
 
 availableFormats
 	"Answer a <collection> of the currently available clipboard format <readableString> names. This may not include all formats, as the built-in formats are unnamed, and we don't keep an entry for them all in our map."
@@ -49,7 +49,7 @@ availableFormats
 			| name |
 			name := idToName at: fmt ifAbsent: [self getFormatName: fmt].
 			name isNil ifFalse: [names nextPut: name]].
-	^names contents!
+	^names grabContents!
 
 basicEmpty
 	"Private - Empty the clipboard (assumes it is open)."

--- a/Core/Object Arts/Dolphin/MVP/Gdiplus/Tests/GdiplusFileResource.cls
+++ b/Core/Object Arts/Dolphin/MVP/Gdiplus/Tests/GdiplusFileResource.cls
@@ -3286,7 +3286,7 @@ rgb0000FF_100x100bmpBytes
 	byteStream nextPutAll: ##(ByteArray
 				fromHexString: '424D667500000000000036000000280000006400000064000000010018000000000030750000130B0000130B00000000000000000000').
 	10000 timesRepeat: [byteStream nextPutAll: ##(ByteArray fromHexString: 'FF0000')].
-	^byteStream contents!
+	^byteStream grabContents!
 
 seattleNightJpgBytes
 	^ByteArray 

--- a/Core/Object Arts/Dolphin/MVP/Models/Tree/TreeModelAbstract.cls
+++ b/Core/Object Arts/Dolphin/MVP/Models/Tree/TreeModelAbstract.cls
@@ -64,7 +64,7 @@ asArray
 	| stream |
 	stream := Array writeStream: self approxSize.
 	self do: [:e | stream nextPut: e].
-	^stream contents!
+	^stream grabContents!
 
 asBag
 	"Answer a Bag whose elements are those stored in the receiver"

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/DateToText.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/DateToText.cls
@@ -51,13 +51,14 @@ format: aStringOrNil
 leftToRight: aDate
 	"Answers the result of converting aDate to a String"
 
-	| stream |
-	stream := String writeStream: 32.
+	| stream fmt |
+	fmt := self actualFormat.
+	stream := String writeStream: fmt size.
 	self actualLocale
 		printDate: aDate
 		on: stream
-		format: self actualFormat.
-	^stream contents!
+		format: fmt.
+	^stream grabContents!
 
 locale
 	"Answer the locale to use for the receiver's conversions"

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/DurationToText.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/DurationToText.cls
@@ -28,7 +28,7 @@ leftToRight: aDuration
 		printDuration: aDuration
 		on: stream
 		format: fmt.
-	^stream contents!
+	^stream grabContents!
 
 rightToLeft: aString
 	"Convert aString into a Duration.  

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/TimeToText.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Date Time/TimeToText.cls
@@ -40,10 +40,11 @@ format: aStringOrNil
 leftToRight: aTime
 	"Private - Answers the result of converting aTime to a String"
 
-	| stream |
-	stream := String writeStream: 32.
-	aTime printOn: stream format: self actualFormat.
-	^stream contents!
+	| stream fmt |
+	fmt := self actualFormat.
+	stream := String writeStream: fmt size.
+	aTime printOn: stream format: fmt.
+	^stream grabContents!
 
 locale
 	"Private - Answer the locale to use for the receiver's conversions"

--- a/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/List/ListControlView.cls
@@ -483,12 +483,13 @@ selections
 	"Answer a <sequencedReadableCollection> of the <Object>s selected from the list.
 	If there is no selection, then the collection will be empty."
 
-	| answer |
-	answer := Array writeStream: 8.
+	| answer indices |
+	indices := self selectionsByIndex.
+	answer := Array writeStream: indices size.
 	"There is a window of opportunity for the list content to change between retrieving the selections and looking up the objects"
-	self selectionsByIndex
+	indices
 		do: [:each | (self objectFromHandle: each ifAbsent: []) ifNotNil: [:object | answer nextPut: object]].
-	^answer contents!
+	^answer grabContents!
 
 selections: aSequencedReadableCollection
 	"Set the objects selected in the receiver to be the elements of the <sequencedReadableCollection> argument.

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -632,7 +632,7 @@ getSelectionsByIndex
 	"Private - Query the actual current selections from the control."
 
 	| selections index |
-	selections := Array writeStream.
+	selections := Array writeStream: 1.
 	index := -1.
 	
 	[(index := self
@@ -640,7 +640,7 @@ getSelectionsByIndex
 				wParam: index
 				lParam: LVNI_SELECTED) == -1]
 			whileFalse: [selections nextPut: index + 1].
-	^selections contents!
+	^selections grabContents!
 
 getSingleSelection
 	"Private - Answer the one-based <integer> index of the selected object in the receiver or

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
@@ -4105,7 +4105,7 @@ lexerNamedStyles
 			| style |
 			style := ScintillaLexerNamedStyle view: self id: i - 1.
 			style name isEmpty ifFalse: [styles nextPut: style]].
-	^styles contents!
+	^styles grabContents!
 
 lexerProperties
 	"Answer a <collection> of the <ScintillaLexerProperty> objects representing the current lexers' properties."

--- a/Core/Object Arts/Dolphin/System/Base64/Dolphin Base64.pax
+++ b/Core/Object Arts/Dolphin/System/Base64/Dolphin Base64.pax
@@ -72,7 +72,7 @@ fromBase64String: aString
 	| stream |
 	stream := self writeStream: (aString size * 3 bitShift: -2).
 	Base64Codec decodeFrom: aString readStream onto: stream.
-	^stream contents! !
+	^stream grabContents! !
 !ByteArray class categoriesFor: #fromBase64String:!instance creation!public! !
 
 "End of package definition"!


### PR DESCRIPTION
This is an optimisation for some cases where the number of elements written to the stream exactly fills the underlying collection, and the stream is a local of known ownership that is about to go out of scope. In this case it is possible to grab the streamed over collection as the contents, rather than copying. There are relatively few cases where this is always beneficial, but some of them its a simple win.