### PR TITLE
Fix String>>copyWithout: to correctly recognize non-ASCII characters in a Utf8String (fixes #957)

### DIFF
--- a/Core/Object Arts/Dolphin/Base/MultiByteStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/MultiByteStringTest.cls
@@ -64,6 +64,13 @@ testBeginsWithIgnoreCase
 	self assert: (subject beginsWith: comperand ignoreCase: true).
 	self deny: (subject beginsWith: comperand ignoreCase: false)!
 
+testCopyWithout
+	| string |
+	super testCopyWithout.
+	"Try a non-ANSI case as well:"
+	string := self newCollection: #($a ##(Character dolphin)).
+	self assert: (string copyWithout: Character dolphin) equals: 'a'.!
+
 testEncodeOnPut
 	{Character dolphin.
 		Character codePoint: 16r10FFFD.
@@ -168,6 +175,7 @@ withAllTestCases
 !MultiByteStringTest categoriesFor: #testAnsiStringRoundTrip!public!unit tests! !
 !MultiByteStringTest categoriesFor: #testBeginsWith!public!unit tests! !
 !MultiByteStringTest categoriesFor: #testBeginsWithIgnoreCase!public!unit tests! !
+!MultiByteStringTest categoriesFor: #testCopyWithout!public!unit tests! !
 !MultiByteStringTest categoriesFor: #testEncodeOnPut!public!unit tests! !
 !MultiByteStringTest categoriesFor: #testGothicSubStrings!public!unit tests! !
 !MultiByteStringTest categoriesFor: #testIdentityIncludes!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StringTest.cls
@@ -106,6 +106,17 @@ testClassReadFrom
 				remainder := stream upToEnd.
 				self assert: remainder equals: each last]!
 
+testCopyWithout
+	| string |
+	string := self assimilateString: 'abcba'.
+	self assert: (string copyWithout: $a) equals: 'bcb'.
+	self assert: (string copyWithout: $b) equals: 'aca'.
+	self assert: (string copyWithout: $c) equals: 'abba'.
+	"#957--non-ascii characters were unable to be recognized in a Utf8String in particular,
+	might as well test all types of string"
+	string := self assimilateString: 'ab©ba'.
+	self assert: (string copyWithout: $©) equals: 'abba'.!
+
 testEmpty
 	self assert: self collectionClass empty class identicalTo: self collectionClass!
 
@@ -799,6 +810,7 @@ withAllTestCases
 !StringTest categoriesFor: #testCapitalized!public!unit tests! !
 !StringTest categoriesFor: #testCaseConversions!public!unit tests! !
 !StringTest categoriesFor: #testClassReadFrom!public!unit tests! !
+!AbstractStringTest categoriesFor: #testCopyWithout!public!unit tests! !
 !StringTest categoriesFor: #testEmpty!public!testing / accessing! !
 !StringTest categoriesFor: #testEquals!public!unit tests! !
 !StringTest categoriesFor: #testFindStringStartingAt!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/UtfEncodedString.cls
+++ b/Core/Object Arts/Dolphin/Base/UtfEncodedString.cls
@@ -61,6 +61,18 @@ copyWith: newElement
 
 	^self, (self class with: newElement)!
 
+copyWithout: aCharacter
+	"Answer a <String> which is a copy of the receiver, but in
+	which all occurrences of the <Character> aCharacter have been removed.
+
+	N.B. Use a ReadStream to process whole UTF-8 codepoints at once--otherwise
+	we will be unable to recognize non-ASCII characters in a UTF-8 string."
+
+	| aStream |
+	aStream := (self copyLikeOfSize: self copySize) writeStream.
+	self readStream do: [:element | element = aCharacter ifFalse: [aStream nextPut: element]].
+	^aStream contents.!
+
 decodeFrom: aReadStream upTo: anObject
 	"Private - Answer the future sequence values of the <ReadStream>, aReadStream, up to but not including, the <Object>, anObject.
 	The stream is left positioned after anObject. If there are no occurrences of anObject in the future sequence values of the
@@ -142,6 +154,7 @@ skipEncodingMarkerFrom: aPositionableStream
 !UtfEncodedString categoriesFor: #asArray!converting!public! !
 !UtfEncodedString categoriesFor: #bom!constants!encode/decode!private! !
 !UtfEncodedString categoriesFor: #copyWith:!copying!public! !
+!UtfEncodedString categoriesFor: #copyWithout:!converting!public! !
 !UtfEncodedString categoriesFor: #decodeFrom:upTo:!encode/decode!private! !
 !UtfEncodedString categoriesFor: #emitEncodingMarkerOn:!accessing!public! !
 !UtfEncodedString categoriesFor: #encodedAt:put:!accessing!encode/decode!private! !


### PR DESCRIPTION
Override on UtfEncodedString to iterate using a ReadStream rather than directly.