### PR TITLE
Speed up rebuild of SmalltalkSystem message selector cache

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Behavior.cls
+++ b/Core/Object Arts/Dolphin/Base/Behavior.cls
@@ -978,7 +978,7 @@ understoodSelectorsDo: aMonadicValuable
 	"Evaluate the <monadicValuable> argument for each of the message selectors understood by the receiver at run time, not necessarily including those understood by superclasses.
 	The block may be evaluated more than once for the same selector."
 
-	self selectors do: aMonadicValuable.
+	methodDictionary ifNotNil: [methodDictionary keysDo: aMonadicValuable].
 	self dynamicSelectorsDo: aMonadicValuable!
 
 whichClassIncludesSelector: selector

--- a/Core/Object Arts/Dolphin/Base/Behavior.cls
+++ b/Core/Object Arts/Dolphin/Base/Behavior.cls
@@ -125,9 +125,10 @@ allSelectors
 	"Answer a <Set> of <Symbol>s, being all the message selectors to which the receiver 
 	is able to respond (this includes messages understood by superclasses)."
 
-	| answer |
+	| answer accumulate |
 	answer := IdentitySet new.
-	self withAllSuperclassesDo: [:each | answer addAll: each selectors].
+	accumulate := [:s | answer add: s].
+	self withAllSuperclassesDo: [:each | each understoodSelectorsDo: accumulate].
 	^answer!
 
 allSubclasses

--- a/Core/Object Arts/Dolphin/Base/BehaviorTest.cls
+++ b/Core/Object Arts/Dolphin/Base/BehaviorTest.cls
@@ -44,6 +44,13 @@ testIsNonInstantiable
 	self deny: subject isNonInstantiable.
 	self deny: subject class isNonInstantiable!
 
+testUnderstoodSelectors
+	self assert: Association understoodSelectors equals: Association selectors.
+	self assert: (MSGBOXPARAMSW understoodSelectors difference: MSGBOXPARAMSW selectors) asArray
+		equals: #(#dwLanguageId:).
+	self assertIsNil: (IntrosortAlgorithm class instVarNamed: 'methodDictionary').
+	self assert: IntrosortAlgorithm class understoodSelectors isEmpty!
+
 testWhichMethodsOnlySelfSend
 	| subject |
 	subject := BehaviorTestClasses current classWithAbstractMethod1.
@@ -58,6 +65,7 @@ testWhichMethodsOnlySelfSend
 !BehaviorTest categoriesFor: #testHasAbstractMethods!public! !
 !BehaviorTest categoriesFor: #testIsAbstract!public! !
 !BehaviorTest categoriesFor: #testIsNonInstantiable!public! !
+!BehaviorTest categoriesFor: #testUnderstoodSelectors!public! !
 !BehaviorTest categoriesFor: #testWhichMethodsOnlySelfSend!public! !
 
 !BehaviorTest class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/ExternalStructureTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalStructureTest.cls
@@ -10,6 +10,16 @@ ExternalStructureTest comment: 'SUnitBrowser openOnTestCase: self'!
 !ExternalStructureTest categoriesForClass!Unclassified! !
 !ExternalStructureTest methodsFor!
 
+testCanUnderstand
+	"Test canUnderstand: works for implemented, inherited, and dynamic selectors"
+
+	| subject |
+	subject := MSGBOXPARAMSW new.
+	#(#text: #alignment #dwLanguageId:) do: 
+			[:each |
+			self assert: (subject respondsTo: each).
+			self assert: (subject class canUnderstand: each)]!
+
 testCompileDefinition
 	"Test that compiling structure fields defines the right set of accessors:
 		- get selector for read-only fields
@@ -103,6 +113,7 @@ testIsNull
 
 	struct bytes: ExternalAddress new.
 	self assert: struct isNull.! !
+!ExternalStructureTest categoriesFor: #testCanUnderstand!public!unit tests! !
 !ExternalStructureTest categoriesFor: #testCompileDefinition!public!unit tests! !
 !ExternalStructureTest categoriesFor: #testDynamicSelectors!public!unit tests! !
 !ExternalStructureTest categoriesFor: #testEquals!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/MSGBOXPARAMSW.cls
+++ b/Core/Object Arts/Dolphin/Base/MSGBOXPARAMSW.cls
@@ -92,6 +92,18 @@ text: aString
 
 !MSGBOXPARAMSW class methodsFor!
 
+canUnderstand: aSymbol
+	^(super canUnderstand: aSymbol) or: 
+			[| size field |
+			size := aSymbol size.
+			(aSymbol at: size) == $:
+				ifTrue: 
+					[field := self template at: (aSymbol copyFrom: 1 to: size - 1).
+					field notNil and: [field isWriteable]]
+				ifFalse: 
+					[field := self template at: aSymbol.
+					field notNil and: [field isWriteable]]]!
+
 defineFields
 	"Define the fields of the Win32 MSGBOXPARAMSW structure.
 
