### PR TITLE
Changes to wrap up #1026

### DIFF
--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -1301,7 +1301,7 @@ Win32Structure subclass: #MSGBOXPARAMSW
 	poolDictionaries: 'MessageBoxConstants'
 	classInstanceVariableNames: ''!
 Win32Structure subclass: #NUMBERFMTW
-	instanceVariableNames: 'decimalSeparator numberGrouping thousandSeparator'
+	instanceVariableNames: 'decimalSeparator numberGrouping groupSeparator'
 	classVariableNames: '_OffsetOf_Grouping _OffsetOf_LeadingZero _OffsetOf_lpDecimalSep _OffsetOf_lpThousandSep _OffsetOf_NegativeOrder _OffsetOf_NumDigits'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Base/Float.cls
+++ b/Core/Object Arts/Dolphin/Base/Float.cls
@@ -1096,13 +1096,12 @@ truncated
 !Float class methodsFor!
 
 defaultDecimalExponents
-	"Answer an <Interval> that specifies the range of exponents over which Floats are (by default) printed in decimal (as opposed to scientific) format by the #printOn:base:significantFigures: method."
+	"Answer an <Interval> that specifies the range of exponents over which Floats are (by default) printed in decimal (as opposed to scientific) format by printing methods."
 
 	^DefaultDecimalExponents!
 
 defaultDecimalExponents: anInteger
-	"Set the <Interval> that is used as the default range of exponents over which Floats are printed in decimal (as opposed to scientific) format by the #printOn:base:significantFigures: method.
-	Note that Float>>printOn: always prints floats in exactly in a fixed format as this is used to print Floats as literals that can be recompiled back to the same value. It does not use this value."
+	"Set the <Interval> that is used as the default range of exponents over which Floats are printed in decimal (as opposed to scientific) format by print methods."
 
 	DefaultDecimalExponents := anInteger!
 

--- a/Core/Object Arts/Dolphin/Base/Locale.cls
+++ b/Core/Object Arts/Dolphin/Base/Locale.cls
@@ -503,11 +503,17 @@ printDuration: aDuration on: aWriteStream format: aString
 		formatters: self durationFormatters!
 
 printFloat: aFloat
-	"Answer a <String> representation of the <Float> first argument in the format defined for this locale."
+	"Answer a <String> representation of the <Float> argument in the format defined for this locale."
 
 	^self
 		printFloat: aFloat
 		format: self numberFormat
+		lcid: self lcid!
+
+printFloat: aFloat format: aNUMBERFMT
+	^self
+		printFloat: aFloat
+		format: aNUMBERFMT
 		lcid: self lcid!
 
 printFloat: aFloat format: aNUMBERFMT lcid: lcidInteger
@@ -696,6 +702,7 @@ yearMonthFormat
 !Locale categoriesFor: #printDateTime:on:format:!printing!public! !
 !Locale categoriesFor: #printDuration:on:format:!printing!public! !
 !Locale categoriesFor: #printFloat:!printing!public! !
+!Locale categoriesFor: #printFloat:format:!printing!public! !
 !Locale categoriesFor: #printFloat:format:lcid:!printing!public! !
 !Locale categoriesFor: #printFloat:on:format:!printing!public! !
 !Locale categoriesFor: #printFractionalPart:on:places:!printing!private! !

--- a/Core/Object Arts/Dolphin/Base/LocaleTest.cls
+++ b/Core/Object Arts/Dolphin/Base/LocaleTest.cls
@@ -14,9 +14,6 @@ LocaleTest comment: ''!
 defaultSubject
 	^self subclassResponsibility!
 
-displayFloat: aFloat with: subject
-	^String streamContents: [:s | subject displayFloat: aFloat on: s]!
-
 setUp
 	super setUp.
 	savedLocale := Locale userDefault.
@@ -25,9 +22,6 @@ setUp
 tearDown
 	savedLocale ifNotNil: [Locale userDefault: savedLocale. savedLocale := nil].
 	super tearDown!
