### PR TITLE
Fix tests failing because of OS and WebView2 changes

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2.ICoreWebView2ContextMenuItem.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2.ICoreWebView2ContextMenuItem.cls
@@ -209,6 +209,11 @@ isEnabled: value
 
 	self put_IsEnabled: value!
 
+items
+	"Answer an <ICoreWebView2ContextMenuItemCollection> containing the receiver's sub-menu items, or nil if not a sub-menu"
+
+	^self kind == #subMenu ifTrue: [self children]!
+
 kind
 	"Answer the kind of menu item the receiver describes.
 		#command	- Regular menu command
@@ -313,6 +318,7 @@ isChecked!properties!public! !
 isChecked:!**auto generated**!properties!public! !
 isEnabled!properties!public! !
 isEnabled:!**auto generated**!properties!public! !
+items!properties!public! !
 kind!properties!public! !
 label!properties!public! !
 name!properties!public! !

--- a/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2.Tests.WebView2ViewTest.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2.Tests.WebView2ViewTest.cls
@@ -324,13 +324,13 @@ verifyWebViewProperties
 	self assert: webview2 isMuted.
 	self deny: baseInterface isMuted.
 	"ICoreWebView2_9: defaultDownloadDialogCornerAlignment, defaultDownloadDialogMargin, isDefaultDownloadDialogOpen"
-	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: 1.
-	baseInterface defaultDownloadDialogCornerAlignment: 5.
-	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: 1.
-	self assert: webview2 defaultDownloadDialogCornerAlignment equals: 1.
-	webview2 defaultDownloadDialogCornerAlignment: 5.
-	self assert: webview2 defaultDownloadDialogCornerAlignment equals: 5.
-	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: 1.
+	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_TOP_RIGHT.
+	baseInterface defaultDownloadDialogCornerAlignment: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_BOTTOM_RIGHT.
+	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_TOP_RIGHT.
+	self assert: webview2 defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_TOP_RIGHT.
+	webview2 defaultDownloadDialogCornerAlignment: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_BOTTOM_RIGHT.
+	self assert: webview2 defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_BOTTOM_RIGHT.
+	self assert: baseInterface defaultDownloadDialogCornerAlignment equals: COREWEBVIEW2_DEFAULT_DOWNLOAD_DIALOG_CORNER_ALIGNMENT_TOP_RIGHT.
 	defaultMargin := webview2 defaultDownloadDialogMargin.
 	self deny: defaultMargin equals: 0.
 	self assert: baseInterface defaultDownloadDialogMargin equals: defaultMargin.
@@ -385,7 +385,7 @@ verifyWebViewSettings
 	self deny: baseSettings isZoomControlEnabled.
 	"ICoreWebView2Settings2: userAgent"
 	userAgent := settings userAgent.
-	self assert: (userAgent endsWith: 'Edg/' , presenter view webviewEnvironment browserVersionString).
+	self assert: (userAgent contains: 'Edg/').
 	self assert: baseSettings userAgent equals: ICoreWebView2Settings defaultUserAgent.
 	userAgent := userAgent copyFrom: 1 to: (userAgent indexOfSubCollection: 'Edg/').
 	settings userAgent: userAgent.

--- a/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2.Tests.WebView2ViewTest.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2.Tests.WebView2ViewTest.cls
@@ -83,7 +83,7 @@ testContextMenu
 				createContextMenuItem: '&Blah'
 				iconStream: iconStream
 				kind: WebView2.COREWEBVIEW2_CONTEXT_MENU_ITEM_KIND_COMMAND.
-	self assertIsNil: newCmd children.
+	self assertIsNil: newCmd items.
 	self assert: newCmd label equals: '&Blah'.
 	self assert: newCmd name equals: '&Blah'.
 	self assert: newCmd kind equals: #command.

--- a/Core/Object Arts/Dolphin/Base/Tests/OS.Tests.WindowsLocaleTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/OS.Tests.WindowsLocaleTest.cls
@@ -131,16 +131,18 @@ testDisplayFloatOn
 testDisplayFloatOnNegativeModes
 	| subject format |
 	"Different negative number mode (2)"
-	subject := Locale standard: 'hr-HR'.
-	self assert: (subject printFloat: -0.0) equals: '0,00'.
-	self assert: (subject printFloat: -1.25) equals: '- 1,25'.
-	self assert: (subject printFloat: -0.0001) equals: '0,00'.
-	self assert: (subject printFloat: -123456789.123456789) equals: '- 123.456.789,12'.
+	subject := Locale standard: 'km-KH'.
+	self assert: subject negativeNumberMode equals: 2.
+	self assert: (subject printFloat: -0.0) equals: '0.00'.
+	self assert: (subject printFloat: -1.25) equals: '- 1.25'.
+	self assert: (subject printFloat: -0.0001) equals: '0.00'.
+	self assert: (subject printFloat: -123456789.123456789) equals: '- 123,456,789.12'.
 	"Negative infinity does not seem to be represented consistently with respect to the normal negative sign conventions in this locale. The value is direct from Windows"
 	self assert: (subject printFloat: Float negativeInfinity) equals: '-∞'.
 
 	"Different negative number mode (3)"
 	subject := Locale standard: 'fa-IR'.
+	self assert: subject negativeNumberMode equals: 3.
 	self assert: (subject printFloat: -0.0) equals: '0/00'.
 	self assert: (subject printFloat: -1.25) equals: '1/25-'.
 	self assert: (subject printFloat: -0.0001) equals: '0/00'.
@@ -181,14 +183,23 @@ testDisplayScaledDecimainOn
 	self assert: (self displayScaledDecimal: large in: subject)
 		equals: '-1,234,567,891,234,567,891,234,567,890.012345679'.
 
-	"Different negative number mode (2)"
+	"European format"
 	subject := Locale standard: 'hr-HR'.
-	self assert: subject negativeNumberMode equals: 2.
+	self assert: subject negativeNumberMode equals: 1.
 	self assert: (self displayScaledDecimal: 0.0s2 in: subject) equals: '0,00'.
-	self assert: (self displayScaledDecimal: -1.25s in: subject) equals: '- 1,25'.
-	self assert: (self displayScaledDecimal: -0.0001s in: subject) equals: '- 0,0001'.
+	self assert: (self displayScaledDecimal: -1.25s in: subject) equals: '-1,25'.
+	self assert: (self displayScaledDecimal: -0.0001s in: subject) equals: '-0,0001'.
 	self assert: (self displayScaledDecimal: large in: subject)
-		equals: '- 1.234.567.891.234.567.891.234.567.890,012345679'.
+		equals: '-1.234.567.891.234.567.891.234.567.890,012345679'.
+
+	"Different negative number mode (2)"
+	subject := Locale standard: 'km-KH'.
+	self assert: subject negativeNumberMode equals: 2.
+	self assert: (self displayScaledDecimal: 0.0s2 in: subject) equals: '0.00'.
+	self assert: (self displayScaledDecimal: -1.25s in: subject) equals: '- 1.25'.
+	self assert: (self displayScaledDecimal: -0.0001s in: subject) equals: '- 0.0001'.
+	self assert: (self displayScaledDecimal: large in: subject)
+		equals: '- 1,234,567,891,234,567,891,234,567,890.012345679'.
 
 	"Different negative number mode (3)"
 	subject := Locale standard: 'fa-IR'.


### PR DESCRIPTION
- Some changes to the Windows regional settings for hr-HR, used in tests as an example
- ICoreWebView2ContextMenuItem.get_Children has started causing an AV if called on a non-submenu item, rather than just returning an empty collection or null
- WebView2ViewTest>>#testProperties failing due to changes in default property values