### PR TITLE
Mitigate #1191 by removing the ExternalDescriptor shared instance cache

### DIFF
--- a/Core/DolphinVM/Compiler/Compiler.vcxproj
+++ b/Core/DolphinVM/Compiler/Compiler.vcxproj
@@ -94,7 +94,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <ExceptionHandling>Sync</ExceptionHandling>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -142,7 +142,7 @@
       <SDLCheck>true</SDLCheck>
       <ExceptionHandling>Sync</ExceptionHandling>
       <AdditionalIncludeDirectories>$(ProjectDir)\..;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -201,7 +201,7 @@
       <ExceptionHandling>Sync</ExceptionHandling>
       <AdditionalIncludeDirectories>$(ProjectDir)\..;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Core/Object Arts/Dolphin/ActiveX/COM/UnkQIFunction.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/COM/UnkQIFunction.cls
@@ -61,7 +61,7 @@ initialize
 	Descriptor := IUnknown descriptorClass
 				callingConvention: IUnknown stdMethodCallType
 				returnType: 'sdword'
-				argumentTypes: 'GUID* void**'!
+				argumentTypes: '<1p>* void**' << GUID!
 
 uninitialize
 	"Private - Uninitialize the receiver as it is about to be removed from the system."

--- a/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2 Tests.pax
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2 Tests.pax
@@ -43,6 +43,7 @@ PresenterTest subclass: #WebView2ViewTest
 
 "Global Aliases"!
 
+
 "Loose Methods"!
 
 !WebView2View class methodsFor!

--- a/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2ViewTest.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2ViewTest.cls
@@ -226,13 +226,13 @@ verifyWebViewProperties
 	self assert: webview2 isMuted.
 	self deny: baseInterface isMuted.
 	"ICoreWebView2_9: defaultDownloadDialogCornerAlignment, defaultDownloadDialogMargin, isDefaultDownloadDialogOpen"
-	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: 1.
-	baseInterface defaultDownloadDialogCornerAlignment: 5.
-	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: 1.
-	self assert: webview2 defaultDownloadDialogCornerAlignment equals: 1.
-	webview2 defaultDownloadDialogCornerAlignment: 5.
-	self assert: webview2 defaultDownloadDialogCornerAlignment equals: 5.
-	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: 1.
+	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_TOP_RIGHT.
+	baseInterface defaultDownloadDialogCornerAlignment: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_BOTTOM_RIGHT.
+	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_TOP_RIGHT.
+	self assert: webview2 defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_TOP_RIGHT.
+	webview2 defaultDownloadDialogCornerAlignment: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_BOTTOM_RIGHT.
+	self assert: webview2 defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_BOTTOM_RIGHT.
+	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_TOP_RIGHT.
 	defaultMargin := webview2 defaultDownloadDialogMargin.
 	self deny: defaultMargin equals: 0.
 	self assert: baseInterface defaultDownloadDialogMargin equals: defaultMargin.

--- a/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Base Tests.pax
@@ -292,7 +292,7 @@ DolphinTest subclass: #ExternalArrayTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #ExternalDescriptorTest
-	instanceVariableNames: 'savedShared'
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: 'ExtCallArgTypes'
 	classInstanceVariableNames: ''!

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -132,7 +132,7 @@ Object subclass: #ExternalCallback
 	classInstanceVariableNames: ''!
 Object variableSubclass: #ExternalDescriptor
 	instanceVariableNames: 'descriptor'
-	classVariableNames: 'CallingConventions ExternalReferenceTypes ExternalValueTypes RetClassIndex RetTypeMask Shared TypeNames TypeSizes'
+	classVariableNames: 'CallingConventions ExternalReferenceTypes ExternalValueTypes RetClassIndex RetTypeMask TypeNames TypeSizes'
 	poolDictionaries: 'ExtCallArgTypes'
 	classInstanceVariableNames: ''!
 Object subclass: #ExternalLibrary