-
-testDisplayFloatOn
-	self subclassResponsibility!
 
 testPrintDateTimeOnFormat
 	| subject now expected |
@@ -80,12 +74,55 @@ testPrintDurationOnFormat
 						printDuration: -12.1 hours
 						on: s
 						format: '+hh:mm'].
-	self assert: actual equals: '-12:06'! !
+	self assert: actual equals: '-12:06'!
+
+testPrintFloat
+	self subclassResponsibility!
+
+testPrintFloatGrouping
+	"Test printing with different number grouping."
+
+	self subclassResponsibility!
+
+testPrintFloatNumDigits
+	"Test printing different numbers of decimal places, and also what happens beyond the limits as the GetNumberFormatAPI only supports 0..9 decimal digits."
+
+	| subject format |
+	subject := self defaultSubject.
+	format := subject numberFormat copy.
+	"Only up to 9 decimal places can be requested"
+	0 to: 9
+		do: 
+			[:each |
+			format decimalPlaces: each.
+			self assert: (subject printFloat: 0.123404321 format: format)
+				equals: ('0.123404321' copyFrom: 1 to: each + (each > 0 ifTrue: [2] ifFalse: [1]))].
+	self assert: (subject printFloat: 0.0123456789 format: format) equals: '0.012345679'.
+	format grouping: 0.
+	"Of course we may still not have enough precision to display the result accurately as the precision of a 64-bit Float is at most 17 decimal digits"
+	self assert: (subject printFloat: 123456789.0123456789 format: format) equals: '123456789.012345660'.
+	"Attempting to specify more digits than 9 is an error as it is not supported by the GetNumberFormat API"
+	#(-1 10) do: 
+			[:each |
+			self should: [format decimalPlaces: each] raise: Error.
+			"If we force it in, we expect an invalid parameter error from GetNumberFormat"
+			format NumDigits: each.
+			self
+				should: [subject printFloat: 0.0123456789 format: format]
+				raise: Win32Error
+				matching: [:ex | ex tag = (HRESULT win32Error: Win32Errors.ERROR_INVALID_PARAMETER)]]!
+
+testPrintFloatSeparators
+	"Test printing with specific decimal and group separators."
+
+	self subclassResponsibility! !
 !LocaleTest categoriesFor: #defaultSubject!helpers!private! !
-!LocaleTest categoriesFor: #displayFloat:with:!helpers!private! !
 !LocaleTest categoriesFor: #setUp!private!running! !
 !LocaleTest categoriesFor: #tearDown!private!running! !
-!LocaleTest categoriesFor: #testDisplayFloatOn!public! !
-!LocaleTest categoriesFor: #testPrintDateTimeOnFormat!public! !
+!LocaleTest categoriesFor: #testPrintDateTimeOnFormat!public!unit tests! !
 !LocaleTest categoriesFor: #testPrintDurationOnFormat!public!unit tests! !
+!LocaleTest categoriesFor: #testPrintFloat!public!unit tests! !
+!LocaleTest categoriesFor: #testPrintFloatGrouping!public!unit tests! !
+!LocaleTest categoriesFor: #testPrintFloatNumDigits!public!unit tests! !
+!LocaleTest categoriesFor: #testPrintFloatSeparators!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/NUMBERFMTW.cls
+++ b/Core/Object Arts/Dolphin/Base/NUMBERFMTW.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 Win32Structure subclass: #NUMBERFMTW
-	instanceVariableNames: 'decimalSeparator numberGrouping thousandSeparator'
+	instanceVariableNames: 'decimalSeparator numberGrouping groupSeparator'
 	classVariableNames: '_OffsetOf_Grouping _OffsetOf_LeadingZero _OffsetOf_lpDecimalSep _OffsetOf_lpThousandSep _OffsetOf_NegativeOrder _OffsetOf_NumDigits'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -45,15 +45,38 @@ decimalSeparator: aString
 	decimalSeparator := aString asUtf16String.
 	self lpDecimalSep: decimalSeparator!
 
