### PR TITLE
A literal String should not count as "referring to" an equal Symbol.

### DIFF
--- a/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBMethod.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBMethod.cls
@@ -16,11 +16,10 @@ Instance Variables:
 !RBMethod categoriesForClass!Refactory-Model! !
 !RBMethod methodsFor!
 
-literal: anObject containsReferenceTo: aSymbol 
-	anObject = aSymbol ifTrue: [^true].
+literal: anObject containsReferenceTo: aSymbol
+	anObject == aSymbol ifTrue: [^true].
 	anObject class = Array ifFalse: [^false].
-	anObject 
-		do: [:each | (self literal: each containsReferenceTo: aSymbol) ifTrue: [^true]].
+	anObject do: [:each | (self literal: each containsReferenceTo: aSymbol) ifTrue: [^true]].
 	^false!
 
 method

--- a/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBMethod.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBMethod.cls
@@ -50,17 +50,14 @@ refersToClassNamed: aSymbol
 	^(searcher executeTree: self parseTree initialAnswer: false) 
 		or: [self refersToSymbol: aSymbol]!
 
-refersToSymbol: aSymbol 
+refersToSymbol: aSymbol
 	| searcher |
 	searcher := ParseTreeSearcher new.
-	searcher
-		matches: aSymbol printString do: [:node :answer | true];
-		matches: '`#literal'
-			do: [:node :answer | answer or: [self literal: node value containsReferenceTo: aSymbol]].
-	(RBScanner isSelector: aSymbol) 
+	searcher matches: '`#literal'
+		do: [:node :answer | answer or: [self literal: node value containsReferenceTo: aSymbol]].
+	(RBScanner isSelector: aSymbol)
 		ifTrue: 
