### PR TITLE
Backports of some improvements added in 7.2

### DIFF
--- a/Core/Contributions/Camp Smalltalk/SUnit/SUnit.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/SUnit.pax
@@ -34,7 +34,7 @@ Object subclass: #TestCase
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Object subclass: #TestCaseResult
-	instanceVariableNames: 'case outcome duration signal stacktrace'
+	instanceVariableNames: 'case outcome duration signal stacktrace ip testMethod'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Contributions/Camp Smalltalk/SUnit/TestCaseResult.cls
+++ b/Core/Contributions/Camp Smalltalk/SUnit/TestCaseResult.cls
@@ -12,7 +12,7 @@ TestCaseResult comment: 'Represents the results of executing an individual <Test
 
 captureDiagnostics: anException
 	| frame stackStream |
-	stackStream := String smalltalkWriteStream: 512.
+	stackStream := String writeStream: 512.
 	frame := anException raisingFrame.
 	ip := nil.
 	
@@ -47,6 +47,21 @@ diagnostic
 	self printSourceOn: stream.
 	stream nextPutAll: self stacktrace.
 	^stream contents!
+
+displayOn: aPuttableStream
+	aPuttableStream
+		print: self case;
+		nextPutAll: ' (';
+		nextPutAll: self outcome;
+		nextPutAll: ' in '.
+	self outcome == #passed
+		ifTrue: 
+			[self duration printHumanReadableOn: aPuttableStream.
+			aPuttableStream nextPut: $)]
+		ifFalse: 
+			[aPuttableStream nextPutAll: ' in '.
+			self printSourceOn: aPuttableStream.
+			aPuttableStream nextPut: $)]!
 
 duration
 	"Answer the <Duration> of the test execution. If the test didn't pass, the value is undefined."
@@ -102,6 +117,7 @@ stacktrace
 !TestCaseResult categoriesFor: #captureDiagnostics:!initializing!private! !
 !TestCaseResult categoriesFor: #case!accessing!public! !
 !TestCaseResult categoriesFor: #diagnostic!accessing!public! !
+!TestCaseResult categoriesFor: #displayOn:!displaying!public! !
 !TestCaseResult categoriesFor: #duration!accessing!public! !
 !TestCaseResult categoriesFor: #outcome!accessing!public! !
 !TestCaseResult categoriesFor: #printSourceOn:!printing!private! !

--- a/Core/Contributions/Camp Smalltalk/SUnit/TestCaseResult.cls
+++ b/Core/Contributions/Camp Smalltalk/SUnit/TestCaseResult.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #TestCaseResult
-	instanceVariableNames: 'case outcome duration signal stacktrace'
+	instanceVariableNames: 'case outcome duration signal stacktrace ip testMethod'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -10,10 +10,43 @@ TestCaseResult comment: 'Represents the results of executing an individual <Test
 !TestCaseResult categoriesForClass!SUnit! !
 !TestCaseResult methodsFor!
 
+captureDiagnostics: anException
+	| frame stackStream |
+	stackStream := String smalltalkWriteStream: 512.
+	frame := anException raisingFrame.
+	ip := nil.
+	
+	[frame callstackDo: 
+			[:each |
+			"Assume the first TestCase sub-class method is the source of the failure"
+			(ip isNil and: 
+					[| methodClass |
+					methodClass := each method methodClass.
+					methodClass ~~ TestCase and: [methodClass inheritsFrom: TestCase]])
+				ifTrue: 
+					[testMethod := each method.
+					ip := each prevIP].
+			stackStream
+				display: each;
+				cr]
+		depth: -1]
+			on: Error
+			do: [:e | e notify].
+	stacktrace := stackStream contents!
+
 case
 	"Answer the <TestCase> instance for which this object records results."
 
 	^case!
+
+diagnostic
+	"Answer the diagnostic information <String> for the receiver. This includes at least the stacktrace captured when the test failed. It may also include the IP of the assertion and the source of that assertion if these are relevant and available."
+
+	| stream |
+	stream := String writeStream: 512.
+	self printSourceOn: stream.
+	stream nextPutAll: self stacktrace.
+	^stream contents!
 
 duration
 	"Answer the <Duration> of the test execution. If the test didn't pass, the value is undefined."
@@ -25,6 +58,25 @@ outcome
 
 	^outcome!
 
