### PR TITLE
Fix #1079: Scintilla caret is invisible in dark high contrast mode(s)

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/Automation/ActiveX Automation Tests.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Automation/ActiveX Automation Tests.pax
@@ -13,6 +13,7 @@ package classNames
 	yourself.
 
 package methodNames
+	add: #ExternalAddressTest -> #testBSTRFromAddress;
 	add: #ExternalDescriptorTest -> #testComPtrs;
 	yourself.
 
@@ -59,6 +60,17 @@ GenericExternalArrayTest subclass: #SAFEARRAYTest
 
 
 "Loose Methods"!
+
+!ExternalAddressTest methodsFor!
+
+testBSTRFromAddress
+	| empty |
+	self stringFromAddressTestClass: BSTR.
+	"By convention, a null BSTR is equivalent to the empty string"
+	empty := BSTR new.
+	self assert: (BSTR fromAddress: nil) equals: empty.
+	self assert: (BSTR fromAddress: 0) equals: empty! !
+!ExternalAddressTest categoriesFor: #testBSTRFromAddress!public!unit tests! !
 
 !ExternalDescriptorTest methodsFor!
 

--- a/Core/Object Arts/Dolphin/Base/ExternalAddressTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalAddressTest.cls
@@ -35,8 +35,11 @@ testREFGUIDfromAddress
 	self assert: g asString equals: ref asString!
 
 testStringsFromAddress
-	#(#BSTR #AnsiString #Utf8String #Utf16String)
-		do: [:each | self stringFromAddressTestClass: (Smalltalk at: each)]! !
+	{AnsiString. Utf8String. Utf16String} do: 
+			[:each |
+			self stringFromAddressTestClass: each.
+			self assertIsNil: (each fromAddress: nil).
+			self assertIsNil: (each fromAddress: 0)]! !
 !ExternalAddressTest categoriesFor: #stringFromAddressTestClass:!helpers!public! !
 !ExternalAddressTest categoriesFor: #testExternalAddressAtAddress!public!unit tests! !
 !ExternalAddressTest categoriesFor: #testExternalAddressFromAddress!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/SessionManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SessionManager.cls
@@ -660,14 +660,6 @@ onQuit: anInteger
 	self trigger: #quitSessionRequested.
 	self queryEndSession ifTrue: [self quit: anInteger]!
 
-onSettingChanged: aWindowsEvent
-	"Private - A system setting has been changed. This could be any of a wide range of things from a theme change,
-	regional settings, even policy. The notifications come in thick and fast because they are sent to every top-level
-	window. We consolidate them by queuing them up for coalescing any that arrive within a 1-second window."
-
-	settingsChanged add: {Utf16String fromAddress: aWindowsEvent lParam. aWindowsEvent wParam}.
-	inputState msgWindow setTimer: SettingsChangeTimerId interval: 1000!
-
 onStartup: args
 	"Initialize the receiver immediately following system startup.
 	This is the main system initialization routine, and is responsible
@@ -1249,7 +1241,6 @@ windowsDirectory
 !SessionManager categoriesFor: #onPreSaveImage!event handling!private! !
 !SessionManager categoriesFor: #onQueryWindowsShutdown!event handling!public! !
 !SessionManager categoriesFor: #onQuit:!event handling!public! !
-!SessionManager categoriesFor: #onSettingChanged:!event handling!private! !
 !SessionManager categoriesFor: #onStartup:!event handling!public! !
 !SessionManager categoriesFor: #onTimeChanged:!event handling!private! !
 !SessionManager categoriesFor: #onTimer:!event handling!private! !

--- a/Core/Object Arts/Dolphin/Base/Utf8String.cls
+++ b/Core/Object Arts/Dolphin/Base/Utf8String.cls
@@ -503,7 +503,8 @@ codePage
 fromAddress: anAddress
 	"Answer a new String instantiated from the null terminated string at anAddress."
 
-	^self fromAddress: anAddress length: (CRTLibrary default strlen: anAddress)!
+	^anAddress isNull
+		ifFalse: [self fromAddress: anAddress length: (CRTLibrary default strlen: anAddress)]!
 
 initialize
 	self extraInstanceSpec: EncodingUtf8.

--- a/Core/Object Arts/Dolphin/Base/VMLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/VMLibrary.cls
@@ -576,6 +576,14 @@ unsignedFromSigned: anInteger
 		ifTrue: [self errorIntegerMoreThan32Bits: anInteger]
 		ifFalse: [self invalidCall: _failureCode]!
 
+utf16StringFromAddress: pointer
+	"Private - Answer a new <Utf16String> instantiated from the null-terminated string pointed at by the argument."
+
+	<stdcall: lpwstr AnswerDWORD lpvoid>
+	| len |
+	len := KernelLibrary default lstrlenW: pointer.
+	^Utf16String fromAddress: pointer length: len!
+
 versionFormatString
 	"Private - Answer a String containing the version format used by the receiver."
 
@@ -644,6 +652,7 @@ versionFormatString
 !VMLibrary categoriesFor: #stringFromAddress:!helpers!private! !
 !VMLibrary categoriesFor: #unregisterObject:!accessing-registry!private! !
 !VMLibrary categoriesFor: #unsignedFromSigned:!helpers!private! !
+!VMLibrary categoriesFor: #utf16StringFromAddress:!helpers!private! !
 !VMLibrary categoriesFor: #versionFormatString!constants!private! !
 
 !VMLibrary class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/Win32Constants.st
+++ b/Core/Object Arts/Dolphin/Base/Win32Constants.st
@@ -895,6 +895,8 @@ Win32Constants at: 'SPI_SETFLATMENU' put: 16r1023!
 Win32Constants at: 'SPI_SETICONTITLELOGFONT' put: 16r22!
 Win32Constants at: 'SPI_SETLISTBOXSMOOTHSCROLLING' put: 16r1007!
 Win32Constants at: 'SPI_SETNONCLIENTMETRICS' put: 16r2A!
+Win32Constants at: 'SPIF_SENDCHANGE' put: 16r2!
+Win32Constants at: 'SPIF_UPDATEINIFILE' put: 16r1!
 Win32Constants at: 'SRCAND' put: 16r8800C6!
 Win32Constants at: 'SRCCOPY' put: 16rCC0020!
 Win32Constants at: 'SRCINVERT' put: 16r660046!

--- a/Core/Object Arts/Dolphin/IDE/Base/ClassCommentPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/ClassCommentPlugin.cls
@@ -89,7 +89,7 @@ icon
 
 initialize
 	WordWrap := true.
-	ThemeColor addNamed: #commentWorkspace color: Color ivory!
+	ThemeColor addNamed: #commentWorkspace color: Color tooltip!
 
 publishedAspects
 	"Answer a <LookupTable> of the <Aspect>s published by the receiver."

--- a/Core/Object Arts/Dolphin/IDE/Professional/ScintillaFunctionDef.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/ScintillaFunctionDef.cls
@@ -333,11 +333,9 @@ renamedFunctions
 		at: 'SCI_SETEMPTYSELECTION' put: #caretPosition:;
 		at: 'SCI_GETANCHOR' put: #anchorPosition;
 		at: 'SCI_SETANCHOR' put: #anchorPosition:;
-		at: 'SCI_GETCARETFORE' put: #caretForecolor;
 		at: 'SCI_GETCARETPERIOD' put: #caretPeriod;
 		at: 'SCI_SETCARETPERIOD' put: #caretPeriod:;
 		at: 'SCI_GETCARETWIDTH' put: #caretWidth;
-		at: 'SCI_GETCARETLINEBACK' put: #currentLineBackcolor;
 		at: 'SCI_GETCARETLINEBACKALPHA' put: #currentLineAlpha;
 		at: 'SCI_SETCARETLINEBACKALPHA' put: #currentLineAlpha:;
 		at: 'SCI_GETCARETLINEVISIBLE' put: #isCurrentLineHighlighted;
@@ -424,7 +422,6 @@ renamedFunctions
 		at: 'SCI_SETPRINTMAGNIFICATION' put: #printMagnification:;
 		at: 'SCI_CLEARALL' put: #clearAll;
 		at: 'SCI_EDITTOGGLEOVERTYPE' put: #toggleOvertype;
-		at: 'SCI_GETEDGECOLOUR' put: #edgeColor;
 		at: 'SCI_GETTWOPHASEDRAW' put: #isDrawingTwoPhase;
 		at: 'SCI_SETTWOPHASEDRAW' put: #isDrawingTwoPhase:;
 		at: 'SCI_SETREADONLY' put: #setReadOnly:;
@@ -447,8 +444,6 @@ renamedFunctions
 
 	"Hotspot"
 	renamedMessages
-		at: 'SCI_GETHOTSPOTACTIVEBACK' put: #activeHotspotBackcolor;
-		at: 'SCI_GETHOTSPOTACTIVEFORE' put: #activeHotspotForecolor;
 		at: 'SCI_GETHOTSPOTACTIVEUNDERLINE' put: #isActiveHotspotUnderlined;
 		at: 'SCI_SETHOTSPOTACTIVEUNDERLINE' put: #isActiveHotspotUnderlined:;
 		at: 'SCI_GETHOTSPOTSINGLELINE' put: #areHotspotsSingleLine;
@@ -654,7 +649,6 @@ renamedFunctions
 		at: 'SCI_GETADDITIONALSELALPHA' put: #secondarySelectionAlpha;
 		at: 'SCI_SETADDITIONALSELALPHA' put: #secondarySelectionAlpha:;
 		at: 'SCI_ROTATESELECTION' put: #rotateSelection;
-		at: 'SCI_GETADDITIONALCARETFORE' put: #secondaryCaretForecolor;
 		at: 'SCI_GETSELECTIONS' put: #selectionCount;
 		at: 'SCI_SWAPMAINANCHORCARET' put: #swapPrimarySelectionAnchorAndCaret;
 		at: 'SCI_VERTICALCENTRECARET' put: #centerCurrentLine;

--- a/Core/Object Arts/Dolphin/IDE/Professional/ScintillaViewGenerator.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/ScintillaViewGenerator.cls
@@ -1612,6 +1612,9 @@ ignoredMessages
 	"4.1.3: SCI_GET/SETCOMMANDEVENTS are not generated because we don't allow this to be changed (it must be false)"
 	ignoredMessages addAll: #('SCI_GETCOMMANDEVENTS' 'SCI_SETCOMMANDEVENTS').
 
+	"Call tip styles are managed using a text style."
+	ignoredMessages addAll: #('SCI_CALLTIPSETFORE' 'SCI_CALLTIPSETBACK').
+
 	ignoredMessages
 		shrink;
 		isImmutable: true;

--- a/Core/Object Arts/Dolphin/MVP/Base/Color.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Color.cls
@@ -22,6 +22,9 @@ There are also the virtual colours, `ThemeColor` and `PluggableColor`, to repres
 
 	^self == aColor or: [aColor species == self species and: [aColor argbCode = self argbCode]]!
 
+actualColor
+	^self!
+
 adjustBrightness: aNumber
 	"Answer a new <Color> that is derived from this color but with the specified relative brightness."
 
@@ -352,6 +355,7 @@ stbSaveOn: anSTBOutFiler
 				register: self.
 			anSTBOutFiler nextPut: symbol]! !
 !Color categoriesFor: #=!comparing!public! !
+!Color categoriesFor: #actualColor!accessing!private! !
 !Color categoriesFor: #adjustBrightness:!public! !
 !Color categoriesFor: #adjustSaturation:brightness:!public! !
 !Color categoriesFor: #alpha!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/ControlView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ControlView.cls
@@ -139,6 +139,13 @@ forecolor: aColorOrNil
 	self invalidate.
 !
 
+getFont
+	"Private - Get the control's current font."
+
+	| hFont |
+	hFont := self sendMessage: WM_GETFONT.
+	^hFont == 0 ifTrue: [Font system] ifFalse: [Font fromHandle: hFont]!
+
 itemFromId: dwItemSpec 
 	"Private - Answers the sub-item of the receiver with the specified <integer> item spec,
 	or nil if there is no such item. This is only relevant to controls that contain visual elements
@@ -419,6 +426,7 @@ wmWindowPosChanged: message wParam: wParam lParam: lParam
 !ControlView categoriesFor: #fontChanged!public!updating! !
 !ControlView categoriesFor: #forecolor!accessing!public! !
 !ControlView categoriesFor: #forecolor:!accessing!public! !
+!ControlView categoriesFor: #getFont!accessing!private! !
 !ControlView categoriesFor: #itemFromId:!accessing!private! !
 !ControlView categoriesFor: #nmClick:!event handling-win32!private! !
 !ControlView categoriesFor: #nmCustomDraw:!event handling-win32!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -181,6 +181,7 @@ package classNames
 	add: #SelectionChangedEvent;
 	add: #SelectionChangeEvent;
 	add: #SelectionChangingEvent;