--- a/Core/Object Arts/Dolphin/Base/ExternalDescriptor.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalDescriptor.cls
@@ -2,7 +2,7 @@
 
 Object variableSubclass: #ExternalDescriptor
 	instanceVariableNames: 'descriptor'
-	classVariableNames: 'CallingConventions ExternalReferenceTypes ExternalValueTypes RetClassIndex RetTypeMask Shared TypeNames TypeSizes'
+	classVariableNames: 'CallingConventions ExternalReferenceTypes ExternalValueTypes RetClassIndex RetTypeMask TypeNames TypeSizes'
 	poolDictionaries: 'ExtCallArgTypes'
 	classInstanceVariableNames: ''!
 ExternalDescriptor guid: (GUID fromString: '{87b4c487-026e-11d3-9fd7-00a0cc3e4a32}')!
@@ -305,16 +305,11 @@ fromString: aString
 	is a Dolphin format external function descriptor, e.g:
 
 		ExternalDescriptor fromString: 'stdcall: hresult Blah GUID* lppvoid'
+	"
 
-	Implementation Note: As ExternalDescriptors are immutable, they can be shared
-	in order to save space. This facility can be turned off by setting the Shared
-	lookup table (which is weak by default) to nil. Bear in mind, however, that
-	quite a lot of space might otherwise be occupied by descriptors if there
-	are a large number of callback functions in the image."
-
-	Shared isNil ifTrue: [^self newFromString: aString].	
-	^Shared at: aString 
-		ifAbsentPut: [self newFromString: aString]!
+	| array |
+	array := self parseDescriptor: aString.
+	^self descriptor: array first literals: array second!
 
 initialize
 	"Private - Initialize the class variables of the receiver.
@@ -335,8 +330,7 @@ initialize
 				at: ExtCallArgUINTPTR + 1 put: VMConstants.IntPtrSize].
 	self assert: [ExternalValueTypes asSortedCollection last < TypeSizes size].
 	self initializeCallingConventions.
-	self addClassConstant: 'RetClassIndex' value: 4.
-	Shared isNil ifTrue: [Shared := WeakLookupTable new]!
+	self addClassConstant: 'RetClassIndex' value: 4!
 
 initializeCallingConventions
 	"Private - All possible calling conventions (not all are supported)"
@@ -471,17 +465,6 @@ nameOfConvention: anInteger
 	"Answer the calling convention name for the specified convention type ordinal."
 
 	^CallingConventions at: anInteger + 1!
-
-newFromString: aString 
-	"Private - Answer a new, unshared, instance of the receiver instantiated from 
-	the argument, which is a Dolphin format external function descriptor, e.g:
-
-		ExternalDescriptor fromString: 'stdcall: hresult GUID* lppvoid'
-	"
-
-	| array |
-	array := self parseDescriptor: aString.
-	^self descriptor: array first literals: array second!
 
 parseArgDesc: aString 
 	"Private - Parse the next argument type from the input stream argument, aStream, answering
@@ -645,7 +628,6 @@ initializeExternalTypes!development!initializing!private! !
 isPointerToStruct:!helpers!private! !
 nameOf:type:!constants!public! !
 nameOfConvention:!constants!public! !
-newFromString:!instance creation!private! !
 parseArgDesc:!parsing!private! !
 parseCallingConvention:!parsing!private! !
 parseDescriptor:!parsing!public! !

--- a/Core/Object Arts/Dolphin/Base/ExternalDescriptorTest.cls
+++ b/Core/Object Arts/Dolphin/Base/ExternalDescriptorTest.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk"!
 
 DolphinTest subclass: #ExternalDescriptorTest
-	instanceVariableNames: 'savedShared'
+	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: 'ExtCallArgTypes'
 	classInstanceVariableNames: ''!
@@ -11,19 +11,14 @@ ExternalDescriptorTest comment: ''!
 !ExternalDescriptorTest methodsFor!
 
 externalTypes