+printSourceOn: aStream
+	| map entry range source |
+	testMethod ifNil: [^self].
+	map := testMethod textMap.
+	entry := map at: (StackFrame findIP: ip inTextMap: map).
+	range := entry value.
+	source := testMethod getSource.
+	range := range intersection: (1 to: source size).
+	source := source copyFrom: range first to: range last.
+	aStream
+		print: testMethod;
+		nextPut: $@;
+		print: entry key;
+		nextPutAll: ': `';
+		display: source;
+		nextPut: $`;
+		cr;
+		cr!
+
 setCase: aTestCase duration: aDuration
 	case := aTestCase.
 	outcome := #passed.
@@ -34,8 +86,8 @@ setCase: aTestCase outcome: aSymbol signal: anException
 	case := aTestCase.
 	outcome := aSymbol.
 	signal := anException.
-	stacktrace := anException stackTrace: -1.
-	duration := 0 seconds!
+	duration := 0 seconds.
+	self captureDiagnostics: anException!
 
 signal
 	"Answer the <Exception> signalled if the test failed or threw an error, or nil if the test
@@ -47,9 +99,12 @@ stacktrace
 	"Answer the stacktrace capture when the test failed/errored, or nil if the test passed."
 
 	^stacktrace! !
+!TestCaseResult categoriesFor: #captureDiagnostics:!initializing!private! !
 !TestCaseResult categoriesFor: #case!accessing!public! !
+!TestCaseResult categoriesFor: #diagnostic!accessing!public! !
 !TestCaseResult categoriesFor: #duration!accessing!public! !
 !TestCaseResult categoriesFor: #outcome!accessing!public! !
+!TestCaseResult categoriesFor: #printSourceOn:!printing!private! !
 !TestCaseResult categoriesFor: #setCase:duration:!initializing!private! !
 !TestCaseResult categoriesFor: #setCase:outcome:signal:!initializing!private! !
 !TestCaseResult categoriesFor: #signal!accessing!public! !

--- a/Core/Object Arts/Dolphin/Base/Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Character.cls
@@ -53,7 +53,7 @@ At present only byte characters (that are not control characters) have a printab
 !Character methodsFor!
 
 _beginsString: aString
-	^aString readStream peek = self!
+	^aString first = self!
 
 _separateSubStringsIn: tokens
 	| start answer size end codeUnits |

--- a/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Base (Deprecated).pax
@@ -867,12 +867,12 @@ setFilePointer: aHandle lDistanceToMove: loInteger lpDistanceToMoveHigh: anAddre
 	^self invalidCall: _failureCode! !
 !KernelLibrary categoriesFor: #compareStringOrdinal:cchCount1:lpString2:cchCount2:bIgnoreCase:!public!win32 functions-national language support! !
 !KernelLibrary categoriesFor: #getDateFormat:dwFlags:lpDate:lpFormat:lpDateStr:cchDate:!public!win32 functions-national language support! !
-!KernelLibrary categoriesFor: #getFileSize:lpFileSizeHigh:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #getFileSize:lpFileSizeHigh:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #getTimeFormat:dwFlags:lpTime:lpFormat:lpTimeStr:cchBuf:!public!win32 functions-national language support! !
 !KernelLibrary categoriesFor: #getVersionEx:!public!win32 functions-system information! !
 !KernelLibrary categoriesFor: #lstrcmp:lpString2:!public!win32 functions-string manipulation! !
 !KernelLibrary categoriesFor: #lstrcmpi:lpString2:!public!win32 functions-string manipulation! !
-!KernelLibrary categoriesFor: #setFilePointer:lDistanceToMove:lpDistanceToMoveHigh:dwMoveMethod:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #setFilePointer:lDistanceToMove:lpDistanceToMoveHigh:dwMoveMethod:!public!win32 functions-file management! !
 
 !KernelLibrary class methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -933,7 +933,7 @@ writeJunitTestLog: aTestSuite result: aTestResult
 						at: 'message' put: each signal description;
 						at: 'type' put: each signal class name;
 						free.
-					errorNode text: each stacktrace.
+					errorNode text: each diagnostic.
 					errorNode free].
 			outcome == #failed
 				ifTrue: 
@@ -944,7 +944,7 @@ writeJunitTestLog: aTestSuite result: aTestResult
 						at: 'message' put: each signal description;
 						at: 'type' put: each signal class name;
 						free.
-					failureNode text: each stacktrace.
+					failureNode text: each diagnostic.
 					failureNode free].
 			outcome == #skipped
 				ifTrue: 

--- a/Core/Object Arts/Dolphin/Base/File.cls
+++ b/Core/Object Arts/Dolphin/Base/File.cls
@@ -264,6 +264,16 @@ openFlags
 
 	^flags bitAnd: OpenFlagsMask!
 
+pathName
+	"Answer the actual path name of the open file."
+
+	| kernel size buf |
+	kernel := KernelLibrary default.
+	size := kernel getFinalPathNameByHandle: handle lpszFilePath: nil cchFilePath: 0 dwFlags: 0.
+	buf := Utf16String newFixed: size - 1.
+	kernel getFinalPathNameByHandle: handle lpszFilePath: buf cchFilePath: size dwFlags: 0.
+	^buf!
+
 position
 	"Answer the absolute Integer position of the reciver's file pointer
 	or signal a FileException if the operation fails."
@@ -532,6 +542,7 @@ writeByte: anIntegerOrCharacter
 !File categoriesFor: #open:flags:share:!operations!private! !
 !File categoriesFor: #open:mode:check:share:!operations!public! !
 !File categoriesFor: #openFlags!accessing!private! !
+!File categoriesFor: #pathName!accessing!public! !
 !File categoriesFor: #position!positioning!public! !
 !File categoriesFor: #position:!operations!positioning!public! !
 !File categoriesFor: #printOn:!printing!public! !

--- a/Core/Object Arts/Dolphin/Base/FileTest.cls
+++ b/Core/Object Arts/Dolphin/Base/FileTest.cls
@@ -343,6 +343,13 @@ testMakePath
 						with: split second))
 		equals: filename!
 
+testPathName
+	| expected actual |
+	"We'll get a long path name"
+	expected := '\\?\', (File change: SessionManager current imageFileName extension: 'chg').
+	actual := SourceManager default changesStream file pathName.
+	self assert: actual equals: expected!
+
 testRemoveDirectory
 	self createTestDirectories.
 	
@@ -559,6 +566,7 @@ testSplitStemFrom
 !FileTest categoriesFor: #testDeleteDirectory!public!unit tests! !
 !FileTest categoriesFor: #testForDirectoriesIn!public!unit tests! !
 !FileTest categoriesFor: #testMakePath!public!unit tests! !
+!FileTest categoriesFor: #testPathName!public!unit tests! !
 !FileTest categoriesFor: #testRemoveDirectory!public!unit tests! !
 !FileTest categoriesFor: #testRemoveExtension!public!unit tests! !
 !FileTest categoriesFor: #testRemovePathDelimiter!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/KernelLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/KernelLibrary.cls
@@ -676,6 +676,17 @@ getFileType: anExternalHandle
 	<stdcall: dword GetFileType handle>
 	^self invalidCall: _failureCode!
 
+getFinalPathNameByHandle: hFile lpszFilePath: lpszFilePath cchFilePath: cchFilePath dwFlags: dwFlags
+	"DWORD GetFinalPathNameByHandleW(
+		HANDLE hFile,
+		LPSTR  lpszFilePath,
+		DWORD  cchFilePath,
+		DWORD  dwFlags
+	);"
+
+	<stdcall: dword GetFinalPathNameByHandleW handle lpwstr dword dword>
+	^self invalidCall: _failureCode!
+
 getFullPathName: fname nBufferLength: anInteger lpBuffer: path lpFilePart: aDWORD
 	"Retrieves the full path and filename of the file with name fname, into the buffer, path.
 
@@ -1645,14 +1656,14 @@ zeroMemory: pvDest length: cBytes
 !KernelLibrary categoriesFor: #close!public!realizing/unrealizing! !
 !KernelLibrary categoriesFor: #closeHandle:!public!win32 functions-handles and objects! !
 !KernelLibrary categoriesFor: #compareString:dwCmpFlags:lpString1:cchCount1:lpString2:cchCount2:!public!win32 functions-national language support! !
-!KernelLibrary categoriesFor: #copyFile:lpNewFileName:bfailIfExists:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #copyFile:lpNewFileName:bfailIfExists:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #copyMemory:source:length:!public!win32 functions-memory management! !
-!KernelLibrary categoriesFor: #createDirectory:lpSecurityAttributes:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #createDirectory:lpSecurityAttributes:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #createEvent:bManualReset:bInitialState:lpName:!**auto generated**!public!win32 functions-synchronization! !
-!KernelLibrary categoriesFor: #createFile:dwDesiredAccess:dwSharedMode:lpSecurityAttributes:dwCreationDistribution:dwFlagsAndAttributes:hTemplateFile:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #createFile:dwDesiredAccess:dwSharedMode:lpSecurityAttributes:dwCreationDistribution:dwFlagsAndAttributes:hTemplateFile:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #createMutex:bInitialOwner:lpName:!**auto generated**!public!win32 functions-synchronization! !
 !KernelLibrary categoriesFor: #debugBreak!**auto generated**!public!win32 functions-debugging! !
-!KernelLibrary categoriesFor: #deleteFile:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #deleteFile:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #deviceIoControl:dwIoControlCode:lpInBuffer:nInBufferSize:lpOutBuffer:nOutBufferSize:lpBytesReturned:lpoverlapped:!public! !
 !KernelLibrary categoriesFor: #duplicateHandle:hSourceHandle:hTargetProcessHandle:lpTargetHandle:dwDesiredAccess:bInheritHandle:dwOptions:!public!win32 functions-handles and objects! !
 !KernelLibrary categoriesFor: #endUpdateResource:fDiscard:!public!win32 functions-resource! !
@@ -1664,11 +1675,11 @@ zeroMemory: pvDest length: cBytes
 !KernelLibrary categoriesFor: #expandEnvironmentStrings:lpDst:nSize:!public!win32 functions-process and thread! !
 !KernelLibrary categoriesFor: #fileTimeToLocalTime:lpLocalFileTime:!public!win32 functions-date and time! !
 !KernelLibrary categoriesFor: #fileTimeToSystemTime:lpSystemTime:!public!win32 functions-date and time! !
-!KernelLibrary categoriesFor: #findClose:!public!win32 functions-file! !
-!KernelLibrary categoriesFor: #findFirstFile:lpFindFileData:!public!win32 functions-file! !
-!KernelLibrary categoriesFor: #findNextFile:lpFindFileData:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #findClose:!public!win32 functions-file management! !
+!KernelLibrary categoriesFor: #findFirstFile:lpFindFileData:!public!win32 functions-file management! !
+!KernelLibrary categoriesFor: #findNextFile:lpFindFileData:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #findResource:lpName:lpType:!public!win32 functions-resource! !
-!KernelLibrary categoriesFor: #flushFileBuffers:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #flushFileBuffers:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #formatMessage:lpSource:dwMessageId:dwLanguageId:lpBuffer:nSize:arguments:!public!win32 functions-error! !
 !KernelLibrary categoriesFor: #formatMessage:source:flags:withArguments:!helpers!public! !
 !KernelLibrary categoriesFor: #freeConsole!**auto generated**!public!win32 functions-console! !
@@ -1683,14 +1694,15 @@ zeroMemory: pvDest length: cBytes
 !KernelLibrary categoriesFor: #getCurrentProcess!public!win32 functions-process and thread! !
 !KernelLibrary categoriesFor: #getCurrentThread!public!win32 functions-process and thread! !
 !KernelLibrary categoriesFor: #getCurrentThreadId!public!win32 functions-process and thread! !
-!KernelLibrary categoriesFor: #getDiskFreeSpace:lpSectorsPerCluster:lpBytesPerSector:lpNumberOfFreeClusters:lpTotalNumberOfClusters:!public!win32 functions-file system! !
+!KernelLibrary categoriesFor: #getDiskFreeSpace:lpSectorsPerCluster:lpBytesPerSector:lpNumberOfFreeClusters:lpTotalNumberOfClusters:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #getDiskFreeSpaceEx:lpFreeBytesAvailable:lpTotalNumberOfBytes:lpTotalNumberOfFreeBytes:!public!win32 functions-file system! !
 !KernelLibrary categoriesFor: #getEnvironmentVariable:lpBuffer:nSize:!public!win32 functions-process and thread! !
-!KernelLibrary categoriesFor: #getFileAttributes:!public!win32 functions-file! !
-!KernelLibrary categoriesFor: #getFileSizeEx:lpFileSize:!**auto generated**!public!win32 functions-file! !
-!KernelLibrary categoriesFor: #getFileTime:lpCreationTime:lpLastAccessTime:lpLastWriteTime:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #getFileAttributes:!public!win32 functions-file management! !
+!KernelLibrary categoriesFor: #getFileSizeEx:lpFileSize:!**auto generated**!public!win32 functions-file management! !
+!KernelLibrary categoriesFor: #getFileTime:lpCreationTime:lpLastAccessTime:lpLastWriteTime:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #getFileType:!public!win32 functions-file system! !
-!KernelLibrary categoriesFor: #getFullPathName:nBufferLength:lpBuffer:lpFilePart:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #getFinalPathNameByHandle:lpszFilePath:cchFilePath:dwFlags:!public!win32 functions-file management! !
+!KernelLibrary categoriesFor: #getFullPathName:nBufferLength:lpBuffer:lpFilePart:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #getLastError!public!win32 functions-error! !
 !KernelLibrary categoriesFor: #getLocaleInfo:lCType:lpLCData:cchData:!public!win32 functions-national language support! !
 !KernelLibrary categoriesFor: #getLocalTime:!public!win32 functions-date and time! !
@@ -1700,7 +1712,7 @@ zeroMemory: pvDest length: cBytes
 !KernelLibrary categoriesFor: #getProcAddress:lpProcName:!public!win32 functions-dynamic link library! !
 !KernelLibrary categoriesFor: #getProcAddressDWORD:lpProcName:!private!win32 functions-dynamic link library! !
 !KernelLibrary categoriesFor: #getProcessHeap!public!win32 functions-memory management! !
-!KernelLibrary categoriesFor: #getShortPathName:lpszShortPath:cchBuffer:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #getShortPathName:lpszShortPath:cchBuffer:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #getStdHandle:!public!win32 functions-console! !
 !KernelLibrary categoriesFor: #getSystemDefaultLCID!public!win32 functions-national language support! !
 !KernelLibrary categoriesFor: #getSystemDirectory:uSize:!public!win32 functions-system information! !
@@ -1708,8 +1720,8 @@ zeroMemory: pvDest length: cBytes
 !KernelLibrary categoriesFor: #getSystemTimeAsFileTime:!**auto generated**!public!win32 functions-date and time! !
 !KernelLibrary categoriesFor: #getSystemTimePreciseAsFileTime:!**auto generated**!public!win32 functions-date and time! !
 !KernelLibrary categoriesFor: #getSystemWindowsDirectory:uSize:!public!win32 functions-system information! !
-!KernelLibrary categoriesFor: #getTempFileName:lpPrefixString:uUnique:lpTempFileName:!public!win32 functions-file! !
-!KernelLibrary categoriesFor: #getTempPath:lpBuffer:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #getTempFileName:lpPrefixString:uUnique:lpTempFileName:!public!win32 functions-file management! !
+!KernelLibrary categoriesFor: #getTempPath:lpBuffer:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #getThreadTimes:lpCreationTime:lpExitTime:lpKernelTime:lpUserTime:!public!win32 functions-process and thread! !
 !KernelLibrary categoriesFor: #getTickCount!public!win32 functions-date and time!win32 functions-system information! !
 !KernelLibrary categoriesFor: #getTimeZoneInformation:!public!win32 functions-date and time! !
@@ -1735,8 +1747,8 @@ zeroMemory: pvDest length: cBytes
 !KernelLibrary categoriesFor: #localFree:!**auto generated**!public!win32 functions-memory management! !
 !KernelLibrary categoriesFor: #lockResource:!public!win32 functions-resource! !
 !KernelLibrary categoriesFor: #lstrlenW:!public!win32 functions-string manipulation! !
-!KernelLibrary categoriesFor: #moveFile:lpNewFileName:!public!win32 functions-file! !
-!KernelLibrary categoriesFor: #moveFileEx:lpNewFileName:dwFlags:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #moveFile:lpNewFileName:!public!win32 functions-file management! !
+!KernelLibrary categoriesFor: #moveFileEx:lpNewFileName:dwFlags:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #multiByteToWideChar:dwFlags:lpMultiByteStr:cchMultiByte:lpWideCharStr:cchWideChar:!public!win32 functions-string manipulation! !
 !KernelLibrary categoriesFor: #openProcess:bInheritHandle:dwProcessId:!public!win32 functions-process and thread! !
 !KernelLibrary categoriesFor: #outputDebugString:!public!win32 functions-debugging! !
@@ -1744,18 +1756,18 @@ zeroMemory: pvDest length: cBytes
 !KernelLibrary categoriesFor: #queryPerformanceCounter:!public!win32 functions-performance monitoring! !
 !KernelLibrary categoriesFor: #queryPerformanceFrequency:!public!win32 functions-performance monitoring! !
 !KernelLibrary categoriesFor: #raiseException:dwExceptionFlags:nNumberOfArguments:lpArguments:!**auto generated**!public! !
-!KernelLibrary categoriesFor: #readFile:lpBuffer:nNumberOfBytesToRead:lpNumberOfBytesRead:lpOverlapped:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #readFile:lpBuffer:nNumberOfBytesToRead:lpNumberOfBytesRead:lpOverlapped:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #releaseMutex:!**auto generated**!public!win32 functions-synchronization! !
-!KernelLibrary categoriesFor: #removeDirectory:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #removeDirectory:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #resetEvent:!**auto generated**!public!win32 functions-synchronization! !
 !KernelLibrary categoriesFor: #setConsoleCP:!**auto generated**!public!win32 functions-console! !
 !KernelLibrary categoriesFor: #setConsoleCtrlHandler:add:!public!win32 functions-console! !
 !KernelLibrary categoriesFor: #setConsoleOutputCP:!**auto generated**!public!win32 functions-console! !
 !KernelLibrary categoriesFor: #setConsoleTitle:!**auto generated**!public! !
-!KernelLibrary categoriesFor: #setEndOfFile:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #setEndOfFile:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #setEnvironmentVariable:lpValue:!public!win32 functions-process and thread! !
 !KernelLibrary categoriesFor: #setEvent:!**auto generated**!public!win32 functions-synchronization! !
-!KernelLibrary categoriesFor: #setFilePointerEx:liDistanceToMove:lpNewFilePointer:dwMoveMethod:!**auto generated**!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #setFilePointerEx:liDistanceToMove:lpNewFilePointer:dwMoveMethod:!**auto generated**!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #setLastError:!public!win32 functions-error! !
 !KernelLibrary categoriesFor: #setStdHandle:hHandle:!public!win32 functions-console! !
 !KernelLibrary categoriesFor: #setVolumeLabel:lpVolumeName:!public!win32 functions-file system! !
@@ -1778,7 +1790,7 @@ zeroMemory: pvDest length: cBytes
 !KernelLibrary categoriesFor: #waitForSingleObject:dwMilliseconds:!**auto generated**!public!win32 functions-synchronization! !
 !KernelLibrary categoriesFor: #wideCharToMultiByte:dwFlags:lpWideCharStr:cchWideChar:lpMultiByteStr:cchMultiByte:lpDefaultChar:lpUsedDefaultChar:!public!win32 functions-string manipulation! !
 !KernelLibrary categoriesFor: #winExec:uCmdShow:!public!win32 functions-process and thread! !
-!KernelLibrary categoriesFor: #writeFile:lpBuffer:nNumberOfBytesToWrite:lpNumberOfBytesWritten:lpOverlapped:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #writeFile:lpBuffer:nNumberOfBytesToWrite:lpNumberOfBytesWritten:lpOverlapped:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #zeroMemory:length:!public!win32 functions-memory management! !
 
 !KernelLibrary class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/StackFrame.cls
+++ b/Core/Object Arts/Dolphin/Base/StackFrame.cls
@@ -158,44 +158,40 @@ callstackDo: aMonadicValuable depth: anInteger
 			frame := frame sender.
 			i := i - 1]!
 
-debugPrintString
-	^self basicPrintString!
-
-displayOn: aStream
-	"Append a short textual description of the receiver to aStream appropriate
-	for displaying in a stack trace."
+displayOn: aPuttableStream
+	"Append to the <puttableStream> first argument a String whose characters are a representation of the receiver that a user would want to see."
 
 	"Display processing will fail if this stack frame is dead"
 
 	| method class mClass selector |
 	self isDead
 		ifTrue: 
-			[aStream nextPutAll: self basicPrintString.
+			[aPuttableStream nextPutAll: self basicPrintString.
 			^self].
 	method := self method.
 	mClass := method methodClass.
 	self receiver
 		ifNil: 
 			["Assume a block which has no receiver refs"
-			aStream display: mClass]
+			aPuttableStream display: mClass]
 		ifNotNil: 
 			[:receiver |
 			class := receiver basicClass.	"Use basic class to avoid deref'ing proxies"
-			aStream nextPutAll: class name.
+			aPuttableStream nextPutAll: class name.
 			mClass == class
 				ifFalse: 
-					[aStream
+					[aPuttableStream
 						nextPut: $(;
 						display: mClass name;
 						nextPut: $)]].
-	aStream nextPutAll: '>>'.
+	aPuttableStream nextPutAll: '>>'.
 	selector := method selector.
 	method isUnbound
 		ifTrue: 
 			["Method is unbound if it is either not in the class' method dictionary, or it doesn't have the same
 			source as that currently in the dictionary"
-			aStream nextPutAll: '{unbound}'].
-	aStream nextPutAll: selector!
+			aPuttableStream nextPutAll: '{unbound}'].
+	aPuttableStream nextPutAll: selector!
 
 environment
 	"Private - Answer the environment associated with the stack frame, if any.
@@ -344,7 +340,10 @@ method: aCompiledMethod
 outer
 	^self environment!
 
-printOn: aStream 
+prevIP
+	^self method byteCodeDispatcher prevIP: self ip!
+
+printOn: aStream
 	self displayOn: aStream.
 	aStream
 		nextPutAll: ' @ ';
@@ -465,7 +464,6 @@ textMap
 !StackFrame categoriesFor: #bp!accessing!private! !
 !StackFrame categoriesFor: #bp:!accessing!private! !
 !StackFrame categoriesFor: #callstackDo:depth:!private! !
-!StackFrame categoriesFor: #debugPrintString!public! !
 !StackFrame categoriesFor: #displayOn:!printing!public! !
 !StackFrame categoriesFor: #environment!accessing!private! !
 !StackFrame categoriesFor: #environment:!accessing!private! !
@@ -489,6 +487,7 @@ textMap
 !StackFrame categoriesFor: #method!accessing!private! !
 !StackFrame categoriesFor: #method:!accessing!private! !
 !StackFrame categoriesFor: #outer!accessing!private! !
+!StackFrame categoriesFor: #prevIP!accessing!private! !
 !StackFrame categoriesFor: #printOn:!public! !
 !StackFrame categoriesFor: #printStackOn:depth:!public! !
 !StackFrame categoriesFor: #process!accessing!private! !
@@ -508,6 +507,17 @@ textMap
 !StackFrame categoriesFor: #textMap!accessing!development!private! !
 
 !StackFrame class methodsFor!
+
+findIP: anInteger inTextMap: aTextMap
+	"Private - Answer the index of the source map entry corresponding to the
+    	specified <integer> ip. The key of each text map entry identifies the first IP of the code generated for the range
+	of source which is held as the <interval> value."
+
+	| i size |
+	i := 1.
+	size := aTextMap size.
+	[i < size and: [anInteger > (aTextMap at: i) key]] whileTrue: [i := i + 1].
+	^i!
 
 frameClassFor: aProcess at: anInteger
 	"Private - Answer the subclass of the receiver to use to represent a stack frame in aProcess
@@ -530,6 +540,7 @@ process: aProcess index: anInteger
 
 	^(self frameClassFor: aProcess at: anInteger)
 		ifNotNil: [:frameClass | frameClass onProcess: aProcess index: anInteger]! !
+!StackFrame class categoriesFor: #findIP:inTextMap:!helpers!private! !
 !StackFrame class categoriesFor: #frameClassFor:at:!instance creation!private! !
 !StackFrame class categoriesFor: #onProcess:index:!instance creation!private! !
 !StackFrame class categoriesFor: #process:index:!instance creation!public! !

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -1734,9 +1734,9 @@ withAll: aCollectionOfCharacters
 	"Answer a new instance of the receiver containing all of the <Character> elements of the <collection>, aCollectionOfCharacters."
 
 	| stream |
-	stream := self writeStream: 10.
-	aCollectionOfCharacters readStream do: [:each | stream nextPut: each].
-	^stream contents! !
+	stream := self writeStream: aCollectionOfCharacters size.
+	aCollectionOfCharacters do: [:each | stream nextPut: each].
+	^stream grabContents! !
 !String class categoriesFor: #ansiClass!constants!public! !
 !String class categoriesFor: #basicEncoding!accessing!public! !
 !String class categoriesFor: #characterForCodeUnit:!enquiries!public! !

--- a/Core/Object Arts/Dolphin/Base/StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StringTest.cls
@@ -66,7 +66,7 @@ testAfter
 		should: [(self assimilateString: 'ab') after: $b]
 		raise: Error
 		matching: [:ex | ex description = '$b is my last object'].
-	self should: [(self assimilateString: '') after: $a] raise: NotFoundError.
+	self should: [self collectionClass empty after: $a] raise: NotFoundError.
 	self should: [(self assimilateString: 'a') after: $b] raise: NotFoundError!
 
 testAsByteArray
@@ -80,7 +80,7 @@ testAsByteArray
 				= (self newCopy: each)]!
 
 testAt
-	self assert: ((self newCollection: 'Hello') at: 1) equals: $H!
+	self assert: ((self assimilateString: 'Hello') at: 1) equals: $H!
 
 testBefore
 	self beforeTestCases do: 
@@ -95,29 +95,29 @@ testBefore
 		should: [(self assimilateString: 'ab') before: $a]
 		raise: Error
 		matching: [:ex | ex description = '$a is my first object'].
-	self should: [(self assimilateString: '') before: $a] raise: NotFoundError.
+	self should: [self collectionClass empty before: $a] raise: NotFoundError.
 	self should: [(self assimilateString: 'a') before: $b] raise: NotFoundError!
 
 testCapitalized
 	| string cap |
-	string := self assimilateString: ''.
+	string := self collectionClass empty.
 	self assert: string capitalized equals: string.
-	string := self newCollection: 'a'.
+	string := self assimilateString: 'a'.
 	cap := string capitalized.
-	self assert: cap equals: (self newCollection: 'A').
-	self assert: string equals: (self newCollection: 'a').
-	string := self newCollection: 'A'.
+	self assert: cap equals: (self assimilateString: 'A').
+	self assert: string equals: (self assimilateString: 'a').
+	string := self assimilateString: 'A'.
 	cap := string capitalized.
-	self assert: cap equals: (self newCollection: 'A').
-	self assert: string equals: (self newCollection: 'A').
-	string := self newCollection: 'ab'.
+	self assert: cap equals: (self assimilateString: 'A').
+	self assert: string equals: (self assimilateString: 'A').
+	string := self assimilateString: 'ab'.
 	cap := string capitalized.
-	self assert: cap equals: (self newCollection: 'Ab').
-	self assert: string equals: (self newCollection: 'ab').
-	string := self newCollection: 'Ab'.
+	self assert: cap equals: (self assimilateString: 'Ab').
+	self assert: string equals: (self assimilateString: 'ab').
+	string := self assimilateString: 'Ab'.
 	cap := string capitalized.
-	self assert: cap equals: (self newCollection: 'Ab').
-	self assert: string equals: (self newCollection: 'Ab')!
+	self assert: cap equals: (self assimilateString: 'Ab').
+	self assert: string equals: (self assimilateString: 'Ab')!
 
 testCaseConversions
 	| subject actual expected |
@@ -205,47 +205,47 @@ testEquals
 
 testFindStringStartingAt
 	| searchee abc a empty ba ab bb bba abba |
-	searchee := self newCollection: 'a£cdefga£cdef'.
-	abc := self newCollection: 'a£c'.
+	searchee := self assimilateString: 'a£cdefga£cdef'.
+	abc := self assimilateString: 'a£c'.
 	self assert: (searchee findString: abc startingAt: 1) equals: 1.
 	self assert: (searchee findString: abc startingAt: 2) equals: (searchee lastIndexOf: $£) - 1.
 	self assert: (searchee findString: abc startingAt: searchee size) equals: 0.
 	self assert: (searchee findString: abc startingAt: 11) equals: 0.
 	self assert: (searchee findString: abc startingAt: 1) equals: 1.
-	searchee := self newCollection: 'aabcabc'.
+	searchee := self assimilateString: 'aabcabc'.
 	self assert: (searchee findString: abc startingAt: 6) equals: 0.
-	a := self newCollection: 'a'.
-	empty := self newCollection: ''.
+	a := self assimilateString: 'a'.
+	empty := self collectionClass empty.
 	self assert: (empty findString: a startingAt: 1) equals: 0.
 	self assert: ('b' findString: a startingAt: 1) equals: 0.
 	self assert: (a findString: a startingAt: 1) equals: 1.
 
 	"Search for empty string, should return zero"
 	self assert: (a findString: empty startingAt: 1) equals: 0.
-	ba := self newCollection: 'ba'.
+	ba := self assimilateString: 'ba'.
 	self assert: (ba findString: a startingAt: 1) equals: 2.
-	ab := self newCollection: 'ab'.
+	ab := self assimilateString: 'ab'.
 	self assert: (ab findString: a startingAt: 1) equals: 1.
-	bb := self newCollection: 'bb'.
+	bb := self assimilateString: 'bb'.
 	self assert: (bb findString: a startingAt: 1) equals: 0.
-	bba := self newCollection: 'bba'.
+	bba := self assimilateString: 'bba'.
 	self assert: (bba findString: a startingAt: 1) equals: 3.
 	self assert: (bba findString: a startingAt: 2) equals: 3.
 	self assert: (bba findString: a startingAt: 3) equals: 3.
-	abba := self newCollection: 'abba'.
+	abba := self assimilateString: 'abba'.
 	self assert: (abba findString: ab startingAt: 3) equals: 0.
 	self assert: (abba findString: ab startingAt: 4) equals: 0.
 	self assert: (abba findString: ab startingAt: 2) equals: 0.
 	self assert: (abba findString: ab startingAt: 1) equals: 1.
 	searchee := self
-				newCollection: 'Now''s the time for all good men to come to the aid of their country.'.
-	self assert: (searchee findString: (self newCollection: 'time') startingAt: 1) equals: 11.
-	self assert: (searchee findString: (self newCollection: 'timid') startingAt: 1) equals: 0.
-	self assert: (searchee findString: (self newCollection: 'try') startingAt: 1) equals: 65.
-	searchee := self newCollection: 'babcbabcabcaabcabcabcacabc'.
+				assimilateString: 'Now''s the time for all good men to come to the aid of their country.'.
+	self assert: (searchee findString: (self assimilateString: 'time') startingAt: 1) equals: 11.
+	self assert: (searchee findString: (self assimilateString: 'timid') startingAt: 1) equals: 0.
+	self assert: (searchee findString: (self assimilateString: 'try') startingAt: 1) equals: 65.
+	searchee := self assimilateString: 'babcbabcabcaabcabcabcacabc'.
 	self assert: (searchee findString: 'abcabcacab' startingAt: 1) equals: 16.
-	searchee := self newCollection: 'aaaaaaabcabcadefg'.
-	self assert: (searchee findString: (self newCollection: 'abcad') startingAt: 1) equals: 10.
+	searchee := self assimilateString: 'aaaaaaabcabcadefg'.
+	self assert: (searchee findString: (self assimilateString: 'abcad') startingAt: 1) equals: 10.
 	self assert: (searchee findString: ab startingAt: 1) equals: 7!
 
 testFindStringStartingAtIgnoreCase
@@ -437,7 +437,7 @@ testIndexOfStartingAt
 
 testInvalidComparisons
 	| str literals |
-	str := self newCollection: 'blah'.
+	str := self assimilateString: 'blah'.
 	literals := #(1.0 1 16rFFFFFFFF 1s2 $a #()).
 	literals do: [:each | self deny: str equals: each].
 	literals do: [:each | self deny: str equals: each].
@@ -470,11 +470,15 @@ testLength
 testLines
 	| subject crlf actual empty |
 	crlf := String lineDelimiter.
-	subject := self newCollection: 'A' , crlf , crlf , 'bc' , crlf , ' ' , crlf.
+	subject := self assimilateString: 'A' , crlf , crlf , 'bc' , crlf , ' ' , crlf.
 	actual := subject lines.
-	empty := self newCollection: ''.
+	empty := self collectionClass empty.
 	self assert: actual
-		equals: {self newCollection: 'A'. empty. self newCollection: 'bc'. self newCollection: ' '. empty}!
+		equals: {self assimilateString: 'A'.
+				empty.
+				self assimilateString: 'bc'.
+				self assimilateString: ' '.
+				empty}!
 
 testMutableCopy
 	self caseConversionCases do: 
@@ -528,47 +532,47 @@ testSplitByString
 	"Test String>>split:, which tokenizes the argument string into sequences that are separated by the receiver string."
 
 	| sep empty |
-	empty := self newCollection: ''.
+	empty := self collectionClass empty.
 	"The separator but must not be empty"
-	self should: [empty split: (self newCollection: 'abc')] raise: Error.
+	self should: [empty split: (self assimilateString: 'abc')] raise: Error.
 
 	"And again but using a string argument of more than one character"
-	sep := self newCollection: String lineDelimiter.
-	self assert: (sep split: empty) equals: (#() collect: [:e | self newCollection: e]).
-	self assert: (sep split: (self newCollection: 'a'))
-		equals: (#('a') collect: [:e | self newCollection: e]).
-	self assert: (sep split: (self newCollection: sep , 'a'))
+	sep := self assimilateString: String lineDelimiter.
+	self assert: (sep split: empty) equals: (#() collect: [:e | self assimilateString: e]).
+	self assert: (sep split: (self assimilateString: 'a'))
+		equals: (#('a') collect: [:e | self assimilateString: e]).
+	self assert: (sep split: (self assimilateString: sep , 'a'))
 		equals: (#('' 'a') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: 'a' , sep))
+	self assert: (sep split: (self assimilateString: 'a' , sep))
 		equals: (#('a' '') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: sep , sep , 'a'))
+	self assert: (sep split: (self assimilateString: sep , sep , 'a'))
 		equals: (#('' '' 'a') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: 'a' , sep , sep))
+	self assert: (sep split: (self assimilateString: 'a' , sep , sep))
 		equals: (#('a' '' '') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: 'ab'))
-		equals: (#('ab') collect: [:e | self newCollection: e]).
-	self assert: (sep split: (self newCollection: sep , 'ab'))
+	self assert: (sep split: (self assimilateString: 'ab'))
+		equals: (#('ab') collect: [:e | self assimilateString: e]).
+	self assert: (sep split: (self assimilateString: sep , 'ab'))
 		equals: (#('' 'ab') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: 'ab' , sep))
+	self assert: (sep split: (self assimilateString: 'ab' , sep))
 		equals: (#('ab' '') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: 'ab' , sep , sep , sep))
+	self assert: (sep split: (self assimilateString: 'ab' , sep , sep , sep))
 		equals: (#('ab' '' '' '') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: sep , sep , 'ab'))
+	self assert: (sep split: (self assimilateString: sep , sep , 'ab'))
 		equals: (#('' '' 'ab') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: 'a' , sep , 'b'))
+	self assert: (sep split: (self assimilateString: 'a' , sep , 'b'))
 		equals: (#('a' 'b') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: 'a' , sep , sep , 'b'))
+	self assert: (sep split: (self assimilateString: 'a' , sep , sep , 'b'))
 		equals: (#('a' '' 'b') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: 'ab' , sep , 'c' , sep))
+	self assert: (sep split: (self assimilateString: 'ab' , sep , 'c' , sep))
 		equals: (#('ab' 'c' '') collect: [:e | self newCopy: e]).
-	self assert: (sep split: (self newCollection: 'a' , sep , 'b' , sep , sep , 'c'))
+	self assert: (sep split: (self assimilateString: 'a' , sep , 'b' , sep , sep , 'c'))
 		equals: (#('a' 'b' '' 'c') collect: [:e | self newCopy: e]).
 	1 to: 3
 		do: 
 			[:i |
 			| subject |
 			subject := self
-						newCollection: (String streamContents: [:strm | i timesRepeat: [strm nextPutAll: 'ab']]).
+						assimilateString: (String streamContents: [:strm | i timesRepeat: [strm nextPutAll: 'ab']]).
 			self assert: ('ab' split: subject) equals: (Array new: i + 1 withAll: empty)]!
 
 testSplitSingle
@@ -753,7 +757,7 @@ testTrimNulls
 	string := self newCollection: #($a $\0 $\0).
 	trimmed := string trimNulls.
 	self assert: trimmed size equals: 1.
-	self assert: (self newCollection: trimmed) equals: (self newCollection: 'a')!
+	self assert: (self assimilateString: trimmed) equals: (self assimilateString: 'a')!
 
 testUrlDecoded
 	"Test URI decoding per RFC3986"
@@ -846,20 +850,20 @@ testWithAll
 	self withAllTestCases do: 
 			[:each |
 			| actual |
-			actual := self collectionClass withAll: each.
-			self assert: actual equals: each]!
+			actual := self collectionClass withAll: each first.
+			self assert: actual equals: each last]!
 
 testWithNormalizedLineDelimiters
 	"Empty"
 
 	| cr lf crlf char |
-	char := self newCollection: '+'.
-	cr := self newCollection: (self collectionClass with: Character cr).
-	crlf := self newCollection: self collectionClass lineDelimiter.
-	lf := self newCollection: (self collectionClass with: Character lf).
-	self assert: (self newCollection: '') withNormalizedLineDelimiters equals: (self newCopy: '').
+	char := self assimilateString: '+'.
+	cr := self collectionClass with: Character cr.
+	crlf := self assimilateString: self collectionClass lineDelimiter.
+	lf := self collectionClass with: Character lf.
+	self assert: self collectionClass empty withNormalizedLineDelimiters equals: (self newCopy: '').
 	"Not empty, but no delims"
-	self assert: (self newCollection: '') withNormalizedLineDelimiters equals: (self newCopy: '').
+	self assert: self collectionClass empty withNormalizedLineDelimiters equals: (self newCopy: '').
 	"Single CR"
 	self assert: cr withNormalizedLineDelimiters equals: (self newCopy: crlf).
 	self assert: (char , cr) withNormalizedLineDelimiters equals: char , crlf.
@@ -902,7 +906,7 @@ verifyConcatenationResult: resultString of: receiverString with: argumentString
 	self assert: resultString equals: expected!
 
 withAllTestCases
-	^#('' 'a' 'abc' '£€')! !
+	^#(#('') #('a') #('abc') #('£€') #(#($a $£ $1 $\x20AC) 'a£1€'))! !
 !StringTest categoriesFor: #afterTestCases!constants!private! !
 !StringTest categoriesFor: #assimilate:!helpers!private! !
 !StringTest categoriesFor: #assimilateString:!helpers!private! !

--- a/Core/Object Arts/Dolphin/Base/UtfEncodedStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/UtfEncodedStringTest.cls
@@ -534,7 +534,10 @@ testWithDo
 	self should: [subject with: (1 to: 4) do: [:a :b | ]] raise: Error!
 
 withAllTestCases
-	^super withAllTestCases , #('a 🐬 test' 'Приве́т नमस्ते שָׁלוֹם' 'áèȋöû')! !
+	^super withAllTestCases , {{'a 🐬 è' asUtf16String}.
+				{'a 🐬 è' asUtf8String}.
+				#('Приве́т नमस्ते שָׁלוֹם').
+				#('áèȋöû')}! !
 !UtfEncodedStringTest categoriesFor: #afterTestCases!constants!private! !
 !UtfEncodedStringTest categoriesFor: #beforeTestCases!constants!private! !
 !UtfEncodedStringTest categoriesFor: #caseConversionCases!constants!private! !

--- a/Core/Object Arts/Dolphin/Base/WindowsLocale.cls
+++ b/Core/Object Arts/Dolphin/Base/WindowsLocale.cls
@@ -366,9 +366,7 @@ shortAmDesignator
 		ifAbsentPut: 
 			[VMLibrary default isWindows10OrGreater
 				ifTrue: [self getLocaleInfoString: LOCALE_SSHORTESTAM]
-				ifFalse: 
-					["Might be a wide character"
-					self amDesignator readStream next: 1]]!
+				ifFalse: [self amDesignator first]]!
 
 shortDateFormat
 	"Answer the short date format for the receiver locale."
@@ -387,9 +385,7 @@ shortPmDesignator
 		ifAbsentPut: 
 			[VMLibrary default isWindows10OrGreater
 				ifTrue: [self getLocaleInfoString: LOCALE_SSHORTESTPM]
-				ifFalse: 
-					["Might be a wide character"
-					self pmDesignator readStream next: 1]]!
+				ifFalse: [self pmDesignator first]]!
 
 shortTimeFormat
 	"Answer the short time format for the receiver locale."

--- a/Core/Object Arts/Dolphin/IDE/Base/Aspect.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Aspect.cls
@@ -697,13 +697,15 @@ multilineString: aStringAspectSymbol
 
 	^self name: aStringAspectSymbol
 		presenterBlock: 
-			[:p :m | 
+			[:p :m |
 			| presenter |
-			presenter := TextPresenter 
+			presenter := TextPresenter
 						create: 'Multiline text'
 						in: p
 						on: m.
-			presenter view updatePerChar: true.
+			presenter view
+				updatePerChar: true;
+				tabWidth: 4.
 			presenter]!
 
 name: aSymbol

--- a/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/CompilerTest.cls
@@ -58,17 +58,6 @@ evalTestMethod: aCompiledMethod withArgs: anArray
 evaluateExpression: aString 
 	^Compiler evaluate: aString!
 
-findIP: anInteger inTextMap: aTextMap 
-    	"Private - Answer the index of the source map entry corresponding to the
-    	specified <integer> ip. The key of each text map entry identifies the first IP of the code generated for the range
-	of source which is held as the <interval> value."
-    
-    	| i size |
-    	i := 1.
-    	size := aTextMap size.
-	[i < size and: [anInteger > (aTextMap at: i) key]] whileTrue: [i := i + 1].
-	^i!
-
 getTestMethod: aSymbol 
 	| oldMethod result method |
 	oldMethod := DolphinCompilerTestMethods compiledMethodAt: aSymbol.
@@ -681,11 +670,11 @@ testIncrementDecrementOptimisation
 	debugMethod := method asDebugMethod.
 	debugMap := debugMethod debugInfo textMap.
 	self assert: map size equals: debugMap size.
-	i := self findIP: 5 inTextMap: map.
+	i := StackFrame findIP: 5 inTextMap: map.
 	self assert: (map at: i) key equals: 5.
 	self assert: (map at: i) value equals: (debugMap at: i) value.
 	self assert: (debugMethod byteCodes at: (debugMap at: i) key) equals: Increment.
-	i := self findIP: 6 inTextMap: map.
+	i := StackFrame findIP: 6 inTextMap: map.
 	self assert: (map at: i) key equals: 6.
 	self assert: (map at: i) value equals: (debugMap at: i) value.
 	self assert: (debugMethod byteCodes at: (debugMap at: i) key) equals: ShortPopTemp + 1!
@@ -716,7 +705,7 @@ testIncrementPushTempOptimisation
 	self assert: (method byteCodes at: 5) equals: IncPushTemp.
 	self assert: (method byteCodes at: 6) equals: StoreTemp.
 	self assert: (method byteCodes at: 7) equals: 0.	"temp 0"
-	i := self findIP: 5 inTextMap: map.
+	i := StackFrame findIP: 5 inTextMap: map.
 	self assert: (map at: i) key equals: 5.
 	self assert: (method getSource copyFrom: (map at: i) value start to: (map at: i) value stop)
 		equals: 'i + 1'.
@@ -724,7 +713,7 @@ testIncrementPushTempOptimisation
 	debugMap := debugMethod debugInfo textMap.
 	self assert: (map at: i) value equals: (debugMap at: i) value.
 	self assert: (debugMethod byteCodes at: (debugMap at: i) key) equals: Increment.
-	i := self findIP: 6 inTextMap: map.
+	i := StackFrame findIP: 6 inTextMap: map.
 	self assert: (map at: i) key equals: 6.
 	self assert: (map at: i) value equals: (debugMap at: i) value.
 	self assert: (debugMethod byteCodes at: (debugMap at: i) key) equals: ShortStoreTemp + 0.
@@ -794,11 +783,11 @@ testIncrementTempOptimisation
 	map := method debugInfo textMap.
 	debugMethod := method asDebugMethod.
 	debugMap := debugMethod debugInfo textMap.
-	i := self findIP: 5 inTextMap: map.
+	i := StackFrame findIP: 5 inTextMap: map.
 	self assert: (map at: i) key equals: 5.
 	self assert: (map at: i) value equals: (debugMap at: i) value.
 	self assert: (debugMethod byteCodes at: (debugMap at: i) key) equals: Increment.
-	i := self findIP: 6 inTextMap: map.
+	i := StackFrame findIP: 6 inTextMap: map.
 	self assert: (map at: i) key equals: 6.
 	self assert: (map at: i) value equals: (debugMap at: i) value.
 	self assert: (debugMethod byteCodes at: (debugMap at: i) key) equals: ShortPopTemp + 0!
@@ -1233,7 +1222,7 @@ testTextMapOfEmptyBlock
 		do: 
 			[:ip |
 			| debugIp |
-			debugIp := self findIP: ip inTextMap: method textMap.
+			debugIp := StackFrame findIP: ip inTextMap: method textMap.
 			self assert: (debugMethod byteCodes at: (debugMethod textMap at: debugIp) key)
 				equals: (method byteCodes at: ip)]!
 
@@ -1488,7 +1477,6 @@ verifyTextMapsOf: each
 !CompilerTest categoriesFor: #evalTestMethod:!helpers!private! !
 !CompilerTest categoriesFor: #evalTestMethod:withArgs:!helpers!private! !
 !CompilerTest categoriesFor: #evaluateExpression:!helpers!private! !
-!CompilerTest categoriesFor: #findIP:inTextMap:!private! !
 !CompilerTest categoriesFor: #getTestMethod:!private! !
 !CompilerTest categoriesFor: #messageFromError:!helpers!private! !
 !CompilerTest categoriesFor: #scan:class:!helpers!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Debugger.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Debugger.cls
@@ -1006,12 +1006,6 @@ populateStackModel
 	stackPresenter noEventsDo: [stackPresenter list: (topFrame getFrames: depth)].
 	stackPresenter selectionOrNil: topFrame!
 
-prevIPOfFrame: aStackFrame 
-	"Private - Answer the IP of the instruction before that at which the IP of the <StackFrame>,
-	frame, is currently pointing."
-
-	^aStackFrame method byteCodeDispatcher prevIP: aStackFrame ip!
-
 process: aProcess topFrame: aStackFrame 
 	"Private - Sets the process being debugged and the top stack frame (of interest). The stack
 	frame list is populated."
@@ -1520,8 +1514,8 @@ selectionIP
 	frame := self frame.
 	ip := frame ip.
 	(ip = 1 or: [self isDisassembled]) ifTrue: [^ip].
-	prevIP := self prevIPOfFrame: frame.
-	^(frame = topFrame and: [(frame method byteCodes at: prevIP) = Break]) 
+	prevIP := frame prevIP.
+	^(frame = topFrame and: [(frame method byteCodes at: prevIP) = Break])
 		ifTrue: [ip]
 		ifFalse: [prevIP]!
 
@@ -1589,7 +1583,7 @@ source
 	^sourcePresenter source!
 
 sourceRangeAt: anInteger inTextMap: aTextMap
-	^(aTextMap lookup: (self frame findIP: anInteger inTextMap: aTextMap))
+	^(aTextMap lookup: (StackFrame findIP: anInteger inTextMap: aTextMap))
 		ifNil: [1 to: 0]
 		ifNotNil: [:entry | entry value]!
 
@@ -1951,7 +1945,6 @@ variableAtIndex: anInteger put: anObject
 !Debugger categoriesFor: #performMethodsRefactoring:name:!private!refactoring! !
 !Debugger categoriesFor: #populateImplementMenu:!helpers!private! !
 !Debugger categoriesFor: #populateStackModel!private!updating! !
-!Debugger categoriesFor: #prevIPOfFrame:!accessing!private! !
 !Debugger categoriesFor: #process:topFrame:!accessing!initializing!private! !
 !Debugger categoriesFor: #promptToSaveChanges!commands!private! !
 !Debugger categoriesFor: #queryCommand:!commands!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -373,7 +373,6 @@ package methodNames
 	add: #SpinButton -> #publishedAspects;
 	add: #StAbstractVariableNode -> #displayOn:;
 	add: #StackFrame -> #debugIpFor:;
-	add: #StackFrame -> #findIP:inTextMap:;
 	add: #StackFrame -> #makeDebug;
 	add: #StackFrame -> #stackWorkspace;
 	add: #StAssignmentNode -> #displayOn:;
@@ -1784,7 +1783,7 @@ mapInitialIpFrom: aCompiledMethod to: debugCompiledMethod
 	debugMap := debugCompiledMethod debugInfo textMap.
 	self assert: [map size == debugMap size].
 	ip := self block initialIP.
-	i := self findIP: ip inTextMap: map.
+	i := self class findIP: ip inTextMap: map.
 	self assert: [(map at: i) key = ip].
 	^(debugMap at: i) key! !
 !BlockFrame categoriesFor: #debugIpFor:!private! !
@@ -5908,7 +5907,7 @@ debugIpFor: debugMethod
 	map := method debugInfo textMap.
 	debugMap := debugMethod debugInfo textMap.
 	self assert: [map size == debugMap size].
-	i := self findIP: ip inTextMap: map.
+	i := self class findIP: ip inTextMap: map.
 	(map at: i) key = ip 
 		ifTrue: 
 			["Directly corresponding entry"
@@ -5917,7 +5916,7 @@ debugIpFor: debugMethod
 	previous instructions IP and then step to the next instruction in the debug method"
 	interp := method byteCodeDispatcher.
 	prev := interp prevIP: ip.
-	i := self findIP: prev inTextMap: map.
+	i := self class findIP: prev inTextMap: map.
 	offset := prev - (map at: i) key.
 	debugPrev := offset = 0 
 				ifTrue: [(debugMap at: i) key]
@@ -5942,16 +5941,8 @@ debugIpFor: debugMethod
 	interp next.
 	^interp ip!
 
-findIP: anInteger inTextMap: aTextMap
-	"Private - Answer the index of the source map entry corresponding to the
-    	specified <integer> ip. The key of each text map entry identifies the first IP of the code generated for the range
-	of source which is held as the <interval> value."
-
-	| i size |
-	i := 1.
-	size := aTextMap size.
-	[i < size and: [anInteger > (aTextMap at: i) key]] whileTrue: [i := i + 1].
-	^i!
+debugPrintOn: aStream
+	self basicPrintOn: aStream!
 
 makeDebug
 	"Private - Convert the receiver to a debug frame. This is for the use of the debugger."
@@ -5975,7 +5966,7 @@ stackWorkspace
 
 	^self sender isNil ifTrue: [0] ifFalse: [self sp - index - self frameSize + 1]! !
 !StackFrame categoriesFor: #debugIpFor:!private! !
-!StackFrame categoriesFor: #findIP:inTextMap:!private! !
+!StackFrame categoriesFor: #debugPrintOn:!public! !
 !StackFrame categoriesFor: #makeDebug!private! !
 !StackFrame categoriesFor: #stackWorkspace!accessing!private! !
 

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
@@ -136,7 +136,7 @@ ClassBrowserPlugin subclass: #ResourceListPlugin
 	classInstanceVariableNames: ''!
 ClassBrowserPlugin subclass: #UnitTestPlugin
 	instanceVariableNames: 'result icon autoSwitchProcess defectsPresenter modePresenter detailsPresenter'
-	classVariableNames: 'AutoSwitchDelayMs FailColor NoTestsColor PassColor RunningColor'
+	classVariableNames: 'AutoSwitchDelayMs ErrorColor FailColor NoTestsColor PassColor RunningColor'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ClassSelector subclass: #PackagedClassSelector

--- a/Core/Object Arts/Dolphin/IDE/Professional/UnitTestPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/UnitTestPlugin.cls
@@ -2,7 +2,7 @@
 
 ClassBrowserPlugin subclass: #UnitTestPlugin
 	instanceVariableNames: 'result icon autoSwitchProcess defectsPresenter modePresenter detailsPresenter'
-	classVariableNames: 'AutoSwitchDelayMs FailColor NoTestsColor PassColor RunningColor'
+	classVariableNames: 'AutoSwitchDelayMs ErrorColor FailColor NoTestsColor PassColor RunningColor'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 UnitTestPlugin guid: (GUID fromString: '{e8b10dcb-9855-41f7-95d2-a91639377d01}')!
@@ -23,17 +23,7 @@ Instance Variables:
 	autoSwitchProcess	<Process> started when tests are running to automatically switch to the plugin pane to show progress if the tests take a long time to complete.
 	defectsPresenter	<ListPresenter> showing a list of defects when some tests have failed
 	modePresenter		<TextPresenter> describing the current running state
-	detailsPresenter	<TextPresenter> providing further details about the current running state
-
-Class Variables:
-	AutoSwitchDelayMs	<Integer> count of milliseconds after which the <autoSwitchProcess> will bring the plugin pane to the foreground
-	FailColor			<color> which will be used as a background colour when some tests fail
-	PassColor			<color> which will be used as a background colour when all tests pass
-	RunningColor		<color> which will be used as a background colour when tests are running
-	NoTestsColor		<color> which will be used as a background colour when no tests are available for the browser selection
-
-
-'!
+	detailsPresenter	<TextPresenter> providing further details about t ... etc ...'!
 !UnitTestPlugin categoriesForClass!Browser-Plugins! !
 !UnitTestPlugin methodsFor!
 
@@ -95,9 +85,9 @@ debugTest
 	defectsPresenter hasSelection ifFalse: [defectsPresenter selectionByIndex: 1].
 	self debugTest: defectsPresenter selection!
 
-debugTest: aTestCase 
+debugTest: aTestCaseResult
 	self displayMode: 'Debugging'.
-	aTestCase debug!
+	aTestCaseResult case debug!
 
 defaultHelpId
 	^10994!
@@ -107,13 +97,22 @@ displayColor: aColor
 	detailsPresenter view backcolor: aColor!
 
 displayDefects: aCollection
-	defectsPresenter list: aCollection asSortedCollection.
+	defectsPresenter list: (aCollection asSortedCollection: [:a :b | a case <= b case]).
 	defectsPresenter view isEnabled: aCollection notEmpty!
 
 displayDetails: aString 
 	"Display aString to indicate additional details about the current mode of operation"
 
 	detailsPresenter value: aString!
+
+displayErrors
+	"Indicate that some tests have failed and we have defects"
+
+	self icon: (Icon fromId: 'UnitTestPluginFail.ico').
+	self displayColor: self class errorColor.
+	self displayMode: 'Error'.
+	self displayDetails: result displayString.
+	self ensureVisible!
 
 displayFail
 	"Indicate that some tests have failed and we have defects"
@@ -363,12 +362,12 @@ update: anObject
 		ifFalse: [super update: anObject]!
 
 updateDefects
-	self displayDefects: result defects!
+	self displayDefects: (result defects collect: [:each | result resultFor: each])!
 
 updateWindow
-	result hasPassed
-		ifTrue: [self displayPass]
-		ifFalse: [self displayFail].
+	result hasErrors
+		ifTrue: [self displayErrors]
+		ifFalse: [result hasFailures ifTrue: [self displayFail] ifFalse: [self displayPass]].
 	self updateDefects! !
 !UnitTestPlugin categoriesFor: #allContextMenus!helpers!private! !
 !UnitTestPlugin categoriesFor: #allMenuBarMenus!helpers!private! !
@@ -382,6 +381,7 @@ updateWindow
 !UnitTestPlugin categoriesFor: #displayColor:!private!Updating! !
 !UnitTestPlugin categoriesFor: #displayDefects:!private!Updating! !
 !UnitTestPlugin categoriesFor: #displayDetails:!private!Updating! !
+!UnitTestPlugin categoriesFor: #displayErrors!private!Updating! !
 !UnitTestPlugin categoriesFor: #displayFail!private!Updating! !
 !UnitTestPlugin categoriesFor: #displayMode:!private!Updating! !
 !UnitTestPlugin categoriesFor: #displayOn:!displaying!private! !
@@ -435,11 +435,14 @@ defaultAutoSwitchDelay
 
 	^1 seconds!
 
-defaultFailColor
+defaultErrorColor
 	^Color
 		r: 243
 		g: 27
 		b: 65!
+
+defaultFailColor
+	^Color darkOrange!
 
 defaultNoTestsColor
 	^Color 
@@ -458,6 +461,12 @@ defaultRunningColor
 		r: 235
 		g: 201
 		b: 65!
+
+errorColor
+	^ErrorColor!
+
+errorColor: aColor
+	ErrorColor := aColor = Color default ifTrue: [self defaultErrorColor] ifFalse: [aColor]!
 
 failColor
 	^FailColor!
@@ -478,6 +487,7 @@ initialize
 	AutoSwitchDelayMs := self defaultAutoSwitchDelay.
 	PassColor := self defaultPassColor.
 	FailColor := self defaultFailColor.
+	ErrorColor := self defaultErrorColor.
 	RunningColor := self defaultRunningColor.
 	NoTestsColor := self defaultNoTestsColor!
 
@@ -522,10 +532,13 @@ runningColor: aColor
 !UnitTestPlugin class categoriesFor: #autoSwitchDelayMs!accessing!public! !
 !UnitTestPlugin class categoriesFor: #autoSwitchDelayMs:!accessing!public! !
 !UnitTestPlugin class categoriesFor: #defaultAutoSwitchDelay!constants!private! !
+!UnitTestPlugin class categoriesFor: #defaultErrorColor!constants!private! !
 !UnitTestPlugin class categoriesFor: #defaultFailColor!constants!private! !
 !UnitTestPlugin class categoriesFor: #defaultNoTestsColor!private!Updating! !
 !UnitTestPlugin class categoriesFor: #defaultPassColor!constants!private! !
 !UnitTestPlugin class categoriesFor: #defaultRunningColor!constants!private! !
+!UnitTestPlugin class categoriesFor: #errorColor!accessing!public! !
+!UnitTestPlugin class categoriesFor: #errorColor:!accessing!public! !
 !UnitTestPlugin class categoriesFor: #failColor!accessing!public! !
 !UnitTestPlugin class categoriesFor: #failColor:!accessing!public! !
 !UnitTestPlugin class categoriesFor: #icon!constants!public! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/MultilineTextEdit.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/MultilineTextEdit.cls
@@ -259,12 +259,15 @@ tabFocus
 
 	^self setFocus!
 
-tabWidth: anInteger 
-	"Set the tab width used in the receiver."
+tabWidth: anInteger
+	"Change the visible size of a tab to be a multiple of the width of a space character."
 
-	"Ignored at this level."
-
-	!
+	| canvas spaceWidth |
+	canvas := self canvas.
+	canvas font: self actualFont.
+	spaceWidth := (canvas textExtent: ' ') x.
+	canvas free.
+	self setTabStops: anInteger * spaceWidth!
 
 textAtLine: lineIndex
 	"Private - Answer the text of a line at the given line index (1-based)."

--- a/Core/Object Arts/Dolphin/System/STON/DolphinSTONWriter.cls
+++ b/Core/Object Arts/Dolphin/System/STON/DolphinSTONWriter.cls
@@ -11,15 +11,10 @@ DolphinSTONWriter comment: ''!
 !DolphinSTONWriter methodsFor!
 
 encodeString: aString
-
 	writeStream nextPut: stringQuote.
 	keepNewLines
 		ifTrue: [self encodeStringKeepingNewLines: aString]
-		ifFalse: 
-			[| stream ch |
-			"Superclass implementation does not work correctly for Dolphin's UTF-encoded Strings, as these enumerate code units, not code points. We must stream over the string instead."
-			stream := aString readStream.
-			[(ch := stream nextAvailable) isNil] whileFalse: [self encodeCharacter: ch]].
+		ifFalse: [aString do: [:ch | self encodeCharacter: ch]].
 	writeStream nextPut: stringQuote!
 
 escape: char with: anObject

--- a/Core/Object Arts/Dolphin/System/Win32/Dolphin Memory-Mapped Files.pax
+++ b/Core/Object Arts/Dolphin/System/Win32/Dolphin Memory-Mapped Files.pax
@@ -134,7 +134,7 @@ unmapViewOfFile: lpBaseAddress
 
 	<stdcall: sdword UnmapViewOfFile void*>
 	^self invalidCall: _failureCode! !
-!KernelLibrary categoriesFor: #createFileMapping:lpAttributes:flProtect:dwMaximumSizeHigh:dwMaximumSizeLow:lpName:!public!win32 functions-file! !
+!KernelLibrary categoriesFor: #createFileMapping:lpAttributes:flProtect:dwMaximumSizeHigh:dwMaximumSizeLow:lpName:!public!win32 functions-file management! !
 !KernelLibrary categoriesFor: #flushViewOfFile:dwNumberOfBytesToFlush:!public!win32 functions-memory management! !
 !KernelLibrary categoriesFor: #mapViewOfFile:dwDesiredAccess:dwFileOffsetHigh:dwFileOffsetLow:dwNumberOfBytesToMap:!public!win32 functions-memory management! !
 !KernelLibrary categoriesFor: #openFileMapping:bInheritHandle:lpName:!public!win32 functions-memory management! !


### PR DESCRIPTION
- SUnit failures in CI builds did not always have sufficient information for immediate diagnosis. This adds detection and reporting of the failing assertion, reporting the IP in the code (use the DebugInfoPlugin to map back), and also the source expression.
- File>>pathName is added to get the actual name of the File
- Reduce widths of tabs when inspecting multi-line text
- Add a separate failure colour to distinguish between errors and failures in the UnitTestPlugin. Also include failure diagnostics in the debug list.
- Simplification of String class>>withAll: and some other cases using streams that no longer need to.