### PR TITLE
Avoid holding the NullEventsCollection in SessionManager.events

### DIFF
--- a/Core/Object Arts/Dolphin/Base/SessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SessionManager.cls
@@ -422,7 +422,7 @@ initializeFromSessionManager: oldSessionManager
 	imagePath := oldSessionManager imagePath.
 	stdioStreams := oldSessionManager basicStdioStreams.
 	startupArgs := oldSessionManager startupArgs.
-	events := oldSessionManager events.
+	events := oldSessionManager getEvents.
 	^self!
 
 inputState


### PR DESCRIPTION
Use `#getEvents` instead of `#events` to retrieve the events collection from the old SessionManager.