-	| typeTable |
-	typeTable := ExternalDescriptor classPool at: 'ExternalValueTypes'.
-	^typeTable!
-
-newDescriptor: source 
-	^ExternalDescriptor newFromString: source!
+	^ExternalDescriptor.ExternalValueTypes!
 
 parseStructArg: structClass valueType: typeCodeOrName refType: ptrCodeOrName
 	"First pass-by-value"
 
 	| source desc argTypes |
 	source := 'cdecl: void ' , structClass name.
-	desc := self newDescriptor: source.
+	desc := self subjectClass fromString: source.
 	argTypes := desc argumentTypes.
 	self assert: argTypes size equals: 1.
 	desc argumentsDo: 
@@ -31,12 +26,12 @@ parseStructArg: structClass valueType: typeCodeOrName refType: ptrCodeOrName
 			| type |
 			type := typeCodeOrName isInteger
 						ifTrue: [typeCodeOrName]
-						ifFalse: [ExternalDescriptor typeFromName: typeCodeOrName].
+						ifFalse: [self subjectClass typeFromName: typeCodeOrName].
 			self assert: eachType identicalTo: type.
 			self assert: eachClass identicalTo: structClass].
 	"Now pass-by-ref"
 	source := source , '*'.
-	desc := self newDescriptor: source.
+	desc := self subjectClass fromString: source.
 	argTypes := desc argumentTypes.
 	self assert: argTypes size equals: 1.
 	desc argumentsDo: 
@@ -44,19 +39,12 @@ parseStructArg: structClass valueType: typeCodeOrName refType: ptrCodeOrName
 			| type |
 			type := ptrCodeOrName isInteger
 						ifTrue: [ptrCodeOrName]
-						ifFalse: [ExternalDescriptor typeFromName: ptrCodeOrName].
+						ifFalse: [self subjectClass typeFromName: ptrCodeOrName].
 			self assert: eachType identicalTo: type.
 			self assert: eachClass identicalTo: structClass]!
 
-setUp
-	savedShared := ExternalDescriptor.Shared.
-	ExternalDescriptor.Shared := nil!
-
 subjectClass
 	^ExternalDescriptor!
-
-tearDown
-	ExternalDescriptor.Shared := savedShared!
 
 testBuiltins
 	| typeTable typeNames |
@@ -66,17 +54,17 @@ testBuiltins
 			[:eachKey :eachValue |
 			| argTypes source desc |
 			source := 'cdecl: void ' , eachKey.
-			desc := self newDescriptor: source.
+			desc := self subjectClass fromString: source.
 			argTypes := desc argumentTypes.
 			self assert: eachValue isInteger.
 			self assert: argTypes single equals: (typeNames at: eachValue + 1).
 			source := source , '*'.
 			eachKey = 'lppvoid'
-				ifTrue: [self should: [self newDescriptor: source] raise: Error]
+				ifTrue: [self should: [self subjectClass fromString: source] raise: Error]
 				ifFalse: 
 					[| refType |
 					"Single indirection"
-					desc := self newDescriptor: source.
+					desc := self subjectClass fromString: source.
 					argTypes := desc argumentTypes.
 					refType := self subjectClass referenceTypeFor: eachValue.
 					refType isInteger
@@ -118,10 +106,6 @@ testIndirections
 			source := source , '*'.
 			self should: [desc := self subjectClass fromString: source] raise: Notification]!
 
-testSharedRegister
-	self deny: savedShared hasWeakKeys.
-	self assert: savedShared hasWeakValues!
-
 testSmokeTest
 	"Verify that the compiler is parsing the descriptors in the same way as ExternalDescriptor by
 	checking the descriptor of every ExternalMethod."
@@ -130,7 +114,7 @@ testSmokeTest
 			[:each |
 			| desc text |
 			text := each descriptor description.
-			desc := self newDescriptor: (text copyWithout: $,).
+			desc := self subjectClass fromString: (text copyWithout: $,).
 			self assert: text equals: desc description]!
 
 testStruct4
@@ -160,14 +144,10 @@ testStructs
 		refType: ExtCallArgLP! !
 !ExternalDescriptorTest categoriesForMethods!
 externalTypes!accessing!private! !
-newDescriptor:!private!unit tests! !
 parseStructArg:valueType:refType:!private!unit tests! !
-setUp!public! !
 subjectClass!public!unit tests! !
-tearDown!public! !
 testBuiltins!public!unit tests! !
 testIndirections!public!unit tests! !
-testSharedRegister!public!unit tests! !
 testSmokeTest!public!unit tests! !
 testStruct4!public!unit tests! !
 testStruct8!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Canvas.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Canvas.cls
@@ -323,7 +323,7 @@ fontNames
 			true].
 	^answer!
 
