### PR TITLE
Fix #1051: Missing method of AnsiString required by Collection>>split:

### DIFF
--- a/Core/Object Arts/Dolphin/Base/AnsiString.cls
+++ b/Core/Object Arts/Dolphin/Base/AnsiString.cls
@@ -71,6 +71,11 @@ decodeNextFrom: aReadStream
 
 	^aReadStream basicNextAvailable ifNotNil: [:ch | Character ansiValue: ch]!
 
+encodedSizeAt: anInteger
+	"Private - Answer the <integer> number of code units occuppied by the <Character> whose first code unit is at the specified index in the receiver. Always 1 in the case of an ANSI string (multi-byte code pages are not supported)."
+
+	^1!
+
 encodeOn: aWriteStream put: aCharacter
 	"Private - Encode the <Character> argument onto the <WriteStream> argument as a single byte ANSI code unit.
 	 An error is raised if the <Character> has code point that is not representable in the ANSI encoding."
@@ -164,6 +169,7 @@ urlDecoded
 !AnsiString categoriesFor: #copyToBuffer:ofSize:!copying!private! !
 !AnsiString categoriesFor: #decodeAt:!encode/decode!private! !
 !AnsiString categoriesFor: #decodeNextFrom:!encode/decode!private! !
+!AnsiString categoriesFor: #encodedSizeAt:!encode/decode!private! !
 !AnsiString categoriesFor: #encodeOn:put:!encode/decode!private! !
 !AnsiString categoriesFor: #first:!copying!public! !
 !AnsiString categoriesFor: #nextIndexOfCharacter:from:to:!private!searching! !

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -456,6 +456,11 @@ displayString
 
 	^self!
 
+encodedSizeAt: anInteger
+	"Private - Answer the <integer> number of code units occuppied by the <Character> whose first code unit is at the specified index in the receiver. Throw an error if the code unit at anInteger is not either an ASCII code point or a UTF-8 lead surrogate"
+
+	^self subclassResponsibility!
+
 encodeOn: aWriteStream put: aCharacter
 	"Private - Encode the <Character> argument onto the <WriteStream> argument using the character
 	encoding of the receiver, e.g. for Utf8String, this would be the relevant sequence of 1 to 4
@@ -1253,6 +1258,7 @@ withNormalizedLineDelimiters
 !String categoriesFor: #decodeNextFrom:!encode/decode!private! !
 !String categoriesFor: #displayOn:!printing!public! !
 !String categoriesFor: #displayString!printing!public! !
+!String categoriesFor: #encodedSizeAt:!encode/decode!private! !
 !String categoriesFor: #encodeOn:put:!encode/decode!private! !
 !String categoriesFor: #expandMacros!printing!public! !
 !String categoriesFor: #expandMacrosWith:!printing!public! !

--- a/Core/Object Arts/Dolphin/Base/StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StringTest.cls
@@ -567,6 +567,52 @@ testReverseDo
 			actual := actual contents.
 			self assert: actual equals: expected]!
 
