### PR TITLE
Add binary selector << to String as alias to expandMacros...

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Collection.cls
+++ b/Core/Object Arts/Dolphin/Base/Collection.cls
@@ -323,6 +323,12 @@ errorNotKeyed
 
 	^self error: ('<1p>s do not respond to keyed accessing messages' expandMacrosWith: self class)!
 
+expandMacrosIn: aString
+
+	"Private - Expand aString with the collection of replaceable arguments represented by the receiver."
+
+	^aString expandMacrosWithArguments: self!
+
 fold: aDyadicValuable 
 	"Evaluate the <dyadicValuable> argument, operation, across the elements of the receiver
 	starting with the first two elements. For subsequent evaluations the first argument to the
@@ -629,6 +635,7 @@ union: comperand
 !Collection categoriesFor: #do:separatedBy:!enumerating!public! !
 !Collection categoriesFor: #errorEmptyCollection!exceptions!private! !
 !Collection categoriesFor: #errorNotKeyed!exceptions!private! !
+!Collection categoriesFor: #expandMacrosIn:!double dispatch!private! !
 !Collection categoriesFor: #fold:!enumerating!public! !
 !Collection categoriesFor: #growSize!accessing!private! !
 !Collection categoriesFor: #identityIncludes:!public!searching! !

--- a/Core/Object Arts/Dolphin/Base/Object.cls
+++ b/Core/Object Arts/Dolphin/Base/Object.cls
@@ -630,6 +630,12 @@ events
 		ifTrue: [NullEventsCollection current]
 		ifFalse: [events]!
 
+expandMacrosIn: aString
+
+	"Private - Expand aString with the replaceable argument represented by the receiver."
+
+	^aString expandMacrosWith: self!
+
 finalize
 	"Perform any death-bed operations as the receiver is about to expire. The default is to
 	do nothing.
@@ -1546,6 +1552,7 @@ yourself
 !Object categoriesFor: #errorNotFound:!exceptions!public! !
 !Object categoriesFor: #errorSubscriptBounds:!exceptions!public! !
 !Object categoriesFor: #events!debugger-step over!events!public! !
+!Object categoriesFor: #expandMacrosIn:!double dispatch!private! !
 !Object categoriesFor: #finalize!finalizing!public! !
 !Object categoriesFor: #free!finalizing!public! !
 !Object categoriesFor: #getDependents!dependency!private! !

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -107,6 +107,15 @@ _separateSubStringsIn: aReadableString
 
 	^self <=> aString < 0!
 
