### PR TITLE
Fix intermittent "common control call failed" error working with DateTimePicker (fixes #1045)

### DIFF
--- a/Core/Object Arts/Dolphin/Base/DateAndTime.cls
+++ b/Core/Object Arts/Dolphin/Base/DateAndTime.cls
@@ -86,7 +86,7 @@ asSYSTEMTIME
 				wHour: self hour24;
 				wMinute: self minute;
 				wSecond: secs truncated;
-				wMilliseconds: (secs fractionPart * 1000) rounded;
+				wMilliseconds: (secs fractionPart * 1000) truncated;
 				yourself]!
 
 asUnixTime

--- a/Core/Object Arts/Dolphin/Base/DateAndTimeTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DateAndTimeTest.cls
@@ -119,6 +119,20 @@ testAsSYSTEMTIME
 	self assert: actual wSecond equals: 59.
 	self assert: actual wMilliseconds equals: 667!
 
+testAsSYSTEMTIMEInvalidMilliseconds
+	"#1045 - wMillisecond must never be 1000, even if that is what the millisecond value we have would round to"
+
+	| subject actual |
+	subject := DateAndTime
+				year: 2000
+				day: 1
+				hour: 0
+				minute: 0
+				second: 599995 / 10000.
+	actual := subject asSYSTEMTIME.
+	self assert: actual wSecond equals: 59.
+	self assert: actual wMilliseconds equals: 999!
+
 testAsTime
 	"Offset is ignored - the date is not adjusted to local time"
 
@@ -650,6 +664,7 @@ testYearMonthDayHourMinuteSecondOffsetErrors
 !DateAndTimeTest categoriesFor: #testAsDate!public!unit tests! !
 !DateAndTimeTest categoriesFor: #testAsSeconds!public!unit tests! !
 !DateAndTimeTest categoriesFor: #testAsSYSTEMTIME!public!unit tests! !
+!DateAndTimeTest categoriesFor: #testAsSYSTEMTIMEInvalidMilliseconds!public!unit tests! !
 !DateAndTimeTest categoriesFor: #testAsTime!public!unit tests! !
 !DateAndTimeTest categoriesFor: #testAsUnixTime!public!unit tests! !
 !DateAndTimeTest categoriesFor: #testAsUTC!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/Time.cls
+++ b/Core/Object Arts/Dolphin/Base/Time.cls
@@ -55,7 +55,7 @@ asSYSTEMTIME
 		wHour: self hour24;
 		wMinute: self minute;
 		wSecond: self second truncated;
-		wMilliseconds: self millisecond rounded;
+		wMilliseconds: self millisecond truncated;
 		yourself!
 
 asTimeStamp

--- a/Core/Object Arts/Dolphin/Base/TimeTest.cls
+++ b/Core/Object Arts/Dolphin/Base/TimeTest.cls
@@ -52,7 +52,16 @@ testAsSYSTEMTIME
 	self assert: actual wHour equals: now hour24.
 	self assert: actual wMinute equals: now minute.
 	self assert: actual wSecond equals: now second truncated.
-	self assert: actual wMilliseconds equals: (now second fractionPart * 1000) rounded!
+	self assert: actual wMilliseconds equals: (now second fractionPart * 1000) truncated!
+
+testAsSYSTEMTIMEInvalidMilliseconds
+	"#1045 - wMillisecond must never be 1000, even if that is what the millisecond value we have would round to"
+
+	| subject actual |
+	subject := Time fromSeconds: 599995 / 10000.
+	actual := subject asSYSTEMTIME.
+	self assert: actual wSecond equals: 59.
+	self assert: actual wMilliseconds equals: 999!
 
 testClassReadFrom
 	self assert: (Time readFrom: '00' readStream) asSeconds equals: 0.
@@ -283,6 +292,7 @@ testStoreOn
 !TimeTest categoriesFor: #setUp!private!running! !
 !TimeTest categoriesFor: #tearDown!private!running! !
 !TimeTest categoriesFor: #testAsSYSTEMTIME!public!unit tests! !
+!TimeTest categoriesFor: #testAsSYSTEMTIMEInvalidMilliseconds!public!unit tests! !
 !TimeTest categoriesFor: #testClassReadFrom!public!unit tests! !
 !TimeTest categoriesFor: #testFromDuration!public!testing! !
 !TimeTest categoriesFor: #testHours!public!testing! !


### PR DESCRIPTION
Truncate milliseconds rather than rounding to ensure the value is in range 0..999, rather than occasionally setting 1000 which is invalid.