+testSplitByCharacterArray
+	| empty separators |
+	empty := #().
+	self assert: (empty split: (self assimilateString: 'abc')) equals: #('abc').
+
+	"Split by multiple chars - each of the characters in the separator collection is a potential separator"
+	separators := '.-' asArray.
+	self assert: (separators split: empty) equals: (#() collect: [:e | self assimilateString: e]).
+	self assert: (separators split: (self assimilateString: 'a'))
+		equals: (#('a') collect: [:e | self assimilateString: e]).
+	self assert: (separators split: (self assimilateString: '.a'))
+		equals: (#('' 'a') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: '-a'))
+		equals: (#('' 'a') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: 'a-'))
+		equals: (#('a' '') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: '-.a'))
+		equals: (#('' '' 'a') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: 'a.-'))
+		equals: (#('a' '' '') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: 'ab'))
+		equals: (#('ab') collect: [:e | self assimilateString: e]).
+	self assert: (separators split: (self assimilateString: '-ab'))
+		equals: (#('' 'ab') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: 'ab.'))
+		equals: (#('ab' '') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: 'ab-..'))
+		equals: (#('ab' '' '' '') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: '--ab'))
+		equals: (#('' '' 'ab') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: 'a.b'))
+		equals: (#('a' 'b') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: 'a-.b'))
+		equals: (#('a' '' 'b') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: 'ab-c.'))
+		equals: (#('ab' 'c' '') collect: [:e | self newCopy: e]).
+	self assert: (separators split: (self assimilateString: 'a.b-.c'))
+		equals: (#('a' 'b' '' 'c') collect: [:e | self newCopy: e]).
+	1 to: 3
+		do: 
+			[:i |
+			| subject |
+			subject := self
+						assimilateString: (String streamContents: [:strm | i timesRepeat: [strm nextPut: $-]]).
+			self assert: (#($-) split: subject) equals: (Array new: i + 1 withAll: '')]!
+
 testSplitByString
 	"Test String>>split:, which tokenizes the argument string into sequences that are separated by the receiver string."
 
@@ -981,6 +1027,7 @@ withAllTestCases
 !StringTest categoriesFor: #testRefersToLiteral!public!unit tests! !
 !StringTest categoriesFor: #testReverse!public!unit tests! !
 !StringTest categoriesFor: #testReverseDo!public!unit tests! !
+!StringTest categoriesFor: #testSplitByCharacterArray!public!unit tests! !
 !StringTest categoriesFor: #testSplitByString!public!unit tests! !
 !StringTest categoriesFor: #testSplitSingle!public!unit tests! !
 !StringTest categoriesFor: #testStreamUtfRoundTrip!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/UtfEncodedString.cls
+++ b/Core/Object Arts/Dolphin/Base/UtfEncodedString.cls
@@ -211,11 +211,6 @@ encodedAt: anInteger put: aCharacter
 
 	^self subclassResponsibility!
 
-encodedSizeAt: anInteger
-	"Private - Answer the <integer> number of code units occuppied by the <Character> whose first code unit is at the specified index in the receiver. Throw an error if the code unit at anInteger is not either an ASCII code point or a UTF-8 lead surrogate"
-
-	^self subclassResponsibility!
-
 encodedSizeOf: aCharacter
 	"Private - Answer the number of basic slots occupied by the argument when encoded in the receiver's encoding."
 
@@ -465,7 +460,6 @@ with: otherCollection do: aDyadicValuable
 !UtfEncodedString categoriesFor: #do:!debugger-step through!enumerating!public! !
 !UtfEncodedString categoriesFor: #emitEncodingMarkerOn:!accessing!public! !
 !UtfEncodedString categoriesFor: #encodedAt:put:!accessing!encode/decode!private! !
-!UtfEncodedString categoriesFor: #encodedSizeAt:!encode/decode!private! !
 !UtfEncodedString categoriesFor: #encodedSizeOf:!encode/decode!private! !
 !UtfEncodedString categoriesFor: #encodeOn:next:putAll:startingAt:!encode/decode!private! !
 !UtfEncodedString categoriesFor: #errorIntraCharacterIndex:!encode/decode!private! !

--- a/Core/Object Arts/Dolphin/Base/UtfEncodedStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/UtfEncodedStringTest.cls
@@ -514,7 +514,7 @@ testSelect
 	self assert: actual equals: '文🐬🍺🍻'.
 	self assert: (self collectionClass empty select: [:each | self assert: false]) equals: ''!
 
-testSplitByCharacterArray
+testSplitByCharacterArrayExtended
 	| subject actual separators |
 	subject := self assimilateString: '一1二2三3四'.
 	separators := #($\x4E00 $\x4E8C $\x4E09 $\x56DB).
@@ -610,7 +610,7 @@ withAllTestCases
 !UtfEncodedStringTest categoriesFor: #testRuneSubStrings!public!unit tests! !
 !UtfEncodedStringTest categoriesFor: #testSecondThirdEtc!public!unit tests! !
 !UtfEncodedStringTest categoriesFor: #testSelect!public!unit tests! !
-!UtfEncodedStringTest categoriesFor: #testSplitByCharacterArray!public!unit tests! !
+!UtfEncodedStringTest categoriesFor: #testSplitByCharacterArrayExtended!public!unit tests! !
 !UtfEncodedStringTest categoriesFor: #testSplitByString!public!unit tests! !
 !UtfEncodedStringTest categoriesFor: #testWithDo!public!unit tests! !
 !UtfEncodedStringTest categoriesFor: #withAllTestCases!constants!private! !


### PR DESCRIPTION
Not detected due to a test gap - Collection>>split: not exercised at all for non-UTF-encoded strings.