### PR TITLE
Fix #1070 (or at least prevent the confusion resulting in #1070)

### DIFF
--- a/FetchVM.ps1
+++ b/FetchVM.ps1
@@ -1,14 +1,16 @@
 # Powershell script to pull the VM files from GitHub into the current folder.
-# Edit the following to match the version of the VM that is compatible with this image
+# Either invoke with a VMversion parameter specifying the version you want to download, 
+# or use FetchVM.cmd, which will query git to determine the correct version.
 
 param 
 (
-    [string]$VMversion="v7.1.4"
+    [string]$VMversion
 )
 
 # Override Powershell's default use of TLS1.0 for web requests; this is insecure and no longer works with GitHub
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+if(-not($VMVersion)) { Throw “VMVersion required (hint: Use/see fetchvm.cmd)” }
 
 Try 
 {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Follow these instructions to create the product image and launch Dolphin Smallta
 
 * The master branch is on the bleeding edge and may represent an unstable state, although the tests should always be passing. If you want a stable build then you may want to go back at least to the last tagged version.
 
-* Next you will need to build the binaries as described above, or fetch the VM binaries. For convenience a batch file, `FetchVM.CMD` is supplied and, providing you have PowerShell scripting enabled, you can just double-click this to pull the correct version of the VM down from GitHub. Alternatively, you can right click on the `FetchVM.ps1` file and choose _Run with PowerShell_, which does not require scripting to be explicitly enabled in Windows. If you supply a parameter to either of these script files you can choose to fetch an alternative VM version to the default (not usually recommended).
+* Next you will need to build the binaries as described above, or fetch the VM binaries. For convenience a batch file, `FetchVM.CMD` is supplied that will determine the correct VM version and invoke the helper PowerShell script `FetchVM.ps1` to download it. If you want to download an alternative VM (which is not usually recommended) then this can be done by invoking `FetchVM.ps1` with a parameter..
 
 * Before proceeding you will also need to pull the boot image from github large file storage. To do this execute `git lfs pull`.
 


### PR DESCRIPTION
The presence of an obsolete default in FetchVM.ps1 for the VM version to fetch is not helpful. Even less helpful is the combination of this with out of date instructions in the readme that suggest running it directly, rather than the wrapper script FetchVM.cmd. It is the latter that determines the correct version to download.