### PR TITLE
Fix corrupted ListView scroll state when reducing item count (fixes #1071)

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -111,7 +111,10 @@ testAutoResizeColumns
 	self verifyColumnWidths: #(48 100 48).
 	"Rounding errors do not accumulate"
 	presenter columnsList second width: 101.
-	self verifyColumnWidths: #(48 101 47)!
+	self verifyColumnWidths: #(48 101 47).
+	"Resizes when a column is removed"
+	presenter removeColumnAtIndex: 3.
+	self verifyColumnWidths: #(95 101)!
 
 testAutoResizeColumnsPositionChangedAddingScrollbar
 	| shellNCHeight |

--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -14,6 +14,15 @@ ListViewTest comment: ''!
 classToTest
 	^ListView!
 
+forceColumnResize
+	| width |
+	"Force the view to auto-resize its columns. Force this to happen as the result of a resize event,
+	as this has a different implementation than simply sending #autoResizeColumns."
+	width := presenter width.
+	presenter
+		width: width + 1;
+		width: width!
+
 getColumns
 	| answer |
 	answer := OrderedCollection new.
@@ -124,16 +133,19 @@ testAutoResizeColumnsWithChangedBorderStyles
 	self verifyColumnWidths: #(196).
 	"Static edge adds an additional 1px on each side"
 	presenter hasStaticEdge: true.
+	self forceColumnResize.
 	self verifyColumnWidths: #(194).
 	"This is a special case--we might expect to see 198 here, but when
 	static edge is the *only* border style, the columns must total 2px less
 	than the actual client width or a scrollbar appears."
 	presenter hasClientEdge: false.
+	self forceColumnResize.
 	self verifyColumnWidths: #(196).
 	"Giving the control a border stops this strange behavior,
 	resulting in no actual change in width even though the
 	visual thickness of the border increases by 1px."
 	presenter hasBorder: true.
+	self forceColumnResize.
 	self verifyColumnWidths: #(196)!
 
 testAutoResizeColumnsWithLargeNumberOfItems
@@ -354,6 +366,7 @@ verifyClicks: anArray
 verifyColumnWidths: widths
 	presenter columnsList with: widths do: [:col :width | self assert: col width equals: width]! !
 !ListViewTest categoriesFor: #classToTest!helpers!private! !
+!ListViewTest categoriesFor: #forceColumnResize!helpers!private! !
 !ListViewTest categoriesFor: #getColumns!helpers!private! !
 !ListViewTest categoriesFor: #getItem:!helpers!private! !
 !ListViewTest categoriesFor: #newSelectionAfterLeftClickOutsideList:!constants!private! !

--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -74,9 +74,6 @@ setUpForSelectionTesting
 	super setUpForSelectionTesting.
 	presenter view viewMode: #list!
 
-skip1071
-	self skip: 'Disabled until #1071 is fixed'!
-
 sortSelections
 	^self subclassResponsibility!
 
@@ -94,7 +91,6 @@ test1071
 	self assert: lv lvmGetOrigin equals: Point zero!
 
 testAutoResizeColumns
-	self skip1071.
 	presenter viewMode: #report.
 	"One column, full width"
 	self verifyColumnWidths: #(196).
@@ -124,7 +120,6 @@ testAutoResizeColumnsPositionChangedAddingScrollbar
 	self verifyColumnWidths: {196 - SystemMetrics current scrollbarWidth}!
 
 testAutoResizeColumnsWithChangedBorderStyles
-	self skip1071.
 	presenter viewMode: #report.
 	self verifyColumnWidths: #(196).
 	"Static edge adds an additional 1px on each side"
@@ -366,7 +361,6 @@ verifyColumnWidths: widths
 !ListViewTest categoriesFor: #setColumns:!helpers!private! !
 !ListViewTest categoriesFor: #setupClickIntercept!private! !
 !ListViewTest categoriesFor: #setUpForSelectionTesting!helpers!private! !
-!ListViewTest categoriesFor: #skip1071!helpers!private! !
 !ListViewTest categoriesFor: #sortSelections!helpers!public! !
 !ListViewTest categoriesFor: #test1071!public!unit tests! !
 !ListViewTest categoriesFor: #testAutoResizeColumns!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ListViewTest.cls
@@ -95,14 +95,14 @@ testAutoResizeColumns
 	"One column, full width"
 	self verifyColumnWidths: #(196).
 	"Resizes given the addition of another column"
-	presenter addColumn width: 50.
-	self verifyColumnWidths: #(146 50).
+	presenter addColumn.
+	self verifyColumnWidths: #(96 100).
 	"Two auto-resize columns share non-fixed space equally"
 	presenter addColumn isAutoResize: true.
-	self verifyColumnWidths: #(73 50 73).
+	self verifyColumnWidths: #(48 100 48).
 	"Rounding errors do not accumulate"
-	presenter columnsList second width: 51.
-	self verifyColumnWidths: #(73 51 72)!
+	presenter columnsList second width: 101.
+	self verifyColumnWidths: #(48 101 47)!
 
 testAutoResizeColumnsPositionChangedAddingScrollbar
 	| shellNCHeight |

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -65,15 +65,16 @@ addColumn: newColumn
  
 !
 
-addColumn: newColumn atIndex: columnIndex 
+addColumn: newColumn atIndex: columnIndex
 	"Insert the <ListViewColumn>, newColumn, into the receiver
 	at the <integer> index columnIndex, shifting the positions of all 
 	subsequent columns up by one. Answers the inserted column."
 
-	lastClickedColIndex notNil 
+	lastClickedColIndex notNil
 		ifTrue: [lastClickedColIndex >= columnIndex ifTrue: [lastClickedColIndex := lastClickedColIndex + 1]].
 	columns add: newColumn beforeIndex: columnIndex.
 	self basicAddColumn: newColumn atIndex: columnIndex.
+	self autoResizeColumns.
 	self invalidateLayout.
 	self updateAll.
 	^newColumn!
@@ -2046,7 +2047,8 @@ setViewMode: aSymbol
 setWidthOfColumn: colIndexInteger to: widthInteger
 	"Set the width of the column identified by itemIndex to anInteger."
 
-	self lvmSetColumnWidth: colIndexInteger-1 to: widthInteger.
+	self lvmSetColumnWidth: colIndexInteger - 1 to: widthInteger.
+	self autoResizeColumns.
 	self invalidateLayout!
 
 showDropHighlight: item

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -1886,19 +1886,18 @@ removeColumn: aListViewColumn
 
 	self removeColumnAtIndex: (self allColumns indexOf: aListViewColumn)!
 
-removeColumnAtIndex: columnIndex 
+removeColumnAtIndex: columnIndex
 	"Remove the Column at columnIndex with all its subitems."
 
-	lastClickedColIndex isNil 
+	lastClickedColIndex isNil
 		ifFalse: 
-			[columnIndex = lastClickedColIndex 
+			[columnIndex = lastClickedColIndex
 				ifTrue: [lastClickedColIndex := nil]
-				ifFalse: 
-					[columnIndex < lastClickedColIndex 
-						ifTrue: [lastClickedColIndex := lastClickedColIndex - 1]]].
+				ifFalse: [columnIndex < lastClickedColIndex ifTrue: [lastClickedColIndex := lastClickedColIndex - 1]]].
 	(columns removeAtIndex: columnIndex) parent: nil.
 	self basicRemoveColumnAtIndex: columnIndex.
 	self
+		autoResizeColumns;
 		invalidate;
 		update!
 


### PR DESCRIPTION
This gets the two skipped tests working again, and handles responding to added, resized or removed columns. I decided against overriding the edge-style setters to add an explicit `self autoResizeColumns` as this seems like much more of an edge case, though that is an option as well.