### PR TITLE
Fix tests failing in 7.1 because of OS and WebView2 changes

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2ViewTest.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/Components/WebView2/WebView2ViewTest.cls
@@ -287,7 +287,7 @@ verifyWebViewSettings
 	self deny: baseSettings isZoomControlEnabled.
 	"ICoreWebView2Settings2: userAgent"
 	userAgent := settings userAgent.
-	self assert: (userAgent endsWith: 'Edg/' , presenter view webviewEnvironment browserVersionString).
+	self assert: (userAgent contains: 'Edg/').
 	self assert: baseSettings userAgent equals: ICoreWebView2Settings defaultUserAgent.
 	userAgent := userAgent copyFrom: 1 to: (userAgent indexOfSubCollection: 'Edg/').
 	settings userAgent: userAgent.

--- a/Core/Object Arts/Dolphin/Base/Locale.cls
+++ b/Core/Object Arts/Dolphin/Base/Locale.cls
@@ -16,6 +16,11 @@ amDesignator
 
 	^self subclassResponsibility!
 
+basicLcid
+	"Private - Answer the <integer> id (LCID) of the receiver, including any flags encoded in the high order bits outside the 24-bit range of LCIDs."
+
+	^self subclassResponsibility!
+
 dateAndTimeFormatters
 	^##(| formatters yyyyFormater |
 	formatters := LookupTable new.
@@ -347,9 +352,9 @@ lastTwoDigitYear
 	^self subclassResponsibility!
 
 lcid
-	"Answer the <integer> Windows Locale Id."
+	"Answer the <integer> Windows locale id (LCID) of the receiver."
 
-	^self subclassResponsibility!
+	^self basicLcid bitAnd: ##(NLS_VALID_LOCALE_MASK bitOr: (16rF bitShift: 20)	"sort version")!
 
 listSeparator
 	"Answer the String used in the receiver locale to separate items in lists, typically a comma."
@@ -403,6 +408,9 @@ negativeSign
 	"Answer a <String> which is the symbol used to denote negative numbers in this locale."
 
 	^self subclassResponsibility!
+
+noUserOverrides
+	^self basicLcid allMask: NoUserOverrideMask!
 
 numberFormat
 	^numberFormat
@@ -668,6 +676,7 @@ yearMonthFormat
 	^self subclassResponsibility! !
 !Locale categoriesForMethods!
 amDesignator!constants!public! !
+basicLcid!accessing!private! !
 dateAndTimeFormatters!printing!private! !
 dateFormat!constants!public! !
 dayOfWeek:!mapping!public! !
@@ -704,6 +713,7 @@ nativeDigits!constants!public! !
 negativeInfinity!constants!public! !
 negativeNumberMode!constants!public! !
 negativeSign!constants!public! !
+noUserOverrides!public!testing! !
 numberFormat!constants!public! !
 numberFormat:!accessing!private! !
 numberGrouping!constants!public! !
@@ -836,6 +846,11 @@ smalltalk
 
 	^SmalltalkLocale.Current!
 
+standard: aString
+	"Answer an instance of the receiver to represent the locale with the specified name, e.g. 'en-US', ignoring any user customisation of the settings."
+
+	^self named: aString withOverrides: false!
+
 supportedSystemLocales
 	"Private - Answer the supported Win32 system locales.
 		Locale supportedSystemLocales
@@ -877,6 +892,7 @@ onSettingChanged:!event handling!private! !
 onStartup!event handling!private! !
 reset!initializing!private! !
 smalltalk!instance creation!public! !
+standard:!instance creation!public! !
 supportedSystemLocales!enquiries!private! !
 systemDefault!instance creation!public! !
 timeZoneInformation!enquiries!public! !

--- a/Core/Object Arts/Dolphin/Base/SmalltalkLocale.cls
+++ b/Core/Object Arts/Dolphin/Base/SmalltalkLocale.cls
@@ -15,6 +15,13 @@ amDesignator
 
 	^'am'!
 
+basicLcid
+	"Private - Answer the <integer> id (LCID) of the receiver, including any flags encoded in the high order bits outside the 24-bit range of LCIDs."
+
+	"The receiver is not a Windows locale, but it is basically the same as LOCALE_INVARIANT."
+
+	^##(LOCALE_INVARIANT bitOr: NoUserOverrideMask)!
+
 code
 	"Answer the RFC4646 locale code (aka tag) for this locale."
 
