### PR TITLE
Optimise comparison of ScaledDecimals

### DIFF
--- a/Core/Object Arts/Dolphin/Base/ArithmeticValue.cls
+++ b/Core/Object Arts/Dolphin/Base/ArithmeticValue.cls
@@ -195,6 +195,11 @@ equalToInteger: anInteger
 
 	^anInteger retry: #= coercing: self!
 
+equalToScaledDecimal: aScaledDecimal
+	"Private - Answer whether the receiver is equal to the known <ScaledDecimal>, aScaledDecimal, by coercing the less general of it and the receiver and comparing again. Overridden by subclasses which can implement more correctly and/or efficiently."
+
+	^aScaledDecimal retry: #= coercing: self!
+
 floor
 	"Answer the <integer> nearest the receiver toward negative infinity
 	(i.e. the largest integer less than or equal to the receiver)."
@@ -497,6 +502,7 @@ understandsArithmetic
 !ArithmeticValue categoriesFor: #equalToFloat:!double dispatch!private! !
 !ArithmeticValue categoriesFor: #equalToFraction:!double dispatch!private! !
 !ArithmeticValue categoriesFor: #equalToInteger:!double dispatch!private! !
+!ArithmeticValue categoriesFor: #equalToScaledDecimal:!double dispatch!private! !
 !ArithmeticValue categoriesFor: #floor!public!truncation and round off! !
 !ArithmeticValue categoriesFor: #generality!coercing!private! !
 !ArithmeticValue categoriesFor: #greaterThanFloat:!double dispatch!private! !

--- a/Core/Object Arts/Dolphin/Base/Fraction.cls
+++ b/Core/Object Arts/Dolphin/Base/Fraction.cls
@@ -192,6 +192,11 @@ equalToInteger: anInteger
 
 	^anInteger * denominator = numerator!
 
+equalToScaledDecimal: aScaledDecimal
+	"Private - Answer whether the receiver is equal to the known <ScaledDecimal>, aScaledDecimal."
+
+	^self equalToFraction: aScaledDecimal asFraction!
+
 generality
 	"Private - Answer the generality of the receiver."
 
@@ -385,6 +390,7 @@ truncated
 !Fraction categoriesFor: #equalToFloat:!double dispatch!private! !
 !Fraction categoriesFor: #equalToFraction:!double dispatch!private! !
 !Fraction categoriesFor: #equalToInteger:!double dispatch!private! !
+!Fraction categoriesFor: #equalToScaledDecimal:!double dispatch!private! !
 !Fraction categoriesFor: #generality!coercing!private! !
 !Fraction categoriesFor: #greaterThanFloat:!double dispatch!private! !
 !Fraction categoriesFor: #greaterThanFraction:!double dispatch!private! !

--- a/Core/Object Arts/Dolphin/Base/Integer.cls
+++ b/Core/Object Arts/Dolphin/Base/Integer.cls
@@ -358,6 +358,11 @@ equalToInteger: anInteger
 
 	^self - anInteger == 0!
 
+equalToScaledDecimal: aScaledDecimal
+	"Private - Answer whether the receiver is equal to the known <ScaledDecimal>, aScaledDecimal."
+
+	^self equalToFraction: aScaledDecimal asFraction!
+
 even
 	"Answer whether the receiver is an even integer. Zero is considered even.
 	Override superclass as we've a more efficient implementation."
@@ -833,6 +838,7 @@ yourAddress
 !Integer categoriesFor: #equalToFloat:!double dispatch!private! !
 !Integer categoriesFor: #equalToFraction:!double dispatch!private! !
 !Integer categoriesFor: #equalToInteger:!double dispatch!private! !
+!Integer categoriesFor: #equalToScaledDecimal:!double dispatch!private! !
 !Integer categoriesFor: #even!public!testing! !
 !Integer categoriesFor: #exp10!mathematical!public! !
 !Integer categoriesFor: #factorial!factorization!public! !