+<< anObject
+	"Expand the receiver with replacable arguments represented by anObject.
+	anObject may be an individual object mapping to a single parameter (in which case this message is equivalent to #expandMacrosWith:),
+	or a collection mapping to a collection of parameters (in which case this message is equivalent to #expandMacrosWithArguments:).
+
+	See #expandMacrosWithArguments: for further details."
+
+	^anObject expandMacrosIn: self!
+
 <= aString
 	"Answer whether the receiver is lexically less than or equal to the <readableString>, argument, ignoring case, according to the implementation defined collation sequence (see <=>)."
 
@@ -470,31 +479,39 @@ encodeOn: aWriteStream put: aCharacter
 
 expandMacros
 	"Expand the receiver with replacable arguments.
-	See #formatWithArguments: for further details."
+	See #expandMacrosWithArguments: for further details."
 
 	^self expandMacrosWithArguments: #()!
 
+expandMacrosIn: aString
+
+	"Private - Expand aString with the replaceable argument represented by the receiver.
+
+	Overridden here to avoid treating the receiver as a collection of multiple arguments"
+
+	^aString expandMacrosWith: self!
+
 expandMacrosWith: anObject
 	"Expand the receiver with replacable arguments.
-	See #formatWithArguments: for further details."
+	See #expandMacrosWithArguments: for further details."
 
 	^self expandMacrosWithArguments: {anObject}!
 
 expandMacrosWith: anObject with: anotherObject
 	"Expand the receiver with replacable arguments.
-	See #formatWithArguments: for further details."
+	See #expandMacrosWithArguments: for further details."
 
 	^self expandMacrosWithArguments: {anObject. anotherObject}!
 
 expandMacrosWith: anObject with: anotherObject with: thirdObject 
 	"Expand the receiver with replacable arguments.
-	See #formatWithArguments: for further details."
+	See #expandMacrosWithArguments: for further details."
 
 	^self expandMacrosWithArguments: {anObject. anotherObject. thirdObject}!
 
 expandMacrosWith: anObject with: anotherObject with: thirdObject with: fourthObject 
 	"Expand the receiver with replacable arguments.
-	See #formatWithArguments: for further details."
+	See #expandMacrosWithArguments: for further details."
 
 	^self expandMacrosWithArguments: {anObject. anotherObject. thirdObject. fourthObject}!
 
@@ -1218,6 +1235,7 @@ withNormalizedLineDelimiters
 !String categoriesFor: #_sameAsString:!comparing!private! !
 !String categoriesFor: #_separateSubStringsIn:!private!tokenizing! !
 !String categoriesFor: #<!comparing!public! !
+!String categoriesFor: #<<!printing!public! !
 !String categoriesFor: #<=!comparing!public! !
 !String categoriesFor: #<==>!comparing!public! !
 !String categoriesFor: #<=>!comparing!public! !
@@ -1261,6 +1279,7 @@ withNormalizedLineDelimiters
 !String categoriesFor: #encodedSizeAt:!encode/decode!private! !
 !String categoriesFor: #encodeOn:put:!encode/decode!private! !
 !String categoriesFor: #expandMacros!printing!public! !
+!String categoriesFor: #expandMacrosIn:!double dispatch!private! !
 !String categoriesFor: #expandMacrosWith:!printing!public! !
 !String categoriesFor: #expandMacrosWith:with:!printing!public! !
 !String categoriesFor: #expandMacrosWith:with:with:!printing!public! !

--- a/Core/Object Arts/Dolphin/Base/StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StringTest.cls
@@ -137,6 +137,50 @@ testBeginsWithMixedEncodings
 			self deny: (b beginsWith: each).
 			self deny: (ad beginsWith: each)]!
 
+testBinarySelectorExpandMacrosWith
+
+	self assert: (self assimilateString: 'test <1d> displayString') << 1.23s2 equals: 'test 1.23 displayString'.
+	self assert: (self assimilateString: 'test <1p> printString') << 1.23s2 equals: 'test 1.23s printString'.
+	self assert: (self assimilateString: 'test <1s> asString') << $Z equals: 'test Z asString'.
+	self assert: (self assimilateString: 'test <1?yes:no> conditional True') << true equals: 'test yes conditional True'.
+	self assert: (self assimilateString: 'test <1?yes:no> conditional False') << false equals: 'test no conditional False'!
+
+testBinarySelectorExpandMacrosWithArguments
+
+	| pattern expectedResult |
+
+	pattern := 'test displayString <1d> printString <2p> asString <3s> newline<N>tab<T>conditionals <4?yes:no> <5?yes:no> end test'.
+	pattern := self assimilateString: pattern.
+
+	expectedResult := 'test displayString 1.23 printString 4.56s asString Z newline', String lineDelimiter, 'tab	conditionals yes no end test'.
+	expectedResult := self assimilateString: expectedResult.
+
+	self assert: pattern << #(1.23 4.56s2 $Z true false) equals: expectedResult!
+
+testBinarySelectorExpandMacrosWithCollection
+
+	"Test special handling of collections when using << expandMacrosWith... binary selector"
+
+	"A collection should be treated as a collection of arguments"
+	self assert: (self assimilateString: 'test <1d> <2d> <3d> displayString') << (1 to: 10) equals: 'test 1 2 3 displayString'.
+	self assert: (self assimilateString: 'test <1p> <2p> <3p> printString') << #(4 5 6) equals: 'test 4 5 6 printString'.
+	self assert: (self assimilateString: 'test <1s><2s><3s> asString') << #($a $b $c) equals: 'test abc asString'.
+
+	"Wrap in an Array to treat the collection as an individual argument"
+	self assert: (self assimilateString: 'test <1d> displayString') << {(1 to: 10)} equals: 'test 1 .. 10 displayString'.
+	self assert: (self assimilateString: 'test <1p> printString') << {#(4 5 6)} equals: 'test #(4 5 6) printString'.
+	self assert: (self assimilateString: 'test <1s> asString') << {#($a $b $c)} equals: 'test abc asString'.
+
+	"...but a String should always be treated as an individual argument"
+	self assert: (self assimilateString: 'test <1d> displayString') << 'hello world' equals: 'test hello world displayString'.
+	self assert: (self assimilateString: 'test <1p> printString') << 'hello world' equals: 'test ''hello world'' printString'.
+	self assert: (self assimilateString: 'test <1s> asString') << 'hello world' equals: 'test hello world asString'.
+
+	self assert: (self assimilateString: 'test <1d> displayString') << {'hello world'} equals: 'test hello world displayString'.
+	self assert: (self assimilateString: 'test <1p> printString') << {'hello world'} equals: 'test ''hello world'' printString'.
+	self assert: (self assimilateString: 'test <1s> asString') << {'hello world'} equals: 'test hello world asString'
+!
+
 testCapitalized
 	| string cap |
 	string := self collectionClass empty.
@@ -241,6 +285,26 @@ testEquals
 	self assert: #abc equals: abc.
 	self assert: abc equals: #abc.
 !
+
+testExpandMacrosWith
+
+	self assert: ((self assimilateString: 'test <1d> displayString') expandMacrosWith: 1.23s2) equals: 'test 1.23 displayString'.
+	self assert: ((self assimilateString: 'test <1p> printString') expandMacrosWith: 1.23s2) equals: 'test 1.23s printString'.
+	self assert: ((self assimilateString: 'test <1s> asString') expandMacrosWith: $Z) equals: 'test Z asString'.
+	self assert: ((self assimilateString: 'test <1?yes:no> conditional True') expandMacrosWith: true) equals: 'test yes conditional True'.
+	self assert: ((self assimilateString: 'test <1?yes:no> conditional False') expandMacrosWith: false) equals: 'test no conditional False'!
+
+testExpandMacrosWithArguments
+
+	| pattern expectedResult |
+
+	pattern := 'test displayString <1d> printString <2p> asString <3s> newline<N>tab<T>conditionals <4?yes:no> <5?yes:no> end test'.
+	pattern := self assimilateString: pattern.
+
+	expectedResult := 'test displayString 1.23 printString 4.56s asString Z newline', String lineDelimiter, 'tab	conditionals yes no end test'.
+	expectedResult := self assimilateString: expectedResult.
+
+	self assert: (pattern expandMacrosWithArguments: #(1.23 4.56s2 $Z true false)) equals: expectedResult!
 
 testFindStringStartingAt
 	| searchee abc a empty ba ab bb bba abba |
@@ -1008,6 +1072,9 @@ withAllTestCases
 !StringTest categoriesFor: #testBefore!public!unit tests! !
 !StringTest categoriesFor: #testBeginsWithEmbeddedNulls!public!unit tests! !
 !StringTest categoriesFor: #testBeginsWithMixedEncodings!public!unit tests! !
+!StringTest categoriesFor: #testBinarySelectorExpandMacrosWith!public!unit tests! !
+!StringTest categoriesFor: #testBinarySelectorExpandMacrosWithArguments!public!unit tests! !
+!StringTest categoriesFor: #testBinarySelectorExpandMacrosWithCollection!public!unit tests! !
 !StringTest categoriesFor: #testCapitalized!public!unit tests! !
 !StringTest categoriesFor: #testCaseConversions!public!unit tests! !
 !StringTest categoriesFor: #testClassFromAddress!public!unit tests! !
@@ -1015,6 +1082,8 @@ withAllTestCases
 !StringTest categoriesFor: #testCopyWithout!public! !
 !StringTest categoriesFor: #testEmpty!public!testing / accessing! !
 !StringTest categoriesFor: #testEquals!public!unit tests! !
+!StringTest categoriesFor: #testExpandMacrosWith!public!unit tests! !
+!StringTest categoriesFor: #testExpandMacrosWithArguments!public!unit tests! !
 !StringTest categoriesFor: #testFindStringStartingAt!public!unit tests! !
 !StringTest categoriesFor: #testFindStringStartingAtIgnoreCase!public!unit tests! !
 !StringTest categoriesFor: #testHash!public!unit tests! !


### PR DESCRIPTION
Add binary selector `<<` to String as alias to `expandMacrosWith:` / `expandMacrosWithArguments:` (double-dispatched from argument). Also add associated tests and fix incorrect reference in comment to `expandMacros` etc. 
Resolves #1053.