### PR TITLE
char8_t in lexer.h requires C++20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ UpgradeLog.htm
 *.VC.opendb
 *.VC.db
 DolphinBoot
+hooks
+lfs

--- a/Core/DolphinVM/Compiler/Compiler.vcxproj
+++ b/Core/DolphinVM/Compiler/Compiler.vcxproj
@@ -201,6 +201,7 @@
       <ExceptionHandling>Sync</ExceptionHandling>
       <AdditionalIncludeDirectories>$(ProjectDir)\..;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Core/DolphinVM/Compiler/Compiler.vcxproj
+++ b/Core/DolphinVM/Compiler/Compiler.vcxproj
@@ -201,7 +201,7 @@
       <ExceptionHandling>Sync</ExceptionHandling>
       <AdditionalIncludeDirectories>$(ProjectDir)\..;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Core/DolphinVM/strgprim.cpp
+++ b/Core/DolphinVM/strgprim.cpp
@@ -374,7 +374,7 @@ Oop* __fastcall Interpreter::primitiveStringNextIndexOfFromTo(Oop* const sp, pri
 									char32_t c;
 									auto next = i;
 									
-									U8_NEXT(s, next, to, c)
+									U8_NEXT(s, next, to, c);
 
 									if (c == codePoint)
 									{
@@ -415,7 +415,7 @@ Oop* __fastcall Interpreter::primitiveStringNextIndexOfFromTo(Oop* const sp, pri
 								{
 									char32_t c;
 									size_t next = i;
-									U16_NEXT_UNSAFE(s, next, c)
+									U16_NEXT_UNSAFE(s, next, c);
 									if (c == codePoint)
 									{
 										*(sp - 3) = ObjectMemoryIntegerObjectOf(i + 1);


### PR DESCRIPTION
`lexer.h` and `str.h` both make reference to `char8_t` which is part of C++20. To avoid error we need to specify this C++ version ([cite](https://docs.microsoft.com/en-us/cpp/cpp/char-wchar-t-char16-t-char32-t?view=msvc-160)). Also, the system seems to generate some new files in `/hooks` and `/lfs` that I don't understand so will ignore.

I offer this as an alternative to an issue asking what is wrong. These are the things that made it work for me but I don't claim to understand if it is the right thing!