--- a/Core/Object Arts/Dolphin/Base/ScaledDecimal.cls
+++ b/Core/Object Arts/Dolphin/Base/ScaledDecimal.cls
@@ -60,6 +60,11 @@ We are grateful to Richard A. Harmon for contributing his ANSI compliant ScaledD
 	^operand greaterThanScaledDecimal: self
 !
 
+= anObject
+	"Answer whether the receiver is numerically equivalent to the <Object>, anObject - i.e. whether the difference between the receiver and comparand is zero."
+
+	^anObject understandsArithmetic and: [anObject equalToScaledDecimal: self]!
+
 addToScaledDecimal: operand
 	"Private - Answer the <ScaledDecimal> result of adding the receiver
 	to the known <ScaledDecimal>."
@@ -131,6 +136,16 @@ divideIntoScaledDecimal: operand
 	^self species
 		newFromNumber: operand asFraction / fraction
 		scale: (scale max: operand scale)!
+
+equalToInteger: anInteger
+	"Private - Answer whether the receiver is equal to the known <Integer>, anInteger."
+
+	^fraction equalToInteger: anInteger!
+
+equalToScaledDecimal: aScaledDecimal
+	"Private - Answer whether the receiver is equal to the known <ScaledDecimal>, aScaledDecimal."
+
+	^aScaledDecimal asFraction = fraction!
 
 fractionPart
 	"Answer a <number> of the same type as the receiver, representing the 
@@ -260,6 +275,13 @@ storeOn: aStream
 				print: scale;
 				nextPut: $)]!
 
+subtractFromInteger: operand
+	"Private - Subtract the receiver from the known integer, anInteger, and answer the result."
+
+	^self species
+		newFromNumber: operand asFraction - fraction
+		scale: scale!
+
 subtractFromScaledDecimal: operand
 	"Private - Answer the result of subtracting the receiver from the 
 	known <ScaledDecimal>, operand."
@@ -279,6 +301,7 @@ truncated
 !ScaledDecimal categoriesFor: #//!arithmetic!public! !
 !ScaledDecimal categoriesFor: #+!arithmetic!public! !
 !ScaledDecimal categoriesFor: #<!comparing!public! !
+!ScaledDecimal categoriesFor: #=!comparing!public! !
 !ScaledDecimal categoriesFor: #addToScaledDecimal:!double dispatch!private! !
 !ScaledDecimal categoriesFor: #asFloat!converting!public! !
 !ScaledDecimal categoriesFor: #asFraction!converting!public! !
@@ -287,6 +310,8 @@ truncated
 !ScaledDecimal categoriesFor: #denominator!accessing!public! !
 !ScaledDecimal categoriesFor: #displayOn:!printing!public! !
 !ScaledDecimal categoriesFor: #divideIntoScaledDecimal:!double dispatch!private! !
+!ScaledDecimal categoriesFor: #equalToInteger:!double dispatch!private! !
+!ScaledDecimal categoriesFor: #equalToScaledDecimal:!double dispatch!private! !
 !ScaledDecimal categoriesFor: #fractionPart!accessing!public! !
 !ScaledDecimal categoriesFor: #generality!coercing!private! !
 !ScaledDecimal categoriesFor: #greaterThanScaledDecimal:!double dispatch!private! !
@@ -303,12 +328,19 @@ truncated
 !ScaledDecimal categoriesFor: #scale!accessing!public! !
 !ScaledDecimal categoriesFor: #setFraction:scale:!initializing!private! !
 !ScaledDecimal categoriesFor: #storeOn:!public! !
+!ScaledDecimal categoriesFor: #subtractFromInteger:!double dispatch!private! !
 !ScaledDecimal categoriesFor: #subtractFromScaledDecimal:!double dispatch!private! !
 !ScaledDecimal categoriesFor: #truncated!public!truncation and round off! !
 
 ScaledDecimal methodProtocol: #scaledDecimal attributes: #(#ansi #readOnly) selectors: #(#- #* #/ #// #\\ #+ #< #<= #> #>= #abs #asFloat #asFloatD #asFloatE #asFloatQ #asFraction #asInteger #asScaledDecimal: #between:and: #ceiling #floor #fractionPart #integerPart #max: #min: #negated #negative #positive #quo: #raisedTo: #raisedToInteger: #reciprocal #rem: #rounded #roundTo: #scale #sign #sqrt #squared #strictlyPositive #to: #to:by: #to:by:do: #to:do: #truncated #truncateTo:)!
 
 !ScaledDecimal class methodsFor!