+grouping
+	"Answer the <Integer> value of the receiver's grouping format - see #grouping: and #numberGrouping."
+
+	^self Grouping!
+
 Grouping
-	"Answer the <Integer> value of the receiver's 'Grouping' field."
+	"Private - Answer the <Integer> value of the receiver's 'Grouping' field."
 
 	^bytes dwordAtOffset: _OffsetOf_Grouping!
 
+grouping: anInteger
+	"Set the number of digits in each group of numbers to the left of the decimal separator.
+	Examples:
+	0 - no grouping
+	3 - groups of 3 (thousands)
+	32 - groups of 2 except for the last group of 3"
+
+	(anInteger between: 0 and: 9999)
+		ifFalse: [self error: 'Invalid grouping specification ' , anInteger printString].
+	self Grouping: anInteger!
+
 Grouping: anInteger
-	"Set the receiver's 'Grouping' field to the value of the argument, anInteger"
+	"Private - Set the receiver's 'Grouping' field to the value of the argument, anInteger"
 
 	bytes dwordAtOffset: _OffsetOf_Grouping put: anInteger!
+
+groupSeparator
+	^groupSeparator ifNil: [groupSeparator := self lpThousandSep]!
+
+groupSeparator: aString
+	groupSeparator := aString asUtf16String.
+	self lpThousandSep: groupSeparator!
 
 hasLeadingZero
 	^self LeadingZero asBoolean!
@@ -62,32 +85,32 @@ hasLeadingZero: aBoolean
 	self LeadingZero: aBoolean asParameter!
 
 LeadingZero
-	"Answer the <Integer> value of the receiver's 'LeadingZero' field."
+	"Private - Answer the <Integer> value of the receiver's 'LeadingZero' field."
 
 	^bytes dwordAtOffset: _OffsetOf_LeadingZero!
 
 LeadingZero: anInteger
-	"Set the receiver's 'LeadingZero' field to the value of the argument, anInteger"
+	"Private - Set the receiver's 'LeadingZero' field to the value of the argument, anInteger"
 
 	bytes dwordAtOffset: _OffsetOf_LeadingZero put: anInteger!
 
 lpDecimalSep
-	"Answer the <Utf16String> value of the receiver's 'lpDecimalSep' field."
+	"Private - Answer the <Utf16String> value of the receiver's 'lpDecimalSep' field."
 
 	^Utf16String fromAddress: (bytes intPtrAtOffset: _OffsetOf_lpDecimalSep)!
 
 lpDecimalSep: anUtf16String
-	"Set the receiver's 'lpDecimalSep' field to the value of the argument, anUtf16String"
+	"Private - Set the receiver's 'lpDecimalSep' field to the value of the argument, anUtf16String"
 
 	bytes uintPtrAtOffset: _OffsetOf_lpDecimalSep put: anUtf16String yourAddress!
 
 lpThousandSep
-	"Answer the <Utf16String> value of the receiver's 'lpThousandSep' field."
+	"Private - Answer the <Utf16String> value of the receiver's 'lpThousandSep' field."
 
 	^Utf16String fromAddress: (bytes intPtrAtOffset: _OffsetOf_lpThousandSep)!
 
 lpThousandSep: anUtf16String
-	"Set the receiver's 'lpThousandSep' field to the value of the argument, anUtf16String"
+	"Private - Set the receiver's 'lpThousandSep' field to the value of the argument, anUtf16String"
 
 	bytes uintPtrAtOffset: _OffsetOf_lpThousandSep put: anUtf16String yourAddress!
 
@@ -98,12 +121,12 @@ negativeNumberMode: anInteger
 	self NegativeOrder: anInteger!
 
 NegativeOrder
-	"Answer the <Integer> value of the receiver's 'NegativeOrder' field."
+	"Private - Answer the <Integer> value of the receiver's 'NegativeOrder' field."
 
 	^bytes dwordAtOffset: _OffsetOf_NegativeOrder!
 
 NegativeOrder: anInteger