@@ -342,6 +349,7 @@ yearMonthFormat
 	^'MMMM yyyy'! !
 !SmalltalkLocale categoriesForMethods!
 amDesignator!constants!public! !
+basicLcid!accessing!private! !
 code!constants!public! !
 dayOfWeek:!mapping!public! !
 dayOfWeekAbbreviation:!constants!public! !

--- a/Core/Object Arts/Dolphin/Base/Win32Constants.st
+++ b/Core/Object Arts/Dolphin/Base/Win32Constants.st
@@ -713,6 +713,7 @@ Win32Constants at: 'NIF_TIP' put: 16r4!
 Win32Constants at: 'NIM_ADD' put: 16r0!
 Win32Constants at: 'NIM_DELETE' put: 16r2!
 Win32Constants at: 'NIM_MODIFY' put: 16r1!
+Win32Constants at: 'NLS_VALID_LOCALE_MASK' put: 16rFFFFF!
 Win32Constants at: 'NORM_IGNORECASE' put: 16r1!
 Win32Constants at: 'NORM_IGNOREKANATYPE' put: 16r10000!
 Win32Constants at: 'NORM_IGNORENONCASE' put: 16r2!

--- a/Core/Object Arts/Dolphin/Base/WindowsLocale.cls
+++ b/Core/Object Arts/Dolphin/Base/WindowsLocale.cls
@@ -21,6 +21,11 @@ asParameter
 
 	^lcid!
 
+basicLcid
+	"Private - Answer the <integer> id (LCID) of the receiver, including any flags encoded in the high order bits outside the 24-bit range of LCIDs."
+
+	^lcid!
+
 buildDayNamesMap
 	| map |
 	map := LookupTable new: 14.
@@ -175,14 +180,17 @@ getDateFormats: aBoolean
 getIntegerInfo: anIntegerLcType
 	"Private - Get the specified <integer> locale information from Windows, caching for subsequent use."
 
-	^info at: anIntegerLcType ifAbsentPut: [self getLocaleInfoInteger: anIntegerLcType]!
+	^(info lookup: anIntegerLcType)
+		ifNil: [info at: anIntegerLcType put: (self getLocaleInfoInteger: anIntegerLcType)]!
 
 getLocaleInfoInteger: anIntegerLcType
 	| buf |
 	buf := DWORDBytes new.
 	(self nlsLib
-		getLocaleInfo: lcid
-		lCType: (anIntegerLcType bitOr: LOCALE_RETURN_NUMBER)
+		getLocaleInfo: self lcid
+		lCType: ((self noUserOverrides
+				ifTrue: [anIntegerLcType bitOr: LOCALE_NOUSEROVERRIDE]
+				ifFalse: [anIntegerLcType]) bitOr: LOCALE_RETURN_NUMBER)
 		lpLCData: buf
 		cchData: 4) == 0
 		ifTrue: [self nlsLib systemError].
@@ -191,19 +199,23 @@ getLocaleInfoInteger: anIntegerLcType
 getLocaleInfoString: anIntegerLcType
 	"Private - Get the specified <Utf8String> locale information from Windows."
 
-	| buf lib size |
+	| buf lib size id type |
+	id := self lcid.
+	type := self noUserOverrides
+				ifTrue: [anIntegerLcType bitOr: LOCALE_NOUSEROVERRIDE]
+				ifFalse: [anIntegerLcType].
 	lib := self nlsLib.
 	size := lib
-				getLocaleInfo: lcid
-				lCType: anIntegerLcType
+				getLocaleInfo: id
+				lCType: type
 				lpLCData: nil
 				cchData: 0.
 	size == 0 ifTrue: [^lib systemError].
 	"Strings allocate extra space for null automatically"
 	buf := Utf16String newFixed: size - 1.
 	lib
-		getLocaleInfo: lcid
-		lCType: anIntegerLcType
+		getLocaleInfo: id
+		lCType: type
 		lpLCData: buf
 		cchData: size.
 	^buf asUtf8String!
@@ -249,11 +261,6 @@ lastTwoDigitYear
 	For example if this is 2049, then 49 is interpreter as 2049, and 50 as 1950."
 
 	^self getCalendarInfoInteger: CAL_ITWODIGITYEARMAX!
