### PR TITLE
Hide cursor for 100ms at the end of Cursor>>showWhile: 

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Base/Cursor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Cursor.cls
@@ -86,7 +86,7 @@ showWhile: aBlock
 	^aBlock ensure: [
 		Current := previousCurrent.
 		nowActual := UserLibrary default getCursor.
-		nowActual handle = previousActual handle ifFalse: [
+		nowActual handle = (previousActual ifNil: [0] ifNotNil: [previousActual handle]) ifFalse: [
 			UserLibrary default showCursor: false.
 			"https://github.com/dolphinsmalltalk/Dolphin/issues/1154"
 			(Delay forMilliseconds: 100) wait.

--- a/Core/Object Arts/Dolphin/MVP/Base/Cursor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Cursor.cls
@@ -78,13 +78,22 @@ showWhile: aBlock
 	"Maintain the wait cursor while aBlock is executed, answering the result of the block.
 	The actual cursor which was current is restored (rather than the one we think is Current)."
 
-	| previous actual |
-	previous := Current.
+	| previousCurrent previousActual nowActual |
+	previousCurrent := Current.
 	Current := self.
-	actual := self setCursor.
-	^aBlock ensure: 
-			[Current := previous.
-			UserLibrary default setCursor: actual]! !
+	previousActual := UserLibrary default getCursor.
+	self setCursor.
+	^aBlock ensure: [
+		Current := previousCurrent.
+		nowActual := UserLibrary default getCursor.
+		nowActual handle = previousActual handle ifFalse: [
+			UserLibrary default showCursor: false.
+			"https://github.com/dolphinsmalltalk/Dolphin/issues/1154"
+			(Delay forMilliseconds: 100) wait.
+			UserLibrary default setCursor: previousActual.
+			UserLibrary default showCursor: true.
+		].
+	]! !
 !Cursor categoriesForMethods!
 imageType!constants!private! !
 load:fromInstance:extent:!private!realizing/unrealizing! !


### PR DESCRIPTION
This fixes #1154 but is an ugly hack. Yet it is the only thing I can find that works after a full day of debugging. This is almost certainly some sort of timing issue (especially since a delay masks the problem), and it may be related to my Windows system being a VM in Fusion. Without this change many busy actions with a changed cursor end up with the cursor not being restored. 

My test case is opening and closing tabs in an IdeaSpace and the problem is very consistent (about 50% of the time). Moving the mouse into an area with a different cursor (like a text editor) will get the cursor back, so it is easy to just get in the habit of moving the cursor around after a long-running operation, but it makes these operations seem excessively long-running (they appear to hang). 

I can't say that I seriously expect this to be merged, but it serves as a point of reference for those who see the same issue (and I will be incorporating it as a patch in my application).