### PR TITLE
Open new shells on user's active monitor by default

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/ViewComposer.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/ViewComposer.cls
@@ -2409,6 +2409,7 @@ viewTest
 						layoutManager: GridLayout new;
 						yourself].
 	testView := Object fromLiteralStoreArray: (self composingView literalStoreArray) context: parentView.
+	self view repositionShell: testView topView.
 	testView show!
 
 viewUndo

--- a/Core/Object Arts/Dolphin/MVP/AbstractShellViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/AbstractShellViewTest.cls
@@ -1,0 +1,63 @@
+﻿"Filed out from Dolphin Smalltalk"!
+
+DolphinTest subclass: #AbstractShellViewTest
+	instanceVariableNames: 'fakeUser32 cursorPos shells'
+	classVariableNames: ''
+ 	poolDictionaries: ''
+ 	classInstanceVariableNames: ''!
+AbstractShellViewTest guid: (GUID fromString: '{be6c197d-5333-4ba6-aef4-6b93d2970718}')!
+AbstractShellViewTest isNonInstantiable: true!
+AbstractShellViewTest comment: ''!
+!AbstractShellViewTest categoriesForClass!Unclassified! !
+!AbstractShellViewTest methodsFor!
+
+createShell: aRectangle text: aString
+	| shell |
+	shell := ShellView new.
+	shells addLast: shell.
+	^shell
+		create;
+		rectangle: aRectangle;
+		text: aString;
+		show;
+		yourself!
+
+getSecondaryMonitorIfAvailable
+	"Private - Attempt to find a non-primary monitor, which will only be possible if more than one display monitor is attached."
+
+	| monitors |
+	monitors := DisplayMonitor desktopMonitors.
+	^monitors size > 1 ifTrue: [monitors detect: [:each | each isPrimary not]] ifFalse: [monitors first]!
+
+setUp
+	super setUp.
+	shells := OrderedCollection new.
+	cursorPos := 0@0!
+
+setUpFakeUserLibrary
+	fakeUser32 := FakeUserLibrary new.
+	fakeUser32
+		initializeForDesktopActive;
+		getCursorPosBlock: 
+				[:pointl |
+				pointl value: cursorPos.
+				1];
+		open.
+	"In this configuration the active window is nil (i.e. simulating foreground window not a Dolphin window), and the foreground window will be external."
+	self assertIsNil: View active!
+
+tearDown
+	fakeUser32 ifNotNil: [fakeUser32 close].
+	shells do: [:each | each destroy].
+	super tearDown!
+
+workAreaNearest: aPoint
+	^(DisplayMonitor nearestPoint: aPoint) workArea! !
+!AbstractShellViewTest categoriesForMethods!
+createShell:text:!helpers!private! !
+getSecondaryMonitorIfAvailable!helpers!private! !
+setUp!public!running! !
+setUpFakeUserLibrary!helpers!private! !
+tearDown!public!running! !
+workAreaNearest:!helpers!private! !
+!

--- a/Core/Object Arts/Dolphin/MVP/Base/DesktopView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DesktopView.cls
@@ -2,7 +2,7 @@
 
 View subclass: #DesktopView
 	instanceVariableNames: 'resolution defaultExtentBlock dvReserved1 dvReserved2'
-	classVariableNames: 'Current ProgmanClassAtom'
+	classVariableNames: 'Current'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 DesktopView guid: (GUID fromString: '{87b4c70e-026e-11d3-9fd7-00a0cc3e4a32}')!
@@ -211,8 +211,7 @@ onStartup
 	"Make sure the receiver represents the desktop window handle."
 
 	self assumeDesktopHandle.
-	resolution := nil.
-	self class getProgmanClass!
+	resolution := nil!
 
 onViewActivated: anEvent
 	"Default handler for window activation.
@@ -392,13 +391,6 @@ current: aDesktopView
 
 	Current := aDesktopView!
 