-	"Set the receiver's 'NegativeOrder' field to the value of the argument, anInteger"
+	"Private - Set the receiver's 'NegativeOrder' field to the value of the argument, anInteger"
 
 	bytes dwordAtOffset: _OffsetOf_NegativeOrder put: anInteger!
 
@@ -123,7 +146,7 @@ numberGrouping: aString
 	numberGrouping := nil.
 	groups := $; split: aString.
 	groups last = '0' ifTrue: [groups := groups resize: groups size - 1].
-	self Grouping: (groups inject: 0
+	self grouping: (groups inject: 0
 				into: 
 					[:grouping :each |
 					| group |
@@ -131,43 +154,48 @@ numberGrouping: aString
 					grouping * 10 + group])!
 
 NumDigits
-	"Answer the <Integer> value of the receiver's 'NumDigits' field."
+	"Private - Answer the <Integer> value of the receiver's 'NumDigits' field."
 
 	^bytes dwordAtOffset: _OffsetOf_NumDigits!
 
 NumDigits: anInteger
-	"Set the receiver's 'NumDigits' field to the value of the argument, anInteger"
+	"Private - Set the receiver's 'NumDigits' field to the value of the argument, anInteger"
 
 	bytes dwordAtOffset: _OffsetOf_NumDigits put: anInteger!
 
 thousandSeparator
-	^thousandSeparator ifNil: [thousandSeparator := self lpThousandSep]!
+	"This should really be called groupSeparator, and will be deprecated in the next release."
+
+	^self groupSeparator!
 
 thousandSeparator: aString
-	thousandSeparator := aString asUtf16String.
-	self lpThousandSep: thousandSeparator! !
+	self groupSeparator: aString! !
 !NUMBERFMTW categoriesFor: #decimalPlaces!accessing!public! !
 !NUMBERFMTW categoriesFor: #decimalPlaces:!accessing!public! !
 !NUMBERFMTW categoriesFor: #decimalSeparator!accessing!public! !
 !NUMBERFMTW categoriesFor: #decimalSeparator:!accessing!public! !
-!NUMBERFMTW categoriesFor: #Grouping!**compiled accessors**!public! !
-!NUMBERFMTW categoriesFor: #Grouping:!**compiled accessors**!public! !
+!NUMBERFMTW categoriesFor: #grouping!accessing!public! !
+!NUMBERFMTW categoriesFor: #Grouping!**compiled accessors**!private! !
+!NUMBERFMTW categoriesFor: #grouping:!accessing!public! !
+!NUMBERFMTW categoriesFor: #Grouping:!**compiled accessors**!private! !
+!NUMBERFMTW categoriesFor: #groupSeparator!accessing!public! !
+!NUMBERFMTW categoriesFor: #groupSeparator:!accessing!public! !
 !NUMBERFMTW categoriesFor: #hasLeadingZero!accessing!public! !
 !NUMBERFMTW categoriesFor: #hasLeadingZero:!accessing!public! !
-!NUMBERFMTW categoriesFor: #LeadingZero!**compiled accessors**!public! !
-!NUMBERFMTW categoriesFor: #LeadingZero:!**compiled accessors**!public! !
-!NUMBERFMTW categoriesFor: #lpDecimalSep!**compiled accessors**!public! !
-!NUMBERFMTW categoriesFor: #lpDecimalSep:!**compiled accessors**!public! !
-!NUMBERFMTW categoriesFor: #lpThousandSep!**compiled accessors**!public! !
-!NUMBERFMTW categoriesFor: #lpThousandSep:!**compiled accessors**!public! !
+!NUMBERFMTW categoriesFor: #LeadingZero!**compiled accessors**!private! !
+!NUMBERFMTW categoriesFor: #LeadingZero:!**compiled accessors**!private! !
+!NUMBERFMTW categoriesFor: #lpDecimalSep!**compiled accessors**!private! !
+!NUMBERFMTW categoriesFor: #lpDecimalSep:!**compiled accessors**!private! !
+!NUMBERFMTW categoriesFor: #lpThousandSep!**compiled accessors**!private! !
+!NUMBERFMTW categoriesFor: #lpThousandSep:!**compiled accessors**!private! !
 !NUMBERFMTW categoriesFor: #negativeNumberMode!accessing!public! !
 !NUMBERFMTW categoriesFor: #negativeNumberMode:!accessing!public! !
-!NUMBERFMTW categoriesFor: #NegativeOrder!**compiled accessors**!public! !
-!NUMBERFMTW categoriesFor: #NegativeOrder:!**compiled accessors**!public! !
+!NUMBERFMTW categoriesFor: #NegativeOrder!**compiled accessors**!private! !
+!NUMBERFMTW categoriesFor: #NegativeOrder:!**compiled accessors**!private! !
 !NUMBERFMTW categoriesFor: #numberGrouping!accessing!public! !
 !NUMBERFMTW categoriesFor: #numberGrouping:!accessing!public! !
-!NUMBERFMTW categoriesFor: #NumDigits!**compiled accessors**!public! !
-!NUMBERFMTW categoriesFor: #NumDigits:!**compiled accessors**!public! !
+!NUMBERFMTW categoriesFor: #NumDigits!**compiled accessors**!private! !
+!NUMBERFMTW categoriesFor: #NumDigits:!**compiled accessors**!private! !
 !NUMBERFMTW categoriesFor: #thousandSeparator!accessing!public! !
 !NUMBERFMTW categoriesFor: #thousandSeparator:!accessing!public! !
 

--- a/Core/Object Arts/Dolphin/Base/SmalltalkLocale.cls
+++ b/Core/Object Arts/Dolphin/Base/SmalltalkLocale.cls
@@ -286,6 +286,11 @@ pmDesignator
 
 	^'pm'!
 
+printFloat: aFloat
+	"Answer a <String> representation of the <Float> argument in the format defined for this locale."
+
+	^aFloat printString!
+
 printFloat: aFloat on: aStream format: aNUMBERFMTW
 	"Append, to aStream, a String whose characters are a representation of the <Float> argument, aFloat, in <integer> base, baseInteger, using the formatting instructions specified by the <NUMBERFMT>, aNUMBERFMT."
 
@@ -367,6 +372,7 @@ yearMonthFormat
 !SmalltalkLocale categoriesFor: #numberGrouping!constants!public! !
 !SmalltalkLocale categoriesFor: #percentSymbol!constants!public! !
 !SmalltalkLocale categoriesFor: #pmDesignator!constants!public! !
+!SmalltalkLocale categoriesFor: #printFloat:!printing!public! !
 !SmalltalkLocale categoriesFor: #printFloat:on:format:!printing!public! !
 !SmalltalkLocale categoriesFor: #shortAmDesignator!constants!public! !
 !SmalltalkLocale categoriesFor: #shortDateFormat!constants!public! !

--- a/Core/Object Arts/Dolphin/Base/SmalltalkLocaleTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SmalltalkLocaleTest.cls
@@ -13,7 +13,7 @@ SmalltalkLocaleTest comment: ''!
 defaultSubject
 	^Locale smalltalk!
 
-testDisplayFloatOn
+testPrintFloat
 	| subject |
 	subject := Locale smalltalk.
 	{{Float infinity. 'Float.Infinity'}.
@@ -38,8 +38,35 @@ testDisplayFloatOn
 		{50000000000001.25. '5.000000000000125e13'}} do: 
 				[:each |
 				| actual |
-				actual := String streamContents: [:s | subject displayFloat: each first on: s].
-				self assert: actual equals: each second]! !
+				actual := subject printFloat: each first.
+				self assert: actual equals: each second]!
+
+testPrintFloatGrouping
+	"Test printing with different number grouping."
+
+	| subject format |
+	subject := self defaultSubject.
+	format := subject numberFormat copy.
+	format
+		grouping: 3;
+		decimalPlaces: 1.
+	"The SmalltalkLocale doesn't support grouping"
+	self assert: (subject printFloat: 1234567890.0 format: format) equals: '1234567890.0'!
+
+testPrintFloatSeparators
+	"Test printing with different number grouping."
+
+	| subject format |
+	subject := self defaultSubject.
+	format := subject numberFormat copy.
+	"The SmalltalkLocale doesn't support grouping so the grouping separator has no effect"
+	format
+		decimalPlaces: 3;
+		decimalSeparator: $@;
+		thousandSeparator: $^.
+	self assert: (subject printFloat: 1234567890.123 format: format) equals: '1234567890@123'! !
 !SmalltalkLocaleTest categoriesFor: #defaultSubject!helpers!private! !