-fonts: aString do: operation 
+fonts: aString do: operation
 	"Enumerate the fonts in a specified font family that are available on the receiver's device.
 	The triadic valuable argument, operation, is passed the LOGFONTW, TEXTMETRICW and font 
 	type as its three arguments, and should answer true to continue the enueration, false to 
@@ -338,13 +338,14 @@ fonts: aString do: operation
 
 	| callback answer |
 	callback := ExternalCallback block: 
-					[:lplf :lptm :dwType :lpData | 
-					operation 
+					[:lplf :lptm :dwType :lpData |
+					operation
 						value: lplf
 						value: lptm
 						value: dwType]
-				descriptor: (ExternalDescriptor returnType: 'sdword' argumentTypes: 'LOGFONTW* lpvoid dword uintptr').
-	answer := GDILibrary default 
+				descriptor: ##(ExternalDescriptor returnType: 'sdword'
+						argumentTypes: '<1p>* lpvoid dword uintptr' << LOGFONTW).
+	answer := GDILibrary default
 				enumFonts: self asParameter
 				lpFaceName: aString
 				lpFontFunc: callback asParameter

--- a/Core/Object Arts/Dolphin/MVP/Base/DisplayMonitor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DisplayMonitor.cls
@@ -190,8 +190,8 @@ forCanvas: aCanvas intersecting: aRectangle do: aMonadicValuable
 					[:hMonitor :hdc :lprect :lparam |
 					aMonadicValuable value: (DisplayMonitor fromHandle: hMonitor).
 					true]
-				descriptor: (ExternalDescriptor returnType: 'bool'
-						argumentTypes: 'handle handle RECTL* dword').
+				descriptor: ##(ExternalDescriptor returnType: 'bool'
+						argumentTypes: 'handle handle <1p>* dword' << RECTL).
 	answer := user32
 				enumDisplayMonitors: aCanvas asParameter
 				lprcClip: aRectangle asParameter

--- a/Core/Object Arts/Dolphin/MVP/Base/GuiInputState.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/GuiInputState.cls
@@ -18,7 +18,7 @@ aboutToForkUI
 allTopLevelWindowHandlesDo: aMonadicValuable
 	| callback answer |
 	callback := ExternalCallback block: [:hwnd :lParam | aMonadicValuable value: hwnd]
-				descriptor: (ExternalDescriptor returnType: 'bool' argumentTypes: 'ExternalHandle uintptr').
+				descriptor: ##(ExternalDescriptor returnType: 'bool' argumentTypes: 'handle uintptr').
 	answer := UserLibrary default enumWindows: callback asParameter lParam: 0.
 	callback free.
 	^answer!
@@ -49,8 +49,11 @@ isDolphinWindow: hWnd
 topLevelWindowHandlesDo: aMonadicValuable
 	| callback answer |
 	callback := ExternalCallback block: [:hwnd :lParam | aMonadicValuable value: hwnd]