+	add: #SettingsChangeEvent;
 	add: #Shell;
 	add: #ShellView;
 	add: #SIZE;
@@ -673,6 +674,11 @@ WindowsEvent subclass: #PositionEvent
 	classInstanceVariableNames: ''!
 WindowsEvent subclass: #ScrollEvent
 	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+WindowsEvent subclass: #SettingsChangeEvent
+	instanceVariableNames: 'area'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/Base/GUISessionManager.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/GUISessionManager.cls
@@ -84,6 +84,14 @@ isUnattended
 
 	^flags allMask: UnattendedMask!
 
+onSettingChanged: aSettingsChangeEvent
+	"Private - A system setting has been changed. This could be any of a wide range of things from a theme change,
+	regional settings, even policy. The notifications come in thick and fast because they are sent to every top-level
+	window. We consolidate them by queuing them up for coalescing any that arrive within a 1-second window."
+
+	settingsChanged add: {aSettingsChangeEvent area. aSettingsChangeEvent uiAction}.
+	inputState msgWindow setTimer: SettingsChangeTimerId interval: 1000!
+
 parseCmdLineFlags
 	| options |
 	super parseCmdLineFlags.
@@ -177,6 +185,7 @@ windowSystemStartup
 !GUISessionManager categoriesFor: #commandLineParser!helpers!private! !
 !GUISessionManager categoriesFor: #inputStateClass!constants!private! !
 !GUISessionManager categoriesFor: #isUnattended!public!testing! !
+!GUISessionManager categoriesFor: #onSettingChanged:!event handling!private! !
 !GUISessionManager categoriesFor: #parseCmdLineFlags!operations-startup!private! !
 !GUISessionManager categoriesFor: #resourceManager!accessing!public! !
 !GUISessionManager categoriesFor: #restoreWindowState!operations-startup!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/PluggableColor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/PluggableColor.cls
@@ -16,7 +16,7 @@ PluggableColor comment: '`PluggableColor` is the class of `Color`s that dynamica
 !PluggableColor methodsFor!
 
 actualColor
-	^valuable value!
+	^valuable value actualColor!
 
 printOn: aPuttableStream
 	self basicPrintOn: aPuttableStream!

--- a/Core/Object Arts/Dolphin/MVP/Base/SettingsChangeEvent.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/SettingsChangeEvent.cls
@@ -1,0 +1,32 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+WindowsEvent subclass: #SettingsChangeEvent
+	instanceVariableNames: 'area'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+SettingsChangeEvent guid: (GUID fromString: '{8d98098a-b8d5-4e20-97c1-7410fb47c17f}')!
+SettingsChangeEvent comment: ''!
+!SettingsChangeEvent categoriesForClass!MVP-Views-Events! !
+!SettingsChangeEvent methodsFor!
+
+area
+	^area ifNil: [area := lParam == 0 ifTrue: ['All'] ifFalse: [Utf16String fromAddress: lParam]]!
+
+isColorSetChange
+	^self area = 'ImmersiveColorSet'!
+
+isFontChange
+	^wParam == SPI_SETICONTITLELOGFONT!
+
+printLParamOn: aStream
+	aStream print: self area!
+
+uiAction
+	^wParam! !
+!SettingsChangeEvent categoriesFor: #area!accessing!public! !
+!SettingsChangeEvent categoriesFor: #isColorSetChange!public!testing! !
+!SettingsChangeEvent categoriesFor: #isFontChange!public!testing! !
+!SettingsChangeEvent categoriesFor: #printLParamOn:!printing!public! !
+!SettingsChangeEvent categoriesFor: #uiAction!accessing!public! !
+