+
+basicNewFromFraction: aFraction scale: scaleInteger
+	"Private - Answer a new instance of me."
+
+	<primitive: 157>
+	^self basicNew setFraction: aFraction asFraction scale: scaleInteger!
 
 maxPrecision
 	"Private - The maximum allowed precision for <ScaledDecimal>s parsed from literal string format. The
@@ -322,8 +354,8 @@ maxPrecision
 newFromNumber: aNumber scale: scaleInteger
 	"Answer a new instance of me."
 
-	^self basicNew
-		setFraction: aNumber asFraction scale: scaleInteger;
+	^(self basicNewFromFraction: aNumber asFraction scale: scaleInteger)
+		isImmutable: true;
 		yourself!
 
 one
@@ -340,6 +372,7 @@ zero
 		newFromNumber: 0
 		scale: 0
 ! !
+!ScaledDecimal class categoriesFor: #basicNewFromFraction:scale:!instance creation!private! !
 !ScaledDecimal class categoriesFor: #maxPrecision!accessing!private! !
 !ScaledDecimal class categoriesFor: #newFromNumber:scale:!instance creation!public! !
 !ScaledDecimal class categoriesFor: #one!instance creation!public! !

--- a/Core/Object Arts/Dolphin/Base/ScaledDecimalTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ScaledDecimalTest.cls
@@ -10,6 +10,24 @@ ScaledDecimalTest comment: ''!
 !ScaledDecimalTest categoriesForClass!Unclassified! !
 !ScaledDecimalTest methodsFor!
 
+floatTestValues
+	^(self integerTestValues, self fractionTestValues) collect: [ :each | each asFloat]!
+
+fractionTestValues
+	^(self integerTestValues collect: [ :each | each / 17]), (self integerTestValues collect: [ :each | each / 297])!
+
+integerTestValues
+	^self smallIntegerTestValues, self largeIntegerTestValues!
+
+largeIntegerTestValues
+	^self smallIntegerTestValues collect: [ :each | each positive ifTrue: [each + SmallInteger maximum] ifFalse: [each + SmallInteger minimum]]!
+
+numericTestValues
+	^self integerTestValues, self floatTestValues, self fractionTestValues!
+
+smallIntegerTestValues
+	^{0. 1. -1. 999. -999. SmallInteger maximum. SmallInteger minimum}!
+
 testAsNumber
 	"Ensure no loss of precision"
 
@@ -108,6 +126,36 @@ testConvertFromIntegerWithScale
 	sd := -130000000013 asScaledDecimal: 1.
 	self assert: sd scale equals: 0.
 	self assert: sd printString equals: '-130000000013s'!
+
+testEqualityComparisons
+	"Test equality comparisons between ScaledDecimals of various scales, and various classes of numbers (including other ScaledDecimals)"
+
+	0 to: 15 do: 
+		[ :scale |
+		self numericTestValues do: 
+			[ :each || scaledDecimal scaledDecimalPlusOne scaledDecimalMinusFraction |
+			scaledDecimal := each asScaledDecimal: scale.
+			scaledDecimalPlusOne := scaledDecimal + 1.
+			scaledDecimalMinusFraction := scaledDecimal - 0.005s.
+
+			self 
+				assert: scaledDecimal equals: scaledDecimal;
+				assert: scaledDecimal equals: each;
+				assert: each equals: scaledDecimal.
+
+			self 
+				deny: scaledDecimal equals: scaledDecimalPlusOne;
+				deny: scaledDecimalPlusOne equals: scaledDecimal;
+				deny: scaledDecimalPlusOne equals: each;
+				deny: each equals: scaledDecimalPlusOne.
+
+			self 
+				deny: scaledDecimal equals: scaledDecimalMinusFraction;
+				deny: scaledDecimalMinusFraction equals: scaledDecimal;
+				deny: scaledDecimalMinusFraction equals: scaledDecimalPlusOne;
+				deny: scaledDecimalPlusOne equals: scaledDecimalMinusFraction;
+				deny: scaledDecimalMinusFraction equals: each;
+				deny: each equals: scaledDecimalMinusFraction]]!
 
 testExactNthRoot
 	| eight thousandth tenth two |
