### PR TITLE
Fix primitiveFailed error when closing the View Composer

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/ViewComposer.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/ViewComposer.cls
@@ -78,15 +78,9 @@ adornmentRectanglesFor: aView
 	"Private - Answer a collection of rectangles that mark the edges of the secondary
 	selection adornments of aView."
 
-	| viewRects extent rect |
-	extent := Grabber defaultExtent.
-	rect := aView rectangle insetBy: extent // 2 negated.
-	viewRects := #(#topLeft #bottomRight #topRight #bottomLeft #topCenter #bottomCenter #leftCenter #rightCenter)
-				collect: 
-					[:eachAspect |
-					| center |
-					center := self mapPoint: (rect perform: eachAspect) toArenaFromView: aView.
-					Rectangle center: center extent: extent].
+	| viewRects |
+	viewRects := OrderedCollection new.
+	self adornmentRectanglesFor: aView do: [:rect | viewRects add: rect].
 	^viewRects!
 
 adornmentRectanglesFor: aView do: aMonadicValuable
@@ -1776,10 +1770,11 @@ performCommand: aCommand
 	| result |
 	self eraseAdornment.
 	result := super performCommand: aCommand.
-	self validateLayout.
-	self drawAdornment.
-	^result
-!
+	self isOpen
+		ifTrue: 
+			[self validateLayout.
+			self drawAdornment].
+	^result!
 
 performUndoRedo: aNiladicValuable
 	vcFlags := vcFlags maskSet: UndoRedoFlag.

--- a/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/ViewComposerTest.cls
@@ -186,6 +186,19 @@ testDropResourceOverShell
 	self doArenaDropOf: TextPresenter operation: #copy.
 	self assert: vc primarySelection isKindOf: TextEdit!
 
+testExit
+	"Exiting the view composer used to raise an error
+	due to trying to redraw the adornment after the view was closed.
+	
+	N.B. we must simulate the way the command will actually be routed
+	through #performCommand: in order to trigger the bug."
+
+	| query |
+	self openTestSubjectOnNewShell.
+	query := vc commandPolicy query: (CommandDescription command: #exit).
+	self shouldnt: [query perform] raise: Error.
+	self deny: vc isOpen!
+
 testIgnoreShellPreferredExtent
 	"Check to make sure that the VC doesn't allow the choice of shell extents
 	even when they are marked as #userPreferredExtent"
@@ -285,6 +298,7 @@ testZOrderPreservedByMutate
 !ViewComposerTest categoriesFor: #testDropResourceOverEmptyArena!public!unit tests! !
 !ViewComposerTest categoriesFor: #testDropResourceOverHierarchy!public!unit tests! !
 !ViewComposerTest categoriesFor: #testDropResourceOverShell!public!unit tests! !
+!ViewComposerTest categoriesFor: #testExit!public!unit tests! !
 !ViewComposerTest categoriesFor: #testIgnoreShellPreferredExtent!public!unit tests! !
 !ViewComposerTest categoriesFor: #testNoDragResourceOverInUseArena!public!unit tests! !
 !ViewComposerTest categoriesFor: #testPasteToArena!public!unit tests! !


### PR DESCRIPTION
The View Composer tries to redraw the adornment after every command, and if the command was e.g. `#exit` and the composer is now closed, this causes an error. I added a check of `#isOpen` before the redraw to prevent this.

For the test, I did what I've always done in my own work to simulate a button press or menu action—let me know if there's a cleaner or more accurate way. It does need to go through `#performCommand:`, as that's where the bug was.