-				descriptor: (ExternalDescriptor returnType: 'bool' argumentTypes: 'ExternalHandle uintptr').
-	answer := UserLibrary default enumThreadWindows: (KernelLibrary default getCurrentThreadId) lpfn: callback asParameter lParam: 0.
+				descriptor: ##(ExternalDescriptor returnType: 'bool' argumentTypes: 'handle uintptr').
+	answer := UserLibrary default
+				enumThreadWindows: KernelLibrary default getCurrentThreadId
+				lpfn: callback asParameter
+				lParam: 0.
 	callback free.
 	^answer!
 

--- a/Core/Object Arts/Dolphin/MVP/Base/Menu.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Menu.cls
@@ -190,14 +190,14 @@ description
 description: aString 
 	self text: aString!
 
-drawItemImage: itemImage on: hDC at: topLeft disabled: aBoolean 
+drawItemImage: itemImage on: hDC at: topLeft disabled: aBoolean
 	| imageList extent imageIndex callback |
 	extent := SystemMetrics current menuImageExtent.
 	imageList := self imageManager imageListWithExtent: extent.
 	imageIndex := self imageManager indexOfImage: itemImage.
-	aBoolean 
+	aBoolean
 		ifFalse: 
-			[imageList 
+			[imageList
 				draw: imageIndex
 				on: hDC
 				at: topLeft.
@@ -205,16 +205,16 @@ drawItemImage: itemImage on: hDC at: topLeft disabled: aBoolean
 	"Use DrawState() API to get the correct disabled image look, but use the callback option
 	because we want to draw out of an image list rather than from an icon or bitmap"
 	callback := ExternalCallback block: 
-					[:hdc :lData :wData :cx :cy | 
+					[:hdc :lData :wData :cx :cy |
 					"Must draw on the DC supplied to the callback, not the original DC"
-					imageList 
+					imageList
 						draw: wData
 						on: hdc
 						at: 0 @ 0.
 					true]
-				descriptor: (ExternalDescriptor returnType: 'bool'
+				descriptor: ##(ExternalDescriptor returnType: 'bool'
 						argumentTypes: 'handle intptr uintptr sdword sdword').
-	UserLibrary default 
+	UserLibrary default
 		drawState: hDC
 		hbr: nil
 		lpOutputFunc: callback asParameter

--- a/Core/Object Arts/Dolphin/MVP/Metafiles/Metafile.cls
+++ b/Core/Object Arts/Dolphin/MVP/Metafiles/Metafile.cls
@@ -109,7 +109,7 @@ loadFromFile: pathString extent: aPoint
 
 	^GDILibrary default getEnhMetaFile: pathString!
 
-play: operation on: aCanvas at: originPoint extent: sizePoint 
+play: operation on: aCanvas at: originPoint extent: sizePoint
 	"Play the records in the metafile through the triadic valuable, operation, onto the
 	<Canvas>, aCanvas, at origin, originPoint, and with extent, sizePoint. The operation is
 	passed the <Canvas> to which the metafile is being rendered (not necessarily aCanvas), a
@@ -119,18 +119,18 @@ play: operation on: aCanvas at: originPoint extent: sizePoint
 
 	| callback answer lpRect |
 	callback := ExternalCallback block: 
-					[:hDC :lpHTable :lpEMFR :nObj :lpData | 
+					[:hDC :lpHTable :lpEMFR :nObj :lpData |
 					| handles emfr |
 					handles := HandleArray fromAddress: lpHTable length: nObj.
 					emfr := ENHMETARECORD fromAddress: lpEMFR.
-					operation 
+					operation
 						value: (Canvas withNonOwnedDC: hDC)
 						value: emfr
 						value: handles]
-				descriptor: (ExternalDescriptor returnType: 'int'
+				descriptor: (ExternalDescriptor returnType: 'sdword'
 						argumentTypes: 'handle lpvoid lpvoid sdword lpvoid').
 	lpRect := RECT origin: originPoint extent: sizePoint.
-	answer := GDILibrary default 
+	answer := GDILibrary default
 				enumEnhMetaFile: aCanvas asParameter
 				hemf: self asParameter
 				lpEnhMetaFunc: callback asParameter

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/RichTextEdit.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/RichTextEdit.cls
@@ -998,7 +998,7 @@ initialize
 	StreamInIndex := self indexOfInstVar: 'streamIn'.
 
 	"Descriptor for stream out callback"
-	StreamingDescriptor := ExternalDescriptor argumentTypes: 'dword lpvoid sdword DWORD*'.
+	StreamingDescriptor := ExternalDescriptor argumentTypes: 'dword lpvoid sdword <1p>*' << DWORD.
 	ParagraphAlignmentMap := (IdentityDictionary new)
 				at: #left put: PFA_LEFT;
 				at: #right put: PFA_RIGHT;

--- a/Core/Object Arts/Dolphin/Sockets/InternetAddressTest.cls
+++ b/Core/Object Arts/Dolphin/Sockets/InternetAddressTest.cls
@@ -12,23 +12,24 @@ InternetAddressTest comment: ''!
 
 testAllForHost
 	| addresses |
-	self skipUnless: [self isOnline and: [self isCiBuild not]].
-	addresses := InternetAddress allForHost: 'dns.google'.
+	self skipUnless: [self isOnline].
+
+	"dns.google has two fixed and well-known IP addresses"
+	addresses := InternetAddress allForHost: 'dns.google.com'.
 	self assert: addresses size equals: 2.
 	self assert: (addresses collect: [:each | each ipAddress]) asSet
 		equals: #(#[8 8 4 4] #[8 8 8 8]) asSet.
 
 	"google.com has only one"
 	addresses := InternetAddress allForHost: 'google.com'.
-	self assert: addresses size = 1.
-	self assert: (addresses first host endsWith: '1e100.net')!
+	self assert: (addresses anySatisfy: [:each | each host endsWith: '1e100.net'])!
 
 testHost
 	| name ip |
-	self isOnline ifFalse: [^self].
-	name := InternetAddress host: 'dns.google'.
+	self skipUnless: [self isOnline].
+	name := InternetAddress host: 'dns.google.com'.
 	ip := InternetAddress ipAddress: name ipAddress.
-	self assert: ip host equals: name host!
+	self assert: ip host equals: 'dns.google'!
 
 testIsIPString
 	self deny: (InternetAddress isIPString: '').

--- a/Core/Object Arts/Dolphin/System/Win32/FileSystemChangeReader.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/FileSystemChangeReader.cls
@@ -402,7 +402,8 @@ initialize
 		LPOVERLAPPED lpOverlapped
 	);"
 
-	FileIOCompletionRoutineDescriptor := ExternalDescriptor argumentTypes: 'DWORD DWORD OVERLAPPED*'!
+	FileIOCompletionRoutineDescriptor := ExternalDescriptor
+				argumentTypes: 'dword dword <1p>*' << OVERLAPPED!
 
 monitorDirectory: aString 
 	^(self directory: aString)

--- a/Core/Object Arts/Dolphin/System/Win32/FileSystemWatcher.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/FileSystemWatcher.cls
@@ -85,7 +85,8 @@ initialize
 		LPOVERLAPPED lpOverlapped
 	);"
 
-	FileIOCompletionRoutineDescriptor := ExternalDescriptor argumentTypes: 'DWORD DWORD OVERLAPPED*'.
+	FileIOCompletionRoutineDescriptor := ExternalDescriptor
+				argumentTypes: 'dword dword <1p>*' << OVERLAPPED.
 	ActionMap := #(#fileAdded: #fileRemoved: #fileModified: #fileRenamedFrom:to: 5)! !
 !FileSystemWatcher class categoriesForMethods!
 initialize!initializing!public! !


### PR DESCRIPTION
The combination of a structure class references embedded in strings parsed to build descriptors and the shared instance cache can result in stale classes being referred to from descriptors in the cache. #1191 has further details.

See also Dolphin 8 commit https://github.com/dolphinsmalltalk/Dolphin/commit/619d810404b136b83b327bc1e6064d6c8501cf30