### PR TITLE
Truncate seconds when converting from Time to ODBCTIME

### DIFF
--- a/Core/Object Arts/Dolphin/Database/DBConnectionTest.cls
+++ b/Core/Object Arts/Dolphin/Database/DBConnectionTest.cls
@@ -209,6 +209,23 @@ testDSNlessConnection
 	c := DBConnection new.
 	c connectString: 'DRIVER={Microsoft Text Driver (*.txt; *.csv)}'!
 
+testODBCTIMEConversion
+	"Ensure valid conversion of Time to ODBCTIME"
+
+	| increment |
+
+	increment := 1/100.
+
+	0 to: (60 - increment) by: increment do: 
+		[ :seconds || hours minutes time odbctime |
+		hours := seconds truncated \\ 24.
+		minutes := seconds truncated max: 59.
+		time := Time hours: hours minutes: minutes seconds: seconds.
+		odbctime := ODBCTIME fromTime: time.
+		self assert: odbctime hour equals: time hour.
+		self assert: odbctime minute equals: time minute.
+		self assert: odbctime second equals: time second truncated]!
+
 testPackagesCorrectlySetUp
 	"The base package should not be dependent upon the development system."
 	self assert: ((Package manager packageNamed: 'Database Connection Base') prerequisites allSatisfy: [:each | each name = 'Dolphin' or: [each name = 'Dolphin Legacy Date & Time']])!
@@ -263,6 +280,7 @@ testTracing
 !DBConnectionTest categoriesFor: #testConnectionString!public!unit tests! !
 !DBConnectionTest categoriesFor: #testConnectStringDo!public!unit tests! !
 !DBConnectionTest categoriesFor: #testDSNlessConnection!public!unit tests! !
+!DBConnectionTest categoriesFor: #testODBCTIMEConversion!public!unit tests! !
 !DBConnectionTest categoriesFor: #testPackagesCorrectlySetUp!public!unit tests! !
 !DBConnectionTest categoriesFor: #testPreparedQuery!public!unit tests! !
 !DBConnectionTest categoriesFor: #testSpecialColumnsQuery!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Database/Database Tests.pax
+++ b/Core/Object Arts/Dolphin/Database/Database Tests.pax
@@ -26,6 +26,7 @@ package setPrerequisites: #(
 	'..\IDE\Base\Development System'
 	'..\Base\Dolphin'
 	'..\Base\Dolphin Base Tests'
+	'..\Base\Dolphin Legacy Date & Time'
 	'..\..\..\Contributions\Burning River\ExternalProcess\ExternalProcess'
 	'..\..\..\Contributions\Camp Smalltalk\SUnit\SUnit').
 

--- a/Core/Object Arts/Dolphin/Database/ODBCTIME.cls
+++ b/Core/Object Arts/Dolphin/Database/ODBCTIME.cls
@@ -54,7 +54,7 @@ time: aTime
 	self
 		hour: aTime hour;
 		minute: aTime minute;
-		second: aTime second! !
+		second: aTime second truncated "ODBCTIME doesn't support fractional seconds"! !
 !ODBCTIME categoriesFor: #asTime!converting!public! !
 !ODBCTIME categoriesFor: #hour!**compiled accessors**!public! !
 !ODBCTIME categoriesFor: #hour:!**compiled accessors**!public! !


### PR DESCRIPTION
Fixes #1125.