### PR TITLE
Fix regression caused by original fix for #1115

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Base/DialogView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DialogView.cls
@@ -1,4 +1,4 @@
-﻿"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk"!
 
 ShellView subclass: #DialogView
 	instanceVariableNames: 'endModal isModal oldWndProc'
@@ -54,6 +54,20 @@ defaultBackcolor
 	"Private - Answer the default colour for the receiver's background"
 
 	^(self hasCaption or: [self isThemed not]) ifTrue: [Color face3d] ifFalse: [super defaultBackcolor]!
+
+defaultExtent
+	"Answer the default size of the receiver"
+
+	"Implementation Note: This is used only for creation, and as the the initial size and position are ignored when creating a dialog, we may as well answer any fixed point rather than calculating something that will be ignored."
+
+	^260 @ 295!
+
+defaultPositionWithin: aParentView forExtent: aPoint
+	"Private - Answer the default position of the receiver within aParentView given its intended extent aPoint."
+
+	"Implementation Note: This is used only for creation, and as the the initial size and position are ignored when creating a dialog, we may as well answer any fixed point rather than calculating something that will be ignored."
+
+	^0 @ 0!
 
 defaultWindowProcessing: message wParam: wParam lParam: lParam
 	"Private - Pass a Windows message to the 'default' window procedure of the receiver.
@@ -389,6 +403,8 @@ wmInitDialog: message wParam: wParam lParam: lParam
 !DialogView categoriesFor: #basicCreateAt:extent:!private!realizing/unrealizing! !
 !DialogView categoriesFor: #cancel!commands!public! !
 !DialogView categoriesFor: #defaultBackcolor!colors!constants!private! !
+!DialogView categoriesFor: #defaultExtent!constants!public! !
+!DialogView categoriesFor: #defaultPositionWithin:forExtent:!geometry!private! !
 !DialogView categoriesFor: #defaultWindowProcessing:wParam:lParam:!dispatching!private! !
 !DialogView categoriesFor: #defaultWindowStyle!constants!private! !
 !DialogView categoriesFor: #destroy!public!realizing/unrealizing! !

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -1,4 +1,4 @@
-﻿"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk"!
 
 Object subclass: #View
 	instanceVariableNames: 'handle creationParent creationStyle presenter model backcolor preferredExtent flags contextMenu font events interactor'
@@ -1432,6 +1432,11 @@ getItemHandle: anInteger ifAbsent: exceptionHandler
 
 getNoRedrawCount
 	^self propertyAt: #_noRedrawCount ifAbsent: [0]!
+
+getOwner
+	"Private - Answers the handle of owner window, or nil if not owned."
+
+	^self getWindow: GW_HWNDOWNER!
 
 getParent
 	"Private - Answers the handle of the parent (or owner) window."
@@ -3020,7 +3025,11 @@ removeSubView: aView
 repositionShell: aShellView
 	aShellView isInitiallyCentered
 		ifTrue: [aShellView centerNear: (self mapPointToScreen: self clientRectangle center)]
-		ifFalse: [aShellView displayOnMonitor: self displayMonitor]!
+		ifFalse: 
+			["The view may already be positioned over the receiver, but not on the monitor on which the receiver is mostly displayed.
+			We don't want to reposition it in this case, as the shell might be something like an in-place editor and should stay where it is."
+			(self screenRectangle containsPoint: aShellView position)
+				ifFalse: [aShellView displayOnMonitor: self displayMonitor]]!
 
 requestDragImages: session
 	"This is where the receiver specifies any drag image overrides. 
@@ -4745,6 +4754,7 @@ zOrderTop
 !View categoriesFor: #getItem:ifAbsent:!hierarchy!private! !
 !View categoriesFor: #getItemHandle:ifAbsent:!hierarchy!private! !
 !View categoriesFor: #getNoRedrawCount!private! !
+!View categoriesFor: #getOwner!hierarchy!private! !
 !View categoriesFor: #getParent!hierarchy!private! !
 !View categoriesFor: #getPreviousSibling!hierarchy!private! !
 !View categoriesFor: #getScrollInfo:bar:!accessing!private! !

--- a/Core/Object Arts/Dolphin/MVP/DialogViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/DialogViewTest.cls
@@ -1,4 +1,4 @@
-﻿"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk"!
 
 DolphinTest subclass: #DialogViewTest
 	instanceVariableNames: 'owner shell2 fakeUser32 cursorPos'
@@ -124,6 +124,32 @@ testCenteringInOwnerModeless
 				<= 1.
 	dialog destroy!
 
+testInplaceNotRepositioned
+	| desktopMonitors position dialog leftMonitor ownerRect |
+	desktopMonitors := DisplayMonitor desktopMonitors.
+	leftMonitor := desktopMonitors first.
+	"This test requires multiple monitors arranged in a typical horizontal configuration. It could be made to work in a vertical configuration, but there much value."
+	self skipUnless: 
+			[desktopMonitors size > 1
+				and: [(desktopMonitors at: 2) workArea origin >= leftMonitor workArea topRight]].
+	"We need a view that is mainly on the left-most monitor, and partially on the next"
+	ownerRect := (leftMonitor workArea corner x - 400) @ 100 extent: 640 @ 480.
+	owner := self createShell: ownerRect text: self printString , ' owner'.
+	self assert: owner displayMonitor equals: leftMonitor.
+	dialog := DialogView new
+				isInitiallyCentered: false;
+				create;
+				yourself.
+	"Position the dialog on the 2nd monitor, but still over the owner view, before we show it"
+	dialog rectangle: (ownerRect corner - self dialogExtent + 50 extent: self dialogExtent).
+	self deny: dialog displayMonitor equals: leftMonitor.
+	position := dialog position.
+	"Show the dialog - it shouldn't get moved"
+	dialog showModeless: owner.
+	self deny: dialog displayMonitor equals: leftMonitor.
+	self assert: dialog position equals: position.
+	dialog destroy!
+
 testNearOwnerModal
 	"Test that a modal dialog that is not initially centred is at least shown on the same display as its owner."
 
@@ -152,6 +178,7 @@ testNearOwnerModeless
 	secondary := self getSecondaryMonitorIfAvailable.
 	self createTestShells: secondary.
 	dialog := self createSubjectDialog: false.
+	self assert: dialog displayMonitor equals: DisplayMonitor primary.
 	position := dialog position.
 	dialog showModeless: owner.
 	self assert: dialog displayMonitor equals: secondary.
@@ -212,6 +239,7 @@ workAreaNearest: aPoint
 !DialogViewTest categoriesFor: #tearDown!public!running! !
 !DialogViewTest categoriesFor: #testCenteringInOwner!public!unit tests! !
 !DialogViewTest categoriesFor: #testCenteringInOwnerModeless!public!unit tests! !
+!DialogViewTest categoriesFor: #testInplaceNotRepositioned!public!unit tests! !
 !DialogViewTest categoriesFor: #testNearOwnerModal!public!unit tests! !
 !DialogViewTest categoriesFor: #testNearOwnerModeless!public!unit tests! !
 !DialogViewTest categoriesFor: #testRemainsOnScreen!public!unit tests! !


### PR DESCRIPTION
The regression is that in-place editor dialogs can open on the wrong
display when the owner window is split between monitors. It can be
reproduced by placing a View Composer so that it is split between screens,
but mainly on the screen to the left, and with the property inspector on
the monitor to the right. When one of the in-place editor dialogs is opened
from the property inspector, the dialog comes up on the left monitor. This
is because it gets repositioned on to the monitor with which the window is
associated, which is that monitor on which the window is mostly displayed.