### PR TITLE
Fix #1055: Make primitiveChangeBehavior much less picky

### DIFF
--- a/Core/DolphinVM/Interprt.h
+++ b/Core/DolphinVM/Interprt.h
@@ -651,6 +651,8 @@ public:
 
 	// Object mutation
 	static Oop* __fastcall primitiveChangeBehavior(Oop* const sp, primargcount_t argCount);
+	static boolean hasCompatibleShape(OTE* oteReceiver, ST::Behavior* argClass);
+
 	static Oop* __fastcall primitiveResize(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveBecome(Oop* const sp, primargcount_t argCount);
 	static Oop* __fastcall primitiveOneWayBecome(Oop* const sp, primargcount_t argCount);

--- a/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/VMTest.cls
@@ -1374,6 +1374,56 @@ testPrimitiveBytesIsNull
 			bytes := DWORDBytes newFixed: each.
 			self assert: bytes isNull]!
 
+testPrimitiveChangeBehavior
+	"Test the becomeA:/becomeAn: primitive. We have to be careful not to pass literals as we don't want to mutate the test method."
+
+	| method obj |
+	method := self createPrimitiveMethodLike: Object >> #becomeA:.
+	obj := Array new.
+	"Valid cases, although the resulting object is only guaranteed to be valid at the basic level understood by the VM"
+	{{Object new. Array. #()}.
+		{obj. Object. obj}.
+		{'a' -> 'b'. Array. #('a' 'b')}.
+		{{'a'. 'b'}. Association. 'a' -> 'b'}.
+		{10 @ 20 -> (100 @ 200). Rectangle. 10 @ 20 corner: 100 @ 200}.
+		{ExternalHandle fromInteger: 1234. DWORDBytes. DWORDBytes fromInteger: 1234}.
+		{Object guid. CLSID. CLSID fromString: '{87b4c451-026e-11d3-9fd7-00a0cc3e4a32}'}.
+		{{1. 0}. OrderedCollection. OrderedCollection new}.
+		{{1. 2. 'a'. 'b'}. OrderedCollection. OrderedCollection with: 'a' with: 'b'}.
+		{OrderedCollection with: 'a' with: 'b'. Array. #(1 2 'a' 'b')}.
+		{OrderedCollection new. Set. Set with: 0}.
+		{123. SmallInteger. 123}.
+		{16r3FFFFFFF. ByteArray. #[255 255 255 63]}.
+		{Utf8String with: $a. Utf8String. 'a'}.
+		{ByteArray with: 128. ByteArray. #[128]}.
+		{{'a'. 'b'}. Array. #('a' 'b')}} do: 
+				[:each |
+				| subject result operand expected |
+				subject := each first.
+				operand := each second.
+				expected := each third.
+				result := method value: subject withArguments: {operand}.
+				self assert: result class identicalTo: operand.
+				self assert: result equals: expected].
+	"Invalid cases"
+	"Note that byte objects with different element sizes/encodings (e.g. different String encodings) are not considered type compatible. This could be refined in future, but staying with it for now."
+	{{Object new. Association}.
+		{1 -> 2. Object}.
+		{{1. 2. 3}. Association}.
+		{{}. Association}.
+		{{1}. Association}.
+		{ByteArray new. Array}.
+		{{}. ByteArray}.
+		{ExternalAddress new. ByteArray}.
+		{{1}. OrderedCollection}.
+		{AnsiString with: $a. Utf8String}} do: 
+				[:each |
+				| subject operand result |
+				subject := each first.
+				operand := each second.
+				result := method value: subject withArguments: {operand}.
+				self assert: result equals: 'ObjectTypeMismatch']!
+
 testPrimitiveCopyFromTo
 	| method |
 	method := self
@@ -3506,6 +3556,7 @@ verifyPrimitiveNextPutAllOnUtfStrings: method
 !VMTest categoriesFor: #testPrimitiveBitShift!public!unit tests! !
 !VMTest categoriesFor: #testPrimitiveBytesEqual!public!unit tests! !
 !VMTest categoriesFor: #testPrimitiveBytesIsNull!public!unit tests! !
+!VMTest categoriesFor: #testPrimitiveChangeBehavior!public!unit tests! !
 !VMTest categoriesFor: #testPrimitiveCopyFromTo!public!unit tests! !
 !VMTest categoriesFor: #testPrimitiveDiv!public!unit tests! !
 !VMTest categoriesFor: #testPrimitiveDivide!public!unit tests! !


### PR DESCRIPTION
Allow shape changes where the basic size invariants can be met.