--- a/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
@@ -661,11 +661,11 @@ onPreSaveImage
 
 	self isTopView ifTrue: [self propertyAt: #state put: self state]!
 
-onSettingChanged: aWindowsEvent
-	SessionManager current onSettingChanged: aWindowsEvent.
-	self presenter trigger: #settingChanged: with: aWindowsEvent.
-	(aWindowsEvent wParam = SPI_SETICONTITLELOGFONT and: [font isNil]) ifTrue: [self fontChanged].
-	^aWindowsEvent lResult!
+onSettingChanged: aSettingsChangeEvent
+	SessionManager current onSettingChanged: aSettingsChangeEvent.
+	self presenter trigger: #settingChanged: with: aSettingsChangeEvent.
+	self settingChanged: aSettingsChangeEvent.
+	^aSettingsChangeEvent lResult!
 
 onStateRestored
 	self updateMenuBar.
@@ -1130,7 +1130,7 @@ wmSetCursor: message wParam: wParam lParam: lParam
 wmSettingChange: message wParam: wParam lParam: lParam 
 	"Private - Handle the Win32 WM_SETTINGCHANGE message."
 
-	^self presenter onSettingChanged: (WindowsEvent 
+	^self presenter onSettingChanged: (SettingsChangeEvent 
 				window: self
 				message: message
 				wParam: wParam

--- a/Core/Object Arts/Dolphin/MVP/Base/ThemeColor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ThemeColor.cls
@@ -20,7 +20,7 @@ ThemeColor comment: '`ThemeColor` is a class of `VirtualColor`s that provide a n
 !ThemeColor methodsFor!
 
 actualColor
-	^actualColor ?? Color window!
+	^(actualColor ?? Color window) actualColor!
 
 actualColor: aColor
 	actualColor := aColor!

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -1320,13 +1320,11 @@ font: aFontOrNil
 !
 
 fontChanged
-	"Private - The receiver's font has been changed. The default is to cause
-	the receiver ot repaint. Overidden by subclasses that need to apply the 
-	font to a Windows control"
+	"Private - The receiver's font has been changed. The default is to cause the receiver ot repaint. Should be overidden by subclasses that need to apply the  font to a Windows control"
 
-	self subViewsDo: [:each | each fontChanged ].
-	self invalidate; invalidateCalculatedExtent
-!
+	self
+		invalidate;
+		invalidateCalculatedExtent!
 
 forecolor
 	"Answers the foreground colour of the receiver.
@@ -2879,6 +2877,9 @@ printOn: aStream
 		print: self displayString;
 		nextPut: $)!
 
+propagateSettingsChange: aSettingsChangeEvent
+	self subViewsDo: [:each | each settingChanged: aSettingsChangeEvent]!
+
 queryCommand: aCommandQuery
 	"Private - Update aCommandQuery to indicates how a command would be processed.
 	if sent to the receiver. Answers whether the receiver recognised the command
@@ -3285,6 +3286,12 @@ setTimer: id interval: interval
 		nIDEvent: id
 		uElapse: interval
 		lpTimerFunc: nil) ~= 0!
+
+settingChanged: aSettingsChangeEvent
+	"Private - A system wide setting has been changed. Propagate the change event to all sub-views, and updated as required."
+
+	self propagateSettingsChange: aSettingsChangeEvent.
+	self updateSetting: aSettingsChangeEvent!
 
 setWindowExStyle: anInteger
 	"Private - Set the receiver's extended window style bits to anInteger."
@@ -3700,6 +3707,9 @@ updateModel
 	override this method to update the model if there have been
 	changes"
 !
+
+updateSetting: aSettingsChangeEvent
+	(font isNil and: [aSettingsChangeEvent isFontChange]) ifTrue: [self fontChanged]!
 
 usePreferredExtent
 	"Answers true if the receiver's preferred extent should be used by a layout manager when
@@ -4896,6 +4906,7 @@ zOrderTop
 !View categoriesFor: #previousSiblingView!hierarchy!public!sub views! !
 !View categoriesFor: #primHookWindowCreate:!helpers!private! !
 !View categoriesFor: #printOn:!development!printing!public! !
+!View categoriesFor: #propagateSettingsChange:!event handling!private! !
 !View categoriesFor: #queryCommand:!commands!private! !
 !View categoriesFor: #queryCommandRouteFor:!commands!private! !
 !View categoriesFor: #queryContextMenu!menus!public! !
@@ -4938,6 +4949,7 @@ zOrderTop
 !View categoriesFor: #setScrollInfo:bar:!accessing!private! !
 !View categoriesFor: #setStateRestoring!accessing!private! !
 !View categoriesFor: #setTimer:interval:!public!timers! !
+!View categoriesFor: #settingChanged:!event handling!private!updating! !
 !View categoriesFor: #setWindowExStyle:!accessing-styles!private! !
 !View categoriesFor: #setWindowLong:to:!accessing!private! !
 !View categoriesFor: #setWindowPosAfter:x:y:width:height:flags:!geometry!private! !
@@ -4978,6 +4990,7 @@ zOrderTop
 !View categoriesFor: #unregisterHotKeyId:!helpers!public! !
 !View categoriesFor: #update!drawing!public! !
 !View categoriesFor: #updateModel!public!updating! !
+!View categoriesFor: #updateSetting:!event handling!private!updating! !
 !View categoriesFor: #usePreferredExtent!accessing!public! !
 !View categoriesFor: #usePreferredExtent:!accessing!public! !
 !View categoriesFor: #validate!drawing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/VirtualColor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/VirtualColor.cls
@@ -11,9 +11,6 @@ VirtualColor comment: '`VirtualColor` is the abstract class of `Color`s with an 
 !VirtualColor categoriesForClass!Drawing! !
 !VirtualColor methodsFor!
 
-actualColor
-	^self subclassResponsibility!
-
 argbCode
 	"Answer the receiver's colour value in 32-bit ARGB encoding with 8-bits per component in alpha, red, green, blue order."
 
@@ -43,7 +40,6 @@ rgbCode
 	"Answer the receiver's color value in 24-bit RGB encoding with 8-bits per component in (blue, green, red) order."
 
 	^self actualColor rgbCode! !
-!VirtualColor categoriesFor: #actualColor!accessing!private! !
 !VirtualColor categoriesFor: #argbCode!converting!public! !
 !VirtualColor categoriesFor: #asParameter!converting!public! !
 !VirtualColor categoriesFor: #asRGB!converting!public! !

--- a/Core/Object Arts/Dolphin/MVP/ColorTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ColorTest.cls
@@ -13,6 +13,17 @@ ColorTest comment: ''!
 shouldRaiseNotARealColorError: aNiladicValuable
 	self should: aNiladicValuable raise: Error matching: [:ex | ex description equals: 'Cannot convert to an RGB'].!
 
+testActualColor
+	| subject |
+	self assert: Color red actualColor identicalTo: Color red.
+	self assert: Color windowText actualColor identicalTo: Color windowText.
+	subject := PluggableColor with: [Color purple].
+	self assert: subject actualColor identicalTo: Color purple.
+	subject := ThemeColor name: #test actualColor: subject.
+	self assert: subject actualColor identicalTo: Color purple.
+	subject := ThemeColor name: #test actualColor: subject.
+	self assert: subject actualColor identicalTo: Color purple!
+
 testAlpha
 	self assert: Color red alpha equals: 255.
 	self assert: Color none alpha equals: 0.
@@ -515,6 +526,7 @@ testStlRoundTrip
 	self assert: rehydrated actualColor identicalTo: Color window
 ! !
 !ColorTest categoriesFor: #shouldRaiseNotARealColorError:!helpers!private! !
+!ColorTest categoriesFor: #testActualColor!public!unit tests! !
 !ColorTest categoriesFor: #testAlpha!public!unit tests! !
 !ColorTest categoriesFor: #testArgbCode!public!unit tests! !
 !ColorTest categoriesFor: #testAsColorRef!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -124,6 +124,7 @@ package setPrerequisites: #(
 	'Base\Dolphin MVP Base'
 	'Presenters\Number\Dolphin Number Presenter'
 	'Presenters\Radio\Dolphin Radio Buttons'
+	'..\System\Random\Dolphin Random Stream'
 	'Presenters\Text\Dolphin Rich Text Presenter'
 	'Views\Scintilla\Dolphin Scintilla View'
 	'Views\Scrollbars\Dolphin Scrollbars'
@@ -275,11 +276,6 @@ DolphinTest subclass: #ValueConverterTest
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-DolphinTest subclass: #ViewTest
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
 DolphinTest subclass: #VirtualColorTest
 	instanceVariableNames: ''
 	classVariableNames: ''
@@ -425,6 +421,11 @@ PresenterTest subclass: #StaticTextTest
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
+PresenterTest subclass: #ViewTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
 AbstractTextEditTest subclass: #MultilineTextEditTest
 	instanceVariableNames: ''
 	classVariableNames: ''
@@ -443,7 +444,7 @@ MultilineTextEditTest subclass: #RichTextEditTest
 MultilineTextEditTest subclass: #ScintillaViewTest
 	instanceVariableNames: ''
 	classVariableNames: ''
-	poolDictionaries: ''
+	poolDictionaries: 'ScintillaConstants'
 	classInstanceVariableNames: ''!
 ImageViewAbstractTest subclass: #ImageViewTest
 	instanceVariableNames: ''

--- a/Core/Object Arts/Dolphin/MVP/ScintillaViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ScintillaViewTest.cls
@@ -3,7 +3,7 @@
 MultilineTextEditTest subclass: #ScintillaViewTest
 	instanceVariableNames: ''
 	classVariableNames: ''
-	poolDictionaries: ''
+	poolDictionaries: 'ScintillaConstants'
 	classInstanceVariableNames: ''!
 ScintillaViewTest guid: (GUID fromString: '{3c6fbe95-74e0-4325-97e1-82f12133d503}')!
 ScintillaViewTest comment: ''!
@@ -23,6 +23,25 @@ initializePresenter
 
 margins
 	^0 @ 0!
+
+testCallTipColors
+	| fore back style |
+	style := presenter callTipStyle.
+	self assert: style forecolor equals: Color tooltipText.
+	self assert: style backcolor equals: Color tooltip.
+	fore := Color fromRgbCode: (presenter sendMessage: SCI_STYLEGETFORE wParam: STYLE_CALLTIP).
+	self assert: fore equals: Color tooltipText.
+	back := Color fromRgbCode: (presenter sendMessage: SCI_STYLEGETBACK wParam: STYLE_CALLTIP).
+	self assert: back equals: Color tooltip.
+	presenter
+		callTipForecolor: Color purple;
+		callTipBackcolor: Color green.
+	self assert: style forecolor equals: Color purple.
+	self assert: style backcolor equals: Color green.
+	fore := Color fromRgbCode: (presenter sendMessage: SCI_STYLEGETFORE wParam: STYLE_CALLTIP).
+	self assert: fore equals: Color purple.
+	back := Color fromRgbCode: (presenter sendMessage: SCI_STYLEGETBACK wParam: STYLE_CALLTIP).
+	self assert: back equals: Color green!
 
 testFindStringStartingAt
 	| found found2 |
@@ -48,6 +67,34 @@ testFindStringStartingAt
 	self assert: found equals: 0.
 	found := presenter findString: '🐬' startingAt: 50.
 	self assert: found equals: 0!
+
+testImmersiveColorSetChange
+	| textColor settingName requested settableNotGettable rnd |
+	textColor := Color red.
+	presenter caretForecolor: (PluggableColor with: [textColor]).
+	"Selection/whitespace forecolor and background colour are not retrievable from the view; we expect them to change, but can only test by examining calls"
+	requested := OrderedCollection new.
+	rnd := Random new.
+	settableNotGettable := #(#whitespaceForecolor: #whitespaceBackcolor: #selectionForecolor: #selectionBackcolor: #secondarySelectionForecolor: #secondarySelectionBackcolor: #callTipHighlightColor: #foldMarginColor: #foldMarginHiColor: #secondaryCaretForecolor: #edgeColor: #currentLineBackcolor: #activeHotspotForecolor: #activeHotspotBackcolor:)
+				asSet.
+	settableNotGettable do: 
+			[:each |
+			presenter perform: each
+				with: (PluggableColor with: 
+							[requested addLast: each.
+							Color fromRgbCode: (rnd next * 16rFFFFFF) rounded])].
+	self assert: (presenter sendMessage: SCI_GETCARETFORE) equals: Color red rgbCode.
+	self assert: requested asSet equals: settableNotGettable asSet.
+	requested := OrderedCollection new.
+	textColor := Color green.
+	"Simulate the color set changing, e.g. entering/leaving high contrast mode."
+	settingName := 'ImmersiveColorSet' asUtf16String.
+	presenter topShell
+		wmSettingChange: WM_SETTINGCHANGE
+		wParam: 0
+		lParam: settingName yourAddress.
+	self assert: (presenter sendMessage: SCI_GETCARETFORE) equals: Color green rgbCode.
+	self assert: requested asSet equals: settableNotGettable asSet!
 
 testLanguages
 	| lingos |
@@ -108,7 +155,9 @@ testSetGetAnnotations
 !ScintillaViewTest categoriesFor: #classToTest!helpers!private! !
 !ScintillaViewTest categoriesFor: #initializePresenter!public!Running! !
 !ScintillaViewTest categoriesFor: #margins!private!unit tests! !
+!ScintillaViewTest categoriesFor: #testCallTipColors!public!unit tests! !
 !ScintillaViewTest categoriesFor: #testFindStringStartingAt!public!unit tests! !
+!ScintillaViewTest categoriesFor: #testImmersiveColorSetChange!public!unit tests! !
 !ScintillaViewTest categoriesFor: #testLanguages!public!unit tests! !
 !ScintillaViewTest categoriesFor: #testOverrideDefaultKeyBindings!public!unit tests! !
 !ScintillaViewTest categoriesFor: #testSetGetAnnotations!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/ViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ViewTest.cls
@@ -1,6 +1,6 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
-DolphinTest subclass: #ViewTest
+PresenterTest subclass: #ViewTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -10,15 +10,37 @@ ViewTest comment: ''!
 !ViewTest categoriesForClass!Unclassified! !
 !ViewTest methodsFor!
 
+classToTest
+	^TextPresenter!
+
+testFontChangePropagation
+	| edit shell savedDesktopFont |
+	edit := presenter view.
+	shell := edit parentView.
+	savedDesktopFont := View desktop font.
+	
+	[| expected actual |
+	self assert: edit getFont equals: savedDesktopFont.
+	expected := Font name: 'Comic Sans' pointSize: 12.
+	View desktop font: expected.
+	"Pretent we've changed the icon title font, but don't actually do so. It doesn't send a change notification any more anyway, so we simulate the change."
+	shell
+		wmSettingChange: WM_SETTINGCHANGE
+		wParam: SPI_SETICONTITLELOGFONT
+		lParam: 0.
+	"We retrieve the actual font set into the control - if the propagation from the shell worked, then this will be the modified desktop font."
+	actual := edit getFont.
+	self assert: actual equals: expected]
+			ensure: [View desktop font: savedDesktopFont]!
+
 testRecreateMaintainsModelConnection
-	| t |
-	t := TextPresenter show.
-	t model value: 'aaa'.
-	self assert: t view value equals: 'aaa'.
-	t view hasBorder: true.
-	t model value: 'bbb'.
+	presenter model value: 'aaa'.
+	self assert: presenter view value equals: 'aaa'.
+	presenter view hasBorder: true.
+	presenter model value: 'bbb'.
 	"If this fails, then the view did not receive a #valueChanged event from the model"
-	self assert: t view value equals: 'bbb'.
-	t topShell exit! !
+	self assert: presenter view value equals: 'bbb'! !
+!ViewTest categoriesFor: #classToTest!helpers!private! !
+!ViewTest categoriesFor: #testFontChangePropagation!public!unit tests! !
 !ViewTest categoriesFor: #testRecreateMaintainsModelConnection!public!unit tests! !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/Dolphin Scintilla View.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/Dolphin Scintilla View.pax
@@ -42,6 +42,7 @@ package classNames
 	add: #QueryableScintillaAttribute;
 	add: #ScintillaAnnotation;
 	add: #ScintillaAttribute;
+	add: #ScintillaCallTipStyle;
 	add: #ScintillaColorPropertyDescriptor;
 	add: #ScintillaIndicator;
 	add: #ScintillaIndicatorStyle;
@@ -140,8 +141,8 @@ Object subclass: #ScintillaMarker
 	poolDictionaries: 'ScintillaConstants'
 	classInstanceVariableNames: ''!
 Object subclass: #ScintillaPropertyDescriptor
-	instanceVariableNames: 'getSelector defaultValue setMessage setSelector getMessage'
-	classVariableNames: ''
+	instanceVariableNames: 'getSelector defaultValue setMessage setSelector getMessage flags'
+	classVariableNames: 'AlwaysPrintMask'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Object subclass: #ScintillaStyler
@@ -191,12 +192,17 @@ ScintillaAttribute subclass: #ScintillaTextStyle
 	classInstanceVariableNames: ''!
 QueryableScintillaAttribute subclass: #ScintillaIndicatorStyle
 	instanceVariableNames: 'forecolor style under name alpha hoverStyle hoverForecolor flags foreAlpha _reserved12'
-	classVariableNames: 'IndicatorStyles StyleNames'
+	classVariableNames: 'HoverForecolor HoverStyle IndicatorStyles StyleNames'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 QueryableScintillaAttribute subclass: #ScintillaMargin
 	instanceVariableNames: 'width type isSensitive mask cursorType backcolor'
 	classVariableNames: 'CursorTypes MarginTypes'
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ScintillaTextStyle subclass: #ScintillaCallTipStyle
+	instanceVariableNames: ''
+	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ScintillaLexerMetadata subclass: #ScintillaLexerNamedStyle
@@ -220,7 +226,7 @@ ScintillaStyler subclass: #NullScintillaStyler
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 MultilineTextEdit subclass: #ScintillaView
-	instanceVariableNames: 'this currentTextStyles styleIdMap styler markerDefinitions markers wordChars registeredImages modificationEventMask autoCStops autoCFillups whitespaceBackcolor whitespaceForecolor selectionBackcolor selectionForecolor indicators callTipTabWidth punctuation callTipHighlightColor braceChars whitespaces scFlags allTextStyles foldMarginColor foldMarginHiColor foldMarkerStyle foldFlags stringClass keyBindings indicatorStyles secondarySelectionForecolor secondarySelectionBackcolor annotationStyles _unused50'
+	instanceVariableNames: 'this currentTextStyles styleIdMap styler markerDefinitions markers wordChars registeredImages modificationEventMask autoCStops autoCFillups whitespaceBackcolor whitespaceForecolor selectionBackcolor selectionForecolor indicators callTipTabWidth punctuation callTipHighlightColor braceChars whitespaces scFlags allTextStyles foldMarginColor foldMarginHiColor foldMarkerStyle foldFlags stringClass keyBindings indicatorStyles secondarySelectionForecolor secondarySelectionBackcolor annotationStyles caretForecolor secondaryCaretForecolor edgeColor currentLineBackcolor activeHotspotForecolor activeHotspotBackcolor _unused56 _unused57 _unused58 _unused59 _unused60 _unused61 _unused62 _unused63 _unused64 _unused65'
 	classVariableNames: 'AnnotationStylesOffset BackgroundDwellEvents BraceHilightingMask CodePages DefaultCallTipTabWidth DefaultKeyBindings DefaultTextStyles FoldingMask Library MarginStylesOffset'
 	poolDictionaries: 'ScintillaConstants Win32Constants'
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/QueryableScintillaAttribute.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/QueryableScintillaAttribute.cls
@@ -17,7 +17,7 @@ QueryableScintillaAttribute comment: '`QueryableScintillaAttribute` is the abstr
 populateFromView: aScintillaView at: anInteger
 	id := anInteger.
 	view := nil.
-	self propertyMap do: [:each | each getAttribute: self ofView: aScintillaView].
+	self class propertyMap do: [:each | each getAttribute: self ofView: aScintillaView].
 	view := aScintillaView!
 
 postCopy

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaAttribute.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaAttribute.cls
@@ -25,10 +25,8 @@ ScintillaAttribute comment: '`ScintillaAttribute` is the abstract superclass of 
 	^self class == aScintillaAttribute and: [self name = aScintillaAttribute name]!
 
 applyToView: aScintillaView initializing: aBoolean
-	"Private - Apply any non-default properties of this attribute to the <ScintillaView> argument. This should only be used for initialization, or after resetting the corresponding attributes of the view to defaults. See also #updateInView:"
-
 	self view: aScintillaView.
-	self propertyMapDo: 
+	self class propertyMap do: 
 			[:descriptor |
 			descriptor
 				setAttribute: self
@@ -56,12 +54,6 @@ id: anInteger
 name
 	^self id!
 
-printableProperties
-	"Answer the names of properties that should be printed whether or not they have the default
-	value."
-
-	^IdentitySet new!
-
 printOn: aStream
 	"Append a short textual description of the receiver to aStream."
 
@@ -75,13 +67,11 @@ printOn: aStream
 	aStream nextPut: $)!
 
 printPropertiesOn: aStream
-	| alwaysPrint |
-	alwaysPrint := self printableProperties.
-	self propertyMap keysAndValuesDo: 
+	self class propertyMap keysAndValuesDo: 
 			[:name :descriptor |
 			| value |
 			value := descriptor getAttributeValue: self.
-			((alwaysPrint includes: name) or: [value notNil])
+			(value notNil or: [descriptor alwaysPrint])
 				ifTrue: 
 					[aStream
 						nextPutAll: ', ';
@@ -89,14 +79,8 @@ printPropertiesOn: aStream
 						nextPutAll: '=';
 						print: value]]!
 
-propertyMap
-	^self class propertyMap!
-
-propertyMapDo: aMonadicValuable
-	^self propertyMap do: aMonadicValuable!
-
 storeableProperties
-	^{#basicId} , self propertyMap keys asArray!
+	^{#basicId} , self class propertyMap keys asArray!
 
 storeOn: aStream
 	"Append to the <puttableStream> argument an expression which when evaluated will answer a
@@ -124,18 +108,14 @@ storeOn: aStream
 		display: #yourself;
 		nextPut: $)!
 
+updateView: aScintillaView property: aSymbol
+	(self class propertyMap at: aSymbol)
+		setAttribute: self
+		ofView: aScintillaView
+		initializing: false!
+
 updateViewProperty: aSymbol
-	self view
-		ifNotNil: 
-			[:scintilla |
-			| descriptor |
-			descriptor := self propertyMap at: aSymbol.
-			"If the attribute is nil (unspecified) then set the value back to the default value from the descriptor"
-			descriptor
-				setAttribute: self
-				ofView: scintilla
-				initializing: false].
-	^self!
+	self view ifNotNil: [:scintilla | self updateView: scintilla property: aSymbol]!
 
 view
 	^self subclassResponsibility!
@@ -151,13 +131,11 @@ view: aScintillaView
 !ScintillaAttribute categoriesFor: #id!accessing!public! !
 !ScintillaAttribute categoriesFor: #id:!accessing!public! !
 !ScintillaAttribute categoriesFor: #name!accessing!public! !
-!ScintillaAttribute categoriesFor: #printableProperties!development!helpers!printing!private! !
 !ScintillaAttribute categoriesFor: #printOn:!development!printing!public! !
 !ScintillaAttribute categoriesFor: #printPropertiesOn:!development!helpers!printing!private! !
-!ScintillaAttribute categoriesFor: #propertyMap!constants!private! !
-!ScintillaAttribute categoriesFor: #propertyMapDo:!helpers!private! !
 !ScintillaAttribute categoriesFor: #storeableProperties!development!printing!private! !
 !ScintillaAttribute categoriesFor: #storeOn:!development!printing!public! !
+!ScintillaAttribute categoriesFor: #updateView:property:!helpers!private! !
 !ScintillaAttribute categoriesFor: #updateViewProperty:!helpers!private! !
 !ScintillaAttribute categoriesFor: #view!accessing!private! !
 !ScintillaAttribute categoriesFor: #view:!accessing!private! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaCallTipStyle.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaCallTipStyle.cls
@@ -1,0 +1,36 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+ScintillaTextStyle subclass: #ScintillaCallTipStyle
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ScintillaCallTipStyle guid: (GUID fromString: '{81c766f0-616e-4cf1-bc4b-8eba6720f2d7}')!
+ScintillaCallTipStyle comment: ''!
+!ScintillaCallTipStyle categoriesForClass!MVP-Views-Support! !
+!ScintillaCallTipStyle methodsFor!
+
+initialize
+	super initialize.
+	backcolor := Color tooltip.
+	forecolor := Color tooltipText.
+	self name: #callTip! !
+!ScintillaCallTipStyle categoriesFor: #initialize!initializing!private! !
+
+!ScintillaCallTipStyle class methodsFor!
+
+initialize
+	"
+		self initialize
+	"
+
+	propertyMap := self buildPropertyMap
+				at: #forecolor
+					put: (ScintillaColorPropertyDescriptor
+							getSelector: #forecolor
+							defaultValue: Color gray
+							setMessage: SCI_STYLESETFORE);
+				isImmutable: true;
+				yourself! !
+!ScintillaCallTipStyle class categoriesFor: #initialize!development!initializing!public! !
+

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaIndicatorStyle.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaIndicatorStyle.cls
@@ -2,7 +2,7 @@
 
 QueryableScintillaAttribute subclass: #ScintillaIndicatorStyle
 	instanceVariableNames: 'forecolor style under name alpha hoverStyle hoverForecolor flags foreAlpha _reserved12'
-	classVariableNames: 'IndicatorStyles StyleNames'
+	classVariableNames: 'HoverForecolor HoverStyle IndicatorStyles StyleNames'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ScintillaIndicatorStyle guid: (GUID fromString: '{2de64fd7-5b9f-4ac7-81c6-912b56b41a4f}')!
@@ -72,6 +72,27 @@ alpha: anInteger
 	anInteger isNil ifFalse: [self validateAlpha: anInteger].
 	self basicAlpha: anInteger.
 	self updateViewProperty: #alpha!
+
+applyToView: aScintillaView initializing: aBoolean
+	"Private - Apply any non-default properties of this attribute to the <ScintillaView> argument. This should only be used for initialization, or after resetting the corresponding attributes of the view to defaults. See also #updateInView:"
+
+	self view: aScintillaView.
+	self class propertyMap do: 
+			[:descriptor |
+			(descriptor == HoverForecolor or: [descriptor == HoverStyle])
+				ifFalse: 
+					[descriptor
+						setAttribute: self
+						ofView: aScintillaView
+						initializing: aBoolean]].
+	HoverForecolor
+		setAttribute: self
+		ofView: aScintillaView
+		initializing: aBoolean.
+	HoverStyle
+		setAttribute: self
+		ofView: aScintillaView
+		initializing: aBoolean!
 
 basicAlpha: anIntegerOrNil
 	alpha := anIntegerOrNil!
@@ -173,18 +194,6 @@ name: anObject
 				ifTrue: [id := anObject]
 				ifFalse: [anObject isEmpty ifFalse: [anObject asSymbol]]!
 
-propertyMapDo: aMonadicValuable
-	"Private - Evaluate the <monadicValuable> argument for each of the indicator style settings' property descriptors.
-	The hover styles are enumerated last as these must be applied after the normal style as (unfortunately) setting the
-	normal style resets the hover style."
-
-	| setLast map |
-	setLast := #(#hoverForecolor #hoverStyle).
-	map := self propertyMap.
-	map
-		keysAndValuesDo: [:eachKey :eachValue | (setLast includes: eachKey) ifFalse: [aMonadicValuable value: eachValue]].
-	setLast do: [:each | aMonadicValuable value: (map at: each)]!
-
 style
 	^style ifNotNil: [:s | IndicatorStyles at: s + 1 ifAbsent: []]!
 
@@ -204,6 +213,7 @@ validateAlpha: anInteger
 		ifFalse: [self error: 'Invalid alpha value ' , anInteger displayString]! !
 !ScintillaIndicatorStyle categoriesFor: #alpha!accessing!public! !
 !ScintillaIndicatorStyle categoriesFor: #alpha:!accessing!public! !
+!ScintillaIndicatorStyle categoriesFor: #applyToView:initializing:!helpers!private! !
 !ScintillaIndicatorStyle categoriesFor: #basicAlpha:!accessing!private! !
 !ScintillaIndicatorStyle categoriesFor: #basicForeAlpha:!accessing!private! !
 !ScintillaIndicatorStyle categoriesFor: #basicForecolor:!accessing!private! !
@@ -229,7 +239,6 @@ validateAlpha: anInteger
 !ScintillaIndicatorStyle categoriesFor: #isUnderText:!accessing!public! !
 !ScintillaIndicatorStyle categoriesFor: #name!accessing!public! !
 !ScintillaIndicatorStyle categoriesFor: #name:!accessing!public! !
-!ScintillaIndicatorStyle categoriesFor: #propertyMapDo:!helpers!private! !
 !ScintillaIndicatorStyle categoriesFor: #style!accessing!public! !
 !ScintillaIndicatorStyle categoriesFor: #style:!accessing!public! !
 !ScintillaIndicatorStyle categoriesFor: #styleFromName:!helpers!private! !
@@ -238,6 +247,20 @@ validateAlpha: anInteger
 !ScintillaIndicatorStyle class methodsFor!
 
 buildPropertyMap
+	"Some magic numbers for default values are from the Scintilla code - no consts for these"
+
+	HoverStyle := ScintillaPropertyDescriptor
+				getSelector: #basicHoverStyle
+				defaultValue: INDIC_SQUIGGLE
+				setMessage: SCI_INDICSETHOVERSTYLE
+				setSelector: #basicHoverStyle:
+				getMessage: SCI_INDICGETHOVERSTYLE.
+	HoverForecolor := ScintillaColorPropertyDescriptor
+				getSelector: #hoverForecolor
+				defaultValue: Color black
+				setMessage: SCI_INDICSETHOVERFORE
+				setSelector: #basicHoverForecolor:
+				getMessage: SCI_INDICGETHOVERFORE.
 	^IdentityDictionary new
 		at: #forecolor
 			put: (ScintillaColorPropertyDescriptor
@@ -253,13 +276,7 @@ buildPropertyMap
 					setMessage: SCI_INDICSETSTYLE
 					setSelector: #basicStyle:
 					getMessage: SCI_INDICGETSTYLE);
-		at: #hoverStyle
-			put: (ScintillaPropertyDescriptor
-					getSelector: #basicHoverStyle
-					defaultValue: INDIC_SQUIGGLE
-					setMessage: SCI_INDICSETHOVERSTYLE
-					setSelector: #basicHoverStyle:
-					getMessage: SCI_INDICGETHOVERSTYLE);
+		at: #hoverStyle put: HoverStyle;
 		at: #isUnderText
 			put: (ScintillaPropertyDescriptor
 					getSelector: #basicIsUnderText
@@ -270,17 +287,11 @@ buildPropertyMap
 		at: #alpha
 			put: (ScintillaPropertyDescriptor
 					getSelector: #alpha
-					defaultValue: 30 "Magic number for default value is from the Scintilla code - no const for this"
+					defaultValue: 30
 					setMessage: SCI_INDICSETALPHA
 					setSelector: #basicAlpha:
 					getMessage: SCI_INDICGETALPHA);
-		at: #hoverForecolor
-			put: (ScintillaColorPropertyDescriptor
-					getSelector: #hoverForecolor
-					defaultValue: Color black
-					setMessage: SCI_INDICSETHOVERFORE
-					setSelector: #basicHoverForecolor:
-					getMessage: SCI_INDICGETHOVERFORE);
+		at: #hoverForecolor put: HoverForecolor;
 		at: #flags
 			put: (ScintillaPropertyDescriptor
 					getSelector: #flags
@@ -291,7 +302,7 @@ buildPropertyMap
 		at: #foreAlpha
 			put: (ScintillaPropertyDescriptor
 					getSelector: #foreAlpha
-					defaultValue: 50 "Magic number for default value is from the Scintilla code - no const for this"
+					defaultValue: 50
 					setMessage: SCI_INDICSETOUTLINEALPHA
 					setSelector: #basicForeAlpha:
 					getMessage: SCI_INDICSETOUTLINEALPHA);

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaMarkerDefinition.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaMarkerDefinition.cls
@@ -118,11 +118,6 @@ newForLine: anInteger
 
 	^ScintillaMarker definition: self line: anInteger!
 
-printableProperties
-	^(super printableProperties)
-		add: #glyphName;
-		yourself!
-
 selectionBackcolor
 	"Answer the background <Color> used to draw the marker when selector, or nil if the marker definition does not specify a selection background colour and the Scintilla default (red) should be used."
 
@@ -158,7 +153,6 @@ view: aScintillaView
 !ScintillaMarkerDefinition categoriesFor: #name!accessing!public! !
 !ScintillaMarkerDefinition categoriesFor: #name:!accessing!public! !
 !ScintillaMarkerDefinition categoriesFor: #newForLine:!adding!must not strip!public! !
-!ScintillaMarkerDefinition categoriesFor: #printableProperties!development!helpers!printing!private! !
 !ScintillaMarkerDefinition categoriesFor: #selectionBackcolor!accessing!colors!public! !
 !ScintillaMarkerDefinition categoriesFor: #selectionBackcolor:!accessing!colors!public! !
 !ScintillaMarkerDefinition categoriesFor: #storeableProperties!development!printing!private! !
@@ -285,10 +279,12 @@ buildPropertyMap
 					defaultValue: Color black
 					setMessage: SCI_MARKERSETFORE);
 		at: #glyphName
-			put: (ScintillaPropertyDescriptor
+			put: ((ScintillaPropertyDescriptor
 					getSelector: #code
 					defaultValue: 0
-					setMessage: SCI_MARKERDEFINE);
+					setMessage: SCI_MARKERDEFINE)
+					alwaysPrint: true;
+					yourself);
 		at: #alpha
 			put: (ScintillaPropertyDescriptor
 					getSelector: #alpha

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaPropertyDescriptor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaPropertyDescriptor.cls
@@ -1,11 +1,12 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #ScintillaPropertyDescriptor
-	instanceVariableNames: 'getSelector defaultValue setMessage setSelector getMessage'
-	classVariableNames: ''
+	instanceVariableNames: 'getSelector defaultValue setMessage setSelector getMessage flags'
+	classVariableNames: 'AlwaysPrintMask'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ScintillaPropertyDescriptor guid: (GUID fromString: '{49848e62-c4d7-4cba-b9f5-71b0bf864a2a}')!
+ScintillaPropertyDescriptor addClassConstant: 'AlwaysPrintMask' value: 16r1!
 ScintillaPropertyDescriptor comment: '`ScintillaPropertyDescriptor`s provide metadata for individually settable scalar properties of a `ScintillaView`, e.g. the background colour of a marker.
 
 ## Instance Variables:
@@ -14,11 +15,23 @@ ScintillaPropertyDescriptor comment: '`ScintillaPropertyDescriptor`s provide met
   `setMessage`		`<integer>` id of the message to send to the control to set the property value, e.g. SCI_SETMARKERSETBACK
   `setSelector`		`Symbol`. Mutator message to send to object that represents the composite Scintilla attribute in order to set a property value retrieved from the control.
   `setMessage`		`<iInteger>` id of the message to send to the control to get the property value, e.g. SCI_GETMARKERSETBACK
+  `flags`			`<integer>`
+
+## Class Variables:
+  `AlwaysPrintMask`		`<integer>` flags mask for `alwaysPrint` setting.
+
+
 
 
 '!
 !ScintillaPropertyDescriptor categoriesForClass!Kernel-Objects! !
 !ScintillaPropertyDescriptor methodsFor!
+
+alwaysPrint
+	^flags allMask: AlwaysPrintMask!
+
+alwaysPrint: aBoolean
+	flags := flags mask: AlwaysPrintMask set: aBoolean!
 
 getAttribute: aScintillaAttribute ofView: aScintillaView
 	| value |
@@ -33,6 +46,7 @@ getSelector: aSymbol defaultValue: anObject setMessage: anInteger
 	getSelector := aSymbol.
 	defaultValue := anObject.
 	setMessage := anInteger.
+	flags := 0.
 	^self!
 
 isDefaultValue: anObject
@@ -41,11 +55,21 @@ isDefaultValue: anObject
 lParamFromAttributeValue: value
 	^value asUIntPtr!
 
+printOn: aStream
+	"Append a short textual description of the receiver to aStream."
+
+	aStream
+		basicPrint: self;
+		nextPut: $(;
+		print: getSelector;
+		nextPut: $)!
+
 setAttribute: aScintillaAttribute ofView: aScintillaView initializing: aBoolean
-	"Initialize the property described by the receiver of the attribute, aScintillaAttribute, of the control, aScintillaView, but only if it specified as a non-default value."
+	"Set the property described by the receiver of the attribute, aScintillaAttribute, of the control, aScintillaView.
+	If the final boolean parameter is true, then the property is only set if the attribute has a non-default value."
 
 	| value |
-	value := self getAttributeValue: aScintillaAttribute.
+	value := aScintillaAttribute perform: getSelector.
 	aBoolean
 		ifTrue: [(value isNil or: [self isDefaultValue: value]) ifTrue: [^self]]
 		ifFalse: [value isNil ifTrue: [value := defaultValue]].
@@ -61,11 +85,14 @@ setSelector: aSymbol getMessage: anInteger
 
 valueFromLResult: anObject 
 	^anObject! !
+!ScintillaPropertyDescriptor categoriesFor: #alwaysPrint!public!testing! !
+!ScintillaPropertyDescriptor categoriesFor: #alwaysPrint:!accessing!public! !
 !ScintillaPropertyDescriptor categoriesFor: #getAttribute:ofView:!operations!private! !
 !ScintillaPropertyDescriptor categoriesFor: #getAttributeValue:!operations!private! !
 !ScintillaPropertyDescriptor categoriesFor: #getSelector:defaultValue:setMessage:!initializing!private! !
 !ScintillaPropertyDescriptor categoriesFor: #isDefaultValue:!operations!private! !
 !ScintillaPropertyDescriptor categoriesFor: #lParamFromAttributeValue:!helpers!private! !
+!ScintillaPropertyDescriptor categoriesFor: #printOn:!displaying!public! !
 !ScintillaPropertyDescriptor categoriesFor: #setAttribute:ofView:initializing:!helpers!private! !
 !ScintillaPropertyDescriptor categoriesFor: #setSelector:getMessage:!initializing!private! !
 !ScintillaPropertyDescriptor categoriesFor: #valueFromLResult:!helpers!private! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/ScintillaView.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 MultilineTextEdit subclass: #ScintillaView
-	instanceVariableNames: 'this currentTextStyles styleIdMap styler markerDefinitions markers wordChars registeredImages modificationEventMask autoCStops autoCFillups whitespaceBackcolor whitespaceForecolor selectionBackcolor selectionForecolor indicators callTipTabWidth punctuation callTipHighlightColor braceChars whitespaces scFlags allTextStyles foldMarginColor foldMarginHiColor foldMarkerStyle foldFlags stringClass keyBindings indicatorStyles secondarySelectionForecolor secondarySelectionBackcolor annotationStyles _unused50'
+	instanceVariableNames: 'this currentTextStyles styleIdMap styler markerDefinitions markers wordChars registeredImages modificationEventMask autoCStops autoCFillups whitespaceBackcolor whitespaceForecolor selectionBackcolor selectionForecolor indicators callTipTabWidth punctuation callTipHighlightColor braceChars whitespaces scFlags allTextStyles foldMarginColor foldMarginHiColor foldMarkerStyle foldFlags stringClass keyBindings indicatorStyles secondarySelectionForecolor secondarySelectionBackcolor annotationStyles caretForecolor secondaryCaretForecolor edgeColor currentLineBackcolor activeHotspotForecolor activeHotspotBackcolor _unused56 _unused57 _unused58 _unused59 _unused60 _unused61 _unused62 _unused63 _unused64 _unused65'
 	classVariableNames: 'AnnotationStylesOffset BackgroundDwellEvents BraceHilightingMask CodePages DefaultCallTipTabWidth DefaultKeyBindings DefaultTextStyles FoldingMask Library MarginStylesOffset'
 	poolDictionaries: 'ScintillaConstants Win32Constants'
 	classInstanceVariableNames: ''!
@@ -123,38 +123,24 @@ acceptAutoCompletion
 activeHotspotBackcolor
 	"Get the back colour for active hotspots."
 
-	^this
-		ifNotNil: 
-			[Color fromRgbCode: (Library
-						directFunction: this
-						msg: SCI_GETHOTSPOTACTIVEBACK
-						wParam: 0
-						lParam: 0)]!
+	^activeHotspotBackcolor!
 
 activeHotspotBackcolor: aColorOrNil
-	"Set the back colour for active hotspots."
+	"Set the back colour for active hotspots. If the argument is nil, then the setting is removed."
 
-	aColorOrNil
-		ifNil: [self sciSetHotspotActiveBack: false back: 0]
-		ifNotNil: [self sciSetHotspotActiveBack: true back: aColorOrNil]!
+	activeHotspotBackcolor := aColorOrNil.
+	self setActiveHotspotBackcolor!
 
 activeHotspotForecolor
 	"Get the fore colour for active hotspots."
 
-	^this
-		ifNotNil: 
-			[Color fromRgbCode: (Library
-						directFunction: this
-						msg: SCI_GETHOTSPOTACTIVEFORE
-						wParam: 0
-						lParam: 0)]!
+	^activeHotspotBackcolor!
 
 activeHotspotForecolor: aColorOrNil
-	"Set the foreground colour for active hotspots."
+	"Set the foreground colour for active hotspots. If the argument is nil, then the setting is removed."
 
-	aColorOrNil
-		ifNil: [self sciSetHotspotActiveFore: false fore: 0]
-		ifNotNil: [self sciSetHotspotActiveFore: true fore: aColorOrNil]!
+	activeHotspotForecolor := aColorOrNil.
+	self setActiveHotspotForecolor!
 
 addAnnotation: aScintillaAnnotation 
 	"Append the specified <ScintillaAnnotation> to the current annotations (if any) for the line
@@ -871,33 +857,38 @@ buildViewStyle
 		yourself!
 
 callTipBackcolor
-	"Answer the background <Color> of the call tips box. By default this is white."
+	"Answer the background <Color> of the call tips box. By default this is Color tooltip."
 
 	^self callTipStyle backcolor!
 
 callTipBackcolor: aColorOrNil
-	"Set the background <Color> of the call tips box. If the argument is nil then the default
-	colour (white) is set."
+	"Set the background <Color> of the call tips box. If the argument is nil then the default colour (Color toolTip) is set."
 
-	| color |
-	color := aColorOrNil ifNil: [Color white].
-	self sciCallTipSetBack: color.
-	self callTipStyle backcolor: color!
+	| color style |
+	color := aColorOrNil ifNil: [Color tooltip].
+	style := self callTipStyle.
+	style backcolor = aColorOrNil
+		ifFalse: 
+			[style
+				backcolor: color;
+				updateView: self property: #backcolor]!
 
 callTipForecolor
-	"Answer the foreground <Color> of the unhighlighted text in call tips. By default this is
-	dark grey."
+	"Answer the foreground <Color> of the unhighlighted text in call tips. By default this is Color tooltipText."
 
 	^self callTipStyle forecolor!
 
 callTipForecolor: aColorOrNil
-	"Set the foreground <Color> of the unhighlighted text in call tips. If the argument is nil
-	then the default colour (dark grey) is set."
+	"Set the foreground <Color> of the unhighlighted text in call tips. If the argument is nil then the default colour (the system theme tooltip text colour) is set."
 
-	| color |
-	color := aColorOrNil ifNil: [Color gray].
-	self sciCallTipSetFore: color.
-	self callTipStyle backcolor: color!
+	| color style |
+	color := aColorOrNil ifNil: [Color tooltipText].
+	style := self callTipStyle.
+	style forecolor = aColorOrNil
+		ifFalse: 
+			[style
+				forecolor: color;
+				updateView: self property: #forecolor]!
 
 callTipHighlightColor
 	"Answer the foreground <Color> for the highlighted part of the call tip, or nil if unspecified and the control's default (dark blue) should be used."
@@ -936,7 +927,11 @@ callTipPosition: posStartInteger
 
 callTipStyle
 	^currentTextStyles at: #callTip
-		ifAbsentPut: [styleIdMap at: STYLE_CALLTIP + 1 put: self class defaultCallTipStyle]!
+		ifAbsentPut: 
+			[styleIdMap at: STYLE_CALLTIP + 1
+				put: (self class defaultCallTipStyle
+						view: self;
+						yourself)]!
 
 callTipTabWidth
 	^callTipTabWidth!
@@ -1070,18 +1065,13 @@ canVScroll
 caretForecolor
 	"Get the foreground colour of the caret."
 
-	^this
-		ifNotNil: 
-			[Color fromRgbCode: (Library
-						directFunction: this
-						msg: SCI_GETCARETFORE
-						wParam: 0
-						lParam: 0)]!
+	^caretForecolor ifNil: [Color windowText]!
 
-caretForecolor: foreRGB
+caretForecolor: aColorOrNil
 	"Set the foreground colour of the caret."
 
-	self sciSetCaretFore: (foreRGB ifNil: [Color black])!
+	caretForecolor := aColorOrNil == Color windowText ifFalse: [aColorOrNil].
+	self setCaretForecolor!
 
 caretPeriod
 	"Get the time in milliseconds that the caret is on and off."
@@ -1418,21 +1408,14 @@ currentLineAlpha: alphaInteger
 currentLineBackcolor
 	"Get the colour of the background of the line containing the caret."
 
-	^this
-		ifNotNil: 
-			[Color fromRgbCode: (Library
-						directFunction: this
-						msg: SCI_GETCARETLINEBACK
-						wParam: 0
-						lParam: 0)]!
+	^currentLineBackcolor ifNil: [self defaultCurrentLineBackcolor]!
 
-currentLineBackcolor: backRGB 
-	"Set the colour of the background of the line containing the caret. Note that this will have
-	no effect unless #isCurrentLineHighlighted is set to true. You will also want to set
-	#currentLineAlpha to some reasonable transparency value (100 or less), or the background
-	will obliterate the text."
+currentLineBackcolor: aColorOrNil
+	"Set the colour of the background of the line containing the caret. 
+	Note that this will have no effect unless #isCurrentLineHighlighted is set to true. You will also want to set #currentLineAlpha to some reasonable transparency value (100 or less), or the background will obliterate the text."
 
-	self sciSetCaretLineBack: (backRGB ifNil: [Color yellow])!
+	currentLineBackcolor := aColorOrNil = self defaultCurrentLineBackcolor ifFalse: [aColorOrNil].
+	self setCurrentLineBackcolor!
 
 currentLineFrameWidth
 	"Retrieve the caret line frame width. Width = 0 means this option is disabled."
@@ -1542,6 +1525,12 @@ defaultBraceChars
 		at: #normal put: '()[]{}<>';
 		yourself)!
 
+defaultCurrentLineBackcolor
+	^Color yellow!
+
+defaultEdgeColor
+	^Color silver!
+
 defaultFoldTextTag
 	"Get the default fold display text."
 
@@ -1594,6 +1583,9 @@ defaultModEventMask
 
 	"Enable only the set that we actually respond to"
 	^##(SC_MOD_INSERTTEXT|SC_MOD_DELETETEXT|SC_MOD_CHANGESTYLE | SC_MOD_CHANGEFOLD | SC_MOD_CHANGEANNOTATION | SC_MOD_CHANGEMARGIN)!
+
+defaultSecondardCaretForecolor
+	^##(Color fromRgbCode: 16r7F7F7F)!
 
 defaultTextLimit
 	^SmallInteger maximum!
@@ -1793,18 +1785,13 @@ duplicateSelection
 edgeColor
 	"Retrieve the colour used in edge indication."
 
-	^this
-		ifNotNil: 
-			[Color fromRgbCode: (Library
-						directFunction: this
-						msg: SCI_GETEDGECOLOUR
-						wParam: 0
-						lParam: 0)]!
+	^edgeColor ifNil: [self defaultEdgeColor]!
 
 edgeColor: aColorOrNil
 	"Set the edge colour used to highlight long lines (those longer than the #edgeColumn setting)."
 
-	self sciSetEdgeColour: (aColorOrNil ifNil: [Color fromRgbCode: 16rC0C0C0])!
+	edgeColor := aColorOrNil = self defaultEdgeColor ifFalse: [aColorOrNil].
+	self setEdgeColor!
 
 edgeColumn
 	"Retrieve the column number which text should be kept within."
@@ -3285,6 +3272,8 @@ initializeControl
 
 	"Discard registered images rather than restoring - these can be re-registered dynamically as required"
 
+	"Note that if any primary selection foreground/background colors are set, then any second
+	selection colours will also be set"
 	self initializeRegisteredImages.
 	self sciSetModEventMask: self modificationEventMask.
 	"Not necessary.
@@ -3296,24 +3285,13 @@ initializeControl
 		sciMarginSetStyleOffset: MarginStylesOffset;
 		sciAnnotationSetStyleOffset: AnnotationStylesOffset;
 		sciEOLAnnotationSetStyleOffset: AnnotationStylesOffset.
-	self
-		updateIndicatorStyles;
-		updateTextStyles;
-		initializeMarkerDefinitions.
+	self updateControlStyles.
 	styler ifNotNil: [self invalidateStyling].
 	self sciSetCodePage: stringClass codePage.
 	self setCharacterClasses.
 	autoCFillups ifNotNil: [self sciAutoCSetFillUps: autoCFillups].
 	autoCStops ifNotNil: [self sciAutoCStops: autoCStops].
-	whitespaceForecolor ifNotNil: [self setWhitespaceForecolor].
-	whitespaceBackcolor ifNotNil: [self setWhitespaceBackcolor].
-	"Note that if any primary selection foreground/background colors are set, then any second
-	selection colours will also be set"
-	selectionForecolor ifNotNil: [self setSelectionForecolor].
-	selectionBackcolor = Color silver ifFalse: [self setSelectionBackcolor].
-	callTipHighlightColor ifNotNil: [self setCallTipHighlightColor].
-	foldMarginColor ifNotNil: [self setFoldMarginColor].
-	foldMarginHiColor ifNotNil: [self setFoldMarginHiColor].
+	self updateControlStyles.
 	foldFlags ifNotNil: [self setFoldFlags].
 	keyBindings ifNotNil: [self updateKeyBindings]!
 
@@ -5861,28 +5839,6 @@ sciBraceMatchNext: posInteger startPos: startPosInteger
 				wParam: posInteger - 1
 				lParam: startPosInteger - 1) + 1]!
 
-sciCallTipSetBack: backColor
-	"Private - Set the background colour for the call tip."
-
-	this
-		ifNotNil: 
-			[Library
-				directFunction: this
-				msg: SCI_CALLTIPSETBACK
-				wParam: backColor rgbCode
-				lParam: 0]!
-
-sciCallTipSetFore: foreColor
-	"Private - Set the foreground colour for the call tip."
-
-	this
-		ifNotNil: 
-			[Library
-				directFunction: this
-				msg: SCI_CALLTIPSETFORE
-				wParam: foreColor rgbCode
-				lParam: 0]!
-
 sciCallTipSetForeHlt: foreColor
 	"Private - Set the foreground colour for the highlighted part of the call tip."
 
@@ -7809,17 +7765,6 @@ sciMarkerPrevious: lineStartInteger markerMask: markerMaskInteger
 				msg: SCI_MARKERPREVIOUS
 				wParam: lineStartInteger - 1
 				lParam: markerMaskInteger) + 1]!
-
-sciMarkerSetAlpha: markerNumberInteger alpha: alphaInteger
-	"Private - Set the alpha used for a marker that is drawn in the text area, not the margin."
-
-	this
-		ifNotNil: 
-			[Library
-				directFunction: this
-				msg: SCI_MARKERSETALPHA
-				wParam: markerNumberInteger
-				lParam: alphaInteger]!
 
 sciMarkerSymbolDefined: markerNumberInteger
 	"Private - Which symbol was defined for markerNumber with MarkerDefine"
@@ -9786,23 +9731,15 @@ searchPrev: searchFlagsInteger text: textString
 				lpParam: textString) + 1]!
 
 secondaryCaretForecolor
