### PR TITLE
Attempting to print `LargeInteger new64` appears to hang

### DIFF
--- a/Core/Object Arts/Dolphin/Base/LargeInteger.cls
+++ b/Core/Object Arts/Dolphin/Base/LargeInteger.cls
@@ -403,8 +403,8 @@ printOn: aWriteStream base: baseInteger nDigits: digitsInteger
 	| halfPower half head tail |
 	digitsInteger <= 1
 		ifTrue: 
-			[digitsInteger <= 0 ifTrue: [self error: 'Number of digits must be > 0'].
-			^aWriteStream nextPut: (Character digitValue: self)].
+			[digitsInteger > 0 ifTrue: [aWriteStream nextPut: (Character digitValue: self)].
+			^self].
 	"In order to reduce cost of LargeInteger arithmetic, use a divide and conquer algorithm."
 	halfPower := digitsInteger bitShift: -1.
 	half := baseInteger raisedToInteger: halfPower.

--- a/Core/Object Arts/Dolphin/Base/LargeIntegerTest.cls
+++ b/Core/Object Arts/Dolphin/Base/LargeIntegerTest.cls
@@ -1194,6 +1194,9 @@ testPrintStringBase
 			self assert: (bRaisedToN negated + 1 printStringBase: b) equals: ('-' , (String new: n withAll: (Character digitValue: b-1))).
 			self assert: (bRaisedToN negated printStringBase: b) equals: ('-1' , (String new: n withAll: $0))]].!
 
+testPrintUnnormalized
+	self assert: LargeInteger new64 printString equals: '0'!
+
 testQuo
 	| u v |
 	u := 1490632608.
@@ -1413,6 +1416,7 @@ testMulSmall!public!unit tests! !
 testNegate!public!unit tests! !
 testPrintLargeBase2!public!unit tests! !
 testPrintStringBase!public!unit tests! !
+testPrintUnnormalized!public!unit tests! !
 testQuo!public!unit tests! !
 testQuoRem!public!unit tests! !
 testQuoRem2!public!unit tests! !


### PR DESCRIPTION
Un-normalized LargeIntegers representations of zero can cause the integer printing to go into an infinite loop that is difficult to interrupt.

Fix port from Dolphin 8 to close #1179 