### PR TITLE
Fix #1012: SocketReadStream requires override of `nextAvailable:`

### DIFF
--- a/Core/Object Arts/Dolphin/Sockets/AbstractSocketTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/AbstractSocketTest.cls
@@ -1,11 +1,12 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 DolphinTest subclass: #AbstractSocketTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'sockets'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 AbstractSocketTest guid: (GUID fromString: '{4b35f00d-f9e0-442d-84fd-4721213f82fd}')!
+AbstractSocketTest isAbstract: true!
 AbstractSocketTest comment: ''!
 !AbstractSocketTest categoriesForClass!Unclassified! !
 !AbstractSocketTest methodsFor!
@@ -13,13 +14,24 @@ AbstractSocketTest comment: ''!
 serverSocketClass
 	^self subclassResponsibility!
 
+setUp
+	super setUp.
+	sockets := OrderedCollection new!
+
+tearDown
+	sockets do: [:each | [each close] on: Error do: [:ex | ]].
+	sockets := nil.
+	super tearDown!
+
 testQueryPort
 	"See #1317"
 
 	| s |
 	s := self serverSocketClass port: 1000.
 	[self assert: s queryPort = 1000] ensure: [s close]! !
-!AbstractSocketTest categoriesFor: #serverSocketClass!private!unit tests! !
+!AbstractSocketTest categoriesFor: #serverSocketClass!constants!private! !
+!AbstractSocketTest categoriesFor: #setUp!private!running! !
+!AbstractSocketTest categoriesFor: #tearDown!private!running! !
 !AbstractSocketTest categoriesFor: #testQueryPort!public!unit tests! !
 
 !AbstractSocketTest class methodsFor!

--- a/Core/Object Arts/Dolphin/Sockets/Dolphin Sockets Tests.pax
+++ b/Core/Object Arts/Dolphin/Sockets/Dolphin Sockets Tests.pax
@@ -30,7 +30,7 @@ package!
 "Class Definitions"!
 
 DolphinTest subclass: #AbstractSocketTest
-	instanceVariableNames: ''
+	instanceVariableNames: 'sockets'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Sockets/Socket2Test.cls
+++ b/Core/Object Arts/Dolphin/Sockets/Socket2Test.cls
@@ -10,7 +10,52 @@ Socket2Test comment: ''!
 !Socket2Test categoriesForClass!Unclassified! !
 !Socket2Test methodsFor!
 
+clientSocketClass
+	^Socket2!
+
 serverSocketClass
-	^ServerSocket2! !
-!Socket2Test categoriesFor: #serverSocketClass!public!unit tests! !
+	^ServerSocket2!
+
+testSTBMessages
+	| acceptSocket inbound ready messages outbound sent outfiler |
+	acceptSocket := self serverSocketClass port: 120 backlog: 0.
+	sockets add: acceptSocket.
+	ready := Semaphore new.
+	
+	[inbound := acceptSocket accept.
+	sockets add: inbound.
+	"Signal that we have the inbound socket"
+	ready signal]
+			fork.
+	messages := OrderedCollection new.
+	
+	[| readStream filer |
+	"Wait for the connection to be accepted so that the inbound socket is available"
+	ready wait.
+	readStream := inbound readStream.
+	filer := STBInFiler on: readStream.
+	
+	[| message |
+	message := filer next.
+	messages add: message.
+	readStream atEnd] whileFalse.
+	"Signal that we have finished reading the messages"
+	ready signal]
+			fork.
+	outbound := self clientSocketClass port: 120 address: (InternetAddress fromString: 'localhost').
+	sockets add: outbound.
+	outbound connect.
+	sent := {#Object -> Object comment. Object class}.
+	outfiler := STBOutFiler on: outbound writeStream.
+	sent do: [:each | outfiler nextPut: each].
+	"We have to flush the stream before we close the socket or the data might never get written"
+	outfiler stream flush.
+	outbound close.
+	"Wait for the reader to finish reading the messages"
+	ready wait.
+	messages := messages asArray.
+	self assert: messages equals: sent! !
+!Socket2Test categoriesFor: #clientSocketClass!constants!private! !
+!Socket2Test categoriesFor: #serverSocketClass!constants!private!unit tests! !
+!Socket2Test categoriesFor: #testSTBMessages!public! !
 

--- a/Core/Object Arts/Dolphin/Sockets/SocketReadStream.cls
+++ b/Core/Object Arts/Dolphin/Sockets/SocketReadStream.cls
@@ -82,6 +82,19 @@ nextAvailable
 
 	^self atEnd ifFalse: [self next]!
 
+nextAvailable: anInteger
+	"Answer up to anInteger elements of the receiver's collection. Generally, the answer will be
+	a collection of the same class as the one accessed by the receiver (though this is
+	determined by the receiver), and will contain anInteger elements, or as many as are left in
+	the receiver's collection."
+
+	| newStream count |
+	newStream := self contentsSpecies writeStream: (count := anInteger).
+	[count == 0 or: [self atEnd]] whileFalse: 
+			[newStream nextPut: self next.
+			count := count - 1].
+	^newStream contents!
+
 on: aCollection
 	super on: aCollection.
 	readLimit := 0!
@@ -149,6 +162,7 @@ upToEnd
 !SocketReadStream categoriesFor: #next!accessing!public! !
 !SocketReadStream categoriesFor: #next:into:startingAt:!accessing!public! !
 !SocketReadStream categoriesFor: #nextAvailable!public! !
+!SocketReadStream categoriesFor: #nextAvailable:!accessing!public! !
 !SocketReadStream categoriesFor: #on:!accessing!initializing!private! !
 !SocketReadStream categoriesFor: #readPage!operations!private! !
 !SocketReadStream categoriesFor: #setToEnd!positioning!public! !

--- a/Core/Object Arts/Dolphin/Sockets/SocketTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/SocketTest.cls
@@ -12,5 +12,5 @@ SocketTest comment: ''!
 
 serverSocketClass
 	^ServerSocket! !
-!SocketTest categoriesFor: #serverSocketClass!public!unit tests! !
+!SocketTest categoriesFor: #serverSocketClass!constants!private! !
 


### PR DESCRIPTION
Includes regression test for Socket2 only. Harder to test for old-style message queue based socket because of the need to ensure the message queue is served so that the Windows events for the socket are processed. As the old Sockets are effectively obsolete and the change is in `SocketReadStream` (which is shared) I didn't bother trying to make the test common.