-	"Get the foreground colour of additional carets."
+	"Get the foreground colour of the secondary caret."
 
-	^this
-		ifNotNil: 
-			[Color fromRgbCode: (Library
-						directFunction: this
-						msg: SCI_GETADDITIONALCARETFORE
-						wParam: 0
-						lParam: 0)]!
+	^secondaryCaretForecolor ifNil: [self defaultSecondardCaretForecolor]!
 
-secondaryCaretForecolor: foreRGB
+secondaryCaretForecolor: aColor
 	"Set the foreground colour of the secondary carets."
 
-	self sciSetAdditionalCaretFore: (foreRGB
-				ifNil: 
-					["Use default hardcoded in Scintilla"
-					Color fromRgbCode: 16r7F7F7F])!
+	secondaryCaretForecolor := aColor = self defaultSecondardCaretForecolor ifFalse: [aColor].
+	self setSecondaryCaretForecolor!
 
 secondarySelectionAlpha
 	"Get the alpha of the selection."
@@ -9841,8 +9778,8 @@ secondarySelectionForecolor
 	^secondarySelectionForecolor!
 
 secondarySelectionForecolor: aColorOrNil 
-	"Set the foreground colour for secondary selections. Note that this is ignored unless a
-	primary selection foreground colour has been set."
+	"Set the foreground colour for secondary selections. Note that this is ignored unless a primary selection foreground colour has been set.
+	If the value is nil, then the secondary selection foreground colour is set to be the same as the primary selector foreground colour."
 
 	secondarySelectionForecolor := aColorOrNil.
 	self setSecondarySelectionForecolor!
