### PR TITLE
Replace deprecated function call (use `KernelLibrary` instead of `VMlibrary` for `isWindowsVistaOrGreater`).

### DIFF
--- a/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
+++ b/Core/Contributions/Solutions Software/SSW Widget Enhancements.pax
@@ -366,12 +366,12 @@ wmNotify: message wParam: wParam lParam: lParam
 hasListViewAlphaBlendedHighlights
 	"Does the host support alpha-blended list view selection highlights?"
 
-	^VMLibrary default isWindowsVistaOrGreater!
+	^KernelLibrary default isWindowsVistaOrGreater!
 
 hasListViewHotTracking
 	"Does the host support hot tracking in list views?"
 
-	^VMLibrary default isWindowsVistaOrGreater! !
+	^KernelLibrary default isWindowsVistaOrGreater! !
 !SystemMetrics categoriesFor: #hasListViewAlphaBlendedHighlights!capability enquiries!public! !
 !SystemMetrics categoriesFor: #hasListViewHotTracking!capability enquiries!public! !
 


### PR DESCRIPTION
Porting PR#1100 from master