@@ -250,6 +298,30 @@ testStoreOnRoundTrip
 	BECAUSE compiler would consider 0.5s2 as = 0.5s1 and would reuse same slot..."
 	self assert: 0.25s2 storeString equals: '0.25s'!
 
+testSubtractionFromInteger
+	"Test subtraction of ScaledDecimals of various scales from Integers"
+
+	0 to: 15 do: 
+		[ :scale |
+		self integerTestValues do: 
+			[ :each || scaledDecimal result |
+			scaledDecimal := each asScaledDecimal: scale.
+
+			result := each - scaledDecimal.
+			self assert: result isZero.
+			self assert: result class = ScaledDecimal.
+			self assert: result scale equals: scaledDecimal scale.
+
+			result := (each + each) - scaledDecimal.
+			self assert: result equals: each.
+			self assert: result class = ScaledDecimal.
+			self assert: result scale equals: scaledDecimal scale.
+
+			result := each negated - scaledDecimal.
+			self assert: result equals: (each * -2).
+			self assert: result class = ScaledDecimal.
+			self assert: result scale equals: scaledDecimal scale]]!
+
 testZeroRaisedToInteger
 	"Zero might be handle specially"
 
@@ -260,6 +332,12 @@ testZeroRaisedToInteger
 	self assert: (0.0s1 raisedToInteger: 1) scale equals: 1.
 	self assert: (0.0s1 raisedToInteger: 2) equals: 0.
 	self assert: (0.0s1 raisedToInteger: 2) scale equals: 1! !
+!ScaledDecimalTest categoriesFor: #floatTestValues!constants!private! !
+!ScaledDecimalTest categoriesFor: #fractionTestValues!constants!private! !
+!ScaledDecimalTest categoriesFor: #integerTestValues!constants!private! !
+!ScaledDecimalTest categoriesFor: #largeIntegerTestValues!constants!private! !
+!ScaledDecimalTest categoriesFor: #numericTestValues!constants!private! !
+!ScaledDecimalTest categoriesFor: #smallIntegerTestValues!constants!private! !
 !ScaledDecimalTest categoriesFor: #testAsNumber!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testAsNumberNegatedWithoutDecimalPoint!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testAsNumberNegatedWithoutDecimalPoint2!public!unit tests! !
@@ -272,6 +350,7 @@ testZeroRaisedToInteger
 !ScaledDecimalTest categoriesFor: #testConvertFromFloat!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testConvertFromFraction!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testConvertFromIntegerWithScale!public!unit tests! !
+!ScaledDecimalTest categoriesFor: #testEqualityComparisons!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testExactNthRoot!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testExactSqrt!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testInexactNthRoot!public!unit tests! !
@@ -285,5 +364,6 @@ testZeroRaisedToInteger
 !ScaledDecimalTest categoriesFor: #testRounded!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testScaleExtension!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testStoreOnRoundTrip!public!unit tests! !
+!ScaledDecimalTest categoriesFor: #testSubtractionFromInteger!public!unit tests! !
 !ScaledDecimalTest categoriesFor: #testZeroRaisedToInteger!public!unit tests! !
 


### PR DESCRIPTION
As per #1119, adds `equalToScaledDecimal:` double-dispatch handler in various ArithmeticValue subclasses. 

To optimise SmallInteger=ScaledDecimal comparisons I initially added an implementation of `=` to Integer (implemented as per the primitive fallback code in `LargeInteger>>#=`) however this had a negative effect on SmallInteger=Float comparisons. Instead the performance of SmallInteger=ScaledDecimal comparisons has been improved by optimising Integer-ScaledDecimal subtractions - see `ScaledDecimal>>#subtractFromInteger:`. ScaledDecimal creation has also been optimised slightly by use of primitive 157. 

Resolves #1119.