@@ -10079,6 +10016,16 @@ sendMessage: anIntegerMessageID wParam: wParam lpParam: lpParam
 				wParam: wParam
 				lpParam: lpParam yourAddress]!
 
+setActiveHotspotBackcolor
+	activeHotspotBackcolor
+		ifNil: [self sciSetHotspotActiveBack: false back: 0]
+		ifNotNil: [self sciSetHotspotActiveBack: true back: activeHotspotBackcolor]!
+
+setActiveHotspotForecolor
+	activeHotspotForecolor
+		ifNil: [self sciSetHotspotActiveFore: false fore: 0]
+		ifNotNil: [self sciSetHotspotActiveFore: true fore: activeHotspotForecolor]!
+
 setCallTipHighlightColor
 	self sciCallTipSetForeHlt: (callTipHighlightColor
 				ifNil: 
@@ -10087,6 +10034,9 @@ setCallTipHighlightColor
 
 setCallTipTabWidth
 	self sciCallTipUseStyle: callTipTabWidth!
+
+setCaretForecolor
+	self sciSetCaretFore: self caretForecolor!
 
 setCharacterClasses
 	"Private - Configure the control with current character class settings. 
@@ -10097,6 +10047,9 @@ setCharacterClasses
 	"Whitepace and punctutation character classes will have been reset to defaults."
 	whitespaces ifNotNil: [self sciSetWhitespaceChars: whitespaces].
 	punctuation ifNotNil: [self sciSetPunctuationChars: punctuation]!
+
+setCurrentLineBackcolor
+	self sciSetCaretLineBack: self currentLineBackcolor!
 
 setCurrentTextStyles: aCollection 
 	| newStylesByName allocatedStyles newStylesById availableStyles count |
@@ -10130,6 +10083,9 @@ setDefaultTextStyle
 		basicId: STYLE_DEFAULT;
 		applyToView: self initializing: true.
 	self sciStyleClearAll!
+
+setEdgeColor
+	self sciSetEdgeColour: self edgeColor!
 
 setEolAnnotations: aCollectionOfScintillaAnnotations
 	aCollectionOfScintillaAnnotations do: 
@@ -10205,7 +10161,9 @@ setIndicatorStyles: aCollection
 					each basicId: availableStyles next].
 			newStylesByName at: each name put: each].
 	indicatorStyles := newStylesByName.