-!SmalltalkLocaleTest categoriesFor: #testDisplayFloatOn!public! !
+!SmalltalkLocaleTest categoriesFor: #testPrintFloat!public! !
+!SmalltalkLocaleTest categoriesFor: #testPrintFloatGrouping!public!unit tests! !
+!SmalltalkLocaleTest categoriesFor: #testPrintFloatSeparators!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/Base/WindowsLocaleTest.cls
+++ b/Core/Object Arts/Dolphin/Base/WindowsLocaleTest.cls
@@ -13,8 +13,48 @@ WindowsLocaleTest comment: ''!
 defaultSubject
 	^Locale lcid: 2057!
 
-testDisplayFloatOn
-	| info subject |
+testDisplayFloatOnNegativeModes
+	| info subject format |
+	"Different negative number mode (2)"
+	subject := Locale lcid: 1050.
+	self assert: (subject printFloat: -0.0) equals: '0,00'.
+	self assert: (subject printFloat: -1.25) equals: '- 1,25'.
+	self assert: (subject printFloat: -0.0001) equals: '0,00'.
+	self assert: (subject printFloat: -123456789.123456789) equals: '- 123.456.789,12'.
+	"Negative infinity does not seem to be represented consistently with respect to the normal negative sign conventions in this locale. The value is direct from Windows"
+	self assert: (subject printFloat: Float negativeInfinity) equals: '-∞'.
+
+	"Different negative number mode (3)"
+	subject := Locale lcid: 1065.
+	self assert: (subject printFloat: -0.0) equals: '0/00'.
+	self assert: (subject printFloat: -1.25) equals: '1/25-'.
+	self assert: (subject printFloat: -0.0001) equals: '0/00'.
+	self assert: (subject printFloat: -123456789.123456789) equals: '123,456,789/12-'.
+	"Ditto re: Negative infinity, which is supplied by Windows with an inconsistent representation."
+	self assert: (subject printFloat: Float negativeInfinity) equals: '-∞'.
+
+	"Fake up the other modes - zero is bracketed"
+	subject := Locale lcid: 1033.
+	format := subject numberFormat copy.
+	format negativeNumberMode: 0.
+	self assert: (subject printFloat: -0.0 format: format) equals: '0.00'.
+	self assert: (subject printFloat: -1.25 format: format) equals: '(1.25)'.
+	self assert: (subject printFloat: -0.0001 format: format) equals: '0.00'.
+	self assert: (subject printFloat: -123456789.123456789 format: format) equals: '(123,456,789.12)'.
+
+	"Mode 4 is trailing minus after space"
+	format negativeNumberMode: 4.
+	self assert: (subject printFloat: -0.0 format: format) equals: '0.00'.
+	self assert: (subject printFloat: -1.25 format: format) equals: '1.25 -'.
+	self assert: (subject printFloat: -0.0001 format: format) equals: '0.00'.
+	self assert: (subject printFloat: -123456789.123456789 format: format) equals: '123,456,789.12 -'!
+
+testEnglishName
+	#(1033 'English' 2057 'English' 1034 'Spanish' 1106 'Welsh' 11274 'Spanish') pairsDo: [:lcid :language |
+		self assert: (Locale lcid: lcid) englishLanguageName equals: language]!
+
+testPrintFloat
+	| subject |
 	{{Locale lcid: 2057.
 			{{Float infinity. '∞'}.
 				{Float negativeInfinity. '-∞'}.
@@ -66,50 +106,67 @@ testDisplayFloatOn
 				subject := each first.
 				each second do: 
 						[:pair |
-						actual := self displayFloat: pair first with: subject.
-						self assert: actual equals: pair second]].
+						actual := subject printFloat: pair first.
+						self assert: actual equals: pair second]]!
 
