### PR TITLE
Fix #1183: Wrong seconds calc in Duration class>>hours:minutes:

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Core.Duration.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.Duration.cls
@@ -384,7 +384,7 @@ hours: aNumber
 hours: hoursNumber minutes: minutesNumber
 	"Answer a <Duration> representing the specified <number>s of hours and minutes. "
 
-	^self seconds: (hoursNumber * 3600) + minutesNumber * 60!
+	^self seconds: (hoursNumber * 60 + minutesNumber) * 60!
 
 hours: hoursNumber minutes: minutesNumber seconds: secondsNumber
 	"Answer a <Duration> of the specified <number>s of hours, minutes, and seconds. 

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.DurationTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.DurationTest.cls
@@ -159,6 +159,11 @@ testHours
 	self assert: (1 hours - 1 nanoseconds) hours equals: 0.
 	self assert: -1 nanoseconds hours equals: 0!
 
+testHoursMinutes
+	| subject |
+	subject := Duration hours: 2 minutes: 3.
+	self assert: subject asSeconds equals: (2 * 60 + 3) * 60!
+
 testHumanReadablePrintString
 	self assert: -2.1 days humanReadablePrintString equals: '-2.1 days'.
 	self assert: 2 days humanReadablePrintString equals: '2 days'.
@@ -388,6 +393,7 @@ testFromString!public!unit tests! !
 testGreaterThan!public!unit tests! !
 testHash!public!unit tests! !
 testHours!public!unit tests! !
+testHoursMinutes!public!unit tests! !
 testHumanReadablePrintString!public!unit tests! !
 testLessThan!public!unit tests! !
 testMilliseconds!public!unit tests! !


### PR DESCRIPTION
Missing parenthesis.