-	self updateIndicatorStyles!
+	self
+		hideIndicators;
+		updateIndicatorStyles!
 
 setKeyBindings: aCollectionOfScintillaKeyBindings
 	keyBindings := aCollectionOfScintillaKeyBindings.
@@ -10266,6 +10224,9 @@ setReadOnly: readOnlyBoolean
 				msg: SCI_SETREADONLY
 				wParam: readOnlyBoolean asParameter
 				lParam: 0]!
+
+setSecondaryCaretForecolor
+	self sciSetAdditionalCaretFore: self secondaryCaretForecolor!
 
 setSecondarySelectionBackcolor
 	self sciSetAdditionalSelBack: (secondarySelectionBackcolor
@@ -10456,13 +10417,9 @@ state
 
 	| answer |
 	answer := super state.
-	#(#(#isDrawingBuffered: #isDrawingBuffered true) #(#hoverTime: #hoverTime ##(SC_TIME_FOREVER)) #(#setIndicators: #indicators #()) #(#sciSetCaretStyle: #sciGetCaretStyle ##(CARETSTYLE_LINE)) #(#caretForecolor: #caretForecolor ##(Color
-		black)) #(#secondaryCaretForecolor: #secondaryCaretForecolor ##(Color fromRgbCode: 16r7F7F7F)) #(#currentLineAlpha: #currentLineAlpha ##(SC_ALPHA_NOALPHA)) #(#caretPeriod: #caretPeriod 500) #(#caretWidth: #caretWidth 1) #(#sciSetCaretSticky: #sciGetCaretSticky ##(SC_CARETSTICKY_OFF)) #(#isCurrentLineHighlighted: #isCurrentLineHighlighted false) #(#isCurrentLineHighlightedAlways: #isCurrentLineHighlightedAlways false) #(#currentLineBackcolor: #currentLineBackcolor ##(Color
-		yellow)) #(#sciSetEOLMode: #sciGetEOLMode ##(SC_EOL_CRLF)) #(#hasVisibleLineEndings: #hasVisibleLineEndings false) #(#wordWrap: #wordWrap false) #(#sciSetLayoutCache: #sciGetLayoutCache ##(SC_CACHE_CARET)) #(#margins: #margins #()) #(#markers: #markers ##(IdentitySet
+	#(#(#isDrawingBuffered: #isDrawingBuffered true) #(#hoverTime: #hoverTime ##(SC_TIME_FOREVER)) #(#setIndicators: #indicators #()) #(#sciSetCaretStyle: #sciGetCaretStyle ##(CARETSTYLE_LINE)) #(#currentLineAlpha: #currentLineAlpha ##(SC_ALPHA_NOALPHA)) #(#caretPeriod: #caretPeriod 500) #(#caretWidth: #caretWidth 1) #(#sciSetCaretSticky: #sciGetCaretSticky ##(SC_CARETSTICKY_OFF)) #(#isCurrentLineHighlighted: #isCurrentLineHighlighted false) #(#isCurrentLineHighlightedAlways: #isCurrentLineHighlightedAlways false) #(#sciSetEOLMode: #sciGetEOLMode ##(SC_EOL_CRLF)) #(#hasVisibleLineEndings: #hasVisibleLineEndings false) #(#wordWrap: #wordWrap false) #(#sciSetLayoutCache: #sciGetLayoutCache ##(SC_CACHE_CARET)) #(#margins: #margins #()) #(#markers: #markers ##(IdentitySet
 		new)) #(#isOvertypeEnabled: #isOvertypeEnabled false) #(#printMagnification: #printMagnification 0) #(#printColourMode: #printColourMode ##(SC_PRINT_NORMAL)) #(#canHScroll: #canHScroll true) #(#canScrollPastEnd: #canScrollPastEnd true) #(#scrollWidth: #scrollWidth 2000) #(#xOffset: #xOffset 0) #(#sciSetSelectionMode: #sciGetSelectionMode ##(SC_SEL_STREAM)) #(#backspaceUnindents: #backspaceUnindents false) #(#sciSetIndentationGuides: #sciGetIndentationGuides ##(SC_IV_NONE)) #(#indentation: #indentation 0) #(#tabIndents: #tabIndents true) #(#tabWidth: #tabWidth 8) #(#isUsingTabs: #isUsingTabs true) #(#tabMinimumWidth: #tabMinimumWidth 2) #(#targetRange: #targetRange ##(1