-	"Switch to a locale with a different decimal separator and representations for Nan, Infinity, etc."
-	"Different negative number mode (2)"
-	subject := Locale lcid: 1050.
-	self assert: (self displayFloat: -0.0 with: subject) equals: '0,00'.
-	self assert: (self displayFloat: -1.25 with: subject) equals: '- 1,25'.
-	self assert: (self displayFloat: -0.0001 with: subject) equals: '0,00'.
-	self assert: (self displayFloat: -123456789.123456789 with: subject) equals: '- 123.456.789,12'.
-	"Negative infinity does not seem to be represented consistently with respect to the normal negative sign conventions in this locale. The value is direct from Windows"
-	self assert: (self displayFloat: Float negativeInfinity with: subject) equals: '-∞'.
+testPrintFloatGrouping
+	"Test printing with different number grouping."
 
-	"Different negative number mode (3)"
-	subject := Locale lcid: 1065.
-	self assert: (self displayFloat: -0.0 with: subject) equals: '0/00'.
-	self assert: (self displayFloat: -1.25 with: subject) equals: '1/25-'.
-	self assert: (self displayFloat: -0.0001 with: subject) equals: '0/00'.
-	self assert: (self displayFloat: -123456789.123456789 with: subject) equals: '123,456,789/12-'.
-	"Ditto re: Negative infinity, which is supplied by Windows with an inconsistent representation."
-	self assert: (self displayFloat: Float negativeInfinity with: subject) equals: '-∞'.
+	| subject format |
+	subject := self defaultSubject.
+	format := subject numberFormat copy.
+	#(#(0 '0' '1234567890.12') #(1 '1' '1,2,3,4,5,6,7,8,9,0.12') #(2 '2' '12,34,56,78,90.12') #(3 '3' '1,234,567,890.12') #(4 '4' '12,3456,7890.12') #(5 '5' '12345,67890.12') #(6 '6' '1234,567890.12') #(7 '7' '123,4567890.12') #(8 '8' '12,34567890.12') #(9 '9' '1,234567890.12') #(10 '1;0;0' '123456789,0.12') #(11 '1;1' '1,2,3,4,5,6,7,8,9,0.12') #(12 '1;2' '1,23,45,67,89,0.12') #(32 '3;2' '1,23,45,67,890.12') #(92 '9;2' '1,234567890.12'))
+		do: 
+			[:each |
+			format grouping: each first.
+			self assert: format numberGrouping equals: each second.
+			format numberGrouping: each second.
+			self assert: format grouping equals: each first.
+			self assert: (subject printFloat: 1234567890.123 format: format) equals: each last].
+	"The grouping is actually much more flexible than the documentation suggests. Up to four number groups are supported (the last repeating)."
+	#(#(98 '9;8' '2,00000000,00000000,00000000,000000000.00') #(89 '8;9' '20000000,000000000,000000000,00000000.00') #(99 '9;9' '2000000,000000000,000000000,000000000.00') #(120 '1;2;0;0' '2000000000000000000000000000000,00,0.00') #(123 '1;2;3' '2,000,000,000,000,000,000,000,000,000,000,00,0.00') #(1230 '1;2;3;0;0' '2000000000000000000000000000,000,00,0.00') #(1234 '1;2;3;4' '2000,0000,0000,0000,0000,0000,0000,000,00,0.00') #(4321 '4;3;2;1' '2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,00,000,0000.00') #(9999 '9;9;9;9' '2000000,000000000,000000000,000000000.00'))
+		do: 
+			[:each |
+			format grouping: each first.
+			self assert: format numberGrouping equals: each second.
+			format numberGrouping: each second.
+			self assert: format grouping equals: each first.
+			self assert: (subject printFloat: 2.0e33 format: format) equals: each last].
+	#(-1 10000) do: 
+			[:each |
+			self should: [format grouping: each] raise: Error.
+			format Grouping: each.
+			self
+				should: [subject printFloat: 1.23 format: format]
+				raise: HRESULTError
+				matching: [:ex | ex tag = (HRESULT win32Error: Win32Errors.ERROR_INVALID_PARAMETER)]].
+	self should: [format numberGrouping: '1;2;3;4;5'] raise: Error!
 
