### PR TITLE
Bv consistency002

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Community Edition/ActiveX Automation Development.pax
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/ActiveX Automation Development.pax
@@ -5286,6 +5286,7 @@ printClassCommentPreambleOn: target
 		nextPutAll: ' is the `ExternalLibrary` class to represent the dynamic link library, ';
 		print: (self dllNameIfNone: ['(anon)']);
 		nextPut: $.;
+		space;
 		nextPutAll: 'It was generated from type information in the ';
 		print: lib helpstring;
 		nextPutAll: ' library. It contains methods for each of the functions defined by the corresponding module in that type library.'!

--- a/Core/Object Arts/Dolphin/Sockets/OS.WS2_32Library.cls
+++ b/Core/Object Arts/Dolphin/Sockets/OS.WS2_32Library.cls
@@ -7,7 +7,7 @@ External.DynamicLinkLibrary subclass: #'OS.WS2_32Library'
 	classInstanceVariableNames: ''
 	classConstants: {}!
 OS.WS2_32Library guid: (Core.GUID fromString: '{d368efd5-8705-4c18-ada5-9a1e95868480}')!
-OS.WS2_32Library comment: 'WS2_32Library is the <ExternalLibrary> class to represent the dynamic link library, ''WS2_32.dll''.It was generated from type information in the ''Windows Sockets 2 Type Library'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
+OS.WS2_32Library comment: 'WS2_32Library is the <ExternalLibrary> class to represent the dynamic link library, ''WS2_32.dll''. It was generated from type information in the ''Windows Sockets 2 Type Library'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
 
 This library contains functions pertaining to the use of TCP/IP sockets under Windows through the Sockets 2 (blocking) API.
 

--- a/Core/Object Arts/Dolphin/System/Win32/HttpServer/WinHttpServer.HttpApiLibrary.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HttpServer/WinHttpServer.HttpApiLibrary.cls
@@ -86,7 +86,7 @@ External.DynamicLinkLibrary subclass: #'WinHttpServer.HttpApiLibrary'
 		'HTTP_URL_FLAG_REMOVE_ALL' -> 16r1
 	}!
 WinHttpServer.HttpApiLibrary guid: (Core.GUID fromString: '{06475580-47cf-4641-9eb7-96d83f2d2e96}')!
-WinHttpServer.HttpApiLibrary comment: 'HttpApiLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''HttpApi.dll''.It was generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
+WinHttpServer.HttpApiLibrary comment: 'HttpApiLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''HttpApi.dll''. It was generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
 
 The type library contains the following helpstring for this module
 	"Windows HTTP Server API"

--- a/Core/Object Arts/Dolphin/System/Win32/OS.Crypt32Library.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/OS.Crypt32Library.cls
@@ -7,7 +7,7 @@ External.DynamicLinkLibrary subclass: #'OS.Crypt32Library'
 	classInstanceVariableNames: ''
 	classConstants: {}!
 OS.Crypt32Library guid: (Core.GUID fromString: '{02c78993-ba10-47a1-953f-63f60b7693ab}')!
-OS.Crypt32Library comment: 'Crypt32Library is the <ExternalLibrary> class to represent the dynamic link library, ''Crypt32.dll''.It was generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
+OS.Crypt32Library comment: 'Crypt32Library is the <ExternalLibrary> class to represent the dynamic link library, ''Crypt32.dll''. It was generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
 
 The type library contains the following helpstring for this module
 	"Crypto API"


### PR DESCRIPTION
This puts a space between two comment phrases in autogenerated comments referred to by Dolphin issue #1141. It also fixes the few files I found with this particular formatting issue.