-getProgmanClass
-	| user |
-	user := UserLibrary default.
-	ProgmanClassAtom := user
-				getClassLongPtr: (user findWindow: 'Progman' asUtf16String lpWindowName: nil)
-				nIndex: GCW_ATOM!
-
 icon
 	"Answers an Icon that can be used to represent this class"
 
@@ -411,13 +403,7 @@ initialize
 			assumeDesktopHandle;
 			yourself!
 
-isProgramManager: hWnd
-	"Private - Answer whether the argument is the window handle of the Windows program manager. Here we are relying on the undocumented fact that the 'program manager' (main Windows shell) has a specific name for its Window class, and has done so since the very earliest versions of Windows. It seems unlikely to change, but if it does will fail safe for most purposes."
-
-	^(UserLibrary default getClassLongPtr: hWnd asParameter nIndex: Win32Constants.GCW_ATOM)
-		== ProgmanClassAtom!
-
-stbConvertFromVersion9: anArray 
+stbConvertFromVersion9: anArray
 	"Private - Perform an STB conversion from a version 9 (or earlier) instance
 	of the receiver to version 10,
 		10: append iconTitleFont inst. var., and a couple more reserved for future use
@@ -449,10 +435,8 @@ uninitialize
 !DesktopView class categoriesForMethods!
 current!accessing!public! !
 current:!accessing!public! !
-getProgmanClass!initializing!private! !
 icon!constants!public! !
 initialize!development!initializing!private! !
-isProgramManager:!enquiries!private! !
 stbConvertFromVersion9:!binary filing!private! !
 uninitialize!class hierarchy-removing!private! !
 !

--- a/Core/Object Arts/Dolphin/MVP/Base/DisplayMonitor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DisplayMonitor.cls
@@ -118,14 +118,11 @@ workArea!accessing!public! !
 !DisplayMonitor class methodsFor!
 
 active
-	"Answer an instance of the receiver representing the monitor that is most likely to be the one the user might consider active. There is no completely reliable way to determine this, so we use the heuristic that the monitor of the foreground window (whether that is a Dolphin window or not) is likely to be the one with the users' interest.
-	An exception is if the 'Progman' window is the foreground window, which will be the case if the user has clicked on the desktop (at least in any version of Windows that is currently relevant)."
+	"Answer an instance of the receiver representing the monitor that is most likely to be the one the user might consider active. There is no completely reliable way to determine this, so we use the heuristic that the monitor of the foreground window is to be used if that is a Dolphin window, otherwise the monitor over which the cursor is hovering. The reason for making this distinction is that the foreground window may be some part of the Windows shell if the user clicked on the desktop background or the taskbar, which are always considered as being on the primary monitor only. Up until Windows 11 it was possible to detect this case reasonably well by detecting that the window with focus was the 'Program Manager', but this no longer holds in Windows 11. Therefore we just go for the simpler option of tracking the cursor when the active window is not a Dolphin window."
 
-	UserLibrary default getForegroundWindow
-		ifNotNil: [:hWnd | (DesktopView isProgramManager: hWnd) ifFalse: [^self displayingView: hWnd]].
-
-	"We want to return the display with the mouse cursor if the desktop (really the program manager) has focus, or in the unlikely event that GetForegroundWindow returns null, which according to the docs it can do if activation is in transition."
-	^self containingPoint: Cursor position!
+	^View active
+		ifNil: [self containingPoint: Cursor position]
+		ifNotNil: [:hWnd | self displayingView: hWnd]!
 
 allIntersecting: aRectangle
 	"Answer a `<collection>` containing instances of the receiver describing all the display monitors with display areas that intersect the specified virtual screen area (i.e. desktop area)."

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -1240,7 +1240,7 @@ View subclass: #ControlView
 	classInstanceVariableNames: ''!
 View subclass: #DesktopView
 	instanceVariableNames: 'resolution defaultExtentBlock dvReserved1 dvReserved2'
