### PR TITLE
Fix extraneous horizontal scroll bar in ListView with a large number of items (fixes #1066)

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -77,6 +77,66 @@ setUpForSelectionTesting
 sortSelections
 	^self subclassResponsibility!
 
+testAutoResizeColumns
+	presenter viewMode: #report.
+	"One column, full width"
+	self verifyColumnWidths: #(196).
+	"Resizes given the addition of another column"
+	presenter addColumn width: 50.
+	self verifyColumnWidths: #(146 50).
+	"Two auto-resize columns share non-fixed space equally"
+	presenter addColumn isAutoResize: true.
+	self verifyColumnWidths: #(73 50 73).
+	"Rounding errors do not accumulate"
+	presenter columnsList second width: 51.
+	self verifyColumnWidths: #(73 51 72)!
+
+testAutoResizeColumnsPositionChangedAddingScrollbar
+	| shellNCHeight |
+	shellNCHeight := presenter topShell height - presenter height.
+	presenter viewMode: #report.
+	presenter list: (1 to: 15).
+	self verifyColumnWidths: #(196).
+	"This is the shortest we can be without a vertical scrollbar. Sanity-check that one is in fact not shown."
+	presenter topShell height: 343 + shellNCHeight.
+	self deny: (presenter getWindowStyle allMask: WS_VSCROLL).
+	self verifyColumnWidths: #(196).
+	"One pixel shorter, and a scrollbar appears, which we must compensate for."
+	presenter topShell height: 342 + shellNCHeight.
+	self assert: (presenter getWindowStyle allMask: WS_VSCROLL).
+	self verifyColumnWidths: {196 - SystemMetrics current scrollbarWidth}!
+
+testAutoResizeColumnsWithChangedBorderStyles
+	presenter viewMode: #report.
+	self verifyColumnWidths: #(196).
+	"Static edge adds an additional 1px on each side"
+	presenter hasStaticEdge: true.
+	self verifyColumnWidths: #(194).
+	"This is a special case--we might expect to see 198 here, but when
+	static edge is the *only* border style, the columns must total 2px less
+	than the actual client width or a scrollbar appears."
+	presenter hasClientEdge: false.
+	self verifyColumnWidths: #(196).
+	"Giving the control a border stops this strange behavior,
+	resulting in no actual change in width even though the
+	visual thickness of the border increases by 1px."
+	presenter hasBorder: true.
+	self verifyColumnWidths: #(196)!
+
+testAutoResizeColumnsWithLargeNumberOfItems
+	| font |
+	presenter viewMode: #report.
+	"With reasonably normal font settings, this is squarely in the range where
+	LVM_APPROXIMATEVIEWRECT will overflow and return a negative value."
+	presenter list: (1 to: 2000).
+	self verifyColumnWidths: {196 - SystemMetrics current scrollbarWidth}.
+	"Use a massive font to trigger the bug with a (relatively) small number of rows."
+	font := presenter actualFont copy.
+	font pointSize: font pointSize * 4.
+	presenter font: font.
+	presenter list: (1 to: 500).
+	self verifyColumnWidths: {196 - SystemMetrics current scrollbarWidth}!
+
 testBackImage
 	| watermark |
 	self deny: presenter view backImageIsTiled.
@@ -276,7 +336,10 @@ verifyClicks: anArray
 		do: 
 			[:click :expected |
 			self assert: click iItem equals: expected first - 1.
-			self assert: click position equals: expected second]! !
+			self assert: click position equals: expected second]!
+
+verifyColumnWidths: widths
+	presenter columnsList with: widths do: [:col :width | self assert: col width equals: width]! !
 !ListViewTest categoriesFor: #classToTest!helpers!private! !
 !ListViewTest categoriesFor: #getColumns!helpers!private! !
 !ListViewTest categoriesFor: #getItem:!helpers!private! !
@@ -286,6 +349,10 @@ verifyClicks: anArray
 !ListViewTest categoriesFor: #setupClickIntercept!private! !
 !ListViewTest categoriesFor: #setUpForSelectionTesting!helpers!private! !
 !ListViewTest categoriesFor: #sortSelections!helpers!public! !
+!ListViewTest categoriesFor: #testAutoResizeColumns!public!unit tests! !
+!ListViewTest categoriesFor: #testAutoResizeColumnsPositionChangedAddingScrollbar!public!unit tests! !
+!ListViewTest categoriesFor: #testAutoResizeColumnsWithChangedBorderStyles!public!unit tests! !
+!ListViewTest categoriesFor: #testAutoResizeColumnsWithLargeNumberOfItems!public!unit tests! !
 !ListViewTest categoriesFor: #testBackImage!public!unit tests! !
 !ListViewTest categoriesFor: #testChangeViewMode!public!unit tests! !
 !ListViewTest categoriesFor: #testCheckBoxes!public!unit tests! !
