### PR TITLE
fix issue #990

### DIFF
--- a/Core/Object Arts/Dolphin/Base/ResourceIdentifier.cls
+++ b/Core/Object Arts/Dolphin/Base/ResourceIdentifier.cls
@@ -73,6 +73,7 @@ hiddenObjects
 
 	| stlInFilerClass |
 	stlInFilerClass := Smalltalk at: #STLInFiler.
+	self resource ifNil: [^self error: ('Resource [', owningClass name, '>>', selector, '] does not exist')].
 	^(stlInFilerClass on: self resource readStream)
 		basicNext;
 		readMap!

--- a/Core/Object Arts/Dolphin/Base/ResourceIdentifier.cls
+++ b/Core/Object Arts/Dolphin/Base/ResourceIdentifier.cls
@@ -71,10 +71,11 @@ hiddenObjects
 	Implementation note. This is not particularly fast since it loads the resource
 	classes it needs into the image. View resources will not be realized as windows however."
 
-	| stlInFilerClass |
+	| stlInFilerClass resource |
 	stlInFilerClass := Smalltalk at: #STLInFiler.
-	self resource ifNil: [^self error: ('Resource [', owningClass name, '>>', selector, '] does not exist')].
-	^(stlInFilerClass on: self resource readStream)
+	resource := self resource.
+	resource ifNil: [^self error: ('Resource [', owningClass name, '>>', selector, '] does not exist')].
+	^(stlInFilerClass on: resource readStream)
 		basicNext;
 		readMap!
 

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -85,6 +85,7 @@ package globalAliases: (Set new
 package setPrerequisites: #(
 	'..\IDE\Base\Development System'
 	'..\Base\Dolphin'
+	'..\Base\Dolphin Anonymous Classes'
 	'..\Base\Dolphin Base Tests'
 	'Base\Dolphin Basic Geometry'
 	'Presenters\Boolean\Dolphin Boolean Presenter'

--- a/Core/Object Arts/Dolphin/MVP/ResourceIdentifierTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ResourceIdentifierTest.cls
@@ -22,6 +22,18 @@ createResourceNamed: aString for: aView
 	^rid
 !
 
+createResourceNamed: aString for: aView on: aPresenterClass
+	| filer rid resource |
+
+	filer := STLOutFiler on: Array writeStream.
+	filer nextPut: aView.
+	aView destroy.
+	resource := filer stream contents.
+	rid := ResourceIdentifier class: aPresenterClass name: aString.
+	rid assign: resource.
+	^rid
+!
+
 setUp
 	| shellView filer |
 	super setUp.
@@ -63,22 +75,25 @@ testDeserializeAll
 	ResourceIdentifier allResourceIdentifiers do: [:each | each hiddenObjects]!
 
 testReferenceViewRemoved
-	| childRid parentRid paretView |
+	| childRid parentRid paretView anonPresenterClass anonMetaclass |
 
-	childRid := self createResourceNamed: 'Test view issue990' for: ContainerView new create.
+	anonPresenterClass :=  AnonymousClassBuilder new createNewClass.
+	anonPresenterClass superclass: Presenter.
+	anonMetaclass := anonPresenterClass class.
+	childRid := self createResourceNamed: 'Test view issue990' for: ContainerView new create on: anonPresenterClass.
 
 	paretView := ShellView new create.
 	paretView addSubView: (ReferenceView resourceIdentifier: childRid).
 	parentRid := self createResourceNamed: 'Parent Test view issue990' for: paretView.
 
-	Presenter class removeSelector: #resource_Test_view_issue990 ifAbsent: [].
-	self assert: (Presenter class respondsTo: #resource_Test_view_issue990) not.
+	anonMetaclass removeSelector: #resource_Test_view_issue990 ifAbsent: [].
+	self assert: (anonMetaclass respondsTo: #resource_Test_view_issue990) not.
 
-	self should: [childRid hiddenObjects] raise: Error matching: [:err | err description = 'Resource [Presenter>>resource_Test_view_issue990] does not exist'].
+	self should: [childRid hiddenObjects] raise: Error matching: [:err | err description = 'Resource [a subclass of Presenter>>resource_Test_view_issue990] does not exist'].
 
-	Presenter class removeSelector: #resource_Parent_Test_view_issue990 ifAbsent: [].
+	anonMetaclass removeSelector: #resource_Parent_Test_view_issue990 ifAbsent: [].
 
-	self assert: (Presenter class respondsTo: #resource_Parent_Test_view_issue990) not.
+	self assert: (anonMetaclass respondsTo: #resource_Parent_Test_view_issue990) not.
 	!
 
 testResourceSelector
@@ -90,6 +105,7 @@ testResourceSelector
 	rid := ResourceIdentifier class: self class name: '1Default:view'.
 	self assert: (rid class selectorFromName: rid name) identicalTo: #resource_1Defaultview! !
 !ResourceIdentifierTest categoriesFor: #createResourceNamed:for:!private!unit tests! !
+!ResourceIdentifierTest categoriesFor: #createResourceNamed:for:on:!private!unit tests! !
 !ResourceIdentifierTest categoriesFor: #setUp!private!unit tests! !
 !ResourceIdentifierTest categoriesFor: #tempViewResource!private!unit tests! !
 !ResourceIdentifierTest categoriesFor: #testAssignResource!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/ResourceIdentifierTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ResourceIdentifierTest.cls
@@ -10,6 +10,18 @@ ResourceIdentifierTest comment: ''!
 !ResourceIdentifierTest categoriesForClass!Unclassified! !
 !ResourceIdentifierTest methodsFor!
 
+createResourceNamed: aString for: aView
+	| filer rid resource |
+
+	filer := STLOutFiler on: Array writeStream.
+	filer nextPut: aView.
+	aView destroy.
+	resource := filer stream contents.
+	rid := ResourceIdentifier class: Presenter name: aString.
+	rid assign: resource.
+	^rid
+!
+
 setUp
 	| shellView filer |
 	super setUp.
@@ -50,6 +62,25 @@ testDeserializeAll
 
 	ResourceIdentifier allResourceIdentifiers do: [:each | each hiddenObjects]!
 
+testReferenceViewRemoved
+	| childRid parentRid paretView |
+
+	childRid := self createResourceNamed: 'Test view issue990' for: ContainerView new create.
+
+	paretView := ShellView new create.
+	paretView addSubView: (ReferenceView resourceIdentifier: childRid).
+	parentRid := self createResourceNamed: 'Parent Test view issue990' for: paretView.
+
+	Presenter class removeSelector: #resource_Test_view_issue990 ifAbsent: [].
+	self assert: (Presenter class respondsTo: #resource_Test_view_issue990) not.
+
+	self should: [childRid hiddenObjects] raise: Error matching: [:err | err description = 'Resource [Presenter>>resource_Test_view_issue990] does not exist'].
+
+	Presenter class removeSelector: #resource_Parent_Test_view_issue990 ifAbsent: [].
+
+	self assert: (Presenter class respondsTo: #resource_Parent_Test_view_issue990) not.
+	!
+
 testResourceSelector
 	| rid selector |
 	rid := ResourceIdentifier class: self class name: 'Default view'.
@@ -58,9 +89,11 @@ testResourceSelector
 	self assert: (rid class nameFromSelector: selector) equals: rid name.
 	rid := ResourceIdentifier class: self class name: '1Default:view'.
 	self assert: (rid class selectorFromName: rid name) identicalTo: #resource_1Defaultview! !
+!ResourceIdentifierTest categoriesFor: #createResourceNamed:for:!private!unit tests! !
 !ResourceIdentifierTest categoriesFor: #setUp!private!unit tests! !
 !ResourceIdentifierTest categoriesFor: #tempViewResource!private!unit tests! !
 !ResourceIdentifierTest categoriesFor: #testAssignResource!public!unit tests! !
 !ResourceIdentifierTest categoriesFor: #testDeserializeAll!public!unit tests! !
+!ResourceIdentifierTest categoriesFor: #testReferenceViewRemoved!public!unit tests! !
 !ResourceIdentifierTest categoriesFor: #testResourceSelector!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/MVP/ResourceIdentifierTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ResourceIdentifierTest.cls
@@ -10,18 +10,6 @@ ResourceIdentifierTest comment: ''!
 !ResourceIdentifierTest categoriesForClass!Unclassified! !
 !ResourceIdentifierTest methodsFor!
 
-createResourceNamed: aString for: aView
-	| filer rid resource |
-
-	filer := STLOutFiler on: Array writeStream.
-	filer nextPut: aView.
-	aView destroy.
-	resource := filer stream contents.
-	rid := ResourceIdentifier class: Presenter name: aString.
-	rid assign: resource.
-	^rid
-!
-
 createResourceNamed: aString for: aView on: aPresenterClass
 	| filer rid resource |
 
@@ -84,7 +72,7 @@ testReferenceViewRemoved
 
 	paretView := ShellView new create.
 	paretView addSubView: (ReferenceView resourceIdentifier: childRid).
-	parentRid := self createResourceNamed: 'Parent Test view issue990' for: paretView.
+	parentRid := self createResourceNamed: 'Parent Test view issue990' for: paretView on: anonPresenterClass.
 
 	anonMetaclass removeSelector: #resource_Test_view_issue990 ifAbsent: [].
 	self assert: (anonMetaclass respondsTo: #resource_Test_view_issue990) not.
@@ -104,7 +92,6 @@ testResourceSelector
 	self assert: (rid class nameFromSelector: selector) equals: rid name.
 	rid := ResourceIdentifier class: self class name: '1Default:view'.
 	self assert: (rid class selectorFromName: rid name) identicalTo: #resource_1Defaultview! !
-!ResourceIdentifierTest categoriesFor: #createResourceNamed:for:!private!unit tests! !
 !ResourceIdentifierTest categoriesFor: #createResourceNamed:for:on:!private!unit tests! !
 !ResourceIdentifierTest categoriesFor: #setUp!private!unit tests! !
 !ResourceIdentifierTest categoriesFor: #tempViewResource!private!unit tests! !


### PR DESCRIPTION
This modification prompt a message with the offending resource so it will be easy to track the problem.
Without this message it can take a lot of time to find out the offending resource.