### PR TITLE
Fix #1042: OneOffNoteBubble sends unimplemented message in deployed apps

### DIFF
--- a/Core/Contributions/Solutions Software/HDITEMW.cls
+++ b/Core/Contributions/Solutions Software/HDITEMW.cls
@@ -253,6 +253,6 @@ defineFields
 
 getFieldNames
 	^#(#mask #cxy #pszText #hbm #cchTextMax #fmt #lParam #iImage #iOrder #type #pvFilter #state)! !
-!HDITEMW class categoriesFor: #defineFields!initializing!public! !
+!HDITEMW class categoriesFor: #defineFields!initializing!public!template definition! !
 !HDITEMW class categoriesFor: #getFieldNames!**compiled accessors**!constants!private! !
 

--- a/Core/Contributions/Solutions Software/SSW EditableListView Demo.pax
+++ b/Core/Contributions/Solutions Software/SSW EditableListView Demo.pax
@@ -35,12 +35,8 @@ package setPrerequisites: #(
 	'..\..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters'
 	'..\..\Object Arts\Dolphin\MVP\Models\Value\Dolphin Value Models'
 	'SSW EditableListView'
-	'SSW Widget Development'
 	'SSW Widget Enhancements'
 	'..\..\Object Arts\Samples\MVP\Video Library\Video Library').
-
-package setManualPrerequisites: #(
-	'SSW Widget Development').
 
 package!
 

--- a/Core/Contributions/Solutions Software/Tests/SSW EditableListView Tests.pax
+++ b/Core/Contributions/Solutions Software/Tests/SSW EditableListView Tests.pax
@@ -8,6 +8,10 @@ package classNames
 	add: #EditableListViewTest;
 	yourself.
 
+package methodNames
+	add: #PackageClosureTests -> #testEditableListViewDemo;
+	yourself.
+
 package binaryGlobalNames: (Set new
 	yourself).
 
@@ -17,7 +21,9 @@ package globalAliases: (Set new
 package setPrerequisites: #(
 	'..\..\..\Object Arts\Dolphin\Base\Dolphin'
 	'..\..\..\Object Arts\Dolphin\MVP\Base\Dolphin MVP Base'
+	'..\..\..\Object Arts\Dolphin\Lagoon\Lagoon Tests'
 	'..\SSW EditableListView'
+	'..\SSW EditableListView Demo'
 	'..\..\Camp Smalltalk\SUnit\SUnit').
 
 package!
@@ -34,6 +40,17 @@ TestCase subclass: #EditableListViewTest
 
 
 "Loose Methods"!
+
+!PackageClosureTests methodsFor!
+
+testEditableListViewDemo
+	"Tests predicted unimplemented messages in EditableListViewDemo
+		- defineTemplate- sent from ExternalStructure>>ensureDefined, which is replaced with a no-op stub in deployed apps. Should not be in the UnimplementedMessages section of the actual deployment log for GUI apps.
+		- evaluate: Compiler deliberately removed from the scope of the test to reduce noise. Should not be in the UnimplementedMessages section of the actual deployment log for GUI apps."
+
+	self verifyPackageClosure: (self environmentForAppDeployment: {EditableListViewDemo owningPackage})
+		missing: #(#defineTemplate #evaluate:)! !
+!PackageClosureTests categoriesFor: #testEditableListViewDemo!public!unit tests! !
 
 "End of package definition"!
 

--- a/Core/Object Arts/Dolphin/Base/SessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SessionManager.cls
@@ -853,6 +853,19 @@ primSnapshot: fileName backup: aBoolean type: typeInteger maxObjects: maxInteger
 	<primitive: 97>
 	^self error: 'Dolphin was unable to save the image.'!
 
+productName
+	"Answer the product name from the receiver's <VersionInfo> for this session, extracted from the host executable."
+
+	^self versionInfo productName
+!
+
+productRegistryKey
+	"Answers the <readableString> registry key of this product."
+
+	"This should be overridden in application subclasses that want something more sophisticated than this simple default, for example to include organisation name."
+
+	^'Software\' , self productName!
+
 queryEndSession
 	"Fire off an event to enquire of observers whether they object to the end of this session.
 	If any observer does, then it must set the boolean value argument to the event to false."
@@ -1259,6 +1272,8 @@ windowsDirectory
 !SessionManager categoriesFor: #primaryStartup!operations-startup!public! !
 !SessionManager categoriesFor: #primQuit:!operations-shutdown!private! !
 !SessionManager categoriesFor: #primSnapshot:backup:type:maxObjects:!operations-saving!private! !