-	classVariableNames: 'Current ProgmanClassAtom'
+	classVariableNames: 'Current'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 View subclass: #DoubleBufferedView

--- a/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
@@ -187,7 +187,7 @@ defaultPositionWithin: aParentView forExtent: aPoint
 	"Private - Answer the default position of the receiver within aParentView given its intended extent aPoint.
 	This is used only on creation."
 
-	| testWindow defaultPosition |
+	| testWindow defaultPosition activeMonitor defaultMonitor |
 	self assert: [aParentView notNil].
 	self isInitiallyCentered ifTrue: [^self centerExtent: aPoint within: aParentView].
 
@@ -199,6 +199,15 @@ defaultPositionWithin: aParentView forExtent: aPoint
 		createAt: ##(CW_USEDEFAULT @ CW_USEDEFAULT) extent: aPoint.
 	defaultPosition := testWindow position.
 	testWindow destroy.
+	"Reposition to within bounds of active monitor"
+	activeMonitor := DisplayMonitor active.
+	defaultMonitor := DisplayMonitor containingPoint: defaultPosition.
+	activeMonitor = defaultMonitor
+		ifFalse: 
+			[| workArea |
+			defaultPosition := activeMonitor origin + (defaultPosition - defaultMonitor origin).
+			workArea := activeMonitor workArea.
+			defaultPosition := (defaultPosition min: workArea bottomRight - aPoint) max: workArea topLeft].
 	^defaultPosition!
 
 defaultShowStyle

--- a/Core/Object Arts/Dolphin/MVP/DialogViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/DialogViewTest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smallalk"!
 
-DolphinTest subclass: #DialogViewTest
-	instanceVariableNames: 'owner shell2 fakeUser32 cursorPos'
+AbstractShellViewTest subclass: #DialogViewTest
+	instanceVariableNames: 'owner shell2'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -11,7 +11,10 @@ DialogViewTest comment: ''!
 !DialogViewTest methodsFor!
 
 createShell: aRectangle text: aString
-	^ShellView new
+	| shell |
+	shell := ShellView new.
+	shells addLast: shell.
+	^shell
 		create;
 		rectangle: aRectangle;
 		text: aString;
@@ -54,29 +57,6 @@ evaluateInModalDialog: aBlock owner: ownerView centered: aBoolean
 	dialog isInProc: true.
 	dialog showModalTo: ownerView.
 	self deny: dialog isOpen!
-
-getSecondaryMonitorIfAvailable
-	"Private - Attempt to find a non-primary monitor, which will only be possible if more than one display monitor is attached."
-
-	| monitors |
-	monitors := DisplayMonitor desktopMonitors.
-	^monitors size > 1 ifTrue: [monitors detect: [:each | each isPrimary not]] ifFalse: [monitors first]!
-
-setUpFakeUserLibrary
-	fakeUser32 := FakeUserLibrary new.
-	fakeUser32
-		initializeForDesktopActive;
-		getCursorPosBlock: 
-				[:pointl |
-				pointl value: cursorPos.
-				1];
-		open!
-
-tearDown
-	fakeUser32 ifNotNil: [fakeUser32 close].
-	owner ifNotNil: [owner destroy].
-	shell2 ifNotNil: [shell2 destroy].
-	super tearDown!
 
 testCenteringInOwner
 	"Test that a modal dialog is centered in its owner."
@@ -235,15 +215,12 @@ createSubjectDialog:!helpers!private! !
 createTestShells:!helpers!private! !
 dialogExtent!constants!private! !
 evaluateInModalDialog:owner:centered:!helpers!private! !
-getSecondaryMonitorIfAvailable!helpers!private! !
-setUpFakeUserLibrary!helpers!private! !
-tearDown!public!running! !
 testCenteringInOwner!public!unit tests! !
 testCenteringInOwnerModeless!public!unit tests! !
 testInplaceNotRepositioned!public!unit tests! !
 testNearOwnerModal!public!unit tests! !
 testNearOwnerModeless!public!unit tests! !
 testRemainsOnScreen!public!unit tests! !