@@ -127,6 +139,7 @@ defineFields
 
 getFieldNames
 	^#(#dwSize #hwndOwner #hInstance #lpszText #lpszCaption #dwStyle #lpszIcon #dwLanguageId)! !
+!MSGBOXPARAMSW class categoriesFor: #canUnderstand:!methods-testing!public! !
 !MSGBOXPARAMSW class categoriesFor: #defineFields!public!template definition! !
 !MSGBOXPARAMSW class categoriesFor: #getFieldNames!**compiled accessors**!constants!private! !
 

--- a/Core/Object Arts/Dolphin/IDE/Base/DolphinCompilerTestMethods.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/DolphinCompilerTestMethods.cls
@@ -455,6 +455,8 @@ testWarningWrittenNotReadMethodTemp
 
 testWarnMsgUnimplementedByConst
 	1 asParameter.
+	"A dynamic selector"
+	MSGBOXPARAMSW new dwLanguageId: 1234.
 	Const wibblyWobblySillySelectorThatNoOneCouldPossiblyImplementIHope.
 	self asParameter!
 

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkSystem.cls
@@ -1063,18 +1063,19 @@ buildAllSelectors
 	"Private - Answer a set of all message selectors understood by any class in the system. This
 	needs to run as fast as possible to avoid impacting browser perf when editing."
 
-	| set classes count |
+	| set classes count accumulate |
 	classes := Smalltalk allClasses.
 	"On average there seem to be between 10 and 11 unique selectors per class"
 	count := classes size.
 	set := IdentitySet new: count * 11.
+	accumulate := [:s | set add: s].
 	1 to: count
 		do: 
 			[:i |
-			| each |
+			| each  |
 			each := classes at: i.
-			each understoodSelectorsDo: [:s | set add: s].
-			each class understoodSelectorsDo: [:s | set add: s]].
+			each understoodSelectorsDo: accumulate.
+			each class understoodSelectorsDo: accumulate].
 	^set!
 
 buildMessageMenu: aMenu forMethods: aCollection browseSelector: browseSelector extraArgs: extraArgs browseOtherSelector: browseOtherSelector

--- a/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/SmalltalkWorkspace.cls
@@ -910,13 +910,12 @@ messagesForToken: anAssociation startingWith: aString maxItems: anInteger
 	treat it as possibly being of any type, as most likely it is simply uninitialized."
 	(class == UndefinedObject and: [anAssociation value == #identifier]) ifTrue: [class := nil].
 	selectors := Set new.
-	Smalltalk developmentSystem allSelectors do: 
+	(class ifNil: [Smalltalk developmentSystem]) allSelectors do: 
 			[:each |
-			((each beginsWith: aString ignoreCase: ignoreCase)
-				and: [class isNil or: [class canUnderstand: each]])
-					ifTrue: 
-						[selectors add: each.
-						selectors size > anInteger ifTrue: [^#()]]].
+			(each beginsWith: aString ignoreCase: ignoreCase)
+				ifTrue: 
+					[selectors add: each.
+					selectors size > anInteger ifTrue: [^#()]]].
 	^selectors collect: [:each | ScintillaListItem text: each icon: icon]!
 
 modifiedModel

--- a/Core/Object Arts/Dolphin/IDE/Base/StStyler.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/StStyler.cls
@@ -252,10 +252,6 @@ visitSequenceNode: aSequenceNode
 			self styleTemporaries: aSequenceNode temporaries.
 			self styleIntersticesUpTo: aSequenceNode rightBar - 1.
 			view applyStyle: #tempCloseBar toNext: 1].
-	self tagBeforeTemporaries
-		ifFalse: 
-			[aSequenceNode parent
-				ifNotNil: [:parent | parent isMethod ifTrue: [parent tag ifNotNil: [:tag | self visitNode: tag]]]].
 	aSequenceNode statements do: [:each | self visitNode: each]!
 
 visitVariableNode: aVariableNode

--- a/Core/Object Arts/Dolphin/IDE/IdeaSpaceShellTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/IdeaSpaceShellTest.cls
@@ -154,7 +154,7 @@ testBreakoutCard
 	tools do: 
 			[:each |
 			each exit.
-			self assert: each view isClosed].
+			self deny: each isOpen].
 	ideaShell show.
 	"There should no cards left in the IS"
 	self assert: ideaShell cards isEmpty.


### PR DESCRIPTION
SmalltalkSystem maintains a cache of all implemented messages in the system that is used (e.g.) for auto-completion. The cache is reset when either a new method is added, or removed, or a class is removed. Rebuilding the cache is generally fast (sub-50ms), but might take long enough to cause a noticeable delay in a very large image with a lot of classes and methods. We can easily speed up the the underlying Behaviour>>understoodSelectorsDo: method and about halve the time the cache rebuild takes.