### PR TITLE
Selecting from SortedCollection performs unecessary re-sort

### DIFF
--- a/Core/Object Arts/Dolphin/Base/SequenceableCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollectionTest.cls
@@ -792,6 +792,43 @@ testReversedFromTo
 		raise: BoundsError
 		matching: [:ex | ex tag = 6]!
 
+testSelectAll
+	#('' 'a' 'abc') do: 
+			[:each |
+			| selection subject |
+			subject := self newCollection: each.
+			selection := subject select: [:a | true].
+			self assert: selection equals: subject]!
+
+testSelectEveryOther
+	#('' '' 'a' 'a' 'ab' 'a' 'abc' 'ac' 'abcd' 'ac' 'abcde' 'ace') pairsDo: 
+			[:case :result |
+			| selection subject expected count |
+			subject := self newCollection: case.
+			expected := self newCollection: result.
+			count := 0.
+			selection := subject select: [:a | (count := count + 1) odd].
+			self assert: selection equals: expected]!
+
+testSelectNone
+	| empty |
+	empty := self newCollection: ''.
+	#('' 'a' 'ab' 'abc') do: 
+			[:each |
+			| selection subject |
+			subject := self newCollection: each.
+			selection := subject select: [:a | false].
+			self assert: selection equals: empty]!
+
+testSelectOne
+	#('' '' 'b' '' 'a' 'a' 'abca' 'aa' 'bcd' '') pairsDo: 
+			[:case :result |
+			| selection subject expected |
+			subject := self newCollection: case.
+			expected := self newCollection: result.
+			selection := subject select: [:a | a = (self assimilate: $a)].
+			self assert: selection equals: expected]!
+
 unsortedCollectionClass
 	^self collectionClass!
 
@@ -856,6 +893,10 @@ verifyIndexOfAnyOf: searchFor startingAt: startInteger in: searchee is: foundInt
 !SequenceableCollectionTest categoriesFor: #testResize!public!unit tests! !
 !SequenceableCollectionTest categoriesFor: #testReverse!public!unit tests! !
 !SequenceableCollectionTest categoriesFor: #testReversedFromTo!public!unit tests! !
+!SequenceableCollectionTest categoriesFor: #testSelectAll!public!unit tests! !
+!SequenceableCollectionTest categoriesFor: #testSelectEveryOther!public!unit tests! !
+!SequenceableCollectionTest categoriesFor: #testSelectNone!public!unit tests! !
+!SequenceableCollectionTest categoriesFor: #testSelectOne!public!unit tests! !
 !SequenceableCollectionTest categoriesFor: #unsortedCollectionClass!constants!private! !
 !SequenceableCollectionTest categoriesFor: #verifyConcatenation:with:!helpers!private! !
 !SequenceableCollectionTest categoriesFor: #verifyConcatenationResult:of:with:!helpers!private! !

--- a/Core/Object Arts/Dolphin/Base/SortedCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SortedCollection.cls
@@ -274,6 +274,23 @@ reverse
 	self reverseDo: [:element | answer add: element].
 	^answer!
 
+select: aMonadicValuable
+	"Answer a new Collection like the receiver containing only those elements for which the <monadicValuable> argument evaluates to true."
+
+	"Implementation Note: The superclass implementation works, but ends up sorting the selected elements again, which is unnecessary since we know they will be selected in sorted order."
+
+	| newCollection j |
+	newCollection := self copyEmpty.
+	j := 0.
+	firstIndex to: lastIndex
+		do: 
+			[:i |
+			| each |
+			each := self basicAt: i.
+			(aMonadicValuable value: each) ifTrue: [newCollection basicAt: (j := j + 1) put: each]].
+	newCollection firstIndex: 1 lastIndex: j.
+	^newCollection!
+
 setSortAlgorithm: aSortAlgorithm 
 	algorithm := aSortAlgorithm!
 
@@ -336,6 +353,7 @@ stbSaveOn: anSTBOutFiler
 !SortedCollection categoriesFor: #resize:!mutating!private! !
 !SortedCollection categoriesFor: #reSort!operations!public! !
 !SortedCollection categoriesFor: #reverse!copying!public! !
+!SortedCollection categoriesFor: #select:!enumerating!public! !
 !SortedCollection categoriesFor: #setSortAlgorithm:!initializing!private! !
 !SortedCollection categoriesFor: #sortBlock!accessing!public! !
 !SortedCollection categoriesFor: #sortBlock:!accessing!operations!public! !


### PR DESCRIPTION
The #select: implementation inherited by SortedCollection works, but ends up (in effect) sorting the selected elements again, which is unnecessary since we know they will be selected in sorted order as they are enumerated. 
This change speeds up select: operations on SortedCollections by around an order of magnitude, depending on the sort comparison block overhead.