-workAreaNearest:!helpers!private! !
+workAreaNearest:!public! !
 !
 

--- a/Core/Object Arts/Dolphin/MVP/DisplayMonitorTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/DisplayMonitorTest.cls
@@ -35,9 +35,7 @@ testActive
 		open.
 	"As we have things set up to fake the foreground/active window, sneak in some tests of related View class enquiries."
 	self assertIsNil: View activeHandle.
-	self assert: (DesktopView isProgramManager: View foregroundHandle).
 	self assert: View activeOrDesktop isDesktop.
-	"When the program manager is active, we deliberately choose to regard the display with the mouse cursor as the active display"
 	self assert: DisplayMonitor active equals: (DisplayMonitor containingPoint: Cursor position)]
 			ensure: 
 				[user32 free.

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -9,6 +9,7 @@ package classNames
 	add: #AbstractContainerViewTest;
 	add: #AbstractPointTest;
 	add: #AbstractRectangleTest;
+	add: #AbstractShellViewTest;
 	add: #AbstractTextEditTest;
 	add: #AcceleratorTableTest;
 	add: #ARGBTest;
@@ -72,6 +73,7 @@ package classNames
 	add: #SelectableItemsTest;
 	add: #SelectableListItemsTest;
 	add: #SelectableTreeItemsTest;
+	add: #ShellViewTest;
 	add: #SingleSelectListBoxTest;
 	add: #SingleSelectListViewTest;
 	add: #SliderTest;
@@ -150,7 +152,7 @@ Object subclass: #MockScintillaView
 	poolDictionaries: 'ScintillaConstants'
 	classInstanceVariableNames: ''!
 UserLibrary subclass: #FakeUserLibrary
-	instanceVariableNames: 'user32 getForegroundWindowBlock getActiveWindowBlock getCursorPosBlock'
+	instanceVariableNames: 'user32 process getForegroundWindowBlock getActiveWindowBlock getCursorPosBlock'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -166,6 +168,11 @@ DolphinTest subclass: #AbstractPointTest
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #AbstractRectangleTest
 	instanceVariableNames: 'desktop oddDesktop unary'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+DolphinTest subclass: #AbstractShellViewTest
+	instanceVariableNames: 'fakeUser32 cursorPos shells'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -201,11 +208,6 @@ DolphinTest subclass: #ColorTest
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #CommandDescriptionTest
 	instanceVariableNames: 'savedKeyboardLayout'
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
-DolphinTest subclass: #DialogViewTest
-	instanceVariableNames: 'owner shell2 fakeUser32 cursorPos'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -350,6 +352,16 @@ AbstractRectangleTest subclass: #RectangleTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 ExternalRectangleTest subclass: #RECTLTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+AbstractShellViewTest subclass: #DialogViewTest
+	instanceVariableNames: 'owner shell2'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+AbstractShellViewTest subclass: #ShellViewTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/MVP/FakeUserLibrary.cls
+++ b/Core/Object Arts/Dolphin/MVP/FakeUserLibrary.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smallalk"!
 
 UserLibrary subclass: #FakeUserLibrary
-	instanceVariableNames: 'user32 getForegroundWindowBlock getActiveWindowBlock getCursorPosBlock'
+	instanceVariableNames: 'user32 process getForegroundWindowBlock getActiveWindowBlock getCursorPosBlock'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -21,13 +21,17 @@ free
 	self close!
 
 getActiveWindow
-	^getActiveWindowBlock ifNotNil: [getActiveWindowBlock value] ifNil: [super getActiveWindow]!
+	^(getActiveWindowBlock notNil and: [Processor activeProcess == process])
+		ifTrue: [getActiveWindowBlock value]
+		ifFalse: [super getActiveWindow]!
 
 getActiveWindowBlock: aNiladicValuable
 	getActiveWindowBlock := aNiladicValuable!
 
 getCursorPos: aPOINT
-	^getCursorPosBlock ifNotNil: [getCursorPosBlock value: aPOINT] ifNil: [super getCursorPos: aPOINT]!
+	^(getCursorPosBlock notNil and: [Processor activeProcess == process])
+		ifTrue: [getCursorPosBlock value: aPOINT]
+		ifFalse: [super getCursorPos: aPOINT]!
 
 getCursorPosBlock: aMonadicValuable
 	getCursorPosBlock := aMonadicValuable!
@@ -36,9 +40,9 @@ getForegroundWindow
 	"Answer the handle of the window with which the user is currently working.
 		HWND GetForegroundWindow(VOID)"
 
-	^getForegroundWindowBlock
-		ifNotNil: [getForegroundWindowBlock value]
-		ifNil: [super getForegroundWindow]!
+	^(getForegroundWindowBlock notNil and: [Processor activeProcess == process])
+		ifTrue: [getForegroundWindowBlock value]
+		ifFalse: [super getForegroundWindow]!
 
 getForegroundWindowBlock: aNiladicValuable
 	getForegroundWindowBlock := aNiladicValuable!
@@ -48,6 +52,7 @@ initializeForDesktopActive
 	getActiveWindowBlock := []!
 
 open
+	process := Processor activeProcess.
 	user32 := UserLibrary default.
 	handle := user32 handle.
 	self beFinalizable.

--- a/Core/Object Arts/Dolphin/MVP/ShellViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ShellViewTest.cls
@@ -1,0 +1,47 @@
+﻿"Filed out from Dolphin Smallalk"!
+
+AbstractShellViewTest subclass: #ShellViewTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ShellViewTest guid: (GUID fromString: '{7f45346b-99e0-4c3f-bcf8-19cde00771e0}')!
+ShellViewTest comment: ''!
+!ShellViewTest categoriesForClass!Unclassified! !
+!ShellViewTest methodsFor!
+
+createShell: aString
+	| shell |
+	shell := ShellView new.
+	shells addLast: shell.
+	^shell
+		create;
+		text: aString;
+		show;
+		yourself!
+
+testOpensOnForegroundMonitor
+	"Test that shell opens on the monitor of the monitor with cursor, but preferring the monitor with the foreground window if the program manager has focus."
+
+	| primary secondary shell1 shell2 shell3 |
+	primary := DisplayMonitor primary.
+	secondary := self getSecondaryMonitorIfAvailable.
+	self setUpFakeUserLibrary.
+	cursorPos := secondary workArea center.
+	shell1 := self createShell: self printString , ': shell1'.
+	self assert: shell1 displayMonitor equals: secondary.
+	fakeUser32 getActiveWindowBlock: [shell1 handle].
+	"Position cursor over the primary window - shell should still open on secondary because the foreground window is there."
+	cursorPos := primary workArea center.
+	shell2 := self createShell: self printString , ': shell2'.
+	self assert: shell2 displayMonitor equals: secondary.
+	"Move the foreground window to the primary monitor"
+	shell1 positionNear: primary workArea center.
+	"Now a new shell should open on the primary monitor"
+	shell3 := self createShell: self printString , ': shell3'.
+	self assert: shell3 displayMonitor equals: primary! !
+!ShellViewTest categoriesForMethods!
+createShell:!private! !
+testOpensOnForegroundMonitor!public!unit tests! !
+!
+


### PR DESCRIPTION
As suggested in #1116.

Also:
1. Simplify DisplayMonitor class>>active as the trick to identify when the
program manager has activation is trying to be too clever, and doesn't work
on Windows 11.
2. Ensure that View/Test on a dialog will open the dialog on the same monitor
as the View Composer (specific handling is required because when a Dialog
is created using the Windows API , it takes activation).