### PR TITLE
Aspect class>>block: seems happier with a defaultPresenterBlock

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/Aspect.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Aspect.cls
@@ -349,7 +349,7 @@ block: anAspectSymbol
 	for some kind of <valuable> (not necessarily a block).
 	The aspect is editable using a <ValueWorkspace> presenter."
 
-	^(self name: anAspectSymbol presenterBlock: nil)
+	^(self name: anAspectSymbol presenterBlock: self defaultPresenterBlock)
 		beMultilineValue;
 		yourself!
 


### PR DESCRIPTION
Possible fix for https://github.com/dolphinsmalltalk/Dolphin/issues/955. I have no idea if this is right, but at least is saves the edits!

Thanks for the reminder of the work-around and the earlier report. There was something familiar about this.