-	"Fake up the other modes - zero is bracketed"
-	subject := Locale lcid: 1033.
-	info := subject instVarNamed: 'info'.
-	info at: Win32Constants.LOCALE_INEGNUMBER put: 0.
-	self assert: (self displayFloat: -0.0 with: subject) equals: '0.00'.
-	self assert: (self displayFloat: -1.25 with: subject) equals: '(1.25)'.
-	self assert: (self displayFloat: -0.0001 with: subject) equals: '0.00'.
-	self assert: (self displayFloat: -123456789.123456789 with: subject) equals: '(123,456,789.12)'.
+testPrintFloatSeparators
+	"Test printing with different number grouping."
 
-	"Mode 4 is trailing minus after space"
-	subject := Locale lcid: 1033.
-	(subject instVarNamed: 'info') at: Win32Constants.LOCALE_INEGNUMBER put: 4.
-	self assert: subject negativeNumberMode equals: 4.
-	self assert: (self displayFloat: -0.0 with: subject) equals: '0.00'.
-	self assert: (self displayFloat: -1.25 with: subject) equals: '1.25 -'.
-	self assert: (self displayFloat: -0.0001 with: subject) equals: '0.00'.
-	self assert: (self displayFloat: -123456789.123456789 with: subject) equals: '123,456,789.12 -'!
+	| subject format |
+	subject := self defaultSubject.
+	format := subject numberFormat copy.
+	format
+		decimalPlaces: 3;
+		grouping: 43;
+		decimalSeparator: $@;
+		thousandSeparator: $^.
+	self assert: (subject printFloat: 1234567890.123 format: format) equals: '123^456^7890@123'!
 
