### PR TITLE
Another change for #1116: Ensure initially centred shell views (e.g. splash screen) open on active monitor

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Base/DesktopView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DesktopView.cls
@@ -91,6 +91,11 @@ caption: aString
 	self text: aString.
 	self trigger: #captionChanged!
 
+centerExtent: aPoint
+	"Private - Answer the origin `Point` for a shell view of the specified extent, centred over the active monitor's work area."
+
+	^DisplayMonitor active centerExtent: aPoint!
+
 commandPolicyWithSource: sourceView
 	"Answers a <CommandPolicy> object for routing commands originating
 	from the <View>, source.
@@ -337,6 +342,7 @@ buttonRemoved:!default button!private! !
 canvas!accessing!public! !
 caption!accessing!public! !
 caption:!accessing!public! !
+centerExtent:!geometry!private! !
 commandPolicyWithSource:!commands!public! !
 defaultExtentOf:!geometry!helpers!private! !
 displayOn:!displaying!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/DisplayMonitor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DisplayMonitor.cls
@@ -28,6 +28,19 @@ Having identified a `DisplayMonitor`, one can then query the desktop co-ordinate
 	^self == anObject
 		or: [anObject species == self species and: [anObject deviceName = self deviceName]]!
 
+adjustPosition: originPoint forExtent: extentPoint
+	"Answer the nearest `Point` to originPoint that allows a rectangle with extent, extentPoint, to fit within the receiver's work area.
+	If the extent is larger than the work area, then answer the work area's own origin."
+
+	| workArea |
+	workArea := self workArea.
+	^(originPoint min: workArea bottomRight - extentPoint) max: workArea topLeft!
+
+centerExtent: aPoint
+	"Answer the best origin `Point` for a view rectangle expected to be centred over the receiver of the specified extent."
+
+	^self adjustPosition: self workArea center - (aPoint // 2) forExtent: aPoint!
+
 deviceName
 	"Answer the Window's device name for the monitor that the receiver represents."
 
@@ -101,6 +114,8 @@ workArea
 	^self info rcWork asRectangle! !
 !DisplayMonitor categoriesForMethods!
 =!comparing!public! !
+adjustPosition:forExtent:!geometry!public! !
+centerExtent:!geometry!public! !
 deviceName!accessing!public! !
 devices!accessing!private! !
 handle!accessing!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
@@ -189,11 +189,10 @@ defaultPositionWithin: aParentView forExtent: aPoint
 
 	| testWindow defaultPosition activeMonitor defaultMonitor |
 	self assert: [aParentView notNil].
-	self isInitiallyCentered ifTrue: [^self centerExtent: aPoint within: aParentView].
+	self isInitiallyCentered ifTrue: [^aParentView centerExtent: aPoint].
 
 	"If not creating on the desktop, create at the origin of the parent's client area"
 	aParentView parentView notNil ifTrue: [^0 @ 0].
-	#todo.	"We need a less expensive way to determine a sensible default position than creating and destroying a test window."
 	(testWindow := ShellView new)
 		parentView: aParentView;
 		createAt: ##(CW_USEDEFAULT @ CW_USEDEFAULT) extent: aPoint.
@@ -202,13 +201,11 @@ defaultPositionWithin: aParentView forExtent: aPoint
 	"Reposition to within bounds of active monitor"
 	activeMonitor := DisplayMonitor active.
 	defaultMonitor := DisplayMonitor containingPoint: defaultPosition.
-	activeMonitor = defaultMonitor
+	^activeMonitor = defaultMonitor
+		ifTrue: [defaultPosition]
 		ifFalse: 
-			[| workArea |
-			defaultPosition := activeMonitor origin + (defaultPosition - defaultMonitor origin).
-			workArea := activeMonitor workArea.
-			defaultPosition := (defaultPosition min: workArea bottomRight - aPoint) max: workArea topLeft].
-	^defaultPosition!
+			[activeMonitor adjustPosition: activeMonitor origin + (defaultPosition - defaultMonitor origin)
+				forExtent: aPoint]!
 
 defaultShowStyle
 	^self isMaximized ifTrue: [SW_SHOWMAXIMIZED] ifFalse: [SW_SHOWNORMAL]!
@@ -798,11 +795,9 @@ performCommand: aCommand
 positionNear: aPoint
 	"Attempt to position the receiver at the origin, aPoint, in screen co-ordinates, but ensuring that the receiver's window will be entirely visible if possible, or if not so that at least the top-left corner is visible."
 
-	| workArea position |
-	workArea := (DisplayMonitor nearestPoint: aPoint) workArea.
-	position := (aPoint min: workArea bottomRight - self extent) max: workArea topLeft.
-	position := creationParent mapScreenToClient: position.
-	self position: position!
+	self position: (creationParent
+				mapScreenToClient: ((DisplayMonitor nearestPoint: aPoint) adjustPosition: aPoint
+						forExtent: self extent))!
 
 preTranslateKeyboardInput: aMSG 
 	"Answer whether the receiver would like to consume the argument aMSG, which is a keyboard

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -556,12 +556,10 @@ canvas
 
 	^Canvas forView: self!
 
-centerExtent: aPoint within: aParentView
-	"Private - Answer the position to give a view of extent aPoint in order to center it within aParentView."
+centerExtent: aPoint
+	"Private - Answer the origin `Point` for a child view centred over the receiver of the specified extent."
 
-	^(aParentView extent - aPoint) // 2
-
-!
+	^(self extent - aPoint) // 2!
 
 clearHandle
 	self handle: nil!
@@ -4668,7 +4666,7 @@ calculateExtent!geometry!private! !
 calculateExtent:!geometry!private! !
 canAcceptSubViews!hierarchy!public!sub views!testing! !
 canvas!drawing!public! !
-centerExtent:within:!geometry!private! !
+centerExtent:!geometry!private! !
 clearHandle!private!realizing/unrealizing! !
 clearStateRestoring!helpers!private! !
 clientExtent!geometry!public! !

--- a/Core/Object Arts/Dolphin/MVP/ShellViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/ShellViewTest.cls
@@ -10,10 +10,11 @@ ShellViewTest comment: ''!
 !ShellViewTest categoriesForClass!Unclassified! !
 !ShellViewTest methodsFor!
 
-createShell: aString
+createShell: aString centered: aBoolean
 	| shell |
 	shell := ShellView new.
 	shells addLast: shell.
+	shell isInitiallyCentered: aBoolean.
 	^shell
 		create;
 		text: aString;
@@ -28,20 +29,20 @@ testOpensOnForegroundMonitor
 	secondary := self getSecondaryMonitorIfAvailable.
 	self setUpFakeUserLibrary.
 	cursorPos := secondary workArea center.
-	shell1 := self createShell: self printString , ': shell1'.
+	shell1 := self createShell: self printString , ': shell1' centered: true.
 	self assert: shell1 displayMonitor equals: secondary.
 	fakeUser32 getActiveWindowBlock: [shell1 handle].
 	"Position cursor over the primary window - shell should still open on secondary because the foreground window is there."
 	cursorPos := primary workArea center.
-	shell2 := self createShell: self printString , ': shell2'.
+	shell2 := self createShell: self printString , ': shell2' centered: false.
 	self assert: shell2 displayMonitor equals: secondary.
 	"Move the foreground window to the primary monitor"
 	shell1 positionNear: primary workArea center.
 	"Now a new shell should open on the primary monitor"
-	shell3 := self createShell: self printString , ': shell3'.
+	shell3 := self createShell: self printString , ': shell3' centered: false.
 	self assert: shell3 displayMonitor equals: primary! !
 !ShellViewTest categoriesForMethods!
-createShell:!private! !
+createShell:centered:!private! !
 testOpensOnForegroundMonitor!public!unit tests! !
 !
 


### PR DESCRIPTION
The splash screen (or any other shell view configured to be initially centred) should open on the active monitor, like any other uncentred shell view.