@@ -296,4 +363,5 @@ verifyClicks: anArray
 !ListViewTest categoriesFor: #testSetTextBlockDoesNotAffectSelection!public!unit tests! !
 !ListViewTest categoriesFor: #testSetTextImageDoesNotAffectSelection!public!unit tests! !
 !ListViewTest categoriesFor: #verifyClicks:!helpers!private! !
+!ListViewTest categoriesFor: #verifyColumnWidths:!helpers!private! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -172,11 +172,12 @@ autoResizeColumns
 
 	self isReportMode ifTrue: [self autoResizeColumns: self clientWidth]!
 
-autoResizeColumns: anInteger
-	"Private - Attempt to share the specified <integer> width between all automagically
-	resizeable columns in the receiver. This only has a visible effect in #report mode."
+autoResizeColumns: clientWidth
+	"Private - Attempt to share the specified <integer> width (which must be the client width of the view,
+	after subtracting for borders and such) between all automagically resizeable columns in the receiver.
+	This only has a visible effect in #report mode."
 
-	| cols autoCols fixedWidth idealWidth remainingWidth clientWidth |
+	| cols autoCols fixedWidth idealWidth remainingWidth |
 	fixedWidth := 0.
 	autoCols := 0.
 	cols := self allColumns.
@@ -186,13 +187,11 @@ autoResizeColumns: anInteger
 				ifTrue: [autoCols := autoCols + 1]
 				ifFalse: [fixedWidth := fixedWidth + (self lvmGetColumnWidth: eachKey - 1)]].
 	autoCols == 0 ifTrue: [^self].
-	"Not sure where the magic number 4 comes from, but it doesn't appear to be correct any more"
-	clientWidth := anInteger - 4.
-	"#1063: ListView doesn't seem to report its actual client width correctly if it has a static edge
-	but not one of the other border styles, hence we must 'adjust' it a little in this case."
-	(self hasStaticEdge and: [(self hasClientEdge or: [self hasBorder]) not])
-		ifTrue: [clientWidth := clientWidth - 2].
 	remainingWidth := clientWidth - fixedWidth.
+	"#1063: If we have a static edge but no other edge style, using the full reported client width
+	results in a scrollbar for some reason. Adjust the available width a little to prevent this."
+	(self hasStaticEdge and: [(self hasClientEdge or: [self hasBorder]) not])
+		ifTrue: [remainingWidth := remainingWidth - 2].
 	remainingWidth <= 0 ifTrue: [^self].
 	"Split the available width between the auto columns - note the use of fractional arithmetic to avoid accumulating a rounding error"
 	idealWidth := remainingWidth / autoCols.
@@ -1759,22 +1758,25 @@ onPositionChanged: aPositionEvent
 	control, as that is when it updates scrollbars which can cause the horizontal scrollbar to
 	briefly flicker if the column widths are not adjusted beforehand (#2103)."
 
-	(aPositionEvent isRectangleChanged and: [self isReportMode])
+	(aPositionEvent isClientAreaChanged and: [self isReportMode])
 		ifTrue: 
-			[| width count |
-			width := aPositionEvent width.
+			[| clientWidth requiredHeight count |
+			clientWidth := (self calcClientRectangleFromRectangle: aPositionEvent rectangle) width.
 			count := self itemCount.
+			"We cannot use LVM_APPROXIMATEVIEWRECT on its own,
+			as it will overflow for large numbers of items. Instead we use it to account for
+			the height of the column header and any borders/edge styles, then compute
+			the height of the items separately."
+			requiredHeight := (self
+						lvmApproximateViewRect: 0
+						cx: aPositionEvent width
+						cy: aPositionEvent height) y
+						- SystemMetrics current scrollbarHeight.
 			count > 0
-				ifTrue: 
-					[| extent height |
-					height := aPositionEvent height.
-					extent := self
-								lvmApproximateViewRect: count
-								cx: width
-								cy: height.
-					extent y - SystemMetrics current scrollbarHeight > height
-						ifTrue: [width := width - SystemMetrics current scrollbarWidth]].
-			self autoResizeColumns: width].
+				ifTrue: [requiredHeight := requiredHeight + (self itemRect: count) bottom - (self itemRect: 1) top].
+			requiredHeight > aPositionEvent height
+				ifTrue: [clientWidth := clientWidth - SystemMetrics current scrollbarWidth].
+			self autoResizeColumns: clientWidth].
 	^super onPositionChanged: aPositionEvent!
 
 onRightButtonPressed: aMouseEvent

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -122,6 +122,15 @@ addOrUpdate: aBoolean nonVirtualItems: aSequenceableCollection afterIndex: anInt
 						indent: 0.
 					self lvmSetItem: lvItem]]!
 
