### PR TITLE
Replace deprecated function call

### DIFF
--- a/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
+++ b/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
@@ -363,12 +363,12 @@ wmNotify: message wParam: wParam lParam: lParam
 hasListViewAlphaBlendedHighlights
 	"Does the host support alpha-blended list view selection highlights?"
 
-	^VMLibrary default isWindowsVistaOrGreater!
+	^KernelLibrary default isWindowsVistaOrGreater!
 
 hasListViewHotTracking
 	"Does the host support hot tracking in list views?"
 
-	^VMLibrary default isWindowsVistaOrGreater! !
+	^KernelLibrary default isWindowsVistaOrGreater! !
 !SystemMetrics categoriesFor: #hasListViewAlphaBlendedHighlights!capability enquiries!public! !
 !SystemMetrics categoriesFor: #hasListViewHotTracking!capability enquiries!public! !
 


### PR DESCRIPTION
Use `KernelLibrary` instead of `VMLibrary` for `isWindowsVistaOrGreater`.