-
-lcid
-	"Answer the <integer> Windows Locale Id."
-
-	^lcid!
 
 lcid: anLCID
 	"Private - Set the receiver's Win32 LCID which identifies the locale the
@@ -319,7 +326,13 @@ negativeInfinity
 	^self getStringInfo: LOCALE_SNEGINFINITY!
 
 negativeNumberMode
-	"Answer a <String> which is the symbol used to denote negative numbers in this locale."
+	"Answer an <Integer> describing the way in which negative numbers should be displayed in this locale.
+		0	Left parenthesis, number, right parenthesis; for example, (1.1)
+		1	Negative sign, number; for example, -1.1
+		2	Negative sign, space, number; for example, - 1.1
+		3	Number, negative sign; for example, 1.1-
+		4	Number, space, negative sign; for example, 1.1 -
+	"
 
 	^self getIntegerInfo: LOCALE_INEGNUMBER!
 
@@ -425,6 +438,7 @@ yearMonthFormat
 !WindowsLocale categoriesForMethods!
 amDesignator!constants!public! !
 asParameter!converting!public! !
+basicLcid!accessing!public! !
 buildDayNamesMap!helpers!private! !
 buildMonthNamesMap!helpers!private! !
 calendarId!constants!public! !
@@ -454,7 +468,6 @@ hasLeadingZero!constants!public! !
 indexOfMonth:!enquiries!public! !
 infinity!constants!public! !
 lastTwoDigitYear!constants!public! !
-lcid!accessing!public! !
 lcid:!initializing!private! !
 listSeparator!constants!public! !
 longDateFormat!constants!public! !

--- a/Core/Object Arts/Dolphin/Base/WindowsLocaleTest.cls
+++ b/Core/Object Arts/Dolphin/Base/WindowsLocaleTest.cls
@@ -14,18 +14,20 @@ defaultSubject
 	^Locale lcid: 2057!
 
 testDisplayFloatOnNegativeModes
-	| info subject format |
+	| subject format |
 	"Different negative number mode (2)"
-	subject := Locale lcid: 1050.
-	self assert: (subject printFloat: -0.0) equals: '0,00'.
-	self assert: (subject printFloat: -1.25) equals: '- 1,25'.
-	self assert: (subject printFloat: -0.0001) equals: '0,00'.
-	self assert: (subject printFloat: -123456789.123456789) equals: '- 123.456.789,12'.
+	subject := Locale standard: 'km-KH'.
+	self assert: subject negativeNumberMode equals: 2.
+	self assert: (subject printFloat: -0.0) equals: '0.00'.
+	self assert: (subject printFloat: -1.25) equals: '- 1.25'.
+	self assert: (subject printFloat: -0.0001) equals: '0.00'.
+	self assert: (subject printFloat: -123456789.123456789) equals: '- 123,456,789.12'.
 	"Negative infinity does not seem to be represented consistently with respect to the normal negative sign conventions in this locale. The value is direct from Windows"
 	self assert: (subject printFloat: Float negativeInfinity) equals: '-∞'.
 
 	"Different negative number mode (3)"
-	subject := Locale lcid: 1065.
+	subject := Locale standard: 'fa-IR'.
+	self assert: subject negativeNumberMode equals: 3.
 	self assert: (subject printFloat: -0.0) equals: '0/00'.
 	self assert: (subject printFloat: -1.25) equals: '1/25-'.
 	self assert: (subject printFloat: -0.0001) equals: '0/00'.
@@ -34,9 +36,9 @@ testDisplayFloatOnNegativeModes
 	self assert: (subject printFloat: Float negativeInfinity) equals: '-∞'.
 
 	"Fake up the other modes - zero is bracketed"
-	subject := Locale lcid: 1033.
+	subject := Locale standard: 'en-US'.
 	format := subject numberFormat copy.
-	format negativeNumberMode: 0.
+	format negativeNumberMode:  0.
 	self assert: (subject printFloat: -0.0 format: format) equals: '0.00'.
 	self assert: (subject printFloat: -1.25 format: format) equals: '(1.25)'.
 	self assert: (subject printFloat: -0.0001 format: format) equals: '0.00'.


### PR DESCRIPTION
- Some changes to the Windows regional settings for hr-HR, used in tests as an example
- WebView2ViewTest>>#testProperties failing due to changes in default property values