### PR TITLE
Fix race condition in Delay>>wait when #signal is called at approximately the same time as #wait

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Delay.cls
+++ b/Core/Object Arts/Dolphin/Base/Delay.cls
@@ -45,7 +45,7 @@ Example usage:
 	^self resumptionTime <= anotherDelay resumptionTime!
 
 basicCancel
-	^self == Current
+	self == Current
 		ifTrue: 
 			[self class
 				cancelTimer;

--- a/Core/Object Arts/Dolphin/Base/Delay.cls
+++ b/Core/Object Arts/Dolphin/Base/Delay.cls
@@ -185,20 +185,24 @@ terminateProcess
 	self cancel!
 
 wait
-	"Delay the active Process until the receiver's resumption time. The processes priority is temporarily raised to prevent it holding up the timing process when its critical  section - if we did not do this and the current active process has a low priority, then it might be preempted in its critical section, which will prevent the TimingProcess from operating correctly. The resumption time is calculated outside the critical section so that it is based, as near as possible, on the millisecondClockValue at the time the #wait message is sent. If it were calculated inside, then it would incorrectly include the time taken to acquire the AccessProtect Semaphore."
+	"Delay the active Process until the receiver's resumption time. The processes priority is temporarily raised to prevent it holding up the timing process when its critical  section - if we did not do this and the current active process has a low priority, then it might be preempted in its critical section, which will prevent the TimingProcess from operating correctly.
+
+	The resumption time is calculated outside the critical section so that it is based, as near as possible, on the microsecondClockValue at the time the #wait message is sent. If it were calculated inside, then it would incorrectly include the time taken to acquire the AccessProtect Semaphore. However, we must check again upon entering the critical section that it has not been cleared by a #signal in the interim--in this case we have nothing to do, similar to if we were scheduled for an amount of time less than the current resolution."
 
 	| resumingAt |
 	resumingAt := self calcResumptionTime.
-	AccessProtect critical: [
-		"If the new Delay will be the first to wakeup, schedule it"
-		Current isNil 
-			ifTrue: [self schedule]
-			ifFalse: [
-				resumingAt < Current resumptionTime
-					ifTrue: [ 
-						Current snooze.
-						self schedule]
-					ifFalse: [self snooze]]] atPriority: TimingProcess priority-1.
+	AccessProtect critical: 
+			[resumptionTime isNil ifFalse: 
+					["If the new Delay will be the first to wakeup, schedule it"
+					Current isNil
+						ifTrue: [self schedule]
+						ifFalse: 
+							[resumingAt < Current resumptionTime
+								ifTrue: 
+									[Current snooze.
+									self schedule]
+								ifFalse: [self snooze]]]]
+		atPriority: TimingProcess priority - 1.
 	"Now make the active Process wait"
 	waitSemaphore wait!
 

--- a/Core/Object Arts/Dolphin/Base/Delay.cls
+++ b/Core/Object Arts/Dolphin/Base/Delay.cls
@@ -44,6 +44,14 @@ Example usage:
 
 	^self resumptionTime <= anotherDelay resumptionTime!
 
+basicCancel
+	^self == Current
+		ifTrue: 
+			[self class
+				cancelTimer;
+				scheduleNext]
+		ifFalse: [Pending remove: self ifAbsent: []]!
+
 calcResumptionTime
 	"Private - Calculate and answer the value of the millisecond clock after which any Process
 	waiting on the receiver will be rescheduled. We could lazily evaluate this from the normal
@@ -56,18 +64,10 @@ calcResumptionTime
 	^resumptionTime!
 
 cancel
-	"Cancel the receiver. Any Process waiting on the receiver, remains waiting (but see #resume),
+	"Cancel the receiver. Any Process waiting on the receiver, remains waiting (but see #signal),
 	the receiver is simply removed from the collection of Delays managed by the TimingProcess."
 
-	AccessProtect critical: [
-		self == Current
-			ifTrue: [
-				self class
-					cancelTimer;
-					scheduleNext]
-			ifFalse: [
-				Pending remove: self ifAbsent: []]]
-!
+	AccessProtect critical: [self basicCancel]!
 
 delta: anInteger
 	"Private - Adjust the delay provided by the receiver by the specified delta (e.g. on
@@ -162,9 +162,9 @@ schedule
 signal
 	"Immediately resume the Process waiting on the receiver."
 
-	self cancel.
-	self wakeup
-!
+	AccessProtect critical: 
+			[self basicCancel.
+			self wakeup]!
 
 snooze
 	"Private - The receiver wants a few more moments in bed, press the snooze button on 
@@ -212,6 +212,7 @@ wakeup
 	duration ifNotNil: [resumptionTime := nil].
 	waitSemaphore signal! !
 !Delay categoriesFor: #<=!comparing!public! !
+!Delay categoriesFor: #basicCancel!private!process synchronisation! !
 !Delay categoriesFor: #calcResumptionTime!accessing!private! !
 !Delay categoriesFor: #cancel!process synchronisation!public! !
 !Delay categoriesFor: #delta:!operations!private! !

--- a/Core/Object Arts/Dolphin/Base/DelayTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DelayTest.cls
@@ -10,12 +10,15 @@ DelayTest comment: ''!
 !DelayTest categoriesForClass!Unclassified! !
 !DelayTest methodsFor!
 
-expectDelay: expectedMilliseconds for: nowMicroseconds
+expectDelay: expectedDuration for: nowMicroseconds
 	| elapsed delta |
 	elapsed := nowMicroseconds - startTime.
-	delta := (elapsed - (expectedMilliseconds * 1000)) abs.
-	self assert: delta < 2000
-		description: ('Expected delay of <1d>ms, got <2d>ms' expandMacrosWith: expectedMilliseconds
+	delta := elapsed - expectedDuration asMicroseconds.
+	"Although a Delay could end up waiting much longer than the expected duration,
+	e.g. if the CPU is very busy, this should happen only rarely, and we do not want
+	to tolerate it if it happens all the time as that would indicate an actual bug."
+	self assert: (delta > -1000 and: [delta < 3000])
+		description: ('Expected delay of <1d>ms, got <2d>ms' expandMacrosWith: expectedDuration
 				with: (elapsed // 100 / 10 asScaledDecimal: 1))!
 
 setUp
@@ -30,7 +33,7 @@ tearDown
 testBasicWait
 	delay := Delay forMilliseconds: 20.
 	delay wait.
-	self expectDelay: 20 for: Time microsecondClockValue!
+	self expectDelay: 20 milliseconds for: Time microsecondClockValue!
 
 testCancel
 	| proc endTime |
@@ -40,7 +43,7 @@ testCancel
 			endTime := Time microsecondClockValue] forkAt: Processor userInterruptPriority.
 	
 	[delay cancel.
-	self deny: Delay.Current == delay.
+	self deny: Delay.Current identicalTo: delay.
 	self deny: (Delay.Pending includes: delay).
 	(Delay forMilliseconds: 30) wait.
 	self assertIsNil: endTime.
@@ -58,8 +61,8 @@ testSchedulingMultipleDelays
 	[delay wait.
 	endTime := Time microsecondClockValue] forkAt: Processor userInterruptPriority.
 	(Delay forMilliseconds: 30) wait.
-	self expectDelay: 20 for: endTime.
-	self expectDelay: 30 for: Time microsecondClockValue!
+	self expectDelay: 20 milliseconds for: endTime.
+	self expectDelay: 30 milliseconds for: Time microsecondClockValue!
 
 testSchedulingMultipleDelaysLongerFirst
 	| endTime |
@@ -70,12 +73,12 @@ testSchedulingMultipleDelaysLongerFirst
 	"Wait for a shorter period than the other process"
 	(Delay forMilliseconds: 20) wait.
 	"We should have waited for the correct time, other proc is still waiting"
-	self expectDelay: 20 for: Time microsecondClockValue.
+	self expectDelay: 20 milliseconds for: Time microsecondClockValue.
 	self assertIsNil: endTime.
 	"Now wait long enough for it to be done"
 	(Delay forMilliseconds: 20) wait.
-	self expectDelay: 30 for: endTime.
-	self expectDelay: 40 for: Time microsecondClockValue!
+	self expectDelay: 30 milliseconds for: endTime.
+	self expectDelay: 40 milliseconds for: Time microsecondClockValue!
 
 testSignal
 	| endTime |
@@ -85,7 +88,7 @@ testSignal
 	endTime := Time microsecondClockValue] forkAt: Processor userInterruptPriority.
 	(Delay forMilliseconds: 10) wait.
 	delay signal.
-	self expectDelay: 10 for: endTime!
+	self expectDelay: 10 milliseconds for: endTime!
 
 testSimultaneousWaitAndSignal
 	| waitError signalError signalFinished endTime |
@@ -101,7 +104,7 @@ testSimultaneousWaitAndSignal
 			forkAt: Processor userInterruptPriority.	"Will block on AccessProtect in #cancel too, but higher priority"
 	Delay.AccessProtect signal.	"Allow the bug to unfold"
 	KernelLibrary default sleep: 10.	"Wait for both processes above to finish, without using the Delay mechanism"
-	self expectDelay: 0 for: endTime.	"Process should not have actually waited on the delay"
+	self expectDelay: 0 milliseconds for: endTime.	"Process should not have actually waited on the delay"
 	self assertIsNil: waitError.
 	self assert: signalFinished.
 	self assertIsNil: signalError!

--- a/Core/Object Arts/Dolphin/Base/DelayTest.cls
+++ b/Core/Object Arts/Dolphin/Base/DelayTest.cls
@@ -1,0 +1,128 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #DelayTest
+	instanceVariableNames: 'delay startTime'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+DelayTest guid: (GUID fromString: '{0b7c6875-1051-4b80-b137-cd1c02754bcd}')!
+DelayTest comment: ''!
+!DelayTest categoriesForClass!Unclassified! !
+!DelayTest methodsFor!
+
+expectDelay: expectedMilliseconds for: nowMicroseconds
+	| elapsed delta |
+	elapsed := nowMicroseconds - startTime.
+	delta := (elapsed - (expectedMilliseconds * 1000)) abs.
+	self assert: delta < 2000
+		description: ('Expected delay of <1d>ms, got <2d>ms' expandMacrosWith: expectedMilliseconds
+				with: (elapsed // 100 / 10 asScaledDecimal: 1))!
+
+setUp
+	super setUp.
+	startTime := Time microsecondClockValue.
+	Delay resolution: 1 milliseconds set: true!
+
+tearDown
+	Delay resolution: 1 milliseconds set: false.
+	super tearDown!
+
+testBasicWait
+	delay := Delay forMilliseconds: 20.
+	delay wait.
+	self expectDelay: 20 for: Time microsecondClockValue!
+
+testCancel
+	| proc endTime |
+	delay := Delay forMilliseconds: 20.
+	proc := 
+			[delay wait.
+			endTime := Time microsecondClockValue] forkAt: Processor userInterruptPriority.
+	
+	[delay cancel.
+	self deny: Delay.Current == delay.
+	self deny: (Delay.Pending includes: delay).
+	(Delay forMilliseconds: 30) wait.
+	self assertIsNil: endTime.
+	self assert: proc isWaiting]
+			ensure: [proc terminate]!
+
+testCancelWithOtherShorterDelay
+	[(Delay forMilliseconds: 10) wait] forkAt: Processor userInterruptPriority.
+	self testCancel!
+
+testSchedulingMultipleDelays
+	| endTime |
+	delay := Delay forMilliseconds: 20.
+	
+	[delay wait.
+	endTime := Time microsecondClockValue] forkAt: Processor userInterruptPriority.
+	(Delay forMilliseconds: 30) wait.
+	self expectDelay: 20 for: endTime.
+	self expectDelay: 30 for: Time microsecondClockValue!
+
+testSchedulingMultipleDelaysLongerFirst
+	| endTime |
+	delay := Delay forMilliseconds: 30.
+	
+	[delay wait.
+	endTime := Time microsecondClockValue] forkAt: Processor userInterruptPriority.
+	"Wait for a shorter period than the other process"
+	(Delay forMilliseconds: 20) wait.
+	"We should have waited for the correct time, other proc is still waiting"
+	self expectDelay: 20 for: Time microsecondClockValue.
+	self assertIsNil: endTime.
+	"Now wait long enough for it to be done"
+	(Delay forMilliseconds: 20) wait.
+	self expectDelay: 30 for: endTime.
+	self expectDelay: 40 for: Time microsecondClockValue!
+
+testSignal
+	| endTime |
+	delay := Delay forMilliseconds: 20.
+	
+	[delay wait.
+	endTime := Time microsecondClockValue] forkAt: Processor userInterruptPriority.
+	(Delay forMilliseconds: 10) wait.
+	delay signal.
+	self expectDelay: 10 for: endTime!
+
+testSimultaneousWaitAndSignal
+	| waitError signalError signalFinished endTime |
+	delay := Delay forMilliseconds: 20.
+	signalFinished := false.
+	Delay.AccessProtect wait.	"Ensure that the Delay wait will be blocked"
+	
+	[[delay wait] on: Error do: [:ex | waitError := ex].
+	endTime := Time microsecondClockValue] fork.	"Delay>>wait will calc a resumption time, then block"
+	
+	[[delay signal] on: Error do: [:ex | signalError := ex].
+	signalFinished := true]
+			forkAt: Processor userInterruptPriority.	"Will block on AccessProtect in #cancel too, but higher priority"
+	Delay.AccessProtect signal.	"Allow the bug to unfold"
+	KernelLibrary default sleep: 10.	"Wait for both processes above to finish, without using the Delay mechanism"
+	self expectDelay: 0 for: endTime.	"Process should not have actually waited on the delay"
+	self assertIsNil: waitError.
+	self assert: signalFinished.
+	self assertIsNil: signalError!
+
+testSimultaneousWaitAndSignalWithOtherLongerDelay
+	[(Delay forMilliseconds: 25) wait] forkAt: Processor userInterruptPriority.
+	self testSimultaneousWaitAndSignal!
+
+testSimultaneousWaitAndSignalWithOtherShorterDelay
+	[(Delay forMilliseconds: 15) wait] forkAt: Processor userInterruptPriority.
+	self testSimultaneousWaitAndSignal! !
+!DelayTest categoriesFor: #expectDelay:for:!helpers!private! !
+!DelayTest categoriesFor: #setUp!private!running! !
+!DelayTest categoriesFor: #tearDown!private!running! !
+!DelayTest categoriesFor: #testBasicWait!public!unit tests! !
+!DelayTest categoriesFor: #testCancel!public!unit tests! !
+!DelayTest categoriesFor: #testCancelWithOtherShorterDelay!public!unit tests! !
+!DelayTest categoriesFor: #testSchedulingMultipleDelays!public!unit tests! !
+!DelayTest categoriesFor: #testSchedulingMultipleDelaysLongerFirst!public!unit tests! !
+!DelayTest categoriesFor: #testSignal!public!unit tests! !
+!DelayTest categoriesFor: #testSimultaneousWaitAndSignal!public!unit tests! !
+!DelayTest categoriesFor: #testSimultaneousWaitAndSignalWithOtherLongerDelay!public!unit tests! !
+!DelayTest categoriesFor: #testSimultaneousWaitAndSignalWithOtherShorterDelay!public!unit tests! !
+

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -33,6 +33,7 @@ package classNames
 	add: #DateAndTimeTest;
 	add: #DateTest;
 	add: #DefaultSortAlgorithmTest;
+	add: #DelayTest;
 	add: #DictionaryTest;
 	add: #DiskVolumeInformationTest;
 	add: #DolphinCollectionTest;
@@ -247,6 +248,11 @@ DolphinTest subclass: #DateAndTimeTest
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #DateTest
 	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+DolphinTest subclass: #DelayTest
+	instanceVariableNames: 'delay startTime'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!


### PR DESCRIPTION
Given two processes at different priorities—call them `background` (at relatively low priority) and `foreground` (at relatively high priority)—and a `Delay` object `some_delay`, it is possible for the following sequence to occur:

1. `background` calls `some_delay wait`, enters `Delay>>wait` and executes `calcResumptionTime`.
2. At some point between the return from `calcResumptionTime` and acquiring `Delay.AccessProtect`, `foreground` becomes runnable, preempts and calls `some_delay signal`. This sets `some_delay.resumptionTime` ivar to `nil`, but the `resumingAt` temp in `#wait` is still set.
3. Once `foreground` waits on something else (an overlapped I/O call, in the case where I encountered this), `background` acquires `Delay.AccessProtect` and ultimately tries to either `schedule` or `snooze`, both of which will fail because `resumptionTime` is nil.

My thinking is that, for this to occur, the call to `signal` must happen after the call to `wait`, so the more-correct thing is for the delay to ultimately not wait, and since the `signal` call will have left an unconsumed signal behind, all we need to do is not try to schedule/snooze the delay and everything will work out.

I have a reproducible test-case for this, but at the moment it involves proprietary application code—I haven't managed to trace the exact interaction of the various Processes and reproduce it using only dummy code and other Delays. If doing so is important, I can keep trying, but the mechanism seems clear enough...