-		to: 0)) #(#sciSetViewWS: #sciGetViewWS ##(SCWS_INVISIBLE)) #(#autoCompletionSeparator: #autoCompletionSeparator $\x20) #(#autoCompletionImageIdSeparator: #autoCompletionImageIdSeparator $?) #(#isAutoCompletionCancelledAtStart: #isAutoCompletionCancelledAtStart true) #(#isAutoCompletionCaseInsensitive: #isAutoCompletionCaseInsensitive false) #(#isAutoCompletionCancelledWhenNoMatch: #isAutoCompletionCancelledWhenNoMatch true) #(#isAutoCompletionTruncating: #isAutoCompletionTruncating false) #(#maxCompletionListHeight: #maxCompletionListHeight 5) #(#maxCompletionListWidth: #maxCompletionListWidth 0) #(#edgeColumn: #edgeColumn 0) #(#sciSetEdgeMode: #sciGetEdgeMode ##(EDGE_NONE)) #(#edgeColor: #edgeColor ##(Color
-		silver)) #(#zoomLevel: #zoomLevel 0) #(#setLexerLanguage: #lexer #container) #(#controlCharacter: #controlCharacter nil) #(#selectionAlpha: #selectionAlpha ##(SC_ALPHA_NOALPHA)) #(#secondarySelectionAlpha: #secondarySelectionAlpha ##(SC_ALPHA_NOALPHA)) #(#positionCacheSize: #positionCacheSize 1024) #(#activeHotspotBackcolor: #activeHotspotBackcolor ##(Color
-		white)) #(#activeHotspotForecolor: #activeHotspotForecolor ##(Color blue)) #(#areHotspotsSingleLine: #areHotspotsSingleLine true) #(#sciAnnotationSetVisible: #sciAnnotationGetVisible ##(ANNOTATION_HIDDEN)) #(#setRawAnnotations: #getRawAnnotations #()) #(#sciEOLAnnotationSetVisible: #sciEOLAnnotationGetVisible ##(ANNOTATION_HIDDEN)) #(#setEolAnnotations: #getEolAnnotations #()) #(#extraAscent: #extraAscent 0) #(#extraDescent: #extraDescent 0) #(#areAdditionalCaretsVisible: #areAdditionalCaretsVisible true) #(#sciSetTechnology: #sciGetTechnology ##(SC_TECHNOLOGY_DEFAULT)) #(#sciSetFontQuality: #sciGetFontQuality ##(SC_EFF_QUALITY_DEFAULT)) #(#whitespaceMarkerSize: #whitespaceMarkerSize 1) #(#sciSetMultiPaste: #sciGetMultiPaste ##(SC_MULTIPASTE_ONCE)) #(#sciSetIMEInteraction: #sciGetIMEInteraction ##(SC_IME_WINDOWED)) #(#sciAutoCSetOrder: #sciAutoCGetOrder ##(SC_ORDER_PRESORTED)) #(#sciSetPhasesDraw: #sciGetPhasesDraw ##(SC_PHASES_TWO)) #(#sciSetIdleStyling: #sciGetIdleStyling ##(SC_IDLESTYLING_NONE)) #(#isMouseWheelCaptured: #isMouseWheelCaptured true) #(#sciSetTabDrawMode: #sciGetTabDrawMode 0) #(#sciSetAccessibility: #sciGetAccessibility 0) #(#currentLineFrameWidth: #currentLineFrameWidth 0) #(#isAccessibilityEnabled: #isAccessibilityEnabled false) #(#sciSetWrapIndentMode: #sciGetWrapIndentMode ##(SC_WRAPINDENT_FIXED)) #(#sciFoldDisplayTextSetStyle: #sciFoldDisplayTextGetStyle 0) #(#defaultFoldTextTag: #defaultFoldTextTag '') #(#hasAdditionalSelectionTyping: #hasAdditionalSelectionTyping false))
+		to: 0)) #(#sciSetViewWS: #sciGetViewWS ##(SCWS_INVISIBLE)) #(#autoCompletionSeparator: #autoCompletionSeparator $\x20) #(#autoCompletionImageIdSeparator: #autoCompletionImageIdSeparator $?) #(#isAutoCompletionCancelledAtStart: #isAutoCompletionCancelledAtStart true) #(#isAutoCompletionCaseInsensitive: #isAutoCompletionCaseInsensitive false) #(#isAutoCompletionCancelledWhenNoMatch: #isAutoCompletionCancelledWhenNoMatch true) #(#isAutoCompletionTruncating: #isAutoCompletionTruncating false) #(#maxCompletionListHeight: #maxCompletionListHeight 5) #(#maxCompletionListWidth: #maxCompletionListWidth 0) #(#edgeColumn: #edgeColumn 0) #(#sciSetEdgeMode: #sciGetEdgeMode ##(EDGE_NONE)) #(#zoomLevel: #zoomLevel 0) #(#setLexerLanguage: #lexer #container) #(#controlCharacter: #controlCharacter nil) #(#selectionAlpha: #selectionAlpha ##(SC_ALPHA_NOALPHA)) #(#secondarySelectionAlpha: #secondarySelectionAlpha ##(SC_ALPHA_NOALPHA)) #(#positionCacheSize: #positionCacheSize 1024) #(#areHotspotsSingleLine: #areHotspotsSingleLine true) #(#sciAnnotationSetVisible: #sciAnnotationGetVisible ##(ANNOTATION_HIDDEN)) #(#setRawAnnotations: #getRawAnnotations #()) #(#sciEOLAnnotationSetVisible: #sciEOLAnnotationGetVisible ##(ANNOTATION_HIDDEN)) #(#setEolAnnotations: #getEolAnnotations #()) #(#extraAscent: #extraAscent 0) #(#extraDescent: #extraDescent 0) #(#areAdditionalCaretsVisible: #areAdditionalCaretsVisible true) #(#sciSetTechnology: #sciGetTechnology ##(SC_TECHNOLOGY_DEFAULT)) #(#sciSetFontQuality: #sciGetFontQuality ##(SC_EFF_QUALITY_DEFAULT)) #(#whitespaceMarkerSize: #whitespaceMarkerSize 1) #(#sciSetMultiPaste: #sciGetMultiPaste ##(SC_MULTIPASTE_ONCE)) #(#sciSetIMEInteraction: #sciGetIMEInteraction ##(SC_IME_WINDOWED)) #(#sciAutoCSetOrder: #sciAutoCGetOrder ##(SC_ORDER_PRESORTED)) #(#sciSetPhasesDraw: #sciGetPhasesDraw ##(SC_PHASES_TWO)) #(#sciSetIdleStyling: #sciGetIdleStyling ##(SC_IDLESTYLING_NONE)) #(#isMouseWheelCaptured: #isMouseWheelCaptured true) #(#sciSetTabDrawMode: #sciGetTabDrawMode 0) #(#sciSetAccessibility: #sciGetAccessibility 0) #(#currentLineFrameWidth: #currentLineFrameWidth 0) #(#isAccessibilityEnabled: #isAccessibilityEnabled false) #(#sciSetWrapIndentMode: #sciGetWrapIndentMode ##(SC_WRAPINDENT_FIXED)) #(#sciFoldDisplayTextSetStyle: #sciFoldDisplayTextGetStyle 0) #(#defaultFoldTextTag: #defaultFoldTextTag '') #(#hasAdditionalSelectionTyping: #hasAdditionalSelectionTyping false))
 			do: 
 				[:each |
 				| attrib |
@@ -10954,12 +10911,32 @@ unindent
 				wParam: 0
 				lParam: 0]!
 
+updateControlStyles
+	self
+		updateIndicatorStyles;
+		updateTextStyles;
+		initializeMarkerDefinitions.
+	whitespaceForecolor ifNotNil: [self setWhitespaceForecolor].
+	whitespaceBackcolor ifNotNil: [self setWhitespaceBackcolor].
+	"Note that if any primary selection foreground/background colors are set, then any second
+	selection colours will also be set"
+	selectionForecolor ifNotNil: [self setSelectionForecolor].
+	selectionBackcolor = Color silver ifFalse: [self setSelectionBackcolor].
+	callTipHighlightColor ifNotNil: [self setCallTipHighlightColor].
+	foldMarginColor ifNotNil: [self setFoldMarginColor].
+	foldMarginHiColor ifNotNil: [self setFoldMarginHiColor].
+	self setCaretForecolor.
+	secondaryCaretForecolor ifNotNil: [self setSecondaryCaretForecolor].
+	edgeColor ifNotNil: [self setEdgeColor].
+	currentLineBackcolor ifNotNil: [self setCurrentLineBackcolor].
+	activeHotspotForecolor ifNotNil: [self setActiveHotspotForecolor].
+	activeHotspotBackcolor ifNotNil: [self setActiveHotspotBackcolor]!
+
 updateIndicators
 	self basicClearContainerIndicators.
 	indicators do: [:each | self setIndicator: each styleName range: each range]!
 
 updateIndicatorStyles
-	self hideIndicators.
 	indicatorStyles ifNil: [^self].
 	indicatorStyles do: [:each | each applyToView: self initializing: false].
 	(indicatorStyles lookup: #braceHighlight)
@@ -10982,6 +10959,10 @@ updateKeyBindings
 updateMarkers
 	self deleteMarkers: 0.
 	markers do: [:each | each addToView: self]!
+
+updateSetting: aSettingsChangeEvent
+	super updateSetting: aSettingsChangeEvent.
+	aSettingsChangeEvent isColorSetChange ifTrue: [self updateControlStyles]!
 
 updateTextStyles
 	"Private - Sync. the control's knowledge of the text styles with those recorded in the receiver."
@@ -11337,9 +11318,9 @@ zoomOut
 				wParam: 0
 				lParam: 0]! !
 !ScintillaView categoriesFor: #acceptAutoCompletion!**auto generated**!autocompletion!commands!public!scintilla interface! !
-!ScintillaView categoriesFor: #activeHotspotBackcolor!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
+!ScintillaView categoriesFor: #activeHotspotBackcolor!caret, selection, and hotspot styles!public! !
 !ScintillaView categoriesFor: #activeHotspotBackcolor:!caret, selection, and hotspot styles!public! !
-!ScintillaView categoriesFor: #activeHotspotForecolor!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
+!ScintillaView categoriesFor: #activeHotspotForecolor!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #activeHotspotForecolor:!caret, selection, and hotspot styles!public! !
 !ScintillaView categoriesFor: #addAnnotation:!adding!annotations!public! !
 !ScintillaView categoriesFor: #addKeyBinding:!key bindings!public! !
@@ -11428,7 +11409,7 @@ zoomOut
 !ScintillaView categoriesFor: #canScrollPastEnd:!**auto generated**!public!scintilla interface!scrolling! !
 !ScintillaView categoriesFor: #canUndo!**auto generated**!public!scintilla interface!testing!undo & redo! !
 !ScintillaView categoriesFor: #canVScroll!**auto generated**!public!scintilla interface!scrolling!testing! !
