### PR TITLE
Make sure newly-changed packages move to the top of the list if sorted by status

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/PackageSelector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/PackageSelector.cls
@@ -488,6 +488,7 @@ onPackageChanged: aPackage
 	"Private - The development system has marked aPackage as being changed,
 	update the package list to show any change in the appearance of the package."
 
+	self packagesPresenter beSorted: self packagesPresenter sortBlock.
 	self packagesPresenter view updateAll!
 
 onPackageChosen


### PR DESCRIPTION
Straightforward enough to just re-sort the whole list, though it seems like there should be a way to tell the ListPresenter this directly rather than telling it "hey, be sorted the same way you already are". It also brings to mind that there doesn't seem to be an API for asking "which column, if any, is this ListPresenter currently sorted on?". That state is clearly held by the view somehow, in order to display the little arrow in the header...