### PR TITLE
Remove ExternalStructure class>>#canUnderstand: during Image Stripping

### DIFF
--- a/Core/Object Arts/Dolphin/Lagoon/BasicImageStripper.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/BasicImageStripper.cls
@@ -77,7 +77,7 @@ compileExternalStructuresNow: aCollection
 			ExternalStructure class compile: 'ensureDefined'.
 			aCollection do: [:each | each removeTemplate].
 			"ExternalStructure DNU processing is no longer needed since fully compiled"
-			self removeSelectors: #(#getFieldNames) of: ExternalStructure class.
+			self removeSelectors: #(#getFieldNames #canUnderstand:) of: ExternalStructure class.
 			self removeSelectors: #(#doesNotUnderstand:) of: ExternalStructure].
 	"Field meta-data classes are no longer required"
 	self assert: [self systemPackageManager isProcessingEvents].

--- a/Core/Object Arts/Dolphin/Lagoon/Lagoon Tests.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/Lagoon Tests.pax
@@ -7,7 +7,13 @@ package paxVersion: 1;
 
 package classNames
 	add: #CRTLibraryImportTest;
+	add: #LagoonTests;
 	add: #PackageClosureTests;
+	yourself.
+
+package methodNames
+	add: #ImageStripper -> #initializeForTests;
+	add: 'ImageStripper class' -> #newForTests;
 	yourself.
 
 package binaryGlobalNames: (Set new
@@ -37,6 +43,11 @@ DolphinTest subclass: #CRTLibraryImportTest
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
+DolphinTest subclass: #LagoonTests
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
 DolphinTest subclass: #PackageClosureTests
 	instanceVariableNames: ''
 	classVariableNames: ''
@@ -47,6 +58,23 @@ DolphinTest subclass: #PackageClosureTests
 
 
 "Loose Methods"!
+
+!ImageStripper methodsFor!
+
+initializeForTests
+
+	notifier := DeafObject.Current.
+	logStream := WriteStream on: (String new: 256).
+	elementStack := OrderedCollection new.
+	potentialAspectGetters := IdentitySet new! !
+!ImageStripper categoriesFor: #initializeForTests!initializing!public! !
+
+!ImageStripper class methodsFor!
+
+newForTests
+
+	^self new initializeForTests! !
+!ImageStripper class categoriesFor: #newForTests!instance creation!public! !
 
 "End of package definition"!
 

--- a/Core/Object Arts/Dolphin/Lagoon/LagoonTests.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/LagoonTests.cls
@@ -1,0 +1,54 @@
+﻿"Filed out from Dolphin Smalltalk 7"!
+
+DolphinTest subclass: #LagoonTests
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+LagoonTests guid: (GUID fromString: '{1d062465-a28b-438e-882d-da296eb78bfa}')!
+LagoonTests comment: ''!
+!LagoonTests categoriesForClass!Unclassified! !
+!LagoonTests methodsFor!
+
+nopMethod!
+
+testExternalStructureAfterTemplateRemoval
+
+	"Test the behavior of ExternalStructure after the removal of the ability to instantiate templates during image stripping (specifically its ability to handle canUnderstand:)
+	Regression test for #1095"
+
+	| externalStructureMethodDict externalStructureClassMethodDict basicImageStripperMethodDict  |
+
+	"Cache current and instantiate copy methodDictionaries to enable partial run of image stripper without destroying the system"
+	externalStructureMethodDict := ExternalStructure methodDictionary copy.
+	externalStructureClassMethodDict := ExternalStructure class methodDictionary copy.
+	basicImageStripperMethodDict := BasicImageStripper methodDictionary copy.
+
+	[ExternalStructure
+		methodDictionary: externalStructureMethodDict copy;
+		flushMethodCache.
+	ExternalStructure class 
+		methodDictionary: externalStructureClassMethodDict copy;
+		flushMethodCache.
+	BasicImageStripper 
+		methodDictionary: 
+			(basicImageStripperMethodDict copy
+				at: #uncheckedRemoveClass: put: (##(self)>>#nopMethod); "We don't actually want to remove classes"
+				yourself);
+		flushMethodCache.
+
+	ImageStripper newForTests compileExternalStructuresNow: {ExternalStructure}.
+
+	self assert: ExternalStructure template isNil.
+	self shouldnt: [ExternalStructure canUnderstand: #anything] raise: MessageNotUnderstood.
+	self assert: (ExternalStructure canUnderstand: #value).
+	self deny: (ExternalStructure canUnderstand: #vAlUe)] ensure: 
+		[ExternalStructure methodDictionary: externalStructureMethodDict; flushMethodCache.
+		ExternalStructure class methodDictionary: externalStructureClassMethodDict; flushMethodCache.
+		BasicImageStripper methodDictionary: basicImageStripperMethodDict; flushMethodCache].
+
+	"Ensure things are back to normal"
+	self assert: ExternalStructure template notNil! !
+!LagoonTests categoriesFor: #nopMethod!helpers!private! !
+!LagoonTests categoriesFor: #testExternalStructureAfterTemplateRemoval!public!unit tests! !
+


### PR DESCRIPTION
Prevents subsequent MNU #lookup:. Also add regression test. Resolves #1095.