-			[searcher 
-				matches: '`@object ' , (ParseTreeSearcher buildSelectorString: aSymbol)
+			[searcher matches: '`@object ' , (ParseTreeSearcher buildSelectorString: aSymbol)
 				do: [:node :answer | true]].
 	^searcher executeTree: self parseTree initialAnswer: false!
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Tests/RBMethodTest.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Tests/RBMethodTest.cls
@@ -1,0 +1,22 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+RefactoringBrowserTest subclass: #RBMethodTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+RBMethodTest guid: (GUID fromString: '{dcaa75d7-68c0-41bd-9701-dbecb814444c}')!
+RBMethodTest comment: ''!
+!RBMethodTest categoriesForClass!Refactory-Testing! !
+!RBMethodTest methodsFor!
+
+testLiteralStringsDoNotMatchSymbols
+	| class method |
+	class := RBClass existingNamed: #RefactoryTestDataApp.
+	method := class methodFor: #returnInEnsure.
+	self deny: (method refersToSymbol: #asdf).
+	method := class methodFor: #literalArrayStringsAndSymbols.
+	self deny: (method refersToSymbol: #abc).
+	self assert: (method refersToSymbol: #def)! !
+!RBMethodTest categoriesFor: #testLiteralStringsDoNotMatchSymbols!public! !
+

--- a/Core/Contributions/Refactory/Refactoring Browser/Tests/RBMethodTest.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Tests/RBMethodTest.cls
@@ -16,7 +16,16 @@ testLiteralStringsDoNotMatchSymbols
 	method := class methodFor: #returnInEnsure.
 	self deny: (method refersToSymbol: #asdf).
 	method := class methodFor: #literalArrayStringsAndSymbols.
-	self deny: (method refersToSymbol: #abc).
+	self deny: (method refersToSymbol: #abc)!
+
+testRefersToSymbol
+	| class method |
+	class := RBClass existingNamed: #RefactoryTestDataApp.
+	method := class methodFor: #searchingLiteral.
+	self assert: (method refersToSymbol: #printString).
+	self assert: (method refersToSymbol: #abc).
+	method := class methodFor: #literalArrayStringsAndSymbols.
 	self assert: (method refersToSymbol: #def)! !
 !RBMethodTest categoriesFor: #testLiteralStringsDoNotMatchSymbols!public! !
+!RBMethodTest categoriesFor: #testRefersToSymbol!public! !
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Tests/RBTests.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Tests/RBTests.pax
@@ -36,6 +36,7 @@ package classNames
 	add: #PushUpInstanceVariableTest;
 	add: #PushUpMethodTest;
 	add: #RBClassTest;
+	add: #RBMethodTest;
 	add: #RBNamespaceTest;
 	add: #RefactoringBrowserTest;
 	add: #RefactoringTest;
@@ -119,6 +120,11 @@ RefactoringBrowserTest subclass: #ParserTest
 	classInstanceVariableNames: ''!
 RefactoringBrowserTest subclass: #RBClassTest
 	instanceVariableNames: 'objectClass newClass messageNodeClass'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+RefactoringBrowserTest subclass: #RBMethodTest
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Contributions/Refactory/Refactoring Browser/Tests/RefactoryTestDataApp.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Tests/RefactoryTestDataApp.cls
@@ -224,6 +224,9 @@ justSendsSuper
 literalArrayCharacters
 	^#($a $b $c) includes: $a!
 
+literalArrayStringsAndSymbols
+	^#('abc' #def) includes: 'abc'!
+
 longMethods
 	self printString.
 	self printString.
@@ -444,6 +447,7 @@ yourselfNotUsed
 !RefactoryTestDataApp categoriesFor: #isLiteral!lint!public! !
 !RefactoryTestDataApp categoriesFor: #justSendsSuper!lint!public! !
 !RefactoryTestDataApp categoriesFor: #literalArrayCharacters!lint!public! !
+!RefactoryTestDataApp categoriesFor: #literalArrayStringsAndSymbols!lint!public! !
 !RefactoryTestDataApp categoriesFor: #longMethods!lint!public! !
 !RefactoryTestDataApp categoriesFor: #minMax!lint!public! !
 !RefactoryTestDataApp categoriesFor: #missingYourself!lint!public! !

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -878,11 +878,11 @@ printOn: aStream
 				ifFalse: [(aStream nextPut: ch) == $' ifTrue: [aStream nextPut: $']]].
 	aStream nextPut: $'!
 
-refersToLiteral: anObject 
+refersToLiteral: anObject
 	"Private - Answer whether the receiver is a reference to the literal argument.
 	This assumes that the receiver is in the role of a literal."
 
-	^self = anObject!
+	^anObject isSymbol not and: [self = anObject].!
 
 replaceBytesOf: aByteObject from: start to: stop startingAt: fromStart
 	"Private - Standard method for transfering bytes from one variable

--- a/Core/Object Arts/Dolphin/Base/StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StringTest.cls
@@ -405,6 +405,19 @@ testMutableCopy
 			self assert: actual isKindOf: subject species.
 			self assert: (actual _cmp: subject) equals: 0]!
 
+testRefersToLiteral
+	"Test that string literals in a method do not count as referring to a Symbol with the same contents,
+	now that they are #= to said Symbol.
+
+	N.B. they *should* still count as referring to other encodings of the same string."
+
+	| str |
+	str := 'abc' asUtf8String.
+	self assert: (str refersToLiteral: 'abc' asAnsiString).
+	self assert: (str refersToLiteral: 'abc' asUtf8String).
+	self deny: (str refersToLiteral: #abc).
+	self deny: (str refersToLiteral: 'ab')!
+
 testReverse
 	"Tests reversing a variety of 1, 2, 3 and 4 byte encodings"
 
@@ -810,7 +823,7 @@ withAllTestCases
 !StringTest categoriesFor: #testCapitalized!public!unit tests! !
 !StringTest categoriesFor: #testCaseConversions!public!unit tests! !
 !StringTest categoriesFor: #testClassReadFrom!public!unit tests! !
-!AbstractStringTest categoriesFor: #testCopyWithout!public!unit tests! !
+!StringTest categoriesFor: #testCopyWithout!public! !
 !StringTest categoriesFor: #testEmpty!public!testing / accessing! !
 !StringTest categoriesFor: #testEquals!public!unit tests! !
 !StringTest categoriesFor: #testFindStringStartingAt!public!unit tests! !
@@ -820,6 +833,7 @@ withAllTestCases
 !StringTest categoriesFor: #testLength!public!unit tests! !
 !StringTest categoriesFor: #testLines!public!unit tests! !
 !StringTest categoriesFor: #testMutableCopy!public!unit tests! !
+!StringTest categoriesFor: #testRefersToLiteral!public!unit tests! !
 !StringTest categoriesFor: #testReverse!public!unit tests! !
 !StringTest categoriesFor: #testSplitByString!public!unit tests! !
 !StringTest categoriesFor: #testSplitSingle!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/SymbolTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SymbolTest.cls
@@ -118,6 +118,11 @@ testPrintString
 			print := each asSymbol printString.
 			self assert: (print second == $' and: [print last == $'])]!
 
+testRefersToLiteral
+	self assert: (#abc refersToLiteral: #abc).
+	self deny: (#abc refersToLiteral: 'abc').
+	self deny: (#abc refersToLiteral: #ab)!
+
 testReplaceFromToWithStartingAt
 	self 
 		should: [super testReplaceFromToWithStartingAt]
@@ -144,6 +149,7 @@ testSymbolTable
 !SymbolTest categoriesFor: #testKeywords!public!unit tests! !
 !SymbolTest categoriesFor: #testPrintLiteral!public!unit tests! !
 !SymbolTest categoriesFor: #testPrintString!helpers!public! !
+!SymbolTest categoriesFor: #testRefersToLiteral!public!unit tests! !
 !SymbolTest categoriesFor: #testReplaceFromToWithStartingAt!public!unit tests! !
 !SymbolTest categoriesFor: #testReplaceIdentityWith!public!unit tests! !
 !SymbolTest categoriesFor: #testResize!public!unit tests! !

--- a/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
@@ -1086,6 +1086,18 @@ testSpecialLiteralsAsUnarySelectors
 				raise: self compilationErrorClass.
 			self denyIsNil: method]!
 
+testStringDoesNotReferToSymbol
+	"Test that string literals in a method do not count as referring to a Symbol with the same contents,
+	now that they are #= to said Symbol.
+
+	N.B. they *should* still count as referring to other encodings of the same string."
+
+	| method |
+	method := (self compileExpression: '''abc'' size') method.
+	self assert: (method refersToLiteral: 'abc' asAnsiString).
+	self assert: (method refersToLiteral: 'abc' asUtf8String).
+	self deny: (method refersToLiteral: #abc)!
+
 testSymbolScanning
 	#('#a' '#a1' '#a:' '#a1:' '#a:b:' '#a_:_:' '#a1:b2:' '#|' '#||' '#|||' '#_' '#_a' '#-' '#--' '#''£''' '#''你好''' '#''🐬''') do: 
 			[:each |
@@ -1546,6 +1558,7 @@ verifyTextMapsOf: each
 !CompilerTest categoriesFor: #testScope!public!unit tests! !
 !CompilerTest categoriesFor: #testSharedOuterTemps!public!unit tests! !
 !CompilerTest categoriesFor: #testSpecialLiteralsAsUnarySelectors!public! !
+!CompilerTest categoriesFor: #testStringDoesNotReferToSymbol!public!unit tests! !
 !CompilerTest categoriesFor: #testSymbolScanning!public!unit tests! !
 !CompilerTest categoriesFor: #testTempMaps!public!unit tests! !
 !CompilerTest categoriesFor: #testTempPairing!public!unit tests! !

--- a/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
@@ -1086,18 +1086,6 @@ testSpecialLiteralsAsUnarySelectors
 				raise: self compilationErrorClass.
 			self denyIsNil: method]!
 
-testStringDoesNotReferToSymbol
-	"Test that string literals in a method do not count as referring to a Symbol with the same contents,
-	now that they are #= to said Symbol.
-
-	N.B. they *should* still count as referring to other encodings of the same string."
-
-	| method |
-	method := (self compileExpression: '''abc'' size') method.
-	self assert: (method refersToLiteral: 'abc' asAnsiString).
-	self assert: (method refersToLiteral: 'abc' asUtf8String).
-	self deny: (method refersToLiteral: #abc)!
-
 testSymbolScanning
 	#('#a' '#a1' '#a:' '#a1:' '#a:b:' '#a_:_:' '#a1:b2:' '#|' '#||' '#|||' '#_' '#_a' '#-' '#--' '#''£''' '#''你好''' '#''🐬''') do: 
 			[:each |
@@ -1558,7 +1546,6 @@ verifyTextMapsOf: each
 !CompilerTest categoriesFor: #testScope!public!unit tests! !
 !CompilerTest categoriesFor: #testSharedOuterTemps!public!unit tests! !
 !CompilerTest categoriesFor: #testSpecialLiteralsAsUnarySelectors!public! !
-!CompilerTest categoriesFor: #testStringDoesNotReferToSymbol!public!unit tests! !
 !CompilerTest categoriesFor: #testSymbolScanning!public!unit tests! !
 !CompilerTest categoriesFor: #testTempMaps!public!unit tests! !
 !CompilerTest categoriesFor: #testTempPairing!public!unit tests! !


### PR DESCRIPTION
Different classes of String should still be allowed to "refer to" each other, so the Object implementation isn't appropriate.

I also noticed a similar situation in the Refactoring Browser code, in `RBMethod>>literal:containsReferenceTo:`. Since there the argument clearly must be a `Symbol`, I just changed it to an `==` check. I'm not sure where to test it, though...by the time it works its way through to an actual scenario, I think it would be hideously complicated to set up a test. Any suggestions?