-testEnglishName
-	#(1033 'English' 2057 'English' 1034 'Spanish' 1106 'Welsh' 11274 'Spanish') pairsDo: [:lcid :language |
-		self assert: (Locale lcid: lcid) englishLanguageName equals: language]! !
+testPrintNoLeadingZero
+	| subject format |
+	subject := self defaultSubject.
+	format := subject numberFormat copy.
+	format hasLeadingZero: false.
+	self assert: (subject printFloat: 1234567890.123 format: format) equals: '1,234,567,890.12'.
+	self assert: (subject printFloat: 0.123 format: format) equals: '.12'! !
 !WindowsLocaleTest categoriesFor: #defaultSubject!helpers!private! !
-!WindowsLocaleTest categoriesFor: #testDisplayFloatOn!public!unit tests! !
+!WindowsLocaleTest categoriesFor: #testDisplayFloatOnNegativeModes!public!unit tests! !
 !WindowsLocaleTest categoriesFor: #testEnglishName!public!unit tests! !
+!WindowsLocaleTest categoriesFor: #testPrintFloat!public!unit tests! !
+!WindowsLocaleTest categoriesFor: #testPrintFloatGrouping!public!unit tests! !
+!WindowsLocaleTest categoriesFor: #testPrintFloatSeparators!public!unit tests! !
+!WindowsLocaleTest categoriesFor: #testPrintNoLeadingZero!public!unit tests! !
 


### PR DESCRIPTION
1. Fix the inaccurate comment on the new Float for exponent range not formatted in scientific format
1. Improve tests of Locale Float printing format options