+!SessionManager categoriesFor: #productName!accessing-version!public! !
+!SessionManager categoriesFor: #productRegistryKey!accessing!product!public! !
 !SessionManager categoriesFor: #queryEndSession!event handling!public! !
 !SessionManager categoriesFor: #quit!operations-shutdown!public! !
 !SessionManager categoriesFor: #quit:!operations-shutdown!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DevelopmentSessionManager.cls
@@ -758,7 +758,7 @@ versionString
 !DevelopmentSessionManager categoriesFor: #productDetails!accessing!private!product! !
 !DevelopmentSessionManager categoriesFor: #productDetails:!accessing!private!product! !
 !DevelopmentSessionManager categoriesFor: #productMajorVersion!accessing!product!public! !
-!DevelopmentSessionManager categoriesFor: #productRegistryKey!accessing!private!product! !
+!DevelopmentSessionManager categoriesFor: #productRegistryKey!accessing!product!public! !
 !DevelopmentSessionManager categoriesFor: #productRegistryVersion!accessing!private!product! !
 !DevelopmentSessionManager categoriesFor: #productVersion!accessing!product!public! !
 !DevelopmentSessionManager categoriesFor: #productVersionSpecial!accessing!product!public! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Tooltips/OneOffNoteBubble.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Tooltips/OneOffNoteBubble.cls
@@ -11,7 +11,7 @@ OneOffNoteBubble comment: ''!
 !OneOffNoteBubble class methodsFor!
 
 addPreviouslyViewedNote: aSymbol
-	self registryKey valueAt: aSymbol put: DateAndTime now displayString!
+	self registryKey valueAt: aSymbol put: DateAndTime now printString!
 
 defaultCaption
 	^'One-Off Note'!
@@ -63,7 +63,7 @@ name: aSymbol text: aString for: aView timeout: aDuration
 	bubble notify: aString!
 
 previouslyViewedNotes
-	"Private - Answers the a <Set> of <Symbols> indicating the OneOffNotes that have already been viewed.
+	"Private - Answer a <Set> of <Symbol>s naming the OneOffNotes that have already been viewed.
 
 	self previouslyViewedNotes
 	"
@@ -78,7 +78,7 @@ previouslyViewedNotes: aCollection
 	| regKey timeStamp |
 	self resetPreviouslyViewedNotes.
 	regKey := self registryKey.
-	timeStamp := DateAndTime now displayString.
+	timeStamp := DateAndTime now printString.
 	aCollection do: [:each | regKey valueAt: each put: timeStamp]!
 
 registryKey

--- a/RegressionTestsLoad.st
+++ b/RegressionTestsLoad.st
@@ -8,7 +8,6 @@ Package manager
 	install: 'Core\Contributions\Camp Smalltalk\SUnit\SUnitTests.pax';
 	install: 'Core\Contributions\Camp Smalltalk\ANSI\Tests\CS ANSI Tests.pax';
 	install: 'Core\Contributions\IDB\Tests\IDB Method History Tests.pax';
-	install: 'Core\Contributions\Solutions Software\Tests\SSW EditableListView Tests.pax';
 	install: 'Core\Contributions\Solutions Software\Tests\SSW Widget Enhancements Tests.pax';
 	install: 'Core\Object Arts\Dolphin\System\Base64\Dolphin Base64 Tests.pax';
 	install: 'Core\Object Arts\Dolphin\System\Filer\Dolphin Literal Filer Tests.pax';
@@ -21,6 +20,7 @@ Package manager
 	install: 'Core\Object Arts\Dolphin\MVP\Dolphin MVP Tests.pax';
 	install: 'Core\Object Arts\Dolphin\IDE\Dolphin IDE Tests.pax';
 	install: 'Core\Object Arts\Dolphin\Lagoon\Lagoon Tests.pax';
+	install: 'Core\Contributions\Solutions Software\Tests\SSW EditableListView Tests.pax';
 	install: 'Core\Object Arts\Dolphin\Sockets\Dolphin Sockets Tests.pax';
 	install: 'Core\Object Arts\Dolphin\System\STON\Dolphin STON Tests.pax';
 	install: 'Core\Object Arts\Dolphin\Database\Database Tests.pax';


### PR DESCRIPTION
#productRegistryKey was sent to the current SessionManager by
OneOffNoteBubble to get the name of the registry key under which it stores
a record of the "one-off" notes that have previously been shown. Only the
DevelopmentSessionManager had an implementation of productRegistryKey, so
this would cause failures in a typical deployed application that uses
OneOffNoteBubble. To fix, added a generic definition of productRegistryKey
in SessionManager.

Also add a PackageClosureTest for EditableListView demo to help catch
broken deployment dependencies, and also because his test showed up issue
#1042, and so acts as a regression test for the issue.