### PR TITLE
Fix break caused by loss of stdext::hash_value in VS 17.4

### DIFF
--- a/Core/DolphinVM/objmem.cpp
+++ b/Core/DolphinVM/objmem.cpp
@@ -271,9 +271,21 @@ bool __stdcall ObjectMemory::inheritsFrom(const BehaviorOTE* behaviorPointer, co
 
 #pragma code_seg(GC_SEG)
 
+namespace stdext {
+	template <class _Kty>
+	_NODISCARD size_t hash_value(const _Kty& _Keyval) noexcept {
+		if constexpr (_STD is_pointer_v<_Kty> || _STD is_null_pointer_v<_Kty>) {
+			return reinterpret_cast<size_t>(_Keyval) ^ 0xdeadbeefu;
+		}
+		else {
+			return static_cast<size_t>(_Keyval) ^ 0xdeadbeefu;
+		}
+	}
+};
+
 template <class T> inline size_t hash_value(const TOTE<T>* ote)
 {
-	return std::hash<int>{}(ote->getIndex());
+	return stdext::hash_value(ote->getIndex());
 }
 
 template<class _Kty,

--- a/Core/DolphinVM/objmem.cpp
+++ b/Core/DolphinVM/objmem.cpp
@@ -273,7 +273,7 @@ bool __stdcall ObjectMemory::inheritsFrom(const BehaviorOTE* behaviorPointer, co
 
 template <class T> inline size_t hash_value(const TOTE<T>* ote)
 {
-	return stdext::hash_value(ote->getIndex());
+	return std::hash<int>{}(ote->getIndex());
 }
 
 template<class _Kty,


### PR DESCRIPTION
I can't figure out what changed, but I'm no longer able to build Dolphin using VisualStudio 17.4.3 on Windows 10 or Windows 11. I get an error that hash_value is not found in stdext. I've spent a bit of time learning about this function and looking at how Dolphin uses it, and come up with a one-line change that builds and seems to pass the tests. Comments are welcome especially since if this isn't the right fix then I need another fix!