### PR TITLE
Fix deprecated message send in TextAndImageButton click handling

### DIFF
--- a/Core/Contributions/Solutions Software/Tests/SSW Widget Enhancements Tests.pax
+++ b/Core/Contributions/Solutions Software/Tests/SSW Widget Enhancements Tests.pax
@@ -15,6 +15,7 @@ package globalAliases: (Set new
 	yourself).
 
 package setPrerequisites: #(
+	'..\..\..\Object Arts\Dolphin\Base\Dolphin'
 	'..\..\..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base'
 	'..\SSW Widget Enhancements'
 	'..\..\Camp Smalltalk\SUnit\SUnit').

--- a/Core/Contributions/Solutions Software/Tests/TextAndImageButtonTest.cls
+++ b/Core/Contributions/Solutions Software/Tests/TextAndImageButtonTest.cls
@@ -29,6 +29,22 @@ tearDown
 	button := nil.
 	super tearDown!
 
+testButtonWithMenuClick
+
+	| oc cmd |
+
+	oc := OrderedCollection with: 1.
+	cmd := ClosedCommandDescription command: #removeLast description: 'test' receiver: oc.
+	
+	button 
+		commandDescription: cmd;
+		dropDownMenu: (Menu new addCommandDescription: cmd; yourself).
+
+	"#1037 ensure we're not sending a deprecated (and potentially removed) method"
+	self shouldnt: [button dispatchMessage: Win32Constants.WM_LBUTTONDOWN wParam: 0 lParam: 0] raise: MessageNotUnderstood.
+	button dispatchMessage: Win32Constants.WM_LBUTTONUP wParam: 0 lParam: 0.
+	self assert: oc isEmpty!
+
 testLabelWithAmpersand
 	"Test that labels containing ampersands are not (normally) ellipsised.
 	Inspired by TabViewXPTest>>testLabelWithAmpersand"
@@ -69,5 +85,6 @@ testLabelWithAmpersand
 ! !
 !TextAndImageButtonTest categoriesFor: #setUp!public!running! !
 !TextAndImageButtonTest categoriesFor: #tearDown!public!running! !
+!TextAndImageButtonTest categoriesFor: #testButtonWithMenuClick!public!unit tests! !
 !TextAndImageButtonTest categoriesFor: #testLabelWithAmpersand!public!unit tests! !
 

--- a/Core/Contributions/Solutions Software/TextAndImageButton.cls
+++ b/Core/Contributions/Solutions Software/TextAndImageButton.cls
@@ -288,8 +288,8 @@ wmLButtonDown: message wParam: wParam lParam: lParam
 
 	event := 
 		MouseEvent 
+			window: self
 			message: message
-			handle: handle
 			wParam: wParam
 			lParam: lParam.
 


### PR DESCRIPTION
Also add test for click behaviour. Fixes #1037.