### PR TITLE
Fix #1015: Collection>>split: not working for multi-byte characters

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Collection.cls
+++ b/Core/Object Arts/Dolphin/Base/Collection.cls
@@ -540,23 +540,23 @@ size
 	^self countElements!
 
 split: aReadableString
-	"Answer an Array containing the substrings in aReadableString separated by any of the elements of the receiver (which must be Characters)."
+	"Answer an Array containing the substrings in aReadableString separated by any of the elements of the receiver (which must be instances of Character)."
 
 	| start answer size end |
 	size := aReadableString size.
-	size == 0 ifTrue: [^{}].
+	size == 0 ifTrue: [^#()].
 	end := aReadableString indexOfAnyOf: self startingAt: 1.
 	end == 0 ifTrue: [^{aReadableString}].
 	answer := Array writeStream: 5.
 	start := 1.
 	
 	[answer nextPut: (aReadableString copyFrom: start to: end - 1).
-	start := end + 1.
+	start := end + (aReadableString encodedSizeAt: end).
 	end := aReadableString indexOfAnyOf: self startingAt: start.
 	end == 0]
 			whileFalse.
 	"Copy any remaining chars after the last separator"
-	start <= size ifTrue: [answer nextPut: (aReadableString copyFrom: start to: size)].
+	answer nextPut: (aReadableString copyFrom: start to: size).
 	^answer contents!
 
 storeOn: aStream 

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -987,7 +987,6 @@ split: aReadableString
 
 	| start end answer subSize size |
 	subSize := self size.
-	subSize == 0 ifTrue: [^self error: 'separator must consist of at least one character'].
 	size := aReadableString size.
 	size == 0 ifTrue: [^{}].
 	subSize == 1 ifTrue: [^(self at: 1) split: aReadableString].

--- a/Core/Object Arts/Dolphin/Base/StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StringTest.cls
@@ -533,8 +533,7 @@ testSplitByString
 
 	| sep empty |
 	empty := self collectionClass empty.
-	"The separator but must not be empty"
-	self should: [empty split: (self assimilateString: 'abc')] raise: Error.
+	self assert: (empty split: (self assimilateString: 'abc')) equals: #('abc').
 
 	"And again but using a string argument of more than one character"
 	sep := self assimilateString: String lineDelimiter.

--- a/Core/Object Arts/Dolphin/Base/UtfEncodedStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/UtfEncodedStringTest.cls
@@ -515,6 +515,31 @@ testSelect
 	self assert: actual equals: '文🐬🍺🍻'.
 	self assert: (self collectionClass empty select: [:each | self assert: false]) equals: ''!
 
+testSplitByCharacterArray
+	| subject actual separators |
+	subject := self assimilateString: '一1二2三3四'.
+	separators := #($\x4E00 $\x4E8C $\x4E09 $\x56DB).
+	actual := separators split: subject.
+	"Note that leading/trailing separator results in an empty element in the result collection"
+	self assert: actual equals: #('' '1' '2' '3' '').
+	"Split by empty list of separators should return original string as the single result"
+	self assert: (#() split: subject) equals: {subject}.
+	"Splitting an empty string should return an empty result"
+	subject := self assimilateString: ''.
+	actual := separators split: subject.
+	self assert: actual equals: #()!
+
+testSplitByString
+	| subject actual separators empty |
+	subject := self assimilateString: '£文a£文🐬£1£文🍺£文'.
+	separators := self assimilateString: '£文'.
+	actual := separators split: subject.
+	self assert: actual equals: #('' 'a' '🐬£1' '🍺' '').
+	empty := self assimilateString: ''.
+	self assert: (empty split: subject) equals: {subject}.
+	actual := separators split: empty.
+	self assert: actual equals: #()!
+
 testWithDo
 	| subject reversed pairs testCase expected |
 	testCase := 'a£1文🍺'.
@@ -586,6 +611,8 @@ withAllTestCases
 !UtfEncodedStringTest categoriesFor: #testRuneSubStrings!public!unit tests! !
 !UtfEncodedStringTest categoriesFor: #testSecondThirdEtc!public!unit tests! !
 !UtfEncodedStringTest categoriesFor: #testSelect!public!unit tests! !
+!UtfEncodedStringTest categoriesFor: #testSplitByCharacterArray!public!unit tests! !
+!UtfEncodedStringTest categoriesFor: #testSplitByString!public!unit tests! !
 !UtfEncodedStringTest categoriesFor: #testWithDo!public!unit tests! !
 !UtfEncodedStringTest categoriesFor: #withAllTestCases!constants!private! !
 


### PR DESCRIPTION
- Also fix inconsistent handling of trailing terminator, and allow empty separators.
- Add test coverage.