### PR TITLE
Fix #1111: Add alias for URLMonLibrary and ensure rko281/GitHub loads

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/Structured Storage/OLE Structured Storage (Old Names).pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Structured Storage/OLE Structured Storage (Old Names).pax
@@ -1,0 +1,30 @@
+﻿| package |
+package := Package name: 'OLE Structured Storage (Old Names)'.
+package paxVersion: 2.1;
+	basicComment: 'Dolphin Smalltalk OLE Structure Storage pre-8.0 legacy class names
+
+Aliases for namespaced OLE Structured Storage classes that might be referenced from pre-8.0 code.
+'.
+
+
+package setVariableNames: #(
+	#{Smalltalk.URLMonLibrary}
+).
+
+package setAliasVariableNames: #(
+	#{Smalltalk.URLMonLibrary}
+).
+
+package setPrerequisites: #(
+	'OLE Structured Storage'
+).
+
+package!
+
+"Variable Aliases"!
+
+Smalltalk.URLMonLibrary := OS.COM.URLMonLibrary!
+
+
+"End of package definition"!
+

--- a/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Legacy Package Support.pax
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/Dolphin Legacy Package Support.pax
@@ -46,7 +46,9 @@ package setMethodNames: #(
 	#(#{Kernel.Package} #script:)
 	#(#{Kernel.Package} #script:put:)
 	#(#{Kernel.Package} #versionLookup)
+	#(#{Kernel.Package class} #binaryGlobalExtension)
 	#(#{Kernel.Package class} #name:comment:)
+	#(#{Kernel.Package class} #sourceGlobalExtension)
 ).
 
 package setPrerequisites: #(
@@ -401,12 +403,24 @@ versionLookup
 
 !Kernel.Package class methodsFor!
 
+binaryGlobalExtension
+	"Private - Answer the file extension for the files to which binary globals are stored."
+
+	^ 'stb'!
+
 name: nameString comment: commentString 
 	#deprecated.	"In 4.0, but retained becaused needed to load some old format packages"
 	^(self name: nameString)
 		basicComment: commentString;
-		yourself! !
+		yourself!
+
+sourceGlobalExtension
+	"Private - Answer the file extension for the files to which source globals are stored."
+
+	^ 'st'! !
+!Kernel.Package class categoriesFor: #binaryGlobalExtension!constants!private! !
 !Kernel.Package class categoriesFor: #name:comment:!instance creation!public! !
+!Kernel.Package class categoriesFor: #sourceGlobalExtension!constants!private! !
 
 "End of package definition"!
 

--- a/Core/Object Arts/Dolphin/Base/Kernel.ClassBuilder.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.ClassBuilder.cls
@@ -970,12 +970,13 @@ validateImports
 						ifFalse: 
 							[private := each isPrivate.
 							fullRef := each asString asQualifiedReference].
-					fullRef isDefined
-						ifTrue: 
-							[namespace := fullRef value.
-							(namespace class conformsToProtocol: #importableNamespace) ifFalse: [self error: 'Invalid import: ' , each printString]]
-						ifFalse: 
-							[Warning
+					namespace := fullRef valueOrNil.
+					namespace
+						ifNotNil: 
+							[(namespace class conformsToProtocol: #importableNamespace)
+								ifFalse: [self error: 'Invalid import: ' , each printString]]
+						ifNil: 
+							[Notification
 								signal: ('Imported namespace <1p> does not currently exist.' expandMacrosWith: fullRef asString).
 							namespace := fullRef asSymbol].
 					namespace asQualifiedReference

--- a/Core/Object Arts/Dolphin/Installation Manager/Tools.DolphinCoreProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/Tools.DolphinCoreProduct.cls
@@ -30,6 +30,7 @@ contents
 
 		add: #('Core\Object Arts\Dolphin\ActiveX\COM\OLE COM.pax' #plain #imageBased);
 		add: #('Core\Object Arts\Dolphin\ActiveX\Structured Storage\OLE Structured Storage.pax' #plain #imageBased);
+		add: #('Core\Object Arts\Dolphin\ActiveX\Structured Storage\OLE Structured Storage (Old Names).pax' #plain #imageBased);
 		add: #('Core\Object Arts\Dolphin\ActiveX\Shell\Windows Shell.pax' #plain #imageBased);
 		add: #('Core\Object Arts\Dolphin\ActiveX\Automation\ActiveX Automation.pax' #plain #imageBased);
 		add: #('Core\Object Arts\Dolphin\ActiveX\Components\Picture\OLE Picture.pax' #plain #imageBased);


### PR DESCRIPTION
The GitHub package will save out largely unchanged in a format that should
round trip back to 7.1, except for the the AXTypeLibraryAnalyzer
global. The TLA instance will not deserialize correctly in 7.1 if saved
from 7.2 in legacy package format (with binary-filed non-source globals)
as the class has changed instance variable shape in 7.2.
Generally it is not necessary to retain the TLA instance, so it could
probably be removed along with the references from #initializeTypeLib
class methods on the interface classes.

No guarantee that the package works in 7.2 once loaded, however.