### PR TITLE
Fix #928: Random #gpFault: error when closing Scintilla windows bug

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/DebuggerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/DebuggerTest.cls
@@ -21,7 +21,9 @@ setUp
 tearDown
 	process isNil
 		ifFalse: 
-			[process terminate.
+			[
+			process debugger ifNotNil: [:debugger | debugger view destroy. process debugger: nil].
+			process terminate.
 			process := nil].
 	Debugger
 		showWalkbacks: savedShowWalkbacks;

--- a/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
@@ -621,7 +621,7 @@ onCloseRequested
 			away anyway."
 			flags := flags bitOr: LayoutValidMask.
 			self update.
-			self destroy.
+			Processor isActiveMain ifTrue: [self destroy] ifFalse: [[self destroy] postToInputQueue].
 			^true].
 	^false!
 


### PR DESCRIPTION
The issue is caused by prompt to save changes showing a message box and
starting another main UI process. When the prompt is answered and the
message box closes, the thread continues and may destroy the window that
generated the prompt. If the window is being repainted at this point, then
depending on timing the background thread may destroy the window while the
paint message is being processed.

The fix is simply to push the window destroy operation into the deferred
action queue, so that the main UI process will destroy the window in sync
with it's other activities.

I haven't been able to come up with a useful regression test for this unfortunately.