### PR TITLE
Resolve #1093: Optimization of Collection>>#distinct

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Collection.cls
+++ b/Core/Object Arts/Dolphin/Base/Collection.cls
@@ -288,7 +288,7 @@ distinct
 	"Answer a <collection> like the receiver containing only one occurrence of each element."
 
 	| seen |
-	seen := Set new.
+	seen := Set new: self approxSize .
 	^self select: [:each | seen addNewElement: each]!
 
 do: operation


### PR DESCRIPTION
As discussed in #1093, use Collection>>#approxSize to resize the collection
as it is intended for this kind of purpose, and is expected to have a
constant time implementation (i.e. it should not count the elements).

Collection>>#distinct is already adequately covered with unit tests