-!ScintillaView categoriesFor: #caretForecolor!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
+!ScintillaView categoriesFor: #caretForecolor!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #caretForecolor:!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #caretPeriod!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #caretPeriod:!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
@@ -11466,8 +11447,8 @@ zoomOut
 !ScintillaView categoriesFor: #currentIndicatorValue:!**auto generated**!indicators!public!scintilla interface! !
 !ScintillaView categoriesFor: #currentLineAlpha!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #currentLineAlpha:!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
-!ScintillaView categoriesFor: #currentLineBackcolor!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
-!ScintillaView categoriesFor: #currentLineBackcolor:!caret, selection, and hotspot styles!public!scintilla interface! !
+!ScintillaView categoriesFor: #currentLineBackcolor!caret, selection, and hotspot styles!public! !
+!ScintillaView categoriesFor: #currentLineBackcolor:!caret, selection, and hotspot styles!public! !
 !ScintillaView categoriesFor: #currentLineFrameWidth!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #currentLineFrameWidth:!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #currentLineText!**auto generated**!public!scintilla interface!selection! !
@@ -11475,10 +11456,13 @@ zoomOut
 !ScintillaView categoriesFor: #cutSelection!**auto generated**!clipboard operations!commands!public!scintilla interface! !
 !ScintillaView categoriesFor: #decodeStyledText:!private!text retrieval & modification! !
 !ScintillaView categoriesFor: #defaultBraceChars!brace highlighting!constants!private! !
+!ScintillaView categoriesFor: #defaultCurrentLineBackcolor!caret, selection, and hotspot styles!public!scintilla interface! !
+!ScintillaView categoriesFor: #defaultEdgeColor!long lines!public!scintilla interface! !
 !ScintillaView categoriesFor: #defaultFoldTextTag!**auto generated**!public!scintilla interface! !
 !ScintillaView categoriesFor: #defaultFoldTextTag:!**auto generated**!public!scintilla interface! !
 !ScintillaView categoriesFor: #defaultMarkerDefinitions!constants!markers!private! !
 !ScintillaView categoriesFor: #defaultModEventMask!constants!private! !
+!ScintillaView categoriesFor: #defaultSecondardCaretForecolor!caret, selection, and hotspot styles!private!scintilla interface! !
 !ScintillaView categoriesFor: #defaultTextLimit!constants!private! !
 !ScintillaView categoriesFor: #defaultTextStylesFor:!constants!public!style definition! !
 !ScintillaView categoriesFor: #defaultWhitespaceChars!constants!public! !
@@ -11499,8 +11483,8 @@ zoomOut
 !ScintillaView categoriesFor: #drawingTechnology:!other settings!public! !
 !ScintillaView categoriesFor: #duplicateLine!**auto generated**!commands!public!scintilla interface! !
 !ScintillaView categoriesFor: #duplicateSelection!**auto generated**!commands!public!scintilla interface! !
-!ScintillaView categoriesFor: #edgeColor!**auto generated**!long lines!public!scintilla interface! !
-!ScintillaView categoriesFor: #edgeColor:!long lines!public!scintilla interface! !
+!ScintillaView categoriesFor: #edgeColor!long lines!public! !
+!ScintillaView categoriesFor: #edgeColor:!long lines!public! !
 !ScintillaView categoriesFor: #edgeColumn!**auto generated**!long lines!public!scintilla interface! !
 !ScintillaView categoriesFor: #edgeColumn:!**auto generated**!long lines!public!scintilla interface! !
 !ScintillaView categoriesFor: #edgeMode!long lines!public! !
@@ -11895,8 +11879,6 @@ zoomOut
 !ScintillaView categoriesFor: #sciBraceHighlightIndicator:indicator:!**auto generated**!brace highlighting!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciBraceMatch:maxReStyle:!**auto generated**!brace highlighting!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciBraceMatchNext:startPos:!**auto generated**!private!scintilla interface! !
-!ScintillaView categoriesFor: #sciCallTipSetBack:!**auto generated**!call tips!private!scintilla interface! !
-!ScintillaView categoriesFor: #sciCallTipSetFore:!**auto generated**!call tips!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciCallTipSetForeHlt:!**auto generated**!call tips!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciCallTipShow:definition:!**auto generated**!call tips!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciCallTipUseStyle:!**auto generated**!call tips!private!scintilla interface! !
@@ -12044,7 +12026,6 @@ zoomOut
 !ScintillaView categoriesFor: #sciMarkerNext:markerMask:!**auto generated**!enquiries!markers!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciMarkerNumberFromLine:which:!**auto generated**!markers!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciMarkerPrevious:markerMask:!**auto generated**!enquiries!markers!private!scintilla interface! !
-!ScintillaView categoriesFor: #sciMarkerSetAlpha:alpha:!**auto generated**!markers!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciMarkerSymbolDefined:!**auto generated**!enquiries!markers!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciMultiEdgeAddLine:edgeColour:!**auto generated**!long lines!private!scintilla interface! !
 !ScintillaView categoriesFor: #sciMultipleSelectAddEach!**auto generated**!commands!private!scintilla interface! !
@@ -12210,7 +12191,7 @@ zoomOut
 !ScintillaView categoriesFor: #scrollWidth:!**auto generated**!public!scintilla interface!scrolling! !
 !ScintillaView categoriesFor: #searchNext:text:!**auto generated**!public!scintilla interface! !
 !ScintillaView categoriesFor: #searchPrev:text:!**auto generated**!public!scintilla interface! !
-!ScintillaView categoriesFor: #secondaryCaretForecolor!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
+!ScintillaView categoriesFor: #secondaryCaretForecolor!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #secondaryCaretForecolor:!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #secondarySelectionAlpha!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #secondarySelectionAlpha:!**auto generated**!caret, selection, and hotspot styles!public!scintilla interface! !
@@ -12238,11 +12219,16 @@ zoomOut
 !ScintillaView categoriesFor: #sendMessage:wParam:!operations!private! !
 !ScintillaView categoriesFor: #sendMessage:wParam:lParam:!operations!private! !
 !ScintillaView categoriesFor: #sendMessage:wParam:lpParam:!operations!private! !
+!ScintillaView categoriesFor: #setActiveHotspotBackcolor!caret, selection, and hotspot styles!private! !
+!ScintillaView categoriesFor: #setActiveHotspotForecolor!caret, selection, and hotspot styles!private! !
 !ScintillaView categoriesFor: #setCallTipHighlightColor!call tips!private! !
 !ScintillaView categoriesFor: #setCallTipTabWidth!helpers!private! !
+!ScintillaView categoriesFor: #setCaretForecolor!call tips!private! !
 !ScintillaView categoriesFor: #setCharacterClasses!character classes!helpers!private! !
+!ScintillaView categoriesFor: #setCurrentLineBackcolor!caret, selection, and hotspot styles!public!scintilla interface! !
 !ScintillaView categoriesFor: #setCurrentTextStyles:!private!style definition! !
 !ScintillaView categoriesFor: #setDefaultTextStyle!private!style definition! !
+!ScintillaView categoriesFor: #setEdgeColor!long lines!private! !
 !ScintillaView categoriesFor: #setEolAnnotations:!annotations!private! !
 !ScintillaView categoriesFor: #setFoldFlags!folding!private! !
 !ScintillaView categoriesFor: #setFoldMarginColor!folding!margins!private! !
@@ -12259,6 +12245,7 @@ zoomOut
 !ScintillaView categoriesFor: #setMarginWidths:!helpers!margins!private! !
 !ScintillaView categoriesFor: #setRawAnnotations:!annotations!helpers!private! !
 !ScintillaView categoriesFor: #setReadOnly:!**auto generated**!modes!public!scintilla interface!text retrieval & modification! !
+!ScintillaView categoriesFor: #setSecondaryCaretForecolor!caret, selection, and hotspot styles!private!scintilla interface! !
 !ScintillaView categoriesFor: #setSecondarySelectionBackcolor!caret, selection, and hotspot styles!private! !
 !ScintillaView categoriesFor: #setSecondarySelectionForecolor!caret, selection, and hotspot styles!private! !
 !ScintillaView categoriesFor: #setSelectionBackcolor!caret, selection, and hotspot styles!private! !
@@ -12332,10 +12319,12 @@ zoomOut
 !ScintillaView categoriesFor: #undo!commands!public!scintilla interface!undo & redo! !
 !ScintillaView categoriesFor: #unfoldAll!commands!folding!public! !
 !ScintillaView categoriesFor: #unindent!**auto generated**!commands!public!scintilla interface! !
+!ScintillaView categoriesFor: #updateControlStyles!initializing!private! !
 !ScintillaView categoriesFor: #updateIndicators!helpers!indicators!private! !
 !ScintillaView categoriesFor: #updateIndicatorStyles!helpers!indicators!private! !
 !ScintillaView categoriesFor: #updateKeyBindings!helpers!key bindings!private! !
 !ScintillaView categoriesFor: #updateMarkers!helpers!markers!private! !
+!ScintillaView categoriesFor: #updateSetting:!event handling!private!updating! !
 !ScintillaView categoriesFor: #updateTextStyles!helpers!private!style definition! !
 !ScintillaView categoriesFor: #validateUserInterface!operations!public! !
 !ScintillaView categoriesFor: #whitespaceBackcolor!public!white space! !
@@ -12400,10 +12389,7 @@ defaultAnnotationStyles
 		yourself!
 
 defaultCallTipStyle
-	^(ScintillaTextStyle name: #callTip)
-		backcolor: Color white;
-		forecolor: Color gray;
-		yourself!
+	^ScintillaCallTipStyle new!
 
 defaultKeyMap
 	"Private - This key map is built (using editor macros. from the source code of the Scintilla control.
@@ -12868,6 +12854,7 @@ stbConvert: instVarArray fromVersion: verInteger
 	verInteger < 13 ifTrue: [instVars := super stbConvert: instVarArray fromVersion: verInteger].
 	verInteger < 14 ifTrue: [instVars := self stbConvertFromVersion13: instVars].
 	verInteger < 15 ifTrue: [instVars := self stbConvertFromVersion14: instVars].
+	verInteger < 16 ifTrue: [instVars := self stbConvertFromVersion15: instVars].
 	^instVars!
 
 stbConvertFromVersion13: anArray
@@ -12894,6 +12881,12 @@ stbConvertFromVersion14: anArray
 	anArray at: 44 put: ((anArray at: 44) == 65001 ifTrue: [Utf8String] ifFalse: [AnsiString]).
 	^anArray!
 
+stbConvertFromVersion15: anArray
+	"Private - Perform an STB conversion from a version 15 <ScintillaView> to version 16.
+	Adds some new instance variables."
+
+	^anArray!
+
 stbConvertFromVersion9: anArray 
 	"Private - Perform an STB conversion from a version 9 (or earlier) <ScintillaView> to version 10.
 	The single collection of text styles was replaced by a current collection, and a collection of collections
@@ -12909,7 +12902,7 @@ stbConvertFromVersion9: anArray
 	^array!
 
 stbVersion
-	^15!
+	^16!
 
 tabDrawModes
 	^#(#longArrow #strikeOut)!
@@ -13144,6 +13137,7 @@ xmlTextStyles
 !ScintillaView class categoriesFor: #stbConvert:fromVersion:!binary filing!private! !
 !ScintillaView class categoriesFor: #stbConvertFromVersion13:!binary filing!private! !
 !ScintillaView class categoriesFor: #stbConvertFromVersion14:!binary filing!private! !
+!ScintillaView class categoriesFor: #stbConvertFromVersion15:!binary filing!private! !
 !ScintillaView class categoriesFor: #stbConvertFromVersion9:!binary filing!private! !
 !ScintillaView class categoriesFor: #stbVersion!binary filing!public! !
 !ScintillaView class categoriesFor: #tabDrawModes!constants!public! !


### PR DESCRIPTION
Scintilla always works with RGB values for colours. This means that it cannot itself respond to theme changes by using logical colours, which means that if we are to do so then the Smalltalk wrapper needs to hold all colour settings in instance variables from which an RGB snapshot can be taken, e.g. on control creation, with that value communicated to the control. Various default colours, such as the caret color, are changed from the Scintilla default's white or black, etc, to one of the logical system colours such as `Color window`, or `Color windowText`. These will have different RGB values in high contrast modes. Responding to going into high contrast mode is then a question of listening out for 'ImmersiveColorSet' WM_SETTINGCHANGE messages, and when received resetting all of the colour settings again so that any logical colours are remapped to the current RGB value.
In order to do this it was necessary to add new instance variables, requiring an STB conversion. I haven't bothered to resave the view resources yet.