+adjustForStaticEdgeBug: aRectangle
+	"#1063: If we have a static edge but no other edge style, the view behaves as though it
+	is slightly smaller than the reported client width for the purposes of calculating if scrollbars
+	are shown. Adjust the available width a little to prevent this."
+
+	(self hasStaticEdge and: [(self hasClientEdge or: [self hasBorder]) not])
+		ifTrue: [aRectangle corner: aRectangle corner - 2].
+	^aRectangle!
+
 allColumns
 	"Answer an <sequencedReadableCollection> of all the columns in the view including
 	the primary column."
@@ -170,7 +179,8 @@ autoResizeColumns
 	"Private - Attempt to share the available width in the receiver between all automagically resizeable
 	columns. This only has a visible effect in #report mode, or if the list is subsequently switched to report mode."
 
-	self isReportMode ifTrue: [self autoResizeColumns: self clientWidth]!
+	self isReportMode
+		ifTrue: [self autoResizeColumns: (self adjustForStaticEdgeBug: self clientRectangle) width]!
 
 autoResizeColumns: clientWidth
 	"Private - Attempt to share the specified <integer> width (which must be the client width of the view,
@@ -188,10 +198,6 @@ autoResizeColumns: clientWidth
 				ifFalse: [fixedWidth := fixedWidth + (self lvmGetColumnWidth: eachKey - 1)]].
 	autoCols == 0 ifTrue: [^self].
 	remainingWidth := clientWidth - fixedWidth.
-	"#1063: If we have a static edge but no other edge style, using the full reported client width
-	results in a scrollbar for some reason. Adjust the available width a little to prevent this."
-	(self hasStaticEdge and: [(self hasClientEdge or: [self hasBorder]) not])
-		ifTrue: [remainingWidth := remainingWidth - 2].
 	remainingWidth <= 0 ifTrue: [^self].
 	"Split the available width between the auto columns - note the use of fractional arithmetic to avoid accumulating a rounding error"
 	idealWidth := remainingWidth / autoCols.
@@ -1760,22 +1766,17 @@ onPositionChanged: aPositionEvent
 
 	(aPositionEvent isClientAreaChanged and: [self isReportMode])
 		ifTrue: 
-			[| clientWidth requiredHeight count |
-			clientWidth := (self calcClientRectangleFromRectangle: aPositionEvent rectangle) width.
+			[| clientRect clientWidth count |
+			clientRect := self
+						adjustForStaticEdgeBug: (self calcClientRectangleFromRectangle: aPositionEvent rectangle).
+			clientWidth := clientRect width.
 			count := self itemCount.
-			"We cannot use LVM_APPROXIMATEVIEWRECT on its own,
-			as it will overflow for large numbers of items. Instead we use it to account for
-			the height of the column header and any borders/edge styles, then compute
-			the height of the items separately."
-			requiredHeight := (self
-						lvmApproximateViewRect: 0
-						cx: aPositionEvent width
-						cy: aPositionEvent height) y
-						- SystemMetrics current scrollbarHeight.
 			count > 0
-				ifTrue: [requiredHeight := requiredHeight + (self itemRect: count) bottom - (self itemRect: 1) top].
-			requiredHeight > aPositionEvent height
-				ifTrue: [clientWidth := clientWidth - SystemMetrics current scrollbarWidth].
+				ifTrue: 
+					[| requiredHeight |
+					requiredHeight := self lvmGetOrigin y + (self itemRect: count) bottom.
+					requiredHeight > clientRect height
+						ifTrue: [clientWidth := clientWidth - SystemMetrics current scrollbarWidth]].
 			self autoResizeColumns: clientWidth].
 	^super onPositionChanged: aPositionEvent!
 
@@ -2273,6 +2274,7 @@ wantCustomDrawItemNotifications: pNMHDR
 !ListView categoriesFor: #addColumn:!adding!columns!public! !
 !ListView categoriesFor: #addColumn:atIndex:!adding!columns!public! !
 !ListView categoriesFor: #addOrUpdate:nonVirtualItems:afterIndex:!private!updating! !
+!ListView categoriesFor: #adjustForStaticEdgeBug:!helpers!private! !
 !ListView categoriesFor: #allColumns!columns!public! !
 !ListView categoriesFor: #anchorIndex!public!selection! !
 !ListView categoriesFor: #anchorIndex:!public!selection! !


### PR DESCRIPTION
Compute the required height for the control, and therefore whether it will have a vertical scrollbar, using a method that will not overflow if the required height exceeds 32768 (2**15).
Also change guard condition to isClientAreaChanged rather than isRectangleChanged—changes to edge styles should cause a re-layout, while simple moves don't need to.