### PR TITLE
Adopt new command query annotations in Debugger, class & package browsers

### DIFF
--- a/Core/Contributions/IDB/DiffBrowser.cls
+++ b/Core/Contributions/IDB/DiffBrowser.cls
@@ -50,6 +50,7 @@ about: aString
 		text: aString!
 
 character
+	<commandQuerySelector: #queryDiffMode:>
 	self mode: #character!
 
 compare: upperString id: upperIdString and: lowerString id: lowerIdString
@@ -63,19 +64,16 @@ createComponents
 	diffsPresenter := self add: DifferencesPresenter new name: 'diffs'!
 
 line
+	<commandQuerySelector: #queryDiffMode:>
 	self mode: #line!
 
 mode: aSymbol 
 	diffsPresenter comparisonMode: aSymbol!
 
-queryCommand: aCommandQuery 
-	(#(#character #word #line) identityIncludes: aCommandQuery command) 
-		ifTrue: 
-			[aCommandQuery
-				isEnabled: true;
-				isChecked: diffsPresenter comparisonMode == aCommandQuery command.
-			^true].
-	^super queryCommand: aCommandQuery!
+queryDiffMode: aCommandQuery
+	aCommandQuery
+		isEnabled: true;
+		isChecked: diffsPresenter comparisonMode == aCommandQuery command!
 
 readTextFrom: filename 
 	| stream |
@@ -108,23 +106,24 @@ textStyles: anCollectionOfScintillaTextStyle
 	diffsPresenter textStyles: anCollectionOfScintillaTextStyle!
 
 word
+	<commandQuerySelector: #queryDiffMode:>
 	self mode: #word! !
 !DiffBrowser categoriesForMethods!
-about!commands!public! !
-about:!commands!public! !
-character!commands!public! !
+about!commands-actions!public! !
+about:!operations!public! !
+character!commands-actions!public! !
 compare:id:and:id:!operations!public! !
 createComponents!initializing!public! !
-line!commands!public! !
-mode:!commands!public! !
-queryCommand:!commands!public! !
+line!commands-actions!public! !
+mode:!operations!public! !
+queryDiffMode:!commands-queries!private! !
 readTextFrom:!helpers!public! !
-selectLower!commands!public! !
-selectUpper!commands!public! !
+selectLower!commands-actions!public! !
+selectUpper!commands-actions!public! !
 styler:!accessing!public! !
 textFont:!accessing!public! !
 textStyles:!accessing!public! !
-word!commands!public! !
+word!commands-actions!public! !
 !
 
 !DiffBrowser class methodsFor!

--- a/Core/Contributions/IDB/HistoryBrowser.cls
+++ b/Core/Contributions/IDB/HistoryBrowser.cls
@@ -64,24 +64,14 @@ scannerClass!constants!public! !
 icon
 	^Icon fromId: 'MethodHistory.ico'!
 
-initialize
-	#(#{ClassBrowserAbstract} #{MethodBrowserShell} #{Debugger}) 
-		do: [:each | each value addCommandQueryHandler: #queryMethodHistoryCommand:]!
-
 publishedAspects
 	"Answer a <LookupTable> of the <Aspect>s published by the receiver."
 
 	^(super publishedAspects)
 		removeKey: #reuseIfOpen;
-		yourself!
-
-uninitialize
-	#(#{ClassBrowserAbstract} #{MethodBrowserShell} #{Debugger})
-		do: [:each | each value removeCommandQueryHandler: #queryMethodHistoryCommand:]! !
+		yourself! !
 !HistoryBrowser class categoriesForMethods!
 icon!public! !
-initialize!initializing!private! !
 publishedAspects!operations!public! !
-uninitialize!initializing!private! !
 !
 

--- a/Core/Contributions/IDB/IDB Method History.pax
+++ b/Core/Contributions/IDB/IDB Method History.pax
@@ -32,15 +32,10 @@ package methodNames
 	add: #ChunkSourceFiler -> #sourceDescriptorForPosition:;
 	add: #ClassBrowserAbstract -> #browseMethodHistory;
 	add: #ClassBrowserAbstract -> #browseMethodHistoryForClass;
-	add: #ClassBrowserAbstract -> #canBrowseMethodHistory;
-	add: #ClassBrowserAbstract -> #canBrowseMethodHistoryForClass;
 	add: #CompiledMethod -> #loadedVersion;
 	add: #CompiledMethod -> #versionHistory;
 	add: #Debugger -> #browseMethodHistory;
-	add: #Debugger -> #canBrowseMethodHistory;
 	add: #MethodBrowserShell -> #browseMethodHistory;
-	add: #MethodBrowserShell -> #canBrowseMethodHistory;
-	add: #SmalltalkToolShell -> #queryMethodHistoryCommand:;
 	yourself.
 
 package binaryGlobalNames: (Set new
@@ -131,29 +126,21 @@ sourceDescriptorForPosition:!private!source filing-file in! !
 !ClassBrowserAbstract methodsFor!
 
 browseMethodHistory
+	<commandQuerySelector: #queryHasMethodSelected:>
+	| method |
 	#idbAdded.
-	MethodHistoryBrowser
-		showOnClass: methodBrowserPresenter selectedMethod methodClass
-		selector: methodBrowserPresenter selectedMethod selector!
+	method := self selectedMethod.
+	MethodHistoryBrowser showOnClass: method methodClass selector: method selector!
 
 browseMethodHistoryForClass
 	"Open a browser on the history of methods in the current class"
 
+	<commandQuerySelector: #queryHasClassSelected:>
 	#idbAdded.
-	ClassHistoryBrowser showOnClass: self actualClass!
-
-canBrowseMethodHistory
-	#idbAdded.
-	^methodBrowserPresenter hasMethodSelected!
-
-canBrowseMethodHistoryForClass
-	#idbAdded.
-	^self hasClassSelected! !
+	ClassHistoryBrowser showOnClass: self actualClass! !
 !ClassBrowserAbstract categoriesForMethods!
-browseMethodHistory!accessing!commands!idb goodies!private! !
-browseMethodHistoryForClass!commands!idb goodies!public! !
-canBrowseMethodHistory!idb goodies!private!testing! !
-canBrowseMethodHistoryForClass!idb goodies!private!testing! !
+browseMethodHistory!commands-actions!idb goodies!private! !
+browseMethodHistoryForClass!commands-actions!idb goodies!public! !
 !
 
 !CompiledMethod methodsFor!
@@ -177,51 +164,28 @@ versionHistory!accessing!public! !
 browseMethodHistory
 	"Open a browser on the history of the current method"
 
+	<commandQuerySelector: #queryHasBrowsableMethod:>
+	| method |
 	#idbAdded.
+	method := self selectedMethod.
 	MethodHistoryBrowser
-		showOnClass: self selectedMethod methodClass
-		selector: self selectedMethod selector
-		debugger: self!
-
-canBrowseMethodHistory
-	#idbAdded.
-	^self hasEditableMethodSelected! !
+		showOnClass: method methodClass
+		selector: method selector
+		debugger: self! !
 !Debugger categoriesForMethods!
-browseMethodHistory!commands!idb goodies!private! !
-canBrowseMethodHistory!accessing!idb goodies!private!testing! !
+browseMethodHistory!commands-actions!idb goodies!private! !
 !
 
 !MethodBrowserShell methodsFor!
 
 browseMethodHistory
+	<commandQuerySelector: #queryHasMethodSelected:>
+	| method |
 	#idbAdded.
-	MethodHistoryBrowser showOnClass: self selectedMethod methodClass
-		selector: self selectedMethod selector!
-
-canBrowseMethodHistory
-	#idbAdded.
-	^self browser hasMethodSelected! !
+	method := self selectedMethod.
+	MethodHistoryBrowser showOnClass: method methodClass selector: method selector! !
 !MethodBrowserShell categoriesForMethods!
-browseMethodHistory!accessing!commands!idb goodies!private! !
-canBrowseMethodHistory!accessing!idb goodies!private!testing! !
-!
-
-!SmalltalkToolShell methodsFor!
-
-queryMethodHistoryCommand: aCommandQuery 
-	| selector |
-	selector := aCommandQuery commandSymbol.
-	selector == #browseMethodHistory 
-		ifTrue: 
-			[aCommandQuery isEnabled: self canBrowseMethodHistory.
-			^true].
-	selector == #browseMethodHistoryForClass 
-		ifTrue: 
-			[aCommandQuery isEnabled: self canBrowseMethodHistoryForClass.
-			^true].
-	^false! !
-!SmalltalkToolShell categoriesForMethods!
-queryMethodHistoryCommand:!commands!private! !
+browseMethodHistory!commands-actions!idb goodies!private! !
 !
 
 "End of package definition"!

--- a/Core/Contributions/Odellsoft/SUnitBrowser/SUnitBrowser.pax
+++ b/Core/Contributions/Odellsoft/SUnitBrowser/SUnitBrowser.pax
@@ -197,9 +197,9 @@ queryBrowseTests: aCommandQuery
 testBrowserClass
 	^SmalltalkSystem current testBrowserClass! !
 !ClassSelector categoriesForMethods!
-browseTests!commands!public! !
+browseTests!commands-actions!public! !
 buildTestSuite!helpers!public! !
-queryBrowseTests:!command queries!private! !
+queryBrowseTests:!commands-queries!private! !
 testBrowserClass!constants!private! !
 !
 

--- a/Core/Object Arts/Dolphin/Base/Kernel.StackFrame.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.StackFrame.cls
@@ -313,20 +313,10 @@ isBlockFrame
 	^false!
 
 isDead
-	"Private - Answer whether this is a dead stack frame (i.e. one which has returned).
+	"Answer whether this is a dead stack frame (i.e. one which has returned).
 	Note that this is only an indication."
 
 	^self method isNil!
-
-isRestartable
-	"Private - Answer whether this frame is restartable. Some methods, such as
-	callback entry points, cannot be restarted at all, others not reliably."
-
-	^self isDead not and: 
-			[self sender notNil and: 
-					[| method |
-					method := self basicMethod.
-					method isExpression or: [('not restartable' asMethodCategory includesMethod: method) not]]]!
 
 localAt: anInteger
 	"Private - Answer the argument indexed, anInteger, from the receiver's stack frame."
@@ -497,8 +487,7 @@ ip!accessing!private! !
 ip:!accessing!private! !
 ipBias!constants!private! !
 isBlockFrame!private!testing! !
-isDead!private!testing! !
-isRestartable!development!private!testing! !
+isDead!public!testing! !
 localAt:!accessing!private! !
 localCount!accessing!private! !
 method!accessing!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -386,6 +386,7 @@ package setMethodNames: #(
 	#(#{Graphics.Point3D class} #publishedAspectsOfInstances)
 	#(#{Graphics.Rectangle class} #publishedAspectsOfInstances)
 	#(#{Graphics.TextTileIcon class} #newInstanceAspect:class:)
+	#(#{Kernel.BindingReference} #browse)
 	#(#{Kernel.BlockClosure} #cpuCyclesToRun)
 	#(#{Kernel.BlockClosure class} #publishedAspectsOfInstances)
 	#(#{Kernel.BlockFrame} #debugIpFor:)
@@ -459,8 +460,10 @@ package setMethodNames: #(
 	#(#{Kernel.SourceFiler} #emitResourceMethod:literals:)
 	#(#{Kernel.SourceFiler} #emitResourceMethodHeader:)
 	#(#{Kernel.StAbstractVariableNode} #displayOn:)
+	#(#{Kernel.StackFrame} #canReturn)
 	#(#{Kernel.StackFrame} #debugIpFor:)
 	#(#{Kernel.StackFrame} #debugPrintOn:)
+	#(#{Kernel.StackFrame} #isRestartable)
 	#(#{Kernel.StackFrame} #makeDebug)
 	#(#{Kernel.StackFrame} #stackWorkspace)
 	#(#{Kernel.StackFrame class} #publishedAspectsOfInstances)
@@ -2240,7 +2243,7 @@ renameInstVar: oldString to: newString
 	self logDefinition.
 	Smalltalk classUpdated: self! !
 !Core.ClassDescription categoriesForMethods!
-browse!development!public! !
+browse!commands!development!public! !
 categoriesFor:are:!public!source filing-methods! !
 commentStamp:prior:!public!source filing-methods!squeak! !
 copy:from:!methods-copying!public! !
@@ -2620,7 +2623,7 @@ searchForInTool: aSmalltalkToolShell
 alternateInspectorClass!constants!public! !
 aspectDisplayOn:!private! !
 basicInspect!public! !
-browse!public! !
+browse!commands!public! !
 currentPublishedAspectsAsLiteralsMap!constants!public! !
 debugPrintOn:!printing!public! !
 debugPrintString!printing!public! !
@@ -4539,6 +4542,18 @@ newInstanceAspect: aSymbol class: aspectClass
 newInstanceAspect:class:!adapters!private! !
 !
 
+!Kernel.BindingReference methodsFor!
+
+browse
+	"Open a suitable browser onto the receiver."
+
+	SmalltalkSystem current browseClass: (self bindingOrNil
+				ifNil: [self class]
+				ifNotNil: [:var | var isClassBinding ifTrue: [var value] ifFalse: [var environment]])! !
+!Kernel.BindingReference categoriesForMethods!
+browse!commands!public! !
+!
+
 !Kernel.BlockClosure methodsFor!
 
 cpuCyclesToRun
@@ -4853,7 +4868,7 @@ stylerClass
 	^SmalltalkSystem current methodStylerClass! !
 !Kernel.CompiledMethod categoriesForMethods!
 asDebugMethod!private! !
-browse!public! !
+browse!commands!public! !
 icon!constants!public! !
 infoTip!accessing!development!private! !
 parseContext!accessing!public! !
@@ -5356,6 +5371,11 @@ displayOn:!printing!public! !
 
 !Kernel.StackFrame methodsFor!
 
+canReturn
+	"Answer whether this frame can be returned from."
+
+	^(self isDead or: [self sender isNil]) not!
+
 debugIpFor: debugMethod 
 	| interp debugPrev method prev i offset map debugMap ip |
 	ip := self ip.
@@ -5401,6 +5421,16 @@ debugIpFor: debugMethod
 debugPrintOn: aStream
 	self basicPrintOn: aStream!
 
+isRestartable
+	"Answer whether this frame is restartable. Some methods, such as
+	callback entry points, cannot be restarted at all, others not reliably."
+
+	^self isDead not and: 
+			[self sender notNil and: 
+					[| method |
+					method := self basicMethod.
+					method isExpression or: [('not restartable' asMethodCategory includesMethod: method) not]]]!
+
 makeDebug
 	"Private - Convert the receiver to a debug frame. This is for the use of the debugger."
 
@@ -5423,8 +5453,10 @@ stackWorkspace
 
 	^self sender isNil ifTrue: [0] ifFalse: [self sp - index - self frameSize + 1]! !
 !Kernel.StackFrame categoriesForMethods!
+canReturn!public!testing! !
 debugIpFor:!private! !
 debugPrintOn:!public! !
+isRestartable!public!testing! !
 makeDebug!private! !
 stackWorkspace!accessing!private! !
 !
@@ -6492,7 +6524,7 @@ allMethods!public! !
 allResourcesDo:!enumerating!public! !
 allSelectorsImplemented!enquiries!public! !
 allSelectorsSent!enquiries!public! !
-browse!public! !
+browse!commands!public! !
 definitionsMatching:!browsing!public! !
 definitionsOf:!enquiries!public! !
 dynamicReferencesTo:!environments!public! !
@@ -7806,7 +7838,7 @@ publishedAspectsOfInstances!constants!public! !
 !UI.Presenter methodsFor!
 
 systemModel
-	^self parentPresenter systemModel! !
+	^self parentPresenter ifNil: [SmalltalkSystem current] ifNotNil: [:parent | parent systemModel]! !
 !UI.Presenter categoriesForMethods!
 systemModel!accessing!public! !
 !
@@ -7997,7 +8029,7 @@ reassign
 !UI.ResourceIdentifier categoriesForMethods!
 assign:!accessing!public! !
 assignLiteralResourceData:!development!private! !
-browse!public! !
+browse!commands!public! !
 edit!operations!public! !
 editViewUsing:!operations!public! !
 prompt!operations!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassAspectPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassAspectPlugin.cls
@@ -173,7 +173,7 @@ systemUpdateEvent
 textPresenterClass
 	^SmalltalkSystem current workspaceClass! !
 !Tools.ClassAspectPlugin categoriesForMethods!
-accept!commands!public! !
+accept!commands-actions!public! !
 applyOptions!options!private! !
 aspect!constants!private! !
 backgroundUpdate!private!updating! !
@@ -193,7 +193,7 @@ onClassUpdated:!event handling!private! !
 onShownInBrowser!event handling!private! !
 promptToOverwrite!helpers!private! !
 promptToSaveClassChanges:!helpers!public! !
-queryClassCommand:!command queries!private! !
+queryClassCommand:!commands-queries!private! !
 refreshIcon!private!updating! !
 systemUpdateEvent!constants!private! !
 textPresenterClass!initializing!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
@@ -43,13 +43,8 @@ Class Instance Variables:
 !Tools.ClassBrowserAbstract categoriesForClass!MVP-Presenters! !
 !Tools.ClassBrowserAbstract methodsFor!
 
-accept
-	"Save the source on the currently displayed source card."
-
-	self perform: self acceptItCommand!
-
 acceptItCommand
-	"Private - Answer which of the various accept commands applies at this time."
+	"Private - Answer which of the various accept commands should apply at this time."
 
 	self isDefinitionCardVisible ifTrue: [^#saveDefinition].
 	^nil!
@@ -137,6 +132,7 @@ addMethod: method toCategory: target
 addMethodCategory
 	"Private - Add a new method category to the receiver's category pane."
 
+	<commandQuerySelector: #queryHasClassSelected:>
 	| actualClass newCategory |
 	actualClass := self actualClass.
 	newCategory := (CategoryPrompter choices: MethodCategory allMethodCategories
@@ -148,6 +144,7 @@ addMethodCategory
 addMethodProtocol
 	"Private - Add a new <MethodProtocol> to the selected class in the receiver."
 
+	<commandQuerySelector: #queryHasClassSelected:>
 	| actualClass newProtocol protocols |
 	actualClass := self actualClass.
 	protocols := MethodProtocol allMethodProtocols asSortedCollection: [:a :b | a name < b name].
@@ -195,6 +192,10 @@ applyOptions
 	self isFilteringObjectMethods: self class defaultFilterObjectMethods.
 	self createPlugins!
 
+browseClassHierarchy
+	<commandQuerySelector: #queryHasClassSelected:>
+	self developmentSystem browseHierarchy: self actualClass!
+
 browseContainingText
 	"Prompt for a string and open a method browser displaying the
 	methods containing that string."
@@ -207,24 +208,19 @@ browseDefinitionsMatching: aMethodSearch in: aBrowserEnvironment
 				(aBrowserEnvironment forClassHierarchyOf: self actualClass)
 					definitionsMatching: aMethodSearch}!
 
-browseHierarchy
-	self developmentSystem browseHierarchy: self actualClass!
+browseHierarchyCommand
+	"Answer the <Symbol> of the contextual command to browse the class hierarchy of something, depending on the subview with focus and/or selection."
+
+	^#browseClassHierarchy!
 
 browseInstVarReferences
-	"Browse methods that reference all of the selected instance variables of the selected class."
+	"Browse methods that reference any of the selected instance variables of the selected class."
 
-	self model 
-		browseReferencesToInstVar: self variables first value
+	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
+	self model
+		browseReferencesToInstVars: (self variables collect: [:each | each value])
 		inHierarchyOf: self actualClass
 		within: self searchEnvironment!
-
-browseIt
-	"Open a browser on the selected category/protocol/variables.
-	Note that we only receive this command it one of the filter panes is selected
-	as class hierarchy, method browser, and workspace presenters all handle
-	it themselves."
-
-	self perform: self browseItCommand!
 
 browseItCommand
 	| focus |
@@ -242,6 +238,7 @@ browseMessageDefinitionsIn: aBrowserEnvironment
 	"Private - Prompt for a selector and open a method browser displaying all definitions of
 	that selector in the specified <BrowserEnvironment>."
 
+	<commandQuerySelector: #queryHasClassSelected:>
 	(self developmentSystem promptForDefinitionsOf: '' in: aBrowserEnvironment)
 		ifNotNil: [:search | self browseDefinitionsMatching: search in: aBrowserEnvironment]!
 
@@ -249,29 +246,27 @@ browseMessageReferencesIn: aBrowserEnvironment
 	"Private - Prompt for a selector and open a method browser displaying the references to that
 	selector from methods defined in the specified <BrowserEnvironment>."
 
+	<commandQuerySelector: #queryHasClassSelected:>
 	(self developmentSystem promptForReferencesTo: '' in: aBrowserEnvironment)
 		ifNotNil: [:search | self browseReferencesMatching: search in: aBrowserEnvironment]!
 
 browseMethodCategory
 	"Private - Browse all the methods which are in the currently selected category."
 
+	<commandQuerySelector: #queryHasMethodCategoriesSelected:>
 	self model browseMethodCategories: self categories in: self searchEnvironment!
 
 browseOverriddenMethod
 	"Reposition the browser to the method which the currently selected method is overridding."
 
+	<commandQuerySelector: #queryBrowseOverriddenMethod:>
 	| method |
 	method := self method.
 	self method: (method methodClass superclass lookupMethod: method selector)!
 
-browseReferences
-	"Context-sensitive browse references command (Shift+F12).
-	Should only get here for browsing references to instance variables - browsing references to
-	class and methods is handled by the <ClassHierarchyPresenter> and <MethodBrowser>
-	sub-presenters, respectively."
-
-	<acceleratorKey: 'Shift+F12'>
-	self browseInstVarReferences!
+browseReferencesCommand
+	View focus == variablesPresenter view ifTrue: [^#browseInstVarReferences].
+	^nil!
 
 browseReferencesMatching: aMethodSearch in: aBrowserEnvironment
 	self browseMethodsInEnvironments: {aBrowserEnvironment referencesMatching: aMethodSearch.
@@ -286,10 +281,11 @@ browseSelectorsInProtocol
 	implemented in the receiver and its superclasses, with all those which are
 	part of the protocol selected."
 
+	<commandQuerySelector: #queryHasMutableProtocolSelected:>
 	| protocol newSelectors oldSelectors added removed |
 	protocol := self protocols first.
 	oldSelectors := protocol selectors.
-	(newSelectors := self model chooseSelectorsInProtocol: protocol forClass: self actualClass) notNil 
+	(newSelectors := self model chooseSelectorsInProtocol: protocol forClass: self actualClass) notNil
 		ifFalse: [^self].
 	added := newSelectors difference: oldSelectors.
 	self model addSelectors: added toProtocol: protocol.
@@ -360,6 +356,9 @@ canSaveState
 
 	^true!
 
+canShowLocalHierarchy
+	^false!
+
 cardsPresenter
 	^cardsPresenter!
 
@@ -413,6 +412,7 @@ classMethodFilter
 clearSelection
 	"Private - Remove the selected object from the system"
 
+	<commandQuerySelector: #queryDeleteIt:>
 	self perform: self deleteItCommand!
 
 createAccessors
@@ -421,6 +421,7 @@ createAccessors
 	Accessors' refactoring (which is undoable), otherwise it uses the base Dolphin
 	implementation (which is not undoable)."
 
+	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
 	self model 
 		createVariableAccessors: self variables
 		classVariables: false
@@ -664,6 +665,15 @@ deleteItCommand
 	(self canRefactor and: [focus == variablesPresenter view]) ifTrue: [^#removeInstanceVariables].
 	^nil!
 
+displayLocalHierarchyOf: class
+	"Private - Update the receiver to display only the local hierarchy of the <ClassDescription>,
+	class."
+
+	| instClass |
+	instClass := class instanceClass.
+	classesPresenter model: (ClassHierarchyModel withAllClasses
+				filter: [:x | (instClass allSuperclasses includes: x) or: [instClass withAllSubclasses includes: x]])!
+
 dropMethods: aDragDropSession onto: aClass
 	| changes isMove count |
 	changes := CompositeRefactoryChange new.
@@ -708,6 +718,12 @@ ensureDefinitionVisible
 ensureSourceVisible
 	self view topView isActive ifTrue: [methodBrowserPresenter ensureSourceVisible]!
 
+futureSize
+	"Answer the number of visits in the history which were made after the
+	current one."
+
+	^history futureSize!
+
 hasClassSelected
 	"Answer true if the receiver currently has a class selected
 	in the classesPresenter"
@@ -728,21 +744,16 @@ hasEditableMethodsSelected
 	methods := self selectedMethods.
 	^methods notEmpty and: [methods allSatisfy: [:each | self isEditableMethod: each]]!
 
-hasFuture
-	^history hasFuture!
-
 hasMethodSelected
 	"Answer true if the receiver currently has a method selected in the methodsPresenter"
 
 	^methodBrowserPresenter hasMethodSelected!
 
-hasPast
-	^history hasPast!
-
 hierarchyOfCategory: aMethodCategory 
 	^(categoriesPresenter model withAllChildren: aMethodCategory) reject: [:each | each isIntermediate]!
 
 historyClear
+	<commandQuerySelector: #queryHistoryClear:>
 	history clear!
 
 historySkip: anInteger
@@ -776,18 +787,10 @@ inspectCollection: aCollection
 	(aCollection size = 1 ifTrue: [aCollection first] ifFalse: [aCollection]) inspect!
 
 inspectInstanceVariables
+	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
 	| vars |
 	vars := self variables.
-	self 
-		inspectCollection: (vars isEmpty ifTrue: [variablesPresenter list asArray] ifFalse: [vars])!
-
-inspectIt
-	"Open a browser on the selected category/protocol/variables.
-	Note that we only receive this command it one of the filter panes is selected
-	as class hierarchy, method browser, and workspace presenters all handle
-	it themselves."
-
-	self perform: self inspectItCommand!
+	self inspectCollection: (vars isEmpty ifTrue: [variablesPresenter list asArray] ifFalse: [vars])!
 
 inspectItCommand
 	filterPresenter notNil
@@ -803,6 +806,7 @@ inspectItCommand
 	^nil!
 
 inspectMethodCategories
+	<commandQuerySelector: #queryHasMethodCategoriesSelected:>
 	self inspectCollection: self categories!
 
 inspectMethodProtocols
@@ -860,6 +864,15 @@ isInstanceMode: aBoolean
 	on the selected class."
 
 	modePresenter value: (aBoolean ifTrue: [#instanceMode] ifFalse: [#classMode])!
+
+isLocalHierarchyMode
+	"Private - Answer whether the receiver is in 'local hierarchy' mode displaying a subset of the entire
+	class hierarchy."
+
+	^false!
+
+isLocalHierarchyMode: aBoolean
+	aBoolean ifTrue: [self error: 'Not supported']!
 
 isMethodFiltrate: aCompiledMethod
 	"Private - Answer whether the <CompiledMethod> argument passes through the current method filter.
@@ -959,6 +972,7 @@ modifiedModel: aValueHolder
 newMethod
 	"Sets the receiver up for creating a new method"
 
+	<commandQuerySelector: #queryHasClassSelected:>
 	methodBrowserPresenter newMethod!
 
 onBrowserCardChangedFrom: previousView to: currentView
@@ -1576,12 +1590,16 @@ onTipTextRequired: tool
 		ifTrue: [^'Back to <1p>' expandMacrosWith: history previous].
 	(cmd == #historyForward and: [history hasFuture])
 		ifTrue: [^'Forward to <1p>' expandMacrosWith: history next].
-	cmd := tool command asSymbol.
 	cmd == #toggleShowInheritedMethods
 		ifTrue: 
 			[^self isShowInheritedMethods
 				ifTrue: ['Don''t show inherited methods']
 				ifFalse: ['Show inherited methods']].
+	cmd == #toggleLocalHierarchy
+		ifTrue: 
+			[^self isLocalHierarchyMode
+				ifTrue: ['Browse entire hierarchy']
+				ifFalse: ['Browse local hierarchy of ' , self selectedClass name]].
 	^super onTipTextRequired: tool!
 
 onVariableSelected
@@ -1689,6 +1707,11 @@ parseContext
 parseTree
 	^methodBrowserPresenter parseTree!
 
+pastSize
+	"Answer the number of visits in the history which were made before the current one."
+
+	^history pastSize!
+
 printBasicCaptionOn: aPuttableStream
 	aPuttableStream display: self class!
 
@@ -1773,176 +1796,117 @@ protocolsMethodFilter
 	(self isMethodVisible: m) 
 		and: [self protocols anySatisfy: [:each | each includesSelector: m selector]]]!
 
-queryCommand: aCommandQuery
-	"Private - Enter details about a potential command for the receiver 
-	into the <CommandQuery>."
+queryBrowseOverriddenMethod: aCommandQuery
+	aCommandQuery isEnabled: (self hasMethodSelected and: [self method isOverride])!
 
-	| selector |
-	selector := aCommandQuery commandSymbol.
-	#accept == selector
-		ifTrue: 
-			[selector := self acceptItCommand.
-			selector isNil
-				ifTrue: 
-					[aCommandQuery isEnabled: false.
-					^true]].
-	#renameIt == selector
-		ifTrue: 
-			[selector := self renameItCommand.
-			selector isNil
-				ifTrue: 
-					[aCommandQuery isEnabled: false.
-					^true]].
-	#browseIt == selector
-		ifTrue: 
-			[selector := self browseItCommand.
-			selector isNil
-				ifTrue: 
-					[aCommandQuery isEnabled: false.
-					^true]].
-	#inspectIt == selector
-		ifTrue: 
-			[selector := self inspectItCommand.
-			selector isNil
-				ifTrue: 
-					[aCommandQuery isEnabled: false.
-					^true]].
-	#clearSelection == selector
-		ifTrue: 
-			[selector := self deleteItCommand.
-			selector isNil
-				ifTrue: 
-					[aCommandQuery isEnabled: false.
-					^true]].
-	(#(#saveDefinition #browseMessageDefinitionsIn: #browseMessageReferencesIn:)
-		identityIncludes: selector)
-			ifTrue: 
-				[aCommandQuery isEnabled: self hasClassSelected.
-				^true].
-	#toggleShowInheritedMethods == selector
-		ifTrue: [aCommandQuery isChecked: self isShowInheritedMethods].
-	#toggleFilterObjectMethods == selector
+queryFilterObjectMethods: aCommandQuery
+	aCommandQuery
+		isChecked: self isFilterObjectMethods;
+		isEnabled: self isShowInheritedMethods!
+
+queryHasClassSelected: aCommandQuery
+	aCommandQuery isEnabled: self hasClassSelected!
+
+queryHasInstanceVariableSelected: aCommandQuery
+	aCommandQuery isEnabled: self variables size = 1!
+
+queryHasInstanceVariablesSelected: aCommandQuery
+	aCommandQuery isEnabled: self variables notEmpty!
+
+queryHasMethodCategoriesSelected: aCommandQuery
+	aCommandQuery isEnabled: self categories notEmpty!
+
+queryHasMethodSelected: aCommandQuery
+	aCommandQuery isEnabled: self hasMethodSelected!
+
+queryHasMutableProtocolSelected: aCommandQuery
+	aCommandQuery isEnabled: (self protocols size == 1 and: [self protocols first isReadOnly not])!
+
+queryHasNonVirtualCategorySelected: aCommandQuery
+	| cat |
+	cat := self category.
+	"Virtual categories are permanent/calculated and cannot be removed"
+	aCommandQuery isEnabled: (cat notNil and: [cat isVirtual not])!
+
+queryHasProtocolSelected: aCommandQuery
+	aCommandQuery isEnabled: self protocols size = 1!
+
+queryHasProtocolsSelected: aCommandQuery
+	aCommandQuery isEnabled: self protocols notEmpty!
+
+queryHistoryBack: aCommandQuery
+	self hasPast
 		ifTrue: 
 			[aCommandQuery
-				isChecked: self isFilterObjectMethods;
-				isEnabled: self isShowInheritedMethods.
-			^true].
-	#toggleProtocolReadOnly == selector
+				isEnabled: true;
+				text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: { history previous }
+							locale: Locale smalltalk)]
+		ifFalse: 
+			[aCommandQuery
+				isEnabled: false;
+				text: 'Back']!
+
+queryHistoryClear: aCommandQuery
+	aCommandQuery isEnabled: (self hasPast or: [self hasFuture])!
+
+queryHistoryForward: aCommandQuery
+	self hasFuture
 		ifTrue: 
-			[| prots |
-			prots := self protocols.
-			prots size == 1
-				ifTrue: 
-					[| prot |
-					prot := prots first.
-					aCommandQuery
-						isChecked: prot isReadOnly;
-						isEnabled: prot isANSI not]
-				ifFalse: [aCommandQuery isEnabled: false].
-			^true].
-	(#(#browseSelectorsInProtocol #renameMethodProtocol) identityIncludes: selector)
+			[aCommandQuery
+				isEnabled: true;
+				text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: { history next }
+							locale: Locale smalltalk)]
+		ifFalse: 
+			[aCommandQuery
+				isEnabled: false;
+				text: 'Forward']!
+
+queryRemoveMethodProtocols: aCommandQuery
+	| prots |
+	prots := self protocols.
+	"Can only remove selected protocols if this is the first implementor in the superclass chain"
+	aCommandQuery
+		isEnabled: (prots notEmpty and: [(prots difference: self actualClass protocols) isEmpty])!
+
+queryRemoveMethodsInCategory: aCommandQuery
+	| cat |
+	aCommandQuery
+		isEnabled: ((cat := self category) notNil and: [(cat methodsInBehavior: self actualClass) notEmpty])!
+
+queryRenameItCommand: aCommandQuery
+	| selector |
+	selector := self renameItCommand.
+	selector ifNil: [^false].
+	aCommandQuery isEnabled: true!
+
+queryToggleLocalHierarchy: aCommandQuery
+	self isLocalHierarchyMode
 		ifTrue: 
-			[aCommandQuery isEnabled: (self protocols size == 1 and: [self protocols first isReadOnly not]).
-			^true].
-	(#(#removeMethodProtocol #removeMethodsInProtocol) identityIncludes: selector)
+			[aCommandQuery
+				isEnabled: true;
+				isChecked: true]
+		ifFalse: 
+			[aCommandQuery
+				isEnabled: (self canShowLocalHierarchy
+							and: [self hasClassSelected and: [self actualClass superclass notNil]]);
+				isChecked: false]!
+
+queryToggleProtocolReadOnly: aCommandQuery
+	| prots |
+	prots := self protocols.
+	prots size == 1
 		ifTrue: 
-			[| prots |
-			prots := self protocols.
-			"Can only remove selected protocols if this is the first implementor in the superclass chain"
+			[| prot |
+			prot := prots first.
 			aCommandQuery
-				isEnabled: (prots notEmpty and: 
-							[selector == #removeMethodsInProtocol or: [(prots difference: self actualClass protocols) isEmpty]]).
-			^true].
-	(#(#browseInstVarReferences #browseReferences) identityIncludes: selector)
-		ifTrue: 
-			[| vars |
-			vars := self variables.
-			aCommandQuery isEnabled: (vars notNil and: [vars size = 1]).
-			^true].
-	#browseOverriddenMethod == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: (self hasMethodSelected and: [self method isOverride]).
-			^true].
-	#browseMethodProtocol == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: self protocols notEmpty.
-			^true].
-	(#(#newMethod #browseHierarchy #addMethodProtocol #addMethodCategory #reformatAll)
-		identityIncludes: selector)
-			ifTrue: 
-				[aCommandQuery isEnabled: self hasClassSelected.
-				^true].
-	#historyBack: == selector
-		ifTrue: 
-			[| dist |
-			dist := aCommandQuery command arguments first.
-			aCommandQuery isEnabled: history pastSize >= dist.
-			^true].
-	#historyForward: == selector
-		ifTrue: 
-			[| dist |
-			dist := aCommandQuery command arguments first.
-			aCommandQuery isEnabled: history futureSize >= dist.
-			^true].
-	selector == #historyForward
-		ifTrue: 
-			[self hasFuture
-				ifTrue: 
-					[aCommandQuery
-						isEnabled: true;
-						text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: {history next}
-									locale: Locale smalltalk)]
-				ifFalse: 
-					[aCommandQuery
-						isEnabled: false;
-						text: 'Forward'].
-			^true].
-	selector == #historyBack
-		ifTrue: 
-			[self hasPast
-				ifTrue: 
-					[aCommandQuery
-						isEnabled: true;
-						text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: {history previous}
-									locale: Locale smalltalk)]
-				ifFalse: 
-					[aCommandQuery
-						isEnabled: false;
-						text: 'Back'].
-			^true].
-	selector == #historyClear
-		ifTrue: 
-			[aCommandQuery isEnabled: self hasPast | self hasFuture.
-			^true].
-	#browseMethodCategory == selector
-		ifTrue: 
-			[| cat |
-			cat := self category.
-			aCommandQuery isEnabled: cat notNil.
-			^true].
-	(#(#removeMethodCategory #renameMethodCategory #renameMethodCategoryInPlace)
-		identityIncludes: selector)
-			ifTrue: 
-				[| cat |
-				cat := self category.
-				"Virtual categories are permanent/calculated and cannot be removed"
-				aCommandQuery isEnabled: (cat notNil and: [cat isVirtual not]).
-				^true].
-	#removeMethodsInCategory == selector
-		ifTrue: 
-			[| cat |
-			aCommandQuery
-				isEnabled: ((cat := self category) notNil and: [(cat methodsInBehavior: self actualClass) notEmpty]).
-			^true].
-	#createAccessors == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: self variables notEmpty.
-			^true].
-	#renameInstanceVariable == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: self variables size = 1.
-			^true].
-	^super queryCommand: aCommandQuery!
+				isChecked: prot isReadOnly;
+				isEnabled: prot isANSI not]
+		ifFalse: [aCommandQuery isEnabled: false]!
+
+queryToggleShowInheritedMethods: aCommandQuery
+	aCommandQuery
+		isChecked: self isShowInheritedMethods;
+		isEnabled: (self hasClassSelected and: [self actualClass superclass notNil])!
 
 recordMethodVisit
 	"Add to the visit history - note that the current item is at the top of the history list"
@@ -1960,6 +1924,7 @@ recordMethodVisit
 		ifFalse: [history current: method]!
 
 reformatAll
+	<commandQuerySelector: #queryHasClassSelected:>
 	| env |
 	env := classesPresenter selectionEnvironment.
 	(MessageBox new
@@ -1981,9 +1946,10 @@ removeMethodCategory
 	"Private - Remove the currently selected category without deleting any
 	of the methods."
 
+	<commandQuerySelector: #queryHasNonVirtualCategorySelected:>
 	| actualClass catModel args |
 	actualClass := self actualClass.
-	args := {actualClass. self category}.
+	args := { actualClass. self category }.
 	(MessageBox new
 		owner: self view;
 		headline: 'Remove ''<2d>'' from <1p>?' << args;
@@ -1998,6 +1964,7 @@ removeMethodCategory
 removeMethodProtocol
 	"Private - Remove the currently selected protocols from the class."
 
+	<commandQuerySelector: #queryRemoveMethodProtocols:>
 	self protocols do: [:p |
 		self model removeClass: self actualClass fromProtocol: p ].
 !
@@ -2006,9 +1973,10 @@ removeMethodsInCategory
 	"Private - Remove all of the methods in the currently selected category. As this is rather
 	drastic the user will be prompted."
 
+	<commandQuerySelector: #queryRemoveMethodsInCategory:>
 	| classEnvironment categoryEnvironment searchEnvironment mb |
 	searchEnvironment := self searchEnvironment.
-	classEnvironment := searchEnvironment forClasses: {self actualClass}.
+	classEnvironment := searchEnvironment forClasses: { self actualClass }.
 	categoryEnvironment := classEnvironment forMethodCategories: self categories.
 	categoryEnvironment label: ('methods of <1p> in the ''<2d>'' category and its subcategories'
 				expandMacrosWith: classEnvironment
@@ -2032,6 +2000,7 @@ removeMethodsInProtocol
 	"Private - Remove all of the methods in the currently selected protocol.
 	As this is pretty drastic we give the user a second chance."
 
+	<commandQuerySelector: #queryHasProtocolsSelected:>
 	| actualClass |
 	actualClass := self actualClass.
 	self protocols do: 
@@ -2054,9 +2023,11 @@ removePlugin: aClassBrowserPlugin
 renameInstanceVariable
 	"Private - Initiate a rename of the  first selected instance variable."
 
+	<commandQuerySelector: #queryHasInstanceVariableSelected:>
 	variablesPresenter view editSelectionLabel!
 
 renameIt
+	<commandQuerySelector: #queryRenameItCommand:>
 	<acceleratorKey: 'F2'>
 	self perform: self renameItCommand!
 
@@ -2074,6 +2045,7 @@ renameItCommand
 renameMethodCategory
 	"Private - Prompter for a new name for the current category, and rename it."
 
+	<commandQuerySelector: #queryHasNonVirtualCategorySelected:>
 	| originalCategory newName actualClass |
 	originalCategory := self category.
 	actualClass := self actualClass.
@@ -2116,6 +2088,7 @@ renameMethodCategory: aMethodCategory to: aString
 renameMethodCategoryInPlace
 	"Private - Initiate an in-place rename of the currently selected category node."
 
+	<commandQuerySelector: #queryHasNonVirtualCategorySelected:>
 	categoriesPresenter selectableItems view editSelectionLabel!
 
 renameMethodProtocol
@@ -2137,7 +2110,7 @@ resetForFoundClass: class
 saveDefinition
 	"Private - Save the class definition currently in the definition window"
 
-	"Compile the class definition"
+	<commandQuerySelector: #queryHasClassSelected:>
 
 	| wasModified |
 	wasModified := definitionPresenter isModified.
@@ -2309,12 +2282,14 @@ systemModel
 toggleFilterObjectMethods
 	"Toggle between showing <Object> methods or not"
 
+	<commandQuerySelector: #queryFilterObjectMethods:>
 	self isFilteringObjectMethods: self isFilterObjectMethods not.
 	self onClassSelected!
 
 toggleProtocolReadOnly
 	"Toggle the currenty method protocol between read-only and updatable status."
 
+	<commandQuerySelector: #queryToggleProtocolReadOnly:>
 	| prot |
 	prot := self protocols first.
 	prot isReadOnly: prot isReadOnly not!
@@ -2322,6 +2297,7 @@ toggleProtocolReadOnly
 toggleShowInheritedMethods
 	"Toggle between showing inherited methods or not"
 
+	<commandQuerySelector: #queryToggleShowInheritedMethods:>
 	self isShowingInheritedMethods: self isShowInheritedMethods not.
 	self onClassSelected!
 
@@ -2541,7 +2517,6 @@ variablesMethodFilter
 	indices := self variablesIndices.
 	^[:m | (self isMethodVisible: m) and: [m byteCodeDispatcher accessesInstVarAtAnyOf: indices]]! !
 !Tools.ClassBrowserAbstract categoriesForMethods!
-accept!commands!public! !
 acceptItCommand!helpers!private! !
 actualClass!accessing!public! !
 actualClass:!accessing!public! !
@@ -2552,44 +2527,45 @@ actualClassChainMethods!helpers!private! !
 actualClasses!accessing!public! !
 addCategoriesOfMethod:!helpers!private! !
 addMethod:toCategory:!operations!private! !
-addMethodCategory!commands!private! !
-addMethodProtocol!commands!private! !
-addToCommandRoute:!commands!public! !
+addMethodCategory!commands-actions!private! !
+addMethodProtocol!commands-actions!private! !
+addToCommandRoute:!commands-routing!public! !
 allCategoriesOfMethod:!helpers!private! !
 allCategory!private!updating! !
 applyOptions!operations!options!private! !
-browseContainingText!commands!public! !
+browseClassHierarchy!commands-actions!public! !
+browseContainingText!commands-actions!public! !
 browseDefinitionsMatching:in:!helpers!private! !
-browseHierarchy!commands!public! !
-browseInstVarReferences!commands!public! !
-browseIt!commands!public! !
-browseItCommand!helpers!private! !
-browseMessageDefinitionsIn:!commands!private! !
-browseMessageReferencesIn:!commands!private! !
-browseMethodCategory!commands!private! !
-browseOverriddenMethod!commands!public! !
-browseReferences!commands!public! !
+browseHierarchyCommand!commands-mappings!private! !
+browseInstVarReferences!commands-actions!public! !
+browseItCommand!commands-mappings!private! !
+browseMessageDefinitionsIn:!commands-actions!private! !
+browseMessageReferencesIn:!commands-actions!private! !
+browseMethodCategory!commands-actions!private! !
+browseOverriddenMethod!commands-actions!public! !
+browseReferencesCommand!helpers!private! !
 browseReferencesMatching:in:!helpers!private! !
 browserEnvironment!accessing!public! !
-browseSelectorsInProtocol!commands!private! !
-browseSystem!commands!public! !
+browseSelectorsInProtocol!commands-actions!private! !
+browseSystem!commands-actions!public! !
 buildHistoryFutureMenu!helpers!menus!private! !
 buildHistoryMenu:command:!helpers!menus!private! !
 buildHistoryPastMenu!helpers!menus!private! !
 buildPopupForCommand:!event handling!private! !
-canSaveMethod!commands!private! !
+canSaveMethod!commands-actions!private! !
 canSaveState!private!saved state! !
+canShowLocalHierarchy!private!testing! !
 cardsPresenter!accessing!private! !
 categories!accessing!private! !
-categoriesEnvironment!commands!private! !
+categoriesEnvironment!commands-actions!private! !
 categoriesFilter!accessing!private! !
 categoriesMethodFilter!accessing!private! !
 category!accessing!public! !
 classDefinition!accessing!private! !
 classForNewMethod!operations!private! !
 classMethodFilter!accessing!private! !
-clearSelection!commands!private! !
-createAccessors!commands!private!refactoring! !
+clearSelection!commands-actions!private! !
+createAccessors!commands-actions!private!refactoring! !
 createComponents!initializing!private! !
 createPlugins!initializing!public! !
 createSchematicWiring!initializing!public! !
@@ -2599,42 +2575,43 @@ customDrawProtocols:!helpers!private! !
 customDrawSelector:!helpers!private! !
 definitionCardName!constants!private! !
 definitionOfClass:!event handling!private! !
-deleteItCommand!helpers!private! !
+deleteItCommand!commands-actions!private! !
+displayLocalHierarchyOf:!private!updating! !
 dropMethods:onto:!helpers!private! !
 emphasiseCategoryItem:isRelevant:!helpers!private! !
 emphasiseProtocolItem:isRelevant:!helpers!private! !
 ensureDefinitionVisible!operations!private! !
 ensureSourceVisible!operations!private! !
+futureSize!accessing!public! !
 hasClassSelected!public!refactoring!testing! !
 hasEditableMethodSelected!public!testing! !
 hasEditableMethodsSelected!public!testing! !
-hasFuture!public!testing! !
 hasMethodSelected!public!refactoring!testing! !
-hasPast!public!testing! !
 hierarchyOfCategory:!helpers!private! !
-historyClear!commands!public! !
-historySkip:!commands!private! !
+historyClear!commands-actions!public! !
+historySkip:!commands-actions!private! !
 initialize!initializing!private! !
 inspectCollection:!helpers!private! !
-inspectInstanceVariables!commands!private! !
-inspectIt!commands!public! !
-inspectItCommand!helpers!private! !
-inspectMethodCategories!commands!private! !
-inspectMethodProtocols!commands!private! !
+inspectInstanceVariables!commands-actions!private! !
+inspectItCommand!commands-actions!private! !
+inspectMethodCategories!commands-actions!private! !
+inspectMethodProtocols!commands-actions!private! !
 isDefinitionCardVisible!private!testing! !
-isDisplayingCategories!commands!private! !
-isDisplayingProtocols!commands!private! !
-isDisplayingVariables!commands!private! !
+isDisplayingCategories!commands-actions!private! !
+isDisplayingProtocols!commands-actions!private! !
+isDisplayingVariables!commands-actions!private! !
 isEditableMethod:!modes!public! !
-isFilteringObjectMethods:!commands!public! !
+isFilteringObjectMethods:!commands-actions!public! !
 isFilterObjectMethods!public!refactoring!testing! !
 isInheritedMethod:!modes!public! !
 isInstanceMode!modes!private! !
 isInstanceMode:!modes!private! !
+isLocalHierarchyMode!private!testing! !
+isLocalHierarchyMode:!accessing!private! !
 isMethodFiltrate:!private!testing! !
 isMethodVisible:!private!testing! !
 isModified!public!testing! !
-isShowingInheritedMethods:!commands!public! !
+isShowingInheritedMethods:!commands-actions!public! !
 isShowInheritedMethods!public!refactoring!testing! !
 isSourceCardVisible!private!testing! !
 killVisitTimer!helpers!private! !
@@ -2647,7 +2624,7 @@ methodProtocols!accessing!private! !
 methodProtocols:!accessing!public! !
 methodsMatching:!helpers!private! !
 modifiedModel:!accessing!public! !
-newMethod!commands!public! !
+newMethod!commands-actions!public! !
 onBrowserCardChangedFrom:to:!event handling!private! !
 onCategory:renameTo:accept:!event handling!private! !
 onCategorySelected!event handling!private! !
@@ -2699,38 +2676,58 @@ packageNames:!accessing!public! !
 packages:!accessing!public! !
 parseContext!accessing!public! !
 parseTree!accessing!private! !
+pastSize!accessing!public! !
 printBasicCaptionOn:!private!updating! !
 printCaptionForClass:on:!helpers!private! !
 printCaptionForMethod:on:!private!updating! !
 printClassTitle:on:!private!updating! !
 printShortCaptionForClass:on:!helpers!private! !
-promptToCopyChanges!commands!private! !
-promptToSaveChanges!commands!private! !
+promptToCopyChanges!commands-actions!private! !
+promptToSaveChanges!commands-actions!private! !
 protocols!accessing!public! !
 protocols:!accessing!public! !
 protocolsMethodFilter!accessing!private! !
-queryCommand:!commands!private! !
+queryBrowseOverriddenMethod:!commands-queries!private! !
+queryFilterObjectMethods:!commands-queries!private! !
+queryHasClassSelected:!commands-queries!private! !
+queryHasInstanceVariableSelected:!commands-queries!private! !
+queryHasInstanceVariablesSelected:!commands-queries!private!refactoring! !
+queryHasMethodCategoriesSelected:!commands-queries!private! !
+queryHasMethodSelected:!commands-queries!private! !
+queryHasMutableProtocolSelected:!commands-queries!private! !
+queryHasNonVirtualCategorySelected:!commands-queries!private! !
+queryHasProtocolSelected:!commands-queries!private! !
+queryHasProtocolsSelected:!commands-queries!private! !
+queryHistoryBack:!commands-queries!private! !
+queryHistoryClear:!commands-queries!private! !
+queryHistoryForward:!commands-queries!private! !
+queryRemoveMethodProtocols:!commands-queries!private! !
+queryRemoveMethodsInCategory:!commands-queries!private! !
+queryRenameItCommand:!commands-queries!private! !
+queryToggleLocalHierarchy:!commands-queries!private! !
+queryToggleProtocolReadOnly:!commands-queries!private! !
+queryToggleShowInheritedMethods:!commands-queries!private! !
 recordMethodVisit!helpers!private! !
-reformatAll!commands!public! !
+reformatAll!commands-actions!public! !
 removeMethod:fromCategory:!helpers!private! !
-removeMethodCategory!commands!private! !
-removeMethodProtocol!commands!private! !
-removeMethodsInCategory!commands!private! !
-removeMethodsInProtocol!commands!private! !
+removeMethodCategory!commands-actions!private! !
+removeMethodProtocol!commands-actions!private! !
+removeMethodsInCategory!commands-actions!private! !
+removeMethodsInProtocol!commands-actions!private! !
 removePlugin:!accessing!public! !
-renameInstanceVariable!commands!private!refactoring! !
-renameIt!commands!public! !
+renameInstanceVariable!commands-actions!private!refactoring! !
+renameIt!commands-actions!public! !
 renameItCommand!constants!private! !
-renameMethodCategory!commands!private! !
-renameMethodCategory:to:!commands!public! !
-renameMethodCategoryInPlace!commands!private! !
-renameMethodProtocol!commands!private! !
-resetFor:!commands!private! !
-resetForFoundClass:!commands!private! !
-saveDefinition!operations!private! !
+renameMethodCategory!commands-actions!private! !
+renameMethodCategory:to:!commands-actions!public! !
+renameMethodCategoryInPlace!commands-actions!private! !
+renameMethodProtocol!commands-actions!private! !
+resetFor:!commands-actions!private! !
+resetForFoundClass:!commands-actions!private! !
+saveDefinition!commands-actions!private! !
 saveNewMethod:!operations!private! !
 saveStateOn:!private!saved state! !
-searchEnvironment!commands!public! !
+searchEnvironment!commands-actions!public! !
 searchForClass:!helpers!private! !
 searchForMethod:!helpers!private! !
 selectedClass!accessing!private! !
@@ -2739,7 +2736,7 @@ selectedMethod!public! !
 selectedMethods!accessing!public! !
 selectedMethods:!accessing!public! !
 selectionEnvironment!accessing!private! !
-selectMethod:!browsing!private! !
+selectMethod:!operations!private! !
 setInitialFocus!operations!public! !
 setMethodsFilter:!private!updating! !
 setVisitTimer!helpers!private! !
@@ -2749,9 +2746,9 @@ sourceCardName!constants!private! !
 statusModel!accessing!public! !
 statusText:!accessing!private! !
 systemModel!accessing!private! !
-toggleFilterObjectMethods!commands!public! !
-toggleProtocolReadOnly!commands!public! !
-toggleShowInheritedMethods!commands!public! !
+toggleFilterObjectMethods!commands-actions!public! !
+toggleProtocolReadOnly!commands-actions!public! !
+toggleShowInheritedMethods!commands-actions!public! !
 updateCaption!public!updating! !
 updateCategories!private!updating! !
 updateClass:presenter:source:!helpers!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserShell.cls
@@ -19,6 +19,9 @@ Class Variables:
 !Tools.ClassBrowserShell categoriesForClass!MVP-Presenters! !
 !Tools.ClassBrowserShell methodsFor!
 
+canShowLocalHierarchy
+	^true!
+
 createComponents
 	"Create the presenters contained by the receiver"
 
@@ -31,15 +34,6 @@ createComponents
 defaultHelpId
 	^10734!
 
-displayLocalHierarchyOf: class
-	"Private - Update the receiver to display only the local hierarchy of the <ClassDescription>,
-	class."
-
-	| instClass |
-	instClass := class instanceClass.
-	classesPresenter model: (ClassHierarchyModel withAllClasses
-				filter: [:x | (instClass allSuperclasses includes: x) or: [instClass withAllSubclasses includes: x]])!
-
 isLocalHierarchyMode
 	"Private - Answer whether the receiver is in 'local hierarchy' mode displaying a subset of the entire
 	class hierarchy."
@@ -49,74 +43,19 @@ isLocalHierarchyMode
 isLocalHierarchyMode: aBoolean 
 	flags := flags mask: LocalHierarchyMask set: aBoolean!
 
-onTipTextRequired: tool
-	"Private - Tool tip text is required for the <ToolbarItem>, tool."
-
-	| cmd |
-	cmd := tool command asSymbol.
-	cmd == #toggleLocalHierarchy ifTrue: [
-		^(self isLocalHierarchyMode 
-				ifTrue: ['Browse entire hierarchy']
-				ifFalse: ['Browse local hierarchy of ', self selectedClass name])].
-	^super onTipTextRequired: tool!
-
-queryCommand: aCommandQuery 
-	"Private - Enter details about a potential command for the receiver 
-	into the <CommandQuery>."
-
-	| cmd |
-	cmd := aCommandQuery commandSymbol.
-	#toggleLocalHierarchy == cmd 
-		ifTrue: 
-			[self isLocalHierarchyMode 
-				ifTrue: 
-					[aCommandQuery
-						isEnabled: true;
-						isChecked: true]
-				ifFalse: 
-					[aCommandQuery
-						isEnabled: (self hasClassSelected and: [self actualClass superclass notNil]);
-						isChecked: false].
-			^true].
-	^super queryCommand: aCommandQuery!
-
 resetFor: aClass 
 	"Reset the receiver to place it into a state required to display aClass"
 
 	(self isLocalHierarchyMode 
 		and: [(classesPresenter model filter value: aClass instanceClass) not]) 
-			ifTrue: [self displayLocalHierarchyOf: aClass]!
-
-toggleLocalHierarchy
-	"Toggle between the entire hierarchy and showing only the current class and its subclasses."
-
-	| instClass actualClass |
-	self promptToSaveChanges ifFalse: [^self].
-
-	"Use the selected class rather than the actual class, so always follows instance hierarchy"
-	instClass := self selectedClass.
-	actualClass := self actualClass.
-	self isLocalHierarchyMode: self isLocalHierarchyMode not.
-	self isLocalHierarchyMode 
-		ifTrue: 
-			["Toggled into local hierarchy mode"
-			self displayLocalHierarchyOf: instClass.
-			self actualClass: actualClass]
-		ifFalse: 
-			["Toggled out of local hierarchy mode..."
-			classesPresenter model: self model classHierarchy.
-			actualClass notNil ifTrue: [self actualClass: actualClass]].
-	self validateUserInterface! !
+			ifTrue: [self displayLocalHierarchyOf: aClass]! !
 !Tools.ClassBrowserShell categoriesForMethods!
+canShowLocalHierarchy!private!testing! !
 createComponents!initializing!public! !
 defaultHelpId!public! !
-displayLocalHierarchyOf:!private!updating! !
 isLocalHierarchyMode!private!testing! !
 isLocalHierarchyMode:!accessing!private! !
-onTipTextRequired:!event handling!private! !
-queryCommand:!commands!private! !
-resetFor:!commands!public! !
-toggleLocalHierarchy!commands!public! !
+resetFor:!operations!public! !
 !
 
 !Tools.ClassBrowserShell class methodsFor!

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassSelector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassSelector.cls
@@ -111,7 +111,7 @@ browseInstanceVariables
 browseIt
 	"Browse the selected item in the pane with focus."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #queryBrowseIt:>
 	self perform: self browseItCommand!
 
 browseItCommand
@@ -176,8 +176,7 @@ browseSystem
 	self developmentSystem browseSystem: self actualClass!
 
 browseVariablesMenu
-	<commandQuerySelector: #queryClassCommand:>
-	Sound warningBeep!
+	<commandQuerySelector: #queryClassCommand:>!
 
 buildAllVariablesMenu: aMenu
 	"Private - Build a dynamic pull-out menu which lists all of a class' existing 
@@ -196,7 +195,7 @@ buildAllVariablesMenu: aMenu
 			[self
 				populateVarMenu: aMenu
 				class: class
-				command: #browseReferencesToInstVar:inHierarchyOf:within:
+				command: #browseReferencesToInstVars:inHierarchyOf:within:
 				variables: instVars
 				format: '<1s>.<2s>'
 				abortable: false].
@@ -211,7 +210,7 @@ buildAllVariablesMenu: aMenu
 			[self
 				populateVarMenu: aMenu
 				class: class
-				command: #browseReferencesToClassVar:of:within:
+				command: #browseReferencesToClassVars:of:within:
 				variables: classVars
 				format: '<1s>.<2s>'
 				abortable: false]!
@@ -255,7 +254,7 @@ categorizeClass
 		ifTrue: [aClass categories: chosenCategories]!
 
 chooseVariables: aBoolean caption: aString
-	"Note that this is deliberately _not_ part of the 'Dolphin Refactoring Browse' package"
+	"Note that this is deliberately _not_ part of the 'Dolphin Refactoring Browser' package because it is required by #createVariableAccessors:"
 
 	| varNames class |
 	varNames := (aBoolean
@@ -291,7 +290,7 @@ classPackage
 clearSelection
 	"Private - Remove the selected object from the system"
 
-	<commandQuerySelector: #queryClassesCommand:>
+	<commandQuerySelector: #queryDeleteIt:>
 	self perform: self deleteItCommand!
 
 confirmMoveClass: aClass toPackage: aPackage
@@ -529,8 +528,8 @@ newView
 	selected class. If there are several possibilities allow the user to select
 	the one to edit"
 
-	self developmentSystem openViewComposerOnNewViewFor: self selection
-	!
+	<commandQuerySelector: #queryHasClassSupportingViews:>
+	self developmentSystem openViewComposerOnNewViewFor: self selection!
 
 onAboutToDisplayMenu: aMenu 
 	"The pop-up <Menu>, popup, is about to be displayed.
@@ -771,9 +770,10 @@ populateVarMenu: aMenu class: class command: cmdSelector variables: aCollection 
 			msg := MessageSend
 						receiver: self developmentSystem
 						selector: cmdSelector
-						arguments: {each value. class. self searchEnvironment}.
+						arguments: { { each value }. class. self searchEnvironment }.
 			(aMenu addCommand: msg
-				description: (aString expandMacrosWithArguments: {each key name. each value} locale: Locale smalltalk))
+				description: (aString expandMacrosWithArguments: { each key name. each value }
+						locale: Locale smalltalk))
 				isModalCommand: true;
 				isAbortable: aBoolean]!
 
@@ -805,10 +805,12 @@ queryBrowseHierarchy: aCommandQuery
 	aCommandQuery text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: { name }
 				locale: Locale smalltalk)!
 
-queryBrowseItCommand: aCommandQuery
-	self browseItCommand isNil
-		ifTrue: [aCommandQuery isEnabled: false]
-		ifFalse: [self queryClassCommand: aCommandQuery]!
+queryBrowseIt: aCommandQuery
+	self browseItCommand
+		ifNil: 
+			["Not handled at this level, but continue searching the chain"
+			aCommandQuery isEnabled: false]
+		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
 
 queryBrowsePublishedAspects: aCommandQuery
 	| class |
@@ -836,6 +838,19 @@ queryClassVariablesCommand: aCommandQuery
 	class := self actualClass.
 	aCommandQuery isEnabled: (class notNil and: [class instanceClass definedBindings notEmpty])!
 
+queryDeleteIt: aCommandQuery
+	self deleteItCommand
+		ifNil: 
+			["Not handled at this level, but continue searching the chain"
+			aCommandQuery isEnabled: false]
+		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
+
+queryHasClassSupportingViews: aCommandQuery
+	| class |
+	class := self selectionOrNil.
+	aCommandQuery isEnabled: (class notNil
+				and: [(class includesBehavior: Presenter) or: [class includesBehavior: View]])!
+
 queryInstanceVariablesCommand: aCommandQuery
 	| class |
 	class := self actualClass.
@@ -849,17 +864,14 @@ queryShowFullNames: aCommandQuery
 		isEnabled: true;
 		isChecked: self isShowingFullNames!
 
-queryViewsMenu: aCommandQuery
+queryViewsEditMenu: aCommandQuery
 	| class |
 	class := self selectionOrNil.
-	aCommandQuery isEnabled: (class notNil
-				and: [(class includesBehavior: Presenter) or: [class includesBehavior: View]])!
+	aCommandQuery isEnabled: (class notNil and: [class resourceIdentifiers notEmpty])!
 
-queryViewsSubMenu: aCommandQuery
-	| class |
-	class := self selectionOrNil.
-	aCommandQuery isEnabled: (class notNil and: [class resourceIdentifiers notEmpty]).
-	#viewsShowMenu == aCommandQuery commandSymbol ifTrue: [aCommandQuery isDefault: true]!
+queryViewsShowMenu: aCommandQuery
+	self queryViewsEditMenu: aCommandQuery.
+	aCommandQuery isDefault: true!
 
 removeClass
 	"Removes the selected class(es) from the system. If refactoring is available, then the 'Remove Class' refactoring is employed."
@@ -896,7 +908,7 @@ renameInstanceVariable
 	instVar isNil ifFalse: [self developmentSystem renameInstanceVariable: instVar in: class]!
 
 renameVariables
-	<commandQuerySelector: #queryVariablesCommand:>
+	<commandQuerySelector: #queryHasVariablesSelected:>
 	Sound warningBeep!
 
 searchEnvironment
@@ -938,72 +950,72 @@ toggleShowFullNames
 	self classNamesSelector: (fullNames ifTrue: [#fullName] ifFalse: [#unqualifiedName])!
 
 viewsEditMenu
-	<commandQuerySelector: #queryViewsSubMenu:>
+	<commandQuerySelector: #queryViewsEditMenu:>
 	!
 
 viewsMenu
-	<commandQuerySelector: #queryViewsMenu:>
+	<commandQuerySelector: #queryHasClassSupportingViews:>
 	!
 
 viewsShowMenu
-	<commandQuerySelector: #queryViewsSubMenu:>
+	<commandQuerySelector: #queryViewsShowMenu:>
 	! !
 !Tools.ClassSelector categoriesForMethods!
 actualClass!accessing!public! !
 actualClass:!accessing!public! !
 actualClass:ifAbsent:!accessing!public! !
 actualClasses!accessing!public! !
-browseChangedMethods!commands!public! !
-browseClass!commands!public! !
-browseClassPackage!commands!public! !
-browseClassReferences!commands!public! !
-browseClassVariables!commands!public! !
-browseHierarchy!commands!public! !
-browseInstanceVariables!commands!public! !
-browseIt!commands!public! !
+browseChangedMethods!commands-actions!public! !
+browseClass!commands-actions!public! !
+browseClassPackage!commands-actions!public! !
+browseClassReferences!commands-actions!public! !
+browseClassVariables!commands-actions!public! !
+browseHierarchy!commands-actions!public! !
+browseInstanceVariables!commands-actions!public! !
+browseIt!commands-actions!public! !
 browseItCommand!helpers!private! !
-browseMenu!commands!public! !
-browsePackages!commands!public! !
-browsePublishedAspects!commands!public! !
-browsePublishedEvents!commands!public! !
-browseReferences!commands!public! !
+browseMenu!commands-menus!private! !
+browsePackages!commands-actions!public! !
+browsePublishedAspects!commands-actions!public! !
+browsePublishedEvents!commands-actions!public! !
+browseReferences!commands-actions!public! !
 browserEnvironment!public! !
-browseSystem!commands!public! !
-browseVariablesMenu!commands!public! !
+browseSystem!commands-actions!public! !
+browseVariablesMenu!commands-menus!private! !
 buildAllVariablesMenu:!menus!private! !
 buildViewsMenu:command:!menus!private! !
 canRefactor!public!testing! !
-categorizeClass!commands!public! !
-chooseVariables:caption:!commands!private!refactoring! !
+categorizeClass!commands-actions!public! !
+chooseVariables:caption:!helpers!private! !
 classHierarchyPresenter!accessing!private! !
 classNamesSelector:!accessing!private! !
-classPackage!commands!public! !
-clearSelection!commands!private! !
+classPackage!commands-actions!public! !
+clearSelection!commands-actions!private! !
 confirmMoveClass:toPackage:!operations!private! !
-copyClass!commands!private! !
-createInstanceVariableAccessors!commands!public!refactoring! !
+copyClass!commands-actions!private! !
+createInstanceVariableAccessors!commands-actions!public!refactoring! !
 createSchematicWiring!initializing!public! !
-createVariableAccessors:!commands!public!refactoring! !
+createVariableAccessors:!commands-actions!public!refactoring! !
 deleteItCommand!helpers!private! !
-developmentSystem!commands!private! !
+developmentSystem!commands-actions!private! !
 dropClass:onto:changes:!operations!private! !
 dropMethod:onto:isMove:changes:!helpers!private! !
-editView:!commands!public! !
-fileInClass!commands!public! !
-fileOutClass!commands!public! !
-findClass!commands!public! !
+editView:!commands-actions!public! !
+fileInClass!commands-actions!public! !
+fileOutClass!commands-actions!public! !
+findClass!commands-actions!public! !
 flags!accessing!private! !
 flags:!accessing!private! !
 initialize!initializing!private! !
-initiateRename!commands!private!refactoring! !
-inspectIt!commands!public! !
+initiateRename!helpers!private! !
+inspectIt!commands-actions!public! !
 isInstanceMode!modes!public! !
 isInstanceMode:!modes!public! !
 isShowingFullNames!modes!public! !
 isShowingFullNames:!modes!public! !
 maximumVariableMenuEntries!menus!private! !
 model:!accessing!public! !
-newView!commands!public! !
+newView!commands-actions!public! !
 onAboutToDisplayMenu:!event handling!menus!public! !
 onAboutToRenameClass:!event handling!private! !
 onClass:renameTo:accept:!event handling!public! !
@@ -1018,34 +1030,36 @@ packages:!accessing!public! !
 performDropChanges:target:!helpers!private! !
 permitSelectionChange!helpers!private! !
 populateVarMenu:class:command:variables:format:abortable:!menus!private! !
-queryBrowseClassPackage:!command queries!private! !
-queryBrowseHierarchy:!command queries!private! !
-queryBrowseItCommand:!command queries!private! !
-queryBrowsePublishedAspects:!command queries!private! !
-queryBrowsePublishedEvents:!command queries!private! !
-queryChangeClassNamespace:!command queries!private! !
-queryClassCommand:!command queries!private! !
-queryClassesCommand:!command queries!private! !
-queryClassVariablesCommand:!command queries!private! !
-queryInstanceVariablesCommand:!command queries!private! !
-queryRenameClass:!command queries!private! !
-queryShowFullNames:!command queries!private! !
-queryViewsMenu:!command queries!private! !
-queryViewsSubMenu:!command queries!private! !
-removeClass!commands!public! !
-renameClass!commands!private!refactoring! !
-renameClassVariable!commands!private!refactoring! !
-renameInstanceVariable!commands!private!refactoring! !
-renameVariables!commands!private! !
-searchEnvironment!commands!private! !
+queryBrowseClassPackage:!commands-queries!private! !
+queryBrowseHierarchy:!commands-queries!private! !
+queryBrowseIt:!commands-queries!private! !
+queryBrowsePublishedAspects:!commands-queries!private! !
+queryBrowsePublishedEvents:!commands-queries!private! !
+queryChangeClassNamespace:!commands-queries!private! !
+queryClassCommand:!commands-queries!private! !
+queryClassesCommand:!commands-queries!private! !
+queryClassVariablesCommand:!commands-queries!private! !
+queryDeleteIt:!commands-queries!private! !
+queryHasClassSupportingViews:!commands-queries!private! !
+queryInstanceVariablesCommand:!commands-queries!private! !
+queryRenameClass:!commands-queries!private! !
+queryShowFullNames:!commands-queries!private! !
+queryViewsEditMenu:!commands-queries!private! !
+queryViewsShowMenu:!commands-queries!private! !
+removeClass!commands-actions!public! !
+renameClass!commands-actions!private!refactoring! !
+renameClassVariable!commands-actions!private!refactoring! !
+renameInstanceVariable!commands-actions!private!refactoring! !
+renameVariables!commands-actions!private! !
+searchEnvironment!commands-actions!private! !
 searchEnvironment:!public! !
 selectableItems!accessing!private! !
 selectionEnvironment!accessing!private! !
 setInitialFocus!operations!public! !
-showPresenter:!commands!public! !
-toggleShowFullNames!commands!private!refactoring! !
-viewsEditMenu!commands!public! !
-viewsMenu!commands!public! !
-viewsShowMenu!commands!public! !
+showPresenter:!commands-actions!public! !
+toggleShowFullNames!commands-actions!private!refactoring! !
+viewsEditMenu!commands-actions!public! !
+viewsMenu!commands-actions!public! !
+viewsShowMenu!commands-actions!public! !
 !
 

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.Debugger.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.Debugger.cls
@@ -60,15 +60,8 @@ Class Variables:
 !Tools.Debugger categoriesForClass!MVP-Presenters!MVP-Resources-IDE Tools! !
 !Tools.Debugger methodsFor!
 
-accept
-	"Private - Saves the current method source, restarting the method frame if the system
-	options so indicate."
-
-	self accept: self class restartOnMethodSave methodSource: self source!
-
 accept: aBoolean methodSource: aString
-	"Private - Saves the current method source, optionally restarting the frame depending on the
-	value of the <Boolean> argument.."
+	"Private - Saves the <String> 2nd argument as the source for the current method, optionally restarting the frame depending on the value of the <Boolean> argument.."
 
 	| method originalSelection hadErrors devsys |
 	originalSelection := sourcePresenter view selectionRange.
@@ -103,10 +96,23 @@ accept: aBoolean methodSource: aString
 	sourcePresenter view selectionRange: originalSelection.
 	aBoolean ifTrue: [self restartMethod] ifFalse: [sourcePresenter isModified: false]!
 
+acceptItCommand
+	"Private - Answer the <Symbol> of the contextual command to save changes to something, depending on the subview with focus and/or selection."
+
+	inspectorPresenter hasFocus ifFalse: [^#acceptMethod].
+	^nil!
+
+acceptMethod
+	"Private - Saves the current method source, restarting the method frame if the system options so indicate."
+
+	<commandQuerySelector: #querySaveMethod:>
+	self accept: self class restartOnMethodSave methodSource: self source!
+
 acceptNoRestart
 	"Private - Saves the current method source without restarting the frame (i.e. the debugged
 	process becomes out of sync. with the current method)."
 
+	<commandQuerySelector: #querySaveMethod:>
 	self accept: false methodSource: self source!
 
 addToCommandRoute: aCommandPolicy
@@ -121,6 +127,7 @@ allFrames
 	"Private - Include all stack frames in the call stack. There cannot possibly be any more
 	than the size of the process."
 
+	<commandQuerySelector: #queryShowMoreFrames:>
 	self depth: process size!
 
 animatePause
@@ -201,12 +208,10 @@ breakWhen: discriminator
 
 	breakWhen addLast: discriminator!
 
-browseDefinitions
-	"Private - Open a new method browser on the definitions of the of the currently selected
-	stack frame's selector."
+browseDefinitionsCommand
+	"Private - Open a new method browser on the definitions of the of the currently selected stack frame's selector."
 
-	self browseDefinitionsMatching: (MethodSearch newSelector: self selectedMethod selector)
-		in: self searchEnvironment!
+	^#browseMessageDefinitions!
 
 browseDefinitionsMatching: aMethodSearch in: aBrowserEnvironment
 	| definitions |
@@ -241,6 +246,14 @@ browseIt
 
 	variablesPresenter hasFocus ifTrue: [self browseVariableClass] ifFalse: [self browseHierarchy]!
 
+browseMessageDefinitions
+	"Private - Open a new method browser on the definitions of the of the currently selected
+	stack frame's selector."
+
+	<commandQuerySelector: #queryHasBrowsableMethod:>
+	self browseDefinitionsMatching: (MethodSearch newSelector: self selectedMethod selector)
+		in: self searchEnvironment!
+
 browseMessages
 	"Private - Browse the definitions of one of the messages sent within the method of the
 	currently selected stack frame. Prompt for which message to actually browse."
@@ -248,9 +261,9 @@ browseMessages
 	self model browseMessagesSentBy: self selectedMethod in: self searchEnvironment!
 
 browseMethodInheritanceChain
-	"Private - Open a method browser displaying the definitions of the currently selected stack
-	frame's method's selector in its superclass chain."
+	"Private - Open a method browser displaying the definitions of the currently selected stack frame's method's selector in its superclass chain."
 
+	<commandQuerySelector: #queryBrowseMethodInheritanceChain:>
 	self model browseMethodHierarchyFrom: self selectedMethod!
 
 browseReferences
@@ -291,6 +304,7 @@ browseSystem
 		ifFalse: [self model browseSystemOnMethod: self selectedMethod]!
 
 browseVariableClass
+	<commandQuerySelector: #queryHasVariableSelected:>
 	localAccessor value browse!
 
 buildParseTree
@@ -440,6 +454,10 @@ debugState: aString
 defaultHelpId
 	^10881!
 
+definitionsMenu
+	<commandQuerySelector: #queryMessagesMenu:>
+	!
+
 depth
 	"Private - Answer the requested stack depth to be displayed by the receiver (the actual
 	stack depth may be less if there are insufficient frames)."
@@ -471,8 +489,9 @@ displayFrame
 displayLocal: anAspectAccessor
 	"Private - Inspect the value of the selected local/instance variable."
 
+	
 	localAccessor removeEventsTriggeredFor: self.
-	localAccessor := anAspectAccessor.
+	localAccessor := anAspectAccessor asValue.
 	inspectorPresenter model: localAccessor.
 	localAccessor
 		when: #valueChanged
@@ -571,14 +590,22 @@ generateStubFor: aMessage inClass: aClass
 		notNil!
 
 hasEditableMethodSelected
-	^(self isRunning or: [self isAnimating]) not 
-		and: [self isDisassembled not and: [self hasMethodSelected]]!
+	^self isPaused and: [self isDisassembled not and: [self hasMethodSelected]]!
 
 hasEditableMethodsSelected
 	^self hasEditableMethodSelected!
 
+hasLiveFrame
+	| frame |
+	frame := self frame.
+	^(frame isNil or: [frame isDead]) not!
+
 hasMethodSelected
 	^self selectedMethod notNil and: [self selectedMethod isExpression not]!
+
+implementDNUMenu
+	<commandQuerySelector: #queryImplementMenu:>
+	!
 
 initialize
 	"Private - Initialize the receiver"
@@ -588,10 +615,17 @@ initialize
 	flags := 0.
 	breakWhen := OrderedCollection new!
 
-inspectIt
-	"Private - Open an inspector on the currently selected local variable (or instance variable)."
+inspectFrame
+	"Private - Open an inspector on the currently selected frame."
 
-	localAccessor value inspect!
+	<commandQuerySelector: #queryHasFrameSelected:>
+	self frame inspect!
+
+inspectItCommand
+	"Answer the <Symbol> of the contextual command to inspect something, depending on the subview with focus and/or selection."
+
+	stackPresenter hasFocus ifTrue: [^#inspectFrame].
+	^#inspectVariable!
 
 inspectReferences
 	"Private - Open a new Inspector on all the objects which references the currently selected local variable or instance variable."
@@ -603,6 +637,12 @@ inspectReferences
 			[MessageBox notify: ('There are no additional references to:<n><t><1p>'
 						expandMacrosWith: variablesPresenter selection first)]
 		ifFalse: [refs inspect]!
+
+inspectVariable
+	"Private - Open an inspector on the currently selected local variable (or instance variable)."
+
+	<commandQuerySelector: #queryHasVariableSelected:>
+	localAccessor value inspect!
 
 isAnimating
 	"Private - Answer whether the receiver is in 'Animate' mode (i.e. repeatedly single-stepping
@@ -633,11 +673,19 @@ isMain: aBoolean
 
 	flags := flags mask: MainMask set: aBoolean!
 
+isPaused
+	^flags noMask: ##(RunMask | AnimateMask)!
+
 isResumable
 	"Private - Answer whether the process the receiver is debugging is resumable."
 
 	^flags anyMask: ResumableMask
 !
+
+isRunnable
+	"Runnable if not currently running/animating (i.e. paused), but is resumable."
+
+	^(flags bitAnd: ##(RunMask | AnimateMask | ResumableMask)) == ResumableMask!
 
 isRunning
 	"Private - Answer whether the process the receiver is debugging is currently running."
@@ -691,6 +739,7 @@ markMethodAsUnbound: oldMethod
 moreFrames
 	"Private - Increase the number of stack frames displayed in the call stack."
 
+	<commandQuerySelector: #queryShowMoreFrames:>
 	self depth: depth + StackDepthIncrement!
 
 nameForArgument: anObject 
@@ -711,6 +760,7 @@ newLocalsTreeWithRoots: anOrderedCollection
 nilVariable
 	"Private - Nil the currently selected variable or stack slot."
 
+	<commandQuerySelector: #queryNilVariable:>
 	variablesPresenter model collapse: localAccessor.
 	localAccessor value: nil!
 
@@ -912,7 +962,8 @@ onTempSelected
 			self displayLocal: newTemp.
 			inspectorPresenter view enable]
 		ifNil: 
-			[inspectorPresenter view
+			[self displayLocal: nil.
+			inspectorPresenter view
 				clearAll;
 				disable]!
 
@@ -1030,118 +1081,92 @@ promptToSaveChanges
 
 	^self onPromptToSaveChanges: (SelectionChangingEvent forSource: self)!
 
-queryCommand: aCommandQuery
-	"Private - Enter details about a potential command for the receiver into the 
-	<CommandQuery>."
+queryBrowseMethodInheritanceChain: aCommandQuery
+	aCommandQuery
+		isEnabled: (self selectedMethod ifNil: [false] ifNotNil: [:method | method isOverride])!
 
-	| selector running runnable animating |
-	selector := aCommandQuery commandSymbol.
+queryHasBrowsableMethod: aCommandQuery
+	aCommandQuery isEnabled: (self isPaused and: [self hasMethodSelected])!
+
+queryHasEditableMethodSelected: aCommandQuery
+	aCommandQuery isEnabled: self hasEditableMethodSelected!
+
+queryHasFrameSelected: aCommandQuery
+	aCommandQuery isEnabled: self frame notNil!
+
+queryHasVariableSelected: aCommandQuery
+	aCommandQuery isEnabled: variablesPresenter hasSelection!
+
+queryImplementMenu: aCommandQuery
+	"Note that the implement menu is not just for DNUs any more, but any message which is not directly implemented by its receiver."
+
+	aCommandQuery
+		isEnabled: (self isPaused and: [self class enableDynamicMenus and: [self canImplementMessage]])!
+
+queryMessagesMenu: aCommandQuery
+	aCommandQuery isEnabled: (self class enableDynamicMenus and: [self selectedMethod notNil])!
+
+queryNilVariable: aCommandQuery
+	aCommandQuery isEnabled: (variablesPresenter hasSelection and: [localAccessor canSet])!
+
+queryRestartFrame: aCommandQuery
+	aCommandQuery
+		isEnabled: (self isPaused and: 
+					[| frame |
+					frame := self frame.
+					frame notNil and: [frame isRestartable]])!
+
+queryReturnFromMessage: aCommandQuery
+	aCommandQuery
+		isEnabled: (self isPaused and: 
+					[| frame |
+					frame := self frame.
+					frame notNil and: [frame canReturn]])!
+
+queryRun: aCommandQuery
+	aCommandQuery isEnabled: self isRunnable!
+
+queryRunToCursor: aCommandQuery
+	aCommandQuery
+		isEnabled: (self isRunnable and: 
+					[self hasLiveFrame and: 
+							["Cannot run to cursor in disassembly view"
+							self isDisassembled not]])!
+
+querySaveMethod: aCommandQuery
+	aCommandQuery isEnabled: self canSaveMethod!
+
+queryShowMoreFrames: aCommandQuery
+	aCommandQuery isEnabled: (self isPaused and: [self depth <= self frames size])!
+
+queryShowNextStatement: aCommandQuery
+	aCommandQuery isEnabled: self isPaused!
+
+queryStep: aCommandQuery
+	aCommandQuery isEnabled: (self isRunnable and: [self hasLiveFrame])!
+
+queryStepInto: aCommandQuery
+	aCommandQuery
+		isEnabled: (self isRunnable and: 
+					["Can only step-into in the top stack frame"
+					self frame = topFrame and: [topFrame isDead not]])!
+
+queryTerminateProcess: aCommandQuery
+	aCommandQuery isEnabled: process isTerminated not!
+
+queryToggleAnimation: aCommandQuery
+	| animating |
 	animating := self isAnimating.
-	running := self isRunning or: [animating].
-	runnable := running not and: [self isResumable].
-	#nilVariable == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: (localAccessor notNil and: [localAccessor canSet]).
-			^true].
-	#accept == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: (inspectorPresenter hasFocus not and: [self canSaveMethod]).
-			^true].
-	#browseVariableClass == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: localAccessor notNil.
-			^true].
-	selector == #userBreak
-		ifTrue: 
-			[aCommandQuery isEnabled: (running and: [animating not]).
-			^true].
-	(#(#resumeProcess #runProcess) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: runnable.
-			^true].
-	selector == #toggleDisassembly
-		ifTrue: 
-			[aCommandQuery
-				isEnabled: true;
-				isChecked: self isDisassembled.
-			^true].
-	selector == #toggleAnimation
-		ifTrue: 
-			[aCommandQuery
-				isEnabled: (runnable or: [animating]);
-				isChecked: animating.
-			^true].
-	(#(#moreFrames #allFrames) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: (running not and: [self depth <= self frames size]).
-			^true].
-	#showNextStatement == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: running not.
-			^true].
-	#terminateProcess == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: process isTerminated not.
-			^true].
-	(#(#definitionsMenu #referencesMenu) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: true.
-			^true].
-	^(self queryFrameCommand: aCommandQuery) or: [super queryCommand: aCommandQuery]!
+	aCommandQuery
+		isEnabled: (animating or: [self isRunnable]);
+		isChecked: animating!
 
-queryFrameCommand: aCommandQuery
-	"Private - All of these commands required that a stack frame be selected"
+queryUserBreak: aCommandQuery
+	aCommandQuery isEnabled: (flags bitAnd: ##(RunMask | AnimateMask)) == RunMask!
 
-	| selector running runnable animating frame |
-	selector := aCommandQuery commandSymbol.
-	animating := self isAnimating.
-	running := self isRunning or: [animating].
-	runnable := running not and: [self isResumable].
-	frame := self frame.
-	(frame isNil or: [frame isDead]) ifTrue: [^false].
-	"Note that the implement menu is not just for DNUs any more, but any message which is not directly
-	 implemented by its receiver."
-	selector == #implementDNUMenu
-		ifTrue: 
-			[aCommandQuery
-				isEnabled: (running not and: [self class enableDynamicMenus and: [self canImplementMessage]]).
-			^true].
-	#browseMethodInheritanceChain == selector
-		ifTrue: 
-			[aCommandQuery
-				isEnabled: (self selectedMethod ifNil: [false] ifNotNil: [:method | method isOverride]).
-			^true].
-	#messagesMenu == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: (self class enableDynamicMenus and: [self selectedMethod notNil]).
-			^true].
-	(#(#stepOver #stepOut) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: (runnable and: [frame notNil]).
-			^true].
-	selector == #returnFromMessage
-		ifTrue: 
-			[aCommandQuery isEnabled: (running not and: [frame notNil and: [frame sender notNil]]).
-			^true].
-	selector == #restartFrame
-		ifTrue: 
-			[aCommandQuery isEnabled: (running not and: [frame notNil and: [frame isRestartable]]).
-			^true].
-	selector == #stepInto
-		ifTrue: 
-			["Can only step-into in the top stack frame"
-			aCommandQuery isEnabled: (runnable and: [frame = topFrame]).
-			^true].
-	selector == #runToCursor
-		ifTrue: 
-			["Can run to cursor if not in disassembly view"
-			aCommandQuery isEnabled: (runnable and: [frame notNil and: [self isDisassembled not]]).
-			^true].
-	selector == #acceptNoRestart
-		ifTrue: 
-			[aCommandQuery isEnabled: self canSaveMethod.
-			^true].
-	^false!
+referencesMenu
+	<commandQuerySelector: #queryMessagesMenu:>
+	!
 
 refreshFrame
 	"Private - Update the receiver's display of the existing frame."
@@ -1227,6 +1252,7 @@ restartFrame
 	"Private - Unwind the currently selected frame and reset the IP so that the method starts
 	executing from its beginning again."
 
+	<commandQuerySelector: #queryRestartFrame:>
 	self restartFrameWithFocus: false!
 
 restartFrame: frame 
@@ -1400,6 +1426,7 @@ resumeProcess
 	"Private - Restart the debugged process from the point at which it was last suspended. This
 	might involve being resuspended on a Semaphore."
 
+	<commandQuerySelector: #queryRun:>
 	process debugger: nil.
 	self view close ifFalse: [process debugger: self] ifTrue: [self resume]!
 
@@ -1426,6 +1453,7 @@ returnFromMessage
 	return value for which the user is prompted (may be any expression). Also resets the
 	non-resumable flag allowing debugging to continue after a non-continuable error."
 
+	<commandQuerySelector: #queryReturnFromMessage:>
 	| frame expression returnValue receiver loopCookie |
 	frame := self frame.
 	receiver := frame receiver.
@@ -1472,6 +1500,7 @@ runDebuggedProcess
 runProcess
 	"Private - Run the debugged process to the next breakpoint or step interrupt."
 
+	<commandQuerySelector: #queryRun:>
 	self debugState: 'Run to Next Breakpoint'.
 	self breakWhen: [:iFrame | false].
 	self mainView disable.
@@ -1481,6 +1510,7 @@ runToCursor
 	"Private - Step to the last breakpoint immediately before the current caret position in the
 	source pane."
 
+	<commandQuerySelector: #queryRunToCursor:>
 	| ipInterval method frame |
 	self debugState: 'Run to Cursor'.
 	ipInterval := self cursorIPRange.
@@ -1491,7 +1521,7 @@ runToCursor
 	with blocks (which we would otherwise not run into). This may however prevent running to
 	cursor in a block further down the stack."
 	self breakWhen: 
-			[:iFrame | 
+			[:iFrame |
 			iFrame index < frame index or: [iFrame method = method and: [ipInterval includes: iFrame ip]]].
 	self mainView disable.
 	self runDebuggedProcess!
@@ -1589,7 +1619,8 @@ setVariablesList: aSequenceableCollection
 			wasExpanded ifTrue: [variablesPresenter expand: newSelection]]!
 
 showNextStatement
-	self frame = topFrame 
+	<commandQuerySelector: #queryShowNextStatement:>
+	self frame = topFrame
 		ifTrue: [self setSourceSelection]
 		ifFalse: [stackPresenter selection: topFrame]!
 
@@ -1632,6 +1663,7 @@ stepInto
 	"Private - Process a command to step into the next message send. This can only be done from the top
 	stack frame."
 
+	<commandQuerySelector: #queryStepInto:>
 	self debugState: 'Step Into'.
 	self step!
 
@@ -1649,17 +1681,18 @@ stepIntoBlock
 stepOut
 	"Private - Step out of the currently selected frame (i.e. return to its sender)."
 
+	<commandQuerySelector: #queryStep:>
 	| frame |
 	self debugState: 'Step Out'.
 	frame := self frame.
 	self makeDebugFrame: frame sender.
-	self breakWhen: [:iFrame | iFrame index < frame index].		"break when returned from selected frame"
+	self breakWhen: [:iFrame | iFrame index < frame index].		"break when returned fromselected frame"
 	self runDebuggedProcess!
 
 stepOver
-	"Private - Step to the next expression in the currently selected frame. Note that this
-	should not stop on a breakpoint in any block homed lower in the stack."
+	"Private - Step to the next expression in the currently selected frame. Note that this should not stop on a breakpoint in any block homed lower in the stack."
 
+	<commandQuerySelector: #queryStep:>
 	| frame |
 	self beRunning.
 	self debugState: 'Step over'.
@@ -1745,6 +1778,7 @@ terminateProcess
 	attached debugger, so we don't need to do anything other than just request the process
 	terminate."
 
+	<commandQuerySelector: #queryTerminateProcess:>
 	| mb |
 	self beAnimated: false.
 	mb := MessageBox new.
@@ -1761,25 +1795,13 @@ toggleAnimation
 	fun, rather than anything of serious utility. It is also handy for stress testing the
 	debugger."
 
+	<commandQuerySelector: #queryToggleAnimation:>
 	| newState |
 	newState := self isAnimating not.
 	self beAnimated: newState.
 	newState ifFalse: [^self].
 	self debugState: 'Animate'.
 	self step!
-
-toggleDisassembly
-	"Private - Switch between source/disassembly modes."
-
-	#{Disassembler} isDefined
-		ifFalse: 
-			[MessageBox warning: self selectedMethod disassembly.
-			^self].
-	self beDisassembled: self isDisassembled not.
-	sourcePresenter
-		isReadOnly: self isDisassembled;
-		isAutoParseEnabled: (self isDisassembled not and: [sourcePresenter class isAutoParseEnabled]).
-	self displayFrame!
 
 updateForBreakAt: interruptFrame
 	self
@@ -1873,20 +1895,22 @@ updateTemporaries
 userBreak
 	"Private - The user deliberately broke a process running in the debugger from the menu."
 
+	<commandQuerySelector: #queryUserBreak:>
 	self assert: [process ~~ Processor activeProcess].
 	self beAnimated: false.
-	self beBroken; suspend.
+	self
+		beBroken;
+		suspend.
 	self debugState: 'User break'.
 	topFrame := process topFrame.
-	self populateStackModel
-	
-	! !
+	self populateStackModel! !
 !Tools.Debugger categoriesForMethods!
-accept!commands!private! !
 accept:methodSource:!operations!private! !
-acceptNoRestart!commands!private! !
-addToCommandRoute:!commands!public! !
-allFrames!commands!private! !
+acceptItCommand!commands-mappings!private! !
+acceptMethod!commands-actions!private! !
+acceptNoRestart!commands-actions!private! !
+addToCommandRoute:!commands-routing!public! !
+allFrames!commands-actions!private! !
 animatePause!accessing!private! !
 beAnimated:!modes!private! !
 beBroken!modes!private! !
@@ -1894,21 +1918,22 @@ beDisassembled:!private!testing! !
 beRunning!modes!private! !
 blockedRestartWarning:!operations!private! !
 break:!operations!private! !
-breakFrame:!commands!private! !
+breakFrame:!operations!private! !
 breakWhen:!accessing!private! !
-browseDefinitions!commands!private! !
+browseDefinitionsCommand!commands-mappings!private! !
 browseDefinitionsMatching:in:!private! !
 browseDefinitionsOfSelector:in:!private! !
-browseHierarchy!commands!private! !
-browseIt!commands!public! !
-browseMessages!commands!private! !
-browseMethodInheritanceChain!commands!private! !
-browseReferences!browsing!commands!public! !
+browseHierarchy!commands-actions!private! !
+browseIt!commands-actions!public! !
+browseMessageDefinitions!commands-actions!private! !
+browseMessages!commands-actions!private! !
+browseMethodInheritanceChain!commands-actions!private! !
+browseReferences!browsing!commands-actions!public! !
 browseReferencesMatching:in:!private! !
 browseReferencesToLiteral:in:!browsing!private! !
-browseSystem!commands!public! !
-browseVariableClass!commands!private! !
-buildParseTree!commands!private! !
+browseSystem!commands-actions!public! !
+browseVariableClass!commands-actions!private! !
+buildParseTree!commands-actions!private! !
 canImplementMessage!private!testing! !
 canSaveMethod!private!testing! !
 classForVariable:!public! !
@@ -1916,9 +1941,10 @@ clearCachedMethodInfo!helpers!private! !
 continue:with:!operations!private! !
 createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
-cursorIPRange!commands!private! !
+cursorIPRange!commands-actions!private! !
 debugState:!private!updating! !
 defaultHelpId!public! !
+definitionsMenu!commands-menus!private! !
 depth!accessing!private! !
 depth:!accessing!private! !
 displayFrame!private!updating! !
@@ -1933,25 +1959,31 @@ frames!accessing!private! !
 generateStubFor:inClass:!helpers!private! !
 hasEditableMethodSelected!public!testing! !
 hasEditableMethodsSelected!public!testing! !
+hasLiveFrame!commands-queries!helpers!private! !
 hasMethodSelected!public!testing! !
+implementDNUMenu!commands-menus!private! !
 initialize!initializing!private! !
-inspectIt!commands!private! !
-inspectReferences!commands!private! !
+inspectFrame!commands-actions!private! !
+inspectItCommand!commands-mappings!private! !
+inspectReferences!commands-actions!private! !
+inspectVariable!commands-actions!private! !
 isAnimating!private!testing! !
 isDisassembled!private!testing! !
 isFrameRestartable!private!testing! !
 isInCompositeOp!private!testing! !
 isMain:!accessing!private! !
+isPaused!private!testing! !
 isResumable!private!testing! !
+isRunnable!private!testing! !
 isRunning!private!testing! !
-killProcess!commands!private! !
+killProcess!commands-actions!private! !
 mainView!accessing!private! !
 makeDebugFrame:!helpers!private! !
 markMethodAsUnbound:!helpers!private! !
-moreFrames!commands!private! !
+moreFrames!commands-actions!private! !
 nameForArgument:!helpers!private! !
 newLocalsTreeWithRoots:!private!updating! !
-nilVariable!commands!private! !
+nilVariable!commands-actions!private! !
 onAboutToDisplayMenu:!event handling!public! !
 onBreak:!event handling!private! !
 onCloseRequested:!event handling!private! !
@@ -1969,34 +2001,53 @@ onVariableValueChanged!public! !
 onViewClosed!event handling!private! !
 onWalkback:topFrame:resumable:!event handling!private! !
 parseContext!accessing!public! !
-parseTree!commands!private! !
+parseTree!commands-actions!private! !
 performMethodsRefactoring:name:!private!refactoring! !
 populateImplementMenu:!helpers!private! !
 populateStackModel!private!updating! !
 process:topFrame:!accessing!initializing!private! !
-promptToSaveChanges!commands!private! !
-queryCommand:!commands!private! !
-queryFrameCommand:!commands!private! !
+promptToSaveChanges!commands-actions!private! !
+queryBrowseMethodInheritanceChain:!commands-queries!private! !
+queryHasBrowsableMethod:!commands-queries!private! !
+queryHasEditableMethodSelected:!commands-queries!private! !
+queryHasFrameSelected:!public! !
+queryHasVariableSelected:!commands-queries!private! !
+queryImplementMenu:!commands-queries!private! !
+queryMessagesMenu:!commands-queries!private! !
+queryNilVariable:!commands-queries!private! !
+queryRestartFrame:!commands-queries!private! !
+queryReturnFromMessage:!commands-queries!private! !
+queryRun:!commands-queries!private! !
+queryRunToCursor:!commands-queries!private! !
+querySaveMethod:!commands-queries!private! !
+queryShowMoreFrames:!commands-queries!private! !
+queryShowNextStatement:!commands-queries!private! !
+queryStep:!commands-queries!private! !
+queryStepInto:!commands-queries!private! !
+queryTerminateProcess:!commands-queries!private! !
+queryToggleAnimation:!commands-queries!private! !
+queryUserBreak:!commands-queries!private! !
+referencesMenu!commands-menus!private! !
 refreshFrame!private!updating! !
 restartBlock:inFrame:!operations!private! !
 restartBlockFrame:!operations!private! !
-restartFrame!commands!private! !
+restartFrame!commands-actions!private! !
 restartFrame:!operations!private! !
-restartFrameWithFocus:!commands!private! !
+restartFrameWithFocus:!commands-actions!private! !
 restartMethod!operations!private! !
 restartMethodFrame:!operations!private! !
-restartWithStubFor:inClass:!commands!private! !
+restartWithStubFor:inClass:!commands-actions!private! !
 resumable:!modes!private! !
 resume!operations!private! !
-resumeProcess!commands!private! !
+resumeProcess!commands-actions!private! !
 return:fromFrame:!operations!private! !
 return:toFrame:!operations!private! !
-returnFromMessage!commands!private! !
+returnFromMessage!commands-actions!private! !
 runDebuggedProcess!operations!private! !
 runProcess!operations!private! !
-runToCursor!commands!private! !
-saveNewMethod:!commands!public! !
-searchEnvironment!commands!private! !
+runToCursor!commands-actions!private! !
+saveNewMethod:!commands-actions!public! !
+searchEnvironment!commands-actions!private! !
 selectedMethod!accessing!public! !
 selectedMethods!accessing!public! !
 selectedNode!accessing!private! !
@@ -2004,27 +2055,26 @@ selectionIP!accessing!private! !
 setInitialFocus!operations!public! !
 setSourceSelection!private!updating! !
 setVariablesList:!private!updating! !
-showNextStatement!commands!private! !
+showNextStatement!commands-actions!private! !
 skipMaskFor:!helpers!private! !
 source!accessing!private! !
 sourceRangeAt:inTextMap:!helpers!private! !
 step!operations!private! !
 stepInFrame:!operations!private! !
-stepInto!commands!private! !
-stepIntoBlock!commands!private! !
-stepOut!commands!private! !
-stepOver!commands!private! !
+stepInto!commands-actions!private! !
+stepIntoBlock!commands-actions!private! !
+stepOut!commands-actions!private! !
+stepOver!commands-actions!private! !
 stubTextFor:inClass:!helpers!private! !
 suspend!operations!private! !
 suspendProcess!operations!private! !
 terminateOnClose!private!testing! !
-terminateProcess!commands!private! !
+terminateProcess!commands-actions!private! !
 tipForVariable:!enquiries!public! !
-toggleAnimation!commands!private! !
-toggleDisassembly!commands!private! !
+toggleAnimation!commands-actions!private! !
 updateForBreakAt:!operations!private! !
 updateTemporaries!private!updating! !
-userBreak!commands!private! !
+userBreak!commands-actions!private! !
 !
 
 Tools.Debugger methodProtocol: #debugEventHandler attributes: #(#readOnly) selectors: #(#onBreak: #onHalt: #onStep: #onTerminate #onWalkback:topFrame:resumable:)!

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowserShell.cls
@@ -65,7 +65,7 @@ hasEditableMethodSelected
 	^self selectedMethod ifNil: [false] ifNotNil: [:method | self isEditableMethod: method]!
 
 hasEditableMethodsSelected
-	^self browser hasMethodsSelected!
+	^self selectedMethods allSatisfy: [:each | self isEditableMethod: each]!
 
 hasMethods
 	^self browser hasMethods!
@@ -120,11 +120,11 @@ parseContext
 					env := package ifNil: [class environment] ifNotNil: [package environment ifNil: [class environment]].
 					ParseContext methodClass: class environment: (model modelClassFor: env)]]!
 
-queryMethodCommand: aCommandQuery
+queryHasMethodSelected: aCommandQuery
 	aCommandQuery isEnabled: browserPresenter hasMethodSelected!
 
 recompileDiffs
-	<commandQuerySelector: #queryMethodCommand:>
+	<commandQuerySelector: #queryHasMethodSelected:>
 	self developmentSystem recompileDiffs: self selectedMethod!
 
 saveNewMethod: aString
@@ -145,6 +145,11 @@ selectedMethod
 	"Answer the currently selected method, or nil if there is not exactly one selected."
 
 	^self browser selectedMethod!
+
+selectedMethods
+	"Answer the currently selected methods, or an empty collection if there are no selections."
+
+	^self browser selectedMethods!
 
 setInitialFocus
 	browserPresenter hasMethodSelected 
@@ -177,11 +182,12 @@ methods:!accessing!public! !
 onMethodSelected!event handling!private! !
 onViewOpened!event handling!public! !
 parseContext!accessing!public! !
-queryMethodCommand:!command queries!private! !
+queryHasMethodSelected:!commands-queries!private! !
 recompileDiffs!public! !
 saveNewMethod:!helpers!private! !
 searchEnvironment:!public! !
 selectedMethod!accessing!public! !
+selectedMethods!accessing!public! !
 setInitialFocus!operations!public! !
 statusModel!event handling!public! !
 statusText:!accessing!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodExplorerShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodExplorerShell.cls
@@ -133,11 +133,8 @@ deleteItCommand
 	historyTree hasFocus ifTrue: [^#removeHistoryNode].
 	^nil!
 
-hasFuture
-	^historyList hasFuture!
-
-hasPast
-	^historyList hasPast!
+futureSize
+	^historyList futureSize!
 
 historySkip: anInteger
 	"Private - Move around in the history list by the specified <integer> delta (negative for
@@ -232,6 +229,9 @@ onViewOpened
 		to: self.
 !
 
+pastSize
+	^historyList pastSize!
+
 queryCommand: aCommandQuery
 	"Private - Enter details about a potential command for the receiver 
 	into the <CommandQuery>."
@@ -245,45 +245,31 @@ queryCommand: aCommandQuery
 				ifTrue: 
 					[aCommandQuery isEnabled: false.
 					^true]].
-	#historyBack: == selector
-		ifTrue: 
-			[| dist |
-			dist := aCommandQuery command arguments first.
-			aCommandQuery isEnabled: historyList pastSize >= dist.
-			^true].
-	#historyForward: == selector
-		ifTrue: 
-			[| dist |
-			dist := aCommandQuery command arguments first.
-			aCommandQuery isEnabled: historyList futureSize >= dist.
-			^true].
-	selector == #historyForward
-		ifTrue: 
-			[self hasFuture
-				ifTrue: 
-					[aCommandQuery
-						isEnabled: true;
-						text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: {historyList next}
-									locale: Locale smalltalk)]
-				ifFalse: 
-					[aCommandQuery
-						isEnabled: false;
-						text: 'Forward'].
-			^true].
-	selector == #historyBack
-		ifTrue: 
-			[self hasPast
-				ifTrue: 
-					[aCommandQuery
-						isEnabled: true;
-						text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: {historyList previous}
-									locale: Locale smalltalk)]
-				ifFalse: 
-					[aCommandQuery
-						isEnabled: false;
-						text: 'Back'].
-			^true].
 	^super queryCommand: aCommandQuery!
+
+queryHistoryBack: aCommandQuery
+	self hasPast
+		ifTrue: 
+			[aCommandQuery
+				isEnabled: true;
+				text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: { historyList previous }
+							locale: Locale smalltalk)]
+		ifFalse: 
+			[aCommandQuery
+				isEnabled: false;
+				text: 'Back']!
+
+queryHistoryForward: aCommandQuery
+	self hasFuture
+		ifTrue: 
+			[aCommandQuery
+				isEnabled: true;
+				text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: { historyList next }
+							locale: Locale smalltalk)]
+		ifFalse: 
+			[aCommandQuery
+				isEnabled: false;
+				text: 'Forward']!
 
 recordMethodVisit
 	"Private - Add to the visit history - note that the current item is at the top of the history list"
@@ -345,8 +331,7 @@ createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
 defaultHelpId!public! !
 deleteItCommand!helpers!private! !
-hasFuture!public!testing! !
-hasPast!public!testing! !
+futureSize!accessing!public! !
 historySkip:!commands!private! !
 historyTree!public! !
 initialize!initializing!private! !
@@ -358,7 +343,10 @@ onTimerTick:!event handling!private! !
 onTipTextRequired:!event handling!private! !
 onTreeSelectionChanged!event handling!private! !
 onViewOpened!event handling!private! !
+pastSize!accessing!public! !
 queryCommand:!commands!private! !
+queryHistoryBack:!commands!private! !
+queryHistoryForward:!commands!private! !
 recordMethodVisit!helpers!private! !
 removeHistoryNode!helpers!private! !
 saveStateOn:!private!saved state! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
@@ -34,12 +34,12 @@ Class Variables:
 !Tools.PackageBrowserShell categoriesForClass!MVP-Presenters! !
 !Tools.PackageBrowserShell methodsFor!
 
-accept
-	"Accept the changes to any of the panes in the receiver"
+acceptItCommand
+	"Private - Answer the <Symbol> of the contextual command to save changes, depending on the subview with focus."
 
-	currentCard == #comment ifTrue: [^self saveComment].
-	currentCard == #scripts ifTrue: [currentCard == #scripts ifTrue: [^self saveScript]].
-	Sound errorBeep!
+	currentCard == #comment ifTrue: [^#saveComment].
+	currentCard == #scripts ifTrue: [^#saveScript].
+	^nil!
 
 addToCommandRoute: route 
 	"Update the <OrderedCollection>, path, with the receiver's contribution to the command path
@@ -68,6 +68,7 @@ browseClass
 	class is selected then an <EnvironmentBrowserShell> is opened and configured to display
 	those classes."
 
+	<commandQuerySelector: #queryHasClassesSelected:>
 	| classes |
 	classes := self selectedClasses.
 	^classes size = 1
@@ -78,30 +79,46 @@ browseClassReferences
 	"Browse all the methods in the entire system which refer to the class selected in the
 	receiver."
 
+	<commandQuerySelector: #queryHasClassesSelected:>
 	self browseClassReferencesIn: self browserEnvironment!
 
 browseClassReferencesIn: aBrowserEnvironment
-	| class |
-	class := self selectedClass.
-	self browseMethodsInEnvironments: {aBrowserEnvironment referencesToVariable: class binding.
-				aBrowserEnvironment referencesToClass: class}!
+	| class environments |
+	class := self selectedClasses.
+	environments := Array writeStream.
+	class do: 
+			[:each |
+			environments
+				nextPut: (aBrowserEnvironment referencesToVariable: each binding);
+				nextPut: (aBrowserEnvironment referencesToClass: each)].
+	self browseMethodsInEnvironments: environments contents!
 
-browseDefinitions
-	^self browseMessageDefinitions!
+browseDefinitionsCommand
+	currentCard == #methods ifTrue: [^#browseMessageDefinitions].
+	^nil!
 
-browseHierarchy
-	"Private - Open a hierarchy browser on the currently selected class or method."
+browseHierarchyCommand
+	^##(IdentityDictionary withAll: {
+				#methods -> #browseHierarchyOfMethod.
+				#classes -> #browseHierarchyOfClass.
+				#variables -> #browseHierarchyOfVariable
+			})
+		lookup: currentCard!
 
-	(self selectedMethod notNil and: [currentCard == #methods]) 
-		ifTrue: [^self developmentSystem browseClassHierarchyOfMethod: self selectedMethod].
-	(self selectedClass notNil and: [currentCard == #classes]) 
-		ifTrue: [^self developmentSystem browseHierarchy: self selectedClass].
-	self developmentSystem browseHierarchy!
+browseHierarchyOfClass
+	<commandQuerySelector: #queryHasClassSelected:>
+	self developmentSystem browseHierarchy: self selectedClass!
 
-browseIt
-	"Open a default browser on the currently selected class or method."
+browseHierarchyOfMethod
+	<commandQuerySelector: #queryHasMethodSelected:>
+	self developmentSystem browseClassHierarchyOfMethod: self selectedMethod!
 
-	self perform: self browseItCommand!
+browseHierarchyOfVariable
+	<commandQuerySelector: #queryHasLiveVariableSelected:>
+	| var |
+	var := self sharedVariable binding.
+	self developmentSystem
+		browseHierarchy: (var isClassBinding ifTrue: [var value] ifFalse: [var environment])!
 
 browseItCommand
 	"Private - Answer the command that the context-sensitive 'Browse-It' command would be linked
@@ -112,7 +129,7 @@ browseItCommand
 	focus == packagesPresenter packagesPresenter view ifTrue: [^#browsePackages].
 	focus == classesPresenter view ifTrue: [^#browseClass].
 	focus == methodsPresenter view ifTrue: [^#browseMethods].
-	"focus == variablesPresenter view ifTrue: [^#browseVariables]."
+	focus == variablesPresenter view ifTrue: [^#browseVariableClass].
 	^nil!
 
 browseLocalClassReferences
@@ -125,12 +142,14 @@ browseLocalMessageDefinitions
 	"Open a method browser displaying all implementors of the current selector in the currently
 	selected packages."
 
+	<commandQuerySelector: #queryHasPackagesSelected:>
 	self browseMessageDefinitionsIn: self searchEnvironment!
 
 browseLocalMessageReferences
 	"Open a method browser displaying all references to the current selector in the currently
 	selected packages."
 
+	<commandQuerySelector: #queryHasPackagesSelected:>
 	self browseMessageReferencesIn: self searchEnvironment!
 
 browseLooseMethods: aCollection
@@ -143,50 +162,58 @@ browseLooseMethods: aCollection
 browseMessageDefinitions
 	"Open a method browser displaying all implementors of the current selector in the system."
 
+	<commandQuerySelector: #queryHasMethodsSelected:>
 	self browseMessageDefinitionsIn: self browserEnvironment!
 
 browseMessageDefinitionsIn: aBrowserEnvironment
-	self selectedMethod
-		ifNil: 
-			[(self developmentSystem promptForDefinitionsOf: '' in: aBrowserEnvironment)
-				ifNotNil: [:search | self browseMethodsIn: (aBrowserEnvironment definitionsMatching: search)]]
-		ifNotNil: 
-			[:method |
-			self browseMethodsIn: (aBrowserEnvironment
-						definitionsMatching: (MethodSearch newSelector: method selector))]!
+	| methods |
+	methods := self selectedMethods.
+	methods isEmpty
+		ifTrue: [self model browseMessageDefinitionsIn: aBrowserEnvironment]
+		ifFalse: 
+			[self browseMethodsInEnvironments: (methods
+						collect: [:each | aBrowserEnvironment definitionsMatching: (MethodSearch newSelector: each selector)])]!
 
 browseMessageReferences
 	"Open a method browser displaying all references to the current selector in the entire system."
 
+	<commandQuerySelector: #queryHasMethodsSelected:>
 	self browseMessageReferencesIn: self browserEnvironment!
 
-browseMessageReferencesIn: aBrowserEnvironment 
-	self selectedMethod 
-		ifNil: [self model browseMessageReferencesIn: aBrowserEnvironment]
-		ifNotNil: [:method | self model browseReferencesToLiteral: method selector in: aBrowserEnvironment]!
+browseMessageReferencesIn: aBrowserEnvironment
+	| methods |
+	methods := self selectedMethods.
+	methods isEmpty
+		ifTrue: [self model browseMessageReferencesIn: aBrowserEnvironment]
+		ifFalse: 
+			[self browseMethodsInEnvironments: (methods
+						collect: [:each | aBrowserEnvironment referencesToLiteral: each selector])]!
 
 browseMethodClass
 	"Open a default browser on the currently selected method."
-
+	
+	<commandQuerySelector: #queryHasMethodSelected:>
 	^self selectedMethod browse!
 
 browseMethods
 	"Open a default browser on the currently selected method or methods."
 
+	<commandQuerySelector: #queryBrowseMethods:>
 	| methods |
 	methods := self selectedMethods.
 	methods size == 1 ifTrue: [self browseMethodClass] ifFalse: [self browseLooseMethods: methods]!
 
 browsePackages
+	<commandQuerySelector: #queryHasPackagesSelected:>
 	^packagesPresenter browsePackageSources!
 
-browseReferences
-	<acceleratorKey: 'Shift+F12'>
-	(self selectedMethod notNil and: [currentCard == #methods]) ifTrue: [^self browseMessageReferences].
-	(self selectedClass notNil and: [currentCard == #classes]) ifTrue: [^self browseClassReferences].
-	(self sharedVariable notNil and: [currentCard == #variables])
-		ifTrue: [^self browseVariableReferences].
-	Sound warningBeep!
+browseReferencesCommand
+	^##(IdentityDictionary withAll: {
+				#methods -> #browseMessageReferences.
+				#classes -> #browseClassReferences.
+				#variables -> #browseVariableReferences
+			})
+		lookup: currentCard!
 
 browseSystem
 	"Open a system browser on the currently selected class or method,
@@ -203,11 +230,17 @@ browseSystem
 		ifTrue: [browser actualClass: class].
 	^browser!
 
+browseVariableClass
+	"Open a default browser on the currently selected method."
+
+	<commandQuerySelector: #queryHasLiveVariableSelected:>
+	^self sharedVariable browse!
+
 browseVariableReferences
 	"Browse all the methods which refer to the shared variable selected in the receiver."
 
-	self model browseSharedVariableReferences: self sharedVariable
-		in: self browserEnvironment!
+	<commandQuerySelector: #queryHasVariableSelected:>
+	self model browseSharedVariableReferences: self sharedVariable in: self browserEnvironment!
 
 buildPopupForCommand: aSymbol 
 	"Private - Dynamically build an appropriate popup menu for aSymbol command."
@@ -496,18 +529,11 @@ initialize
 inspectClasses
 	"Open an inspector on the currently selected classes."
 
+	<commandQuerySelector: #queryHasClassesSelected:>
 	self inspectCollection: self selectedClasses!
 
 inspectCollection: aCollection
 	(aCollection size = 1 ifTrue: [aCollection first] ifFalse: [aCollection]) inspect!
-
-inspectIt
-	"Open a browser on the selected category/protocol/variables.
-	Note that we only receive this command it one of the filter panes is selected
-	as class hierarchy, method browser, and workspace presenters all handle
-	it themselves."
-
-	self perform: self inspectItCommand!
 
 inspectItCommand
 	"Private - Answer the command that the context-sensitive 'Inspect-It' command would be linked
@@ -525,6 +551,7 @@ inspectItCommand
 inspectMethods
 	"Open an inspector on the currently selected methods."
 
+	<commandQuerySelector: #queryHasMethodsSelected:>
 	self inspectCollection: self selectedMethods!
 
 inspectResources
@@ -535,6 +562,7 @@ inspectResources
 inspectSharedVariables
 	"Open an inspector on the currently selected variables."
 
+	<commandQuerySelector: #queryHasVariablesSelected:>
 	self inspectCollection: (self variableNames collect: [:each | each bindingOrNil])!
 
 isCardUpToDate: aSymbol
@@ -884,90 +912,55 @@ promptToSaveChanges: aSelectionChangingEvent
 	^(commentPresenter prompt: 'comment' toSaveChanges: aSelectionChangingEvent) 
 		and: [scriptTextPresenter prompt: 'script' toSaveChanges: aSelectionChangingEvent]!
 
-queryCommand: aCommandQuery
-	"Private - Enters details about a potential command for the receiver into 
-	the <CommandQuery>, query"
+queryBrowseMethods: aCommandQuery
+	| methods |
+	methods := self selectedMethods.
+	aCommandQuery isEnabled: methods notEmpty.
+	aCommandQuery text: (aCommandQuery description
+				expandMacrosWithArguments: { methods size = 1 ifTrue: [methods first] ifFalse: ['&Methods'] }
+				locale: Locale smalltalk)!
 
-	| selector |
-	selector := aCommandQuery commandSymbol.
-	selector == #browseIt
-		ifTrue: 
-			[selector := self browseItCommand.
-			selector isNil
-				ifTrue: 
-					[aCommandQuery isEnabled: false.
-					^true]].
-	selector == #inspectIt
-		ifTrue: 
-			[selector := self inspectItCommand.
-			selector isNil
-				ifTrue: 
-					[aCommandQuery isEnabled: false.
-					^true]].
-	selector == #browsePackages
-		ifTrue: 
-			[aCommandQuery isEnabled: ((packagesPresenter respondsTo: selector) and: [self packages notEmpty]).
-			^true].
-	(#(#browseLocalMessageReferences #browseLocalMessageDefinitions) identityIncludes: selector)
-		ifTrue: 
-			[self queryHasPackages: aCommandQuery.
-			^true].
-	(#(#browseHierarchy #browseReferences) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: (self selectedClass notNil
-						or: [self selectedMethod notNil or: [self sharedVariable notNil]]).
-			^true].
-	(#(#browseMethodClass #browseMessageDefinitions #browseMessageReferences #browseDefinitions)
-		identityIncludes: selector)
-			ifTrue: 
-				[aCommandQuery isEnabled: (self selectedMethod notNil and: [currentCard == #methods]).
-				^true].
-	(#(#browseClass #browseClassReferences) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: self selectedClasses notEmpty.
-			^true].
-	#accept == selector
-		ifTrue: 
-			[packagesPresenter hasSinglePackage
-				ifTrue: 
-					[aCommandQuery
-						isEnabled: true;
-						isDefault: true]
-				ifFalse: [aCommandQuery isEnabled: false].
-			^true].
-	(#(#removeClasses #inspectClasses) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: self selectedClasses notEmpty.
-			^true].
-	(#(#removeLooseMethods #inspectMethods) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: self selectedMethods notEmpty.
-			^true].
-	#browseMethods == selector
-		ifTrue: 
-			[| methods |
-			methods := self selectedMethods.
-			aCommandQuery isEnabled: methods notEmpty.
-			aCommandQuery text: (aCommandQuery description
-						expandMacrosWithArguments: { methods size = 1 ifTrue: [methods first] ifFalse: ['&Methods'] }
-						locale: Locale smalltalk).
-			^true].
-	#browseVariableReferences == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: self sharedVariable notNil.
-			^true].
-	(#(#inspectSharedVariables #browseGlobals #removeVariables) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: self variableNames notEmpty.
-			^true].
-	selector == #upgradeResources
-		ifTrue: 
-			[aCommandQuery isEnabled: self resourceIdentifiers notEmpty.
-			^true].
-	^super queryCommand: aCommandQuery!
+queryHasClassesSelected: aCommandQuery
+	aCommandQuery isEnabled: classesPresenter hasSelection!
 
-queryHasPackages: aCommandQuery
+queryHasLiveVariableSelected: aCommandQuery
+	| ref |
+	ref := self sharedVariable.
+	aCommandQuery isEnabled: (ref notNil and: [ref isDefined])!
+
+queryHasMethodSelected: aCommandQuery
+	aCommandQuery isEnabled: self hasMethodSelected!
+
+queryHasMethodsSelected: aCommandQuery
+	aCommandQuery isEnabled: self selectedMethods notEmpty!
+
+queryHasPackagesSelected: aCommandQuery
 	aCommandQuery isEnabled: self hasPackages!
+
+queryHasResourcesSelected: aCommandQuery
+	aCommandQuery isEnabled: self resourceIdentifiers notEmpty!
+
+queryHasVariableSelected: aCommandQuery
+	aCommandQuery isEnabled: self sharedVariable notNil!
+
+queryHasVariablesSelected: aCommandQuery
+	aCommandQuery isEnabled: self variableNames notEmpty!
+
+querySaveComment: aCommandQuery
+	(packagesPresenter hasSinglePackage and: [commentPresenter isModified])
+		ifTrue: 
+			[aCommandQuery
+				isEnabled: true;
+				isDefault: true]
+		ifFalse: [aCommandQuery isEnabled: false]!
+
+querySaveScript: aCommandQuery
+	(packagesPresenter hasSinglePackage and: [scriptTextPresenter isModified])
+		ifTrue: 
+			[aCommandQuery
+				isEnabled: true;
+				isDefault: true]
+		ifFalse: [aCommandQuery isEnabled: false]!
 
 refreshCard: aSymbol
 	currentCard == aSymbol 
@@ -986,6 +979,7 @@ release
 removeClasses
 	"Private - Remove the currently selected classes from the package."
 
+	<commandQuerySelector: #queryHasClassesSelected:>
 	self selectedClasses do: [:e | e owningPackage removeClass: e]!
 
 removeLooseMethods
@@ -993,11 +987,13 @@ removeLooseMethods
 	Note that the methods are not actually removed from the system (i.e.
 	ownership is transferred to the package of their method class)."
 
+	<commandQuerySelector: #queryHasMethodsSelected:>
 	self selectedMethods do: [:each | each owningPackage removeMethod: each]!
 
 removeVariables
 	"Private - Remove the currently selected variables from their packages."
 
+	<commandQuerySelector: #queryHasVariablesSelected:>
 	self variableNames do: [:each | Package manager addVariableNamed: each to: nil]!
 
 resourceIdentifier
@@ -1016,15 +1012,16 @@ resourceIdentifiers
 saveComment
 	"Private - Save the comment from the source text."
 
+	<commandQuerySelector: #querySaveComment:>
 	self singlePackage comment: commentPresenter plainText.
 	commentPresenter isModified: false!
 
 saveScript
 	"Private - Save the script from the source text."
 
+	<commandQuerySelector: #querySaveScript:>
 	self singlePackage scriptAt: self scriptName put: self scriptText.
-	self updateScriptNames.
-!
+	self updateScriptNames!
 
 scriptName
 	"Answer the currently selected script name."
@@ -1255,35 +1252,39 @@ updateVariables
 upgradeResources
 	"Private - Uprade & resave the selected resources, by loading them into a ViewComposer."
 
+	<commandQuerySelector: #queryHasResourcesSelected:>
 	self resourceIdentifiers do: [:each | each reassign]!
 
 variableNames
 	^variablesPresenter selections! !
 !Tools.PackageBrowserShell categoriesForMethods!
-accept!commands!public! !
-addToCommandRoute:!commands!public! !
+acceptItCommand!commands-mappings!private! !
+addToCommandRoute:!commands-routing!public! !
 applyOptions!operations!options!private! !
-browseClass!commands!public! !
-browseClassReferences!commands!public! !
+browseClass!commands-actions!public! !
+browseClassReferences!commands-actions!public! !
 browseClassReferencesIn:!helpers!private! !
-browseDefinitions!commands!public! !
-browseHierarchy!commands!private! !
-browseIt!commands!public! !
+browseDefinitionsCommand!commands-mappings!private! !
+browseHierarchyCommand!commands-mappings!private! !
+browseHierarchyOfClass!commands-actions!private! !
+browseHierarchyOfMethod!commands-actions!private! !
+browseHierarchyOfVariable!commands-actions!private! !
 browseItCommand!helpers!private! !
-browseLocalClassReferences!commands!public! !
-browseLocalMessageDefinitions!commands!public! !
-browseLocalMessageReferences!commands!public! !
+browseLocalClassReferences!commands-actions!public! !
+browseLocalMessageDefinitions!commands-actions!public! !
+browseLocalMessageReferences!commands-actions!public! !
 browseLooseMethods:!helpers!private! !
-browseMessageDefinitions!commands!public! !
+browseMessageDefinitions!commands-actions!public! !
 browseMessageDefinitionsIn:!helpers!private! !
-browseMessageReferences!commands!public! !
+browseMessageReferences!commands-actions!public! !
 browseMessageReferencesIn:!helpers!private! !
-browseMethodClass!commands!public! !
-browseMethods!commands!public! !
-browsePackages!commands!public! !
-browseReferences!commands!public! !
-browseSystem!commands!public! !
-browseVariableReferences!commands!public! !
+browseMethodClass!commands-actions!public! !
+browseMethods!commands-actions!public! !
+browsePackages!commands-actions!public! !
+browseReferencesCommand!commands-mappings!private! !
+browseSystem!commands-actions!public! !
+browseVariableClass!commands-actions!public! !
+browseVariableReferences!commands-actions!public! !
 buildPopupForCommand:!event handling!private! !
 cacheCurrentCard:!event handling!private! !
 canSaveState!private!saved state! !
@@ -1296,8 +1297,8 @@ clearPrerequisites!private!updating! !
 clearResources!private!updating! !
 clearScriptNames!private!updating! !
 clearVariables!private!updating! !
-createComponents!commands!initializing!private! !
-createSchematicWiring!commands!initializing!private! !
+createComponents!commands-actions!private! !
+createSchematicWiring!commands-actions!private! !
 customDrawClassList:!private! !
 defaultHelpId!public! !
 hasClassSelected!public!testing! !
@@ -1307,13 +1308,12 @@ hasMethodSelected!public!testing! !
 hasPackages!private!testing! !
 hasPackageSelected!public!testing! !
 initialize!initializing!private! !
-inspectClasses!commands!public! !
+inspectClasses!commands-actions!public! !
 inspectCollection:!helpers!private! !
-inspectIt!commands!public! !
 inspectItCommand!helpers!private! !
-inspectMethods!commands!public! !
-inspectResources!commands!public! !
-inspectSharedVariables!commands!public! !
+inspectMethods!commands-actions!public! !
+inspectResources!commands-actions!public! !
+inspectSharedVariables!commands-actions!public! !
 isCardUpToDate:!private!testing! !
 markCardDirty:!helpers!private! !
 objectRepackaged:from:to:card:list:!event handling!private! !
@@ -1340,21 +1340,30 @@ onVariableRenamed:from:!event handling!private! !
 onVariableRepackaged:from:to:!event handling!private! !
 onViewClosed!event handling!private! !
 onViewOpened!event handling!private! !
-openWorkspace!commands!public! !
+openWorkspace!commands-actions!public! !
 packages!accessing!public! !
 packages:!accessing!public! !
 promptToSaveChanges!helpers!private! !
 promptToSaveChanges:!helpers!private! !
-queryCommand:!commands!public! !
-queryHasPackages:!command queries!public! !
+queryBrowseMethods:!commands-queries!private! !
+queryHasClassesSelected:!commands-queries!private! !
+queryHasLiveVariableSelected:!commands-queries!public! !
+queryHasMethodSelected:!commands-queries!private! !
+queryHasMethodsSelected:!commands-queries!private! !
+queryHasPackagesSelected:!commands-queries!private! !
+queryHasResourcesSelected:!commands-queries!private! !
+queryHasVariableSelected:!commands-queries!public! !
+queryHasVariablesSelected:!commands-queries!public! !
+querySaveComment:!commands-queries!public! !
+querySaveScript:!commands-queries!public! !
 refreshCard:!helpers!private! !
 release!dependency!public! !
-removeClasses!commands!private! !
-removeLooseMethods!commands!private! !
-removeVariables!commands!private! !
+removeClasses!commands-actions!private! !
+removeLooseMethods!commands-actions!private! !
+removeVariables!commands-actions!private! !
 resourceIdentifier!accessing!private! !
 resourceIdentifiers!accessing!private! !
-saveComment!commands!private! !
+saveComment!commands-actions!private! !
 saveScript!operations!private! !
 scriptName!accessing!private! !
 scriptText!accessing!private! !
@@ -1388,7 +1397,7 @@ updateResources!private!updating! !
 updateScriptNames!private!updating! !
 updateStatus!private!updating! !
 updateVariables!private!updating! !
-upgradeResources!commands!public! !
+upgradeResources!commands-actions!public! !
 variableNames!accessing!public! !
 !
 

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageSelector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageSelector.cls
@@ -95,7 +95,6 @@ browseItCommand
 	to if sent to the receiver at this moment."
 
 	filterPresenter hasFocus ifTrue: [^#browseFolder].
-	packagesPresenter hasFocus ifTrue: [^nil].
 	^nil!
 
 browsePackages

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkSystem.cls
@@ -3,10 +3,22 @@
 Core.Model
 	subclass: #'Tools.SmalltalkSystem'
 	instanceVariableNames: 'systemFolderClass workspaceClass defaultInspectorClass defaultBrowserClass systemFolder packageBrowserClass debuggerClass viewComposerClass protocolBrowserClass workspaceShellClass resourceBrowserClass changedIcon hierarchyBrowserClass preferAlternateInspectors formatterClass classChooserClass resourceIdentifierDialogClass findDetails methodWorkspaceClass allSelectors argumentClasses methodExplorerClass aboutBoxClass testBrowserClass toolbarBitmapSize displayItLocale'
-	classVariableNames: 'ChangedIcon Current FileDrops RegisteredTools'
+	classVariableNames: 'ChangedIcon Current RegisteredTools'
 	imports: #(#{Kernel.CompilerFlags} #{Refactory.Browser} #{Kernel.ParseErrorCodes} #{XProgramming.SUnit private})
 	classInstanceVariableNames: ''
-	classConstants: {}!
+	classConstants: {
+			'FileDrops'
+				-> (LookupTable withAll: {
+								'chg' -> #dropScriptFile:.
+								'cls' -> #dropClassFile:.
+								'pac' -> #dropPackageFile:.
+								'pax' -> #dropPackageFile:.
+								'sml' -> #dropScriptFile:.
+								'st' -> #dropScriptFile:.
+								'txt' -> #dropTextFile:.
+								'xml' -> #dropXmlFile:
+							})
+		}!
 Tools.SmalltalkSystem guid: (Core.GUID fromString: '{87b4c66c-026e-11d3-9fd7-00a0cc3e4a32}')!
 Tools.SmalltalkSystem comment: 'SmalltalkSystem is a Facade onto the Dolphin Smalltalk development environment. Most of the development tools hold the Singleton instance of SmalltalkSystem as their model and use it to act as a go-between between programmer, user interface, and the development image.
 
@@ -513,7 +525,7 @@ browseClassVariables: aClass
 	aVariable notNil
 		ifTrue: 
 			[self
-				browseReferencesToClassVar: aVariable
+				browseReferencesToClassVars: { aVariable }
 				of: aClass
 				within: self browserEnvironment]!
 
@@ -631,7 +643,7 @@ browseInstanceVariables: browseClass
 
 	self 
 		browseInstanceVariables: browseClass
-		action: #browseReferencesToInstVar:inHierarchyOf:within:
+		action: #browseReferencesToInstVars:inHierarchyOf:within:
 		in: self browserEnvironment!
 
 browseInstanceVariables: browseClass action: selector in: aBrowserEnvironment
@@ -646,7 +658,7 @@ browseInstanceVariables: browseClass action: selector in: aBrowserEnvironment
 		ifTrue: 
 			[self
 				perform: selector
-				with: varName
+				with: { varName }
 				with: browseClass
 				with: aBrowserEnvironment]!
 
@@ -852,34 +864,18 @@ browseReferencesTo: anObject
 
 	^self browseReferencesToLiteral: anObject in: self browserEnvironment!
 
-browseReferencesToClassVar: aString of: aClass within: aBrowserEnvironment
-	"Private - Open a MethodBrowser on all the methods that reference the class variable named, aString, in the hierarchy of the <Behavior>, aClass."
+browseReferencesToClassVars: aCollection of: aClass within: aBrowserEnvironment
+	"Private - Open a MethodBrowser on all the methods that reference the class variables in aCollection, in the hierarchy of the <Behavior>, aClass."
 
-	| binding refs matched |
-	binding := aClass hierarchyBindingFor: aString.
-	matched := aBrowserEnvironment filterMethods: [:method1 | method1 refersToLiteral: binding].
-	matched
-		label: ('All methods that reference <1p>.<2s> in <3p>'
-					expandMacrosWith: binding environment
-					with: binding key
-					with: aBrowserEnvironment);
-		addSearchString: binding key.
-	refs := matched.
-	binding isImmutable
-		ifTrue: [self browseMethodsIn: refs]
-		ifFalse: 
-			[| writers readers |
-			writers := refs filterMethods: [:method | method byteCodeDispatcher writesStatic: binding].
-			writers label: ('All methods that assign to <1p>.<2s> in <3p>'
-						expandMacrosWith: binding environment
-						with: aString
-						with: aBrowserEnvironment).
-			readers := refs filterMethods: [:method | method byteCodeDispatcher readsStatic: binding].
-			readers label: ('All methods that read <1p>.<2s> in <3p>'
-						expandMacrosWith: binding environment
-						with: aString
-						with: aBrowserEnvironment).
-			self browseMethodsInEnvironments: {refs. readers. writers}]!
+	| environments |
+	environments := Array writeStream.
+	aCollection do: 
+			[:each |
+			environments nextPutAll: (self
+						referencesToClassVar: each
+						of: aClass
+						within: aBrowserEnvironment)].
+	self browseMethodsInEnvironments: environments contents!
 
 browseReferencesToGlobal: aString 
 	self browseReferencesToGlobal: aString in: self browserEnvironment!
@@ -888,14 +884,18 @@ browseReferencesToGlobal: aString in: aBrowserEnvironment
 	(self promptForReferencesToGlobal: aString in: aBrowserEnvironment) 
 		ifNotNil: [:env | self browseMethodsIn: env]!
 
-browseReferencesToInstVar: aString inHierarchyOf: aBehavior within: aBrowserEnvironment
-	"Private - Open a method browser on all the methods that refer to the instance variable
-	named by the <readableString> argument, in the hierarchy of the <Behavior> argument."
+browseReferencesToInstVars: aCollection inHierarchyOf: aBehavior within: aBrowserEnvironment
+	"Private - Open a method browser on all the methods that refer to the instance variables named by the <collection> of <readableString> argument, in the hierarchy of the <Behavior> argument."
 
-	self browseMethodsInEnvironments: (self
-				referencesToInstVar: aString
-				inHierarchyOf: aBehavior
-				within: aBrowserEnvironment)!
+	| environments |
+	environments := Array writeStream.
+	aCollection do: 
+			[:each |
+			environments nextPutAll: (self
+						referencesToInstVar: each
+						inHierarchyOf: aBehavior
+						within: aBrowserEnvironment)].
+	self browseMethodsInEnvironments: environments contents!
 
 browseReferencesToLiteral: anObject in: aBrowserEnvironment 
 	"Opens a MethodBrowser on all the methods that refer to aString from their literal frames
@@ -1936,7 +1936,8 @@ initializeArgumentClasses
 		add: Integer;
 		add: Boolean;
 		add: Class;
-		add: String.
+		add: String;
+		add: Symbol.
 	argumentClasses shrink!
 
 initializeFrom: aSmalltalkSystem 
@@ -3323,6 +3324,34 @@ referencesTo: anObject in: aBrowserEnvironment
 
 	^aBrowserEnvironment liveReferencesTo: anObject!
 
+referencesToClassVar: aString of: aClass within: aBrowserEnvironment
+	"Private - Open a MethodBrowser on all the methods that reference the class variable named, aString, in the hierarchy of the <Behavior>, aClass."
+
+	| binding matched |
+	binding := aClass hierarchyBindingFor: aString.
+	matched := aBrowserEnvironment filterMethods: [:method | method refersToLiteral: binding].
+	matched
+		label: ('All methods that reference <1p>.<2s> in <3p>'
+					expandMacrosWith: binding environment
+					with: binding key
+					with: aBrowserEnvironment);
+		addSearchString: binding key.
+	^binding isImmutable
+		ifTrue: [{ matched }]
+		ifFalse: 
+			[| writers readers |
+			writers := matched filterMethods: [:method | method byteCodeDispatcher writesStatic: binding].
+			writers label: ('All methods that assign to <1p>.<2s> in <3p>'
+						expandMacrosWith: binding environment
+						with: aString
+						with: aBrowserEnvironment).
+			readers := matched filterMethods: [:method | method byteCodeDispatcher readsStatic: binding].
+			readers label: ('All methods that read <1p>.<2s> in <3p>'
+						expandMacrosWith: binding environment
+						with: aString
+						with: aBrowserEnvironment).
+			{ matched. readers. writers }]!
+
 referencesToInstVar: aString inHierarchyOf: aBehavior within: aBrowserEnvironment
 	| definingBehavior env |
 	definingBehavior := aBehavior whichClassDefinesInstVar: aString.
@@ -3696,7 +3725,7 @@ renameClassVariable: oldName to: newName in: definingBehavior
 renameClassVariable: aString to: newName in: aClass within: aBrowserEnvironment
 	aClass renameClassVar: aString to: newName.
 	self
-		browseReferencesToClassVar: newName
+		browseReferencesToClassVars: { newName }
 		of: aClass
 		within: aBrowserEnvironment!
 
@@ -3730,12 +3759,12 @@ renameInstanceVariable: oldName to: newName in: definingBehavior
 		in: definingBehavior
 		within: self browserEnvironment!
 
-renameInstanceVariable: aString to: newName in: aClass within: aBrowserEnvironment 
+renameInstanceVariable: aString to: newName in: aClass within: aBrowserEnvironment
 	aClass renameInstVar: aString to: newName.
-	self 
-		browseReferencesToInstVar: newName
+	self
+		browseReferencesToInstVars: { newName }
 		inHierarchyOf: aClass
-		within: aBrowserEnvironment .
+		within: aBrowserEnvironment.
 	^newName!
 
 renameVariable: oldSymbol to: newSymbol
@@ -4292,10 +4321,10 @@ browsePackages:!browsing!commands!public! !
 browseProtocols!browsing!commands!protocols!public! !
 browseReferencesMatching:in:!browsing!private! !
 browseReferencesTo:!browsing!public! !
-browseReferencesToClassVar:of:within:!browsing!private! !
+browseReferencesToClassVars:of:within:!browsing!private! !
 browseReferencesToGlobal:!browsing!public! !
 browseReferencesToGlobal:in:!browsing!public! !
-browseReferencesToInstVar:inHierarchyOf:within:!browsing!private! !
+browseReferencesToInstVars:inHierarchyOf:within:!browsing!private! !
 browseReferencesToLiteral:in:!browsing!public! !
 browseReferencesToVariable:!browsing!public! !
 browserEnvFromDom:!helpers!private! !
@@ -4545,6 +4574,7 @@ queryCommand:!commands!private! !
 redoChange!commands!public! !
 referencesTo:!enquiries!public! !
 referencesTo:in:!enquiries!public! !
+referencesToClassVar:of:within:!browsing!private! !
 referencesToInstVar:inHierarchyOf:within:!browsing!public! !
 referencesToLiteral:in:!browsing!public! !
 reformatAllMethodsIn:!commands!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkToolShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkToolShell.cls
@@ -30,6 +30,17 @@ Class Instance Variables:
 !Tools.SmalltalkToolShell categoriesForClass!MVP-Presenters!MVP-Resources-IDE Tools! !
 !Tools.SmalltalkToolShell methodsFor!
 
+accept
+	"Save the source on the currently displayed source card."
+
+	<commandQuerySelector: #queryAcceptIt:>
+	self perform: self acceptItCommand!
+
+acceptItCommand
+	"Private - Answer the <Symbol> of the contextual command to save changes to something, depending on the subview with focus and/or selection."
+
+	^nil!
+
 addToCommandRoute: aCommandPolicy
 	"Update the command routing path of the <CommandPolicy> argument with the receiver's contribution to the command path. "
 
@@ -42,18 +53,61 @@ addToCommandRoute: aCommandPolicy
 applyOptions
 	SmalltalkSystem current applyOptionsToTool: self!
 
-browseIt
-	"Open a new default browser at the same point as the receiver.
-	This is the workspace Browse-It command which is subtly different to the Browse Classes
-	command, but for many cases the appropriate action is to open a class browser so we
-	wire up to the #browseClasses command by default."
+browseDefinitions
+	"Context-sensitive browse definitions command (F12)."
 
-	Object browse!
+	<commandQuerySelector: #queryBrowseDefinitions:>
+	<acceleratorKey: 'F12'>
+	self perform: self browseDefinitionsCommand!
+
+browseDefinitionsCommand
+	"Answer the <Symbol> of the contextual command to browse definitions of something, depending on the subview with focus and/or selection."
+
+	^nil!
+
+browseHierarchy
+	"Open a class hierarchy browser navigated appropriately based on initiating context."
+
+	<commandQuerySelector: #queryBrowseHierarchy:>
+	self perform: self browseHierarchyCommand!
+
+browseHierarchyCommand
+	"Answer the <Symbol> of the contextual command to browse the class hierarchy of something, depending on the subview with focus and/or selection."
+
+	^nil!
+
+browseIt
+	"Open a browser on the selected item in the window with focus."
+
+	<commandQuerySelector: #queryBrowseIt:>
+	self perform: self browseItCommand!
+
+browseItCommand
+	"Answer the <Symbol> of the contextual command to browse something, depending on the subview with focus and/or selection."
+
+	^#browseClass!
 
 browseMethodsIn: aBrowserEnvironment
 	^(self developmentSystem browseMethodsIn: aBrowserEnvironment)
 		model: self model;
 		yourself!
+
+browseMethodsInEnvironments: aCollectionOfBrowserEnvironment
+	^(self developmentSystem browseMethodsInEnvironments: aCollectionOfBrowserEnvironment)
+		model: self model;
+		yourself!
+
+browseReferences
+	"Context-sensitive browse references command (Shift+F12)."
+
+	<commandQuerySelector: #queryBrowseReferences:>
+	<acceleratorKey: 'Shift+F12'>
+	self perform: self browseReferencesCommand!
+
+browseReferencesCommand
+	"Answer the <Symbol> of the contextual command to browse references to something, depending on the subview with focus and/or selection."
+
+	^nil!
 
 browserEnvironment
 	^self systemModel browserEnvironment!
@@ -107,6 +161,11 @@ createSchematicWiring
 		to: self developmentSystem
 		withArguments: {nil. self}!
 
+deleteItCommand
+	"Answer the <Symbol> of the contextual command to delete something, depending on the subview with focus and/or selection."
+
+	^nil!
+
 developmentSystem
 	^SmalltalkSystem current!
 
@@ -126,9 +185,16 @@ fontSize: anInteger
 forgetSize
 	"Forget the default size for new instances of this tool."
 
+	<commandQuerySelector: #queryForgetSize:>
 	(self class)
 		defaultSlideyPinsMap: nil;
 		defaultExtent: nil!
+
+futureSize
+	"Answer the number of visits in the history which were made after the
+	current one."
+
+	^0!
 
 getPinStateFor: aSlideyInneyOuteyThingName 
 	"Private - Attempts to find a named SlideyInneyOuteyThing within the view hierarchy of the receiver.
@@ -139,12 +205,12 @@ getPinStateFor: aSlideyInneyOuteyThingName
 hasFuture
 	"Answer whether there is any future history to visit."
 
-	^false!
+	^self futureSize > 0!
 
 hasPast
 	"Answer whether there is any past history to visit."
 
-	^false!
+	^self pastSize > 0!
 
 help
 	"Bring up a help page for this tool."
@@ -155,24 +221,28 @@ help
 historyBack
 	"Private - Return to the previously visited method."
 
+	<commandQuerySelector: #queryHistoryBack:>
 	self historyBack: 1!
 
 historyBack: delta
 	"Private - Return to a previously visited method <integer>, delta, visits
 	in the past.."
 
+	<commandQuerySelector: #queryHistoryRewind:>
 	self historySkip: delta negated!
 
 historyForward
 	"Private - Return to the previously visited class which has been
 	moved back over by a jump back in time."
 
+	<commandQuerySelector: #queryHistoryForward:>
 	self historyForward: 1!
 
 historyForward: delta
 	"Private - Return to the previously visited class which has been
 	moved back over by a jump back in time."
 
+	<commandQuerySelector: #queryHistoryFastForward:>
 	self historySkip: delta!
 
 historySkip: anInteger
@@ -183,6 +253,22 @@ historySkip: anInteger
 ideaSpace
 	^#{IdeaSpaceShell} valueOrNil
 		ifNotNil: [:ideaSpaceShellClass | (self topShell isKindOf: ideaSpaceShellClass) ifTrue: [self topShell]]!
+
+inspectIt
+	"Open a browser on the selected category/protocol/variables.
+	Note that we only receive this command it one of the filter panes is selected
+	as class hierarchy, method browser, and workspace presenters all handle
+	it themselves."
+
+	<acceleratorKey: 'Ctrl+I'>
+	<acceleratorKey: 'Ctrl+Q'>		"VW compatibility"
+	<commandQuerySelector: #queryInspectIt:>
+	self perform: self inspectItCommand!
+
+inspectItCommand
+	"Answer the <Symbol> of the contextual command to inspect something, depending on the subview with focus and/or selection."
+
+	^nil!
 
 inspectSystemOptions
 	"Open a <PropertyInspector> on the system options."
@@ -232,6 +318,11 @@ packageManager
 
 	^self developmentSystem packageManager!
 
+pastSize
+	"Answer the number of visits in the history which were made before the current one."
+
+	^0!
+
 performCommand: aCommand
 	aCommand commandDescription isAbortable ifFalse: [^super performCommand: aCommand].
 	^[super performCommand: aCommand] on: OperationAborted
@@ -240,29 +331,69 @@ performCommand: aCommand
 			self statusModel value: ex.
 			nil]!
 
-queryCommand: aCommandQuery 
-	"Private - Enter details about a potential command for the receiver into the 
-	<CommandQuery>."
+queryAcceptIt: aCommandQuery
+	self acceptItCommand
+		ifNil: 
+			["Not handled at this level, but continue searching the chain"
+			aCommandQuery isEnabled: false]
+		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
 
-	| command |
-	command := aCommandQuery commandSymbol.
-	#forgetSize == command 
-		ifTrue: 
-			[aCommandQuery isEnabled: self class defaultExtent notNil.
-			^true].
-	command == #historyBack 
-		ifTrue: 
-			[aCommandQuery isEnabled: self hasPast.
-			^true].
-	command == #historyForward 
-		ifTrue: 
-			[aCommandQuery isEnabled: self hasFuture.
-			^true].
-	(#(#dragToolToIdeaSpace #addToNewIdeaSpace) includes: command) 
-		ifTrue: 
-			[aCommandQuery isEnabled: (self isIdeaSpaceCard not and: [self class canUseIdeaSpace]).
-			^true].
-	^super queryCommand: aCommandQuery!
+queryBrowseDefinitions: aCommandQuery
+	self browseDefinitionsCommand
+		ifNil: 
+			["Not handled at this level, but continue searching the chain"
+			aCommandQuery isEnabled: false]
+		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
+
+queryBrowseHierarchy: aCommandQuery
+	self browseHierarchyCommand
+		ifNil: 
+			["Not handled at this level, but continue searching the chain"
+			aCommandQuery isEnabled: false]
+		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
+
+queryBrowseIt: aCommandQuery
+	self browseItCommand
+		ifNil: 
+			["Not handled at this level, but continue searching the chain"
+			aCommandQuery isEnabled: false]
+		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
+
+queryBrowseReferences: aCommandQuery
+	self browseReferencesCommand
+		ifNil: 
+			["Not handled at this level, but continue searching the chain"
+			aCommandQuery isEnabled: false]
+		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
+
+queryDeleteIt: aCommandQuery
+	self deleteItCommand
+		ifNil: 
+			["Not handled at this level, but continue searching the chain"
+			aCommandQuery isEnabled: false]
+		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
+
+queryForgetSize: aCommandQuery
+	aCommandQuery isEnabled: self class defaultExtent notNil!
+
+queryHistoryBack: aCommandQuery
+	aCommandQuery isEnabled: self hasPast!
+
+queryHistoryFastForward: aCommandQuery
+	aCommandQuery isEnabled: self futureSize >= aCommandQuery command arguments first!
+
+queryHistoryForward: aCommandQuery
+	aCommandQuery isEnabled: self hasFuture!
+
+queryHistoryRewind: aCommandQuery
+	aCommandQuery isEnabled: self pastSize >= aCommandQuery command arguments first!
+
+queryInspectIt: aCommandQuery
+	self inspectItCommand
+		ifNil: 
+			["Not handled at this level, but continue searching the chain"
+			aCommandQuery isEnabled: false]
+		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
 
 rememberThisSize
 	"Record the size of the receiver as the default extent for its tool class."
@@ -385,10 +516,20 @@ systemModel
 workspaceClass
 	^SmalltalkSystem current workspaceClass! !
 !Tools.SmalltalkToolShell categoriesForMethods!
-addToCommandRoute:!commands!public! !
+accept!commands-actions!public! !
+acceptItCommand!commands-mappings!private! !
+addToCommandRoute:!commands-routing!public! !
 applyOptions!private! !
-browseIt!commands!public! !
+browseDefinitions!commands-actions!public! !
+browseDefinitionsCommand!commands-mappings!private! !
+browseHierarchy!commands-actions!public! !
+browseHierarchyCommand!commands-mappings!private! !
+browseIt!commands-actions!public! !
+browseItCommand!commands-mappings!private! !
 browseMethodsIn:!operations!public! !
+browseMethodsInEnvironments:!browsing!public! !
+browseReferences!commands-actions!public! !
+browseReferencesCommand!commands-mappings!private! !
 browserEnvironment!accessing!public! !
 buildPopupForCommand:!private! !
 canRefactor!private!testing! !
@@ -396,31 +537,47 @@ canSaveState!private!saved state! !
 configureFromSavedStateString:!public! !
 createComponents!initializing!private! !
 createSchematicWiring!initializing!private! !
+deleteItCommand!commands-mappings!private! !
 developmentSystem!public! !
 displayOn:!displaying!public! !
 fontSize!public! !
 fontSize:!public! !
-forgetSize!commands!public! !
+forgetSize!commands-actions!public! !
+futureSize!accessing!public! !
 getPinStateFor:!accessing!private! !
 hasFuture!public!testing! !
 hasPast!public!testing! !
-help!commands!public! !
-historyBack!commands!private! !
-historyBack:!commands!private! !
-historyForward!commands!private! !
-historyForward:!commands!private! !
-historySkip:!commands!private! !
+help!commands-actions!public! !
+historyBack!commands-actions!private! !
+historyBack:!commands-actions!private! !
+historyForward!commands-actions!private! !
+historyForward:!commands-actions!private! !
+historySkip:!commands-actions!private! !
 ideaSpace!public! !
-inspectSystemOptions!commands!public! !
+inspectIt!commands-actions!public! !
+inspectItCommand!commands-mappings!private! !
+inspectSystemOptions!commands-actions!public! !
 isIdeaSpaceCard!public! !
 methodBrowserClass!constants!private! !
 onDropDown:!private! !
 onViewCreated!event handling!public! !
 onViewOpened!private! !
 packageManager!constants!private! !
-performCommand:!commands!public! !
-queryCommand:!commands!private! !
-rememberThisSize!commands!public! !
+pastSize!accessing!public! !
+performCommand:!commands-routing!public! !
+queryAcceptIt:!commands-queries!private! !
+queryBrowseDefinitions:!commands-queries!private! !
+queryBrowseHierarchy:!commands-queries!private! !
+queryBrowseIt:!commands-queries!private! !
+queryBrowseReferences:!commands-queries!private! !
+queryDeleteIt:!commands-queries!private! !
+queryForgetSize:!commands-queries!private! !
+queryHistoryBack:!commands-queries!private! !
+queryHistoryFastForward:!commands-queries!private! !
+queryHistoryForward:!commands-queries!private! !
+queryHistoryRewind:!commands-queries!private! !
+queryInspectIt:!commands-queries!private! !
+rememberThisSize!commands-actions!public! !
 saveStateAspects:for:on:!helpers!private!saved state! !
 saveStateOn:!private!saved state! !
 saveStateString!private!saved state! !
@@ -429,8 +586,8 @@ searchForMethod:!private! !
 searchForObject:!public! !
 searchForPackage:!public! !
 searchForSymbol:!private! !
-searchSmalltalk!commands!public! !
-searchSmalltalkFor:!commands!public! !
+searchSmalltalk!commands-actions!public! !
+searchSmalltalkFor:!commands-actions!public! !
 selectionEnvironment!public! !
 setPinStateFor:to:!accessing!private! !
 show!operations!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspaceDocument.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspaceDocument.cls
@@ -62,11 +62,6 @@ canSaveState
 
 	^true!
 
-chooseDefaultFont
-	"Launch a dialog to prompt for a change in the default font used by the system tools."
-	
-	self model chooseDefaultFont!
-
 createComponents
 	"Create the presenters contained by the receiver"
 
@@ -88,12 +83,6 @@ createSchematicWiring
 
 defaultHelpId
 	^10729!
-
-destroy
-	"Attempt to forcibly close the receiver's view. If this is an IdeaSpace card then we ask the IdeaSpace to destroy it."
-
-	self isIdeaSpaceCard ifTrue: [^self ideaSpace destroyCard: self].
-	^super destroy!
 
 developmentSystem
 	^SmalltalkSystem current!
@@ -128,12 +117,6 @@ educationCenter
 
 	self model educationCenter!
 
-exit
-	"Attempt to close the receiver's view. If this is an IdeaSpace card then we ask the IdeaSpace to close it."
-
-	self isIdeaSpaceCard ifTrue: [^self ideaSpace closeCard: self].
-	^super exit!
-
 fileFileIn
 	"The user has selected the standard File/File In command. File in the 
 	current contents of the receiver."
@@ -163,6 +146,7 @@ fileOpen
 forgetSize
 	"Forget the default size for new instances of this tool."
 
+	<commandQuerySelector: #queryForgetSize:>
 	self class defaultExtent: nil!
 
 getDocumentData
@@ -265,21 +249,16 @@ openWorkspace
 	openFilename isNil ifTrue: [^nil].
 	^self openOn: openFilename!
 
-queryCommand: aCommandQuery 
-	"Private - Enter details about a potential command for the receiver into the 
-	<CommandQuery>."
+queryForgetSize: aCommandQuery
+	aCommandQuery isEnabled: DefaultExtent notNil!
 
-	| command |
-	command := aCommandQuery commandSymbol.
-	(#(#dragToolToIdeaSpace #addToNewIdeaSpace) includes: command) 
-		ifTrue: 
-			[aCommandQuery isEnabled: self isIdeaSpaceCard not.
-			^true].
-	^super queryCommand: aCommandQuery!
+queryRememberThisSize: aCommandQuery
+	aCommandQuery isEnabled: self view extent ~= self class defaultExtent!
 
 rememberThisSize
 	"Record the size of the receiver as the default extent for its tool class."
 
+	<commandQuerySelector: #queryRememberThisSize:>
 	self class defaultExtent: self view extent!
 
 saveStateOn: aWriteStream
@@ -358,36 +337,33 @@ workspace
 
 	^workspacePresenter! !
 !Tools.SmalltalkWorkspaceDocument categoriesForMethods!
-aboutDolphin!commands!public! !
+aboutDolphin!commands-actions!public! !
 applyOptions!public! !
-browsePackages!commands!public! !
+browsePackages!commands-actions!public! !
 buildPopupForCommand:!private! !
 canSaveState!private!saved state! !
-chooseDefaultFont!commands!public! !
 createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
 defaultHelpId!public! !
-destroy!commands!public! !
 developmentSystem!accessing!private! !
 displayOn:!displaying!public! !
-dropClassFile:!commands!private! !
-dropPackageFile:!commands!private! !
-dropScriptFile:!commands!private! !
-dropTextFile:!commands!private! !
-dropXmlFile:!commands!private! !
-educationCenter!commands!public! !
-exit!commands!public! !
-fileFileIn!commands!public! !
-fileLoad!commands!public! !
-fileNew!commands!public! !
-fileOpen!commands!public! !
-forgetSize!commands!public! !
+dropClassFile:!operations!private! !
+dropPackageFile:!operations!private! !
+dropScriptFile:!operations!private! !
+dropTextFile:!operations!private! !
+dropXmlFile:!operations!private! !
+educationCenter!commands-actions!public! !
+fileFileIn!commands-actions!public! !
+fileLoad!commands-actions!public! !
+fileNew!commands-actions!public! !
+fileOpen!commands-actions!public! !
+forgetSize!commands-actions!public! !
 getDocumentData!accessing!private! !
-guidedTour!commands!public! !
+guidedTour!commands-actions!public! !
 hasContents!public! !
-help!commands!public! !
+help!commands-actions!public! !
 ideaSpace!public! !
-inspectSystemOptions!commands!public! !
+inspectSystemOptions!commands-actions!public! !
 isIdeaSpaceCard!public! !
 isModified!public!testing! !
 isModified:!modes!public! !
@@ -395,23 +371,24 @@ isText!public!testing! !
 language:!public! !
 onDropDown:!private! !
 onViewOpened!event handling!private! !
-openViewComposer!commands!public! !
+openViewComposer!commands-actions!public! !
 openWorkspace!public! !
-queryCommand:!commands!private! !
-rememberThisSize!commands!public! !
+queryForgetSize:!commands-queries!private! !
+queryRememberThisSize:!commands-queries!private! !
+rememberThisSize!commands-actions!public! !
 saveStateOn:!private!saved state! !
 searchForClass:!private! !
 searchForMethod:!private! !
 searchForObject:!public! !
 searchForPackage:!public! !
 searchForSymbol:!private! !
-searchSmalltalk!commands!public! !
-searchSmalltalkFor:!commands!public! !
+searchSmalltalk!commands-actions!public! !
+searchSmalltalkFor:!operations!public! !
 setDocumentData:!accessing!private! !
 setInitialFocus!operations!public! !
 setLexer!helpers!private! !
 show!operations!public! !
-smalltalkExit!commands!public! !
+smalltalkExit!commands-actions!public! !
 systemModel!accessing!private! !
 workspace!accessing!public! !
 !
@@ -464,7 +441,7 @@ defaultExtent
 	"Answer a <Point> which is the user's chosen default extent for new instances
 	of the receiver, or nil if left up to Windows."
 
-	DefaultExtent ifNil: [self loadOptions].
+	self ensureOptionsLoaded.
 	^DefaultExtent ifNil: [self defaultDefaultExtent]!
 
 defaultExtent: aPoint
@@ -539,6 +516,9 @@ displayOn: aPuttableStream
 	"Append to the <puttableStream> argument a String whose characters are a representation of the receiver that an end-user might want to see."
 
 	aPuttableStream nextPutAll: 'Workspace'!
+
+ensureOptionsLoaded
+	OptionFlags ifNil: [self loadOptions]!
 
 fileTypes
 	"Answer an Array of file types that can be associated with this
@@ -760,6 +740,7 @@ defaultTabWidth:!options!public! !
 defaultView!options!public! !
 defaultView:!options!public! !
 displayOn:!displaying!public! !
+ensureOptionsLoaded!public! !
 fileTypes!constants!public! !
 finishedLoadingOptions!options!private! !
 icon!constants!public! !

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
@@ -133,13 +133,14 @@ publishedAspectsOfInstances!must strip!public! !
 browseMethodProtocol
 	"Private - Browse the currently selected protocol."
 
+	<commandQuerySelector: #queryHasProtocolSelected:>
 	| protocol |
 	protocol := self protocols first.
 	self model browseProtocols
 		protocol: protocol;
 		actualClass: (self actualClass whichClassImplementsProtocol: protocol)! !
 !Tools.ClassBrowserAbstract categoriesForMethods!
-browseMethodProtocol!commands!private! !
+browseMethodProtocol!commands-actions!private! !
 !
 
 !Tools.SmalltalkSystem methodsFor!

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/Tools.AXComponentWizard.cls
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/Tools.AXComponentWizard.cls
@@ -57,6 +57,7 @@ apply
 browseIDL
 	"Open a new workspace populated with the IDL for the currently selected library."
 
+	<commandQuerySelector: #queryHasLibrarySelected:>
 	| lib stm |
 	lib := self typeLib.
 	stm := ReadWriteStream on: (String new: 2048).
@@ -69,11 +70,13 @@ browseIDL
 browseTypeClass
 	"Open a new class browser on the class of the selected type."
 
+	<commandQuerySelector: #queryBrowseTypeClass>
 	^types selections first programObject browse!
 
 browseTypesIDL
 	"Open a new workspace populated with the IDL for the currently selected types."
 
+	<commandQuerySelector: #queryHasTypesSelected:>
 	| stm |
 	stm := ReadWriteStream on: (String new: 2048).
 	types selections do: 
@@ -91,6 +94,7 @@ cancel
 !
 
 chooseNamespace
+	<commandQuerySelector: #queryHasLibrarySelected:>
 	| choice namespaces |
 	namespaces := ClassHierarchyModel withRoots: (Namespace subclasses copyWithout: SharedPool).
 	choice := ValueConverter subject: namespaceName model
@@ -107,6 +111,7 @@ chooseNamespace
 choosePackage
 	"Sets the package name from a choice of all the available packages"
 
+	<commandQuerySelector: #queryHasLibrarySelected:>
 	| oldPkg |
 	oldPkg := packageName value isEmpty
 				ifTrue: [nil]
@@ -235,6 +240,7 @@ generatableStructsInTlb: aTypeLibraryAnalyzer
 generate
 	"Apply the attribute changes and attempt to generate the requested interfaces"
 
+	<commandQuerySelector: #queryHasTypesSelected:>
 	| typeLibrary selected progress step |
 	self apply.
 	typeLibrary := self typeLib.
@@ -267,13 +273,7 @@ initialize
 	super initialize.
 	showStandard := false!
 
-inspectIt
-	"Open an inspector on the currently selected library or type."
-
-	self perform: self inspectItCommand!
-
 inspectItCommand
-
 	| focus |
 	focus := View focus.
 	focus == typeLibs view ifTrue: [^#inspectLibrary].
@@ -284,9 +284,11 @@ inspectLibrary
 	"Open an inspector on the <AXTypeLibraryAnalyzer> representing the currently
 	selected library."
 
+	<commandQuerySelector: #queryHasLibrarySelected:>
 	self typeLib inspect!
 
 inspectType
+	<commandQuerySelector: #queryHasTypesSelected:>
 	| selections |
 	selections := types selections.
 	(selections size = 1 ifTrue: [selections first] ifFalse: [selections]) inspect!
@@ -294,6 +296,7 @@ inspectType
 libraryListNextCard
 	"The user has selected a library and is desirous of moving to the next card."
 
+	<commandQuerySelector: #queryLibraryListNextCard:>
 	^cards nextCard!
 
 loadTypeLib
@@ -346,48 +349,31 @@ parametersNextCard
 	self apply.
 	^cards nextCard!
 
-queryCommand: aCommandQuery
-	"Private - Enter details about a potential command for the receiver 
-	into the <CommandQuery>."
+queryBrowseTypeClass: aCommandQuery
+	| selectedTypes |
+	selectedTypes := types selections.
+	aCommandQuery isEnabled: (selectedTypes size = 1 and: [selectedTypes first isVariableDefined])!
 
-	| selected cmd lib |
-	cmd := aCommandQuery commandSymbol.
-	lib := self typeLib.
-	#inspectIt == cmd
-		ifTrue: 
-			[cmd := self inspectItCommand.
-			cmd isNil
-				ifTrue: 
-					[aCommandQuery isEnabled: false.
-					^false]].
-	#typeLibHelp == cmd
-		ifTrue: 
-			[aCommandQuery isEnabled: (lib notNil and: [lib helpfile notEmpty]).
-			^true].
-	#libraryListNextCard == cmd
-		ifTrue: 
-			[aCommandQuery isEnabled: (lib notNil and: [lib isInstalled]).
-			^true].
-	(#(#choosePackage #browseIDL #inspectLibrary #chooseNamespace) identityIncludes: cmd)
-		ifTrue: 
-			[aCommandQuery isEnabled: lib notNil.
-			^true].
-	selected := types selections.
-	(#(#generate #browseTypesIDL #inspectType) identityIncludes: cmd)
-		ifTrue: 
-			[aCommandQuery isEnabled: selected notEmpty.
-			^true].
-	#browseTypeClass == cmd
-		ifTrue: 
-			[aCommandQuery isEnabled: (selected size = 1 and: [selected first isVariableDefined]).
-			^true].
-	#toggleStandardTypes == cmd
-		ifTrue: 
-			[aCommandQuery
-				isEnabled: true;
-				isChecked: showStandard.
-			^true].
-	^super queryCommand: aCommandQuery!
+queryHasLibrarySelected: aCommandQuery
+	aCommandQuery isEnabled: self typeLib notNil!
+
+queryHasTypesSelected: aCommandQuery
+	aCommandQuery isEnabled: types selections notEmpty!
+
+queryLibraryListNextCard: aCommandQuery
+	| tlb |
+	tlb := self typeLib.
+	aCommandQuery isEnabled: (tlb notNil and: [tlb isInstalled])!
+
+queryToggleStandardTypes: aCommandQuery
+	aCommandQuery
+		isEnabled: true;
+		isChecked: showStandard!
+
+queryTypeLibHelp: aCommandQuery
+	| tlb |
+	tlb := self typeLib.
+	aCommandQuery isEnabled: (tlb notNil and: [tlb helpfile notEmpty])!
 
 refresh
 	"Refresh the list of current AXTypeLibraryAnalyzers in the image"
@@ -412,6 +398,7 @@ standardInterfaces
 	^StandardInterfaces!
 
 toggleStandardTypes
+	<commandQuerySelector: #queryToggleStandardTypes:>
 	showStandard := showStandard not.
 	self typeLib ifNotNil: [:typeLib | self updateTypesList: typeLib]!
 
@@ -428,6 +415,7 @@ typeLib: aTypeLibraryAnalyzerOrNil
 typeLibHelp
 	"Open the selected type-libraries help file."
 
+	<commandQuerySelector: #queryTypeLibHelp:>
 	OS.Shell32 shellOpen: self typeLib helpfile!
 
 updateTypelibVariable
@@ -451,39 +439,43 @@ updateTypesList: typelib
 	types list: (list contents asSortedCollection: [:a :b | a name <= b name])! !
 !Tools.AXComponentWizard categoriesForMethods!
 apply!operations!private! !
-browseIDL!commands!public! !
-browseTypeClass!commands!public! !
-browseTypesIDL!commands!public! !
-cancel!commands!public! !
-chooseNamespace!commands!private! !
-choosePackage!commands!public! !
+browseIDL!commands-actions!public! !
+browseTypeClass!commands-actions!public! !
+browseTypesIDL!commands-actions!public! !
+cancel!commands-actions!public! !
+chooseNamespace!commands-actions!public! !
+choosePackage!commands-actions!public! !
 createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
 displayInstalledTypeLib:!private!updating! !
-finish!commands!public! !
+finish!commands-actions!public! !
 generatableEnumsInTlb:!private!updating! !
 generatableInterfacesInTlb:!helpers!private! !
 generatableStructsInTlb:!helpers!private! !
-generate!commands!public! !
+generate!commands-actions!public! !
 initialize!initializing!private! !
-inspectIt!commands!public! !
 inspectItCommand!public! !
-inspectLibrary!commands!public! !
+inspectLibrary!commands-actions!public! !
 inspectType!public! !
-libraryListNextCard!commands!public! !
-loadTypeLib!commands!public! !
+libraryListNextCard!commands-actions!public! !
+loadTypeLib!commands-actions!public! !
 onTypeLibrarySelected!event handling!private! !
 onViewOpened!event handling!public! !
-parametersNextCard!commands!public! !
-queryCommand:!commands!private! !
-refresh!commands!public! !
-selectInstalled!commands!public! !
-selectUninstalled!commands!public! !
+parametersNextCard!commands-actions!public! !
+queryBrowseTypeClass:!commands-queries!private! !
+queryHasLibrarySelected:!commands-queries!private! !
+queryHasTypesSelected:!commands-queries!private! !
+queryLibraryListNextCard:!commands-queries!private! !
+queryToggleStandardTypes:!commands-queries!private! !
+queryTypeLibHelp:!commands-queries!private! !
+refresh!commands-actions!public! !
+selectInstalled!commands-actions!public! !
+selectUninstalled!commands-actions!public! !
 standardInterfaces!private! !
-toggleStandardTypes!commands!private! !
+toggleStandardTypes!commands-actions!private! !
 typeLib!accessing!public! !
 typeLib:!accessing!public! !
-typeLibHelp!commands!public! !
+typeLibHelp!commands-actions!public! !
 updateTypelibVariable!private!updating! !
 updateTypesList:!private!updating! !
 !
@@ -492,7 +484,7 @@ updateTypesList:!private!updating! !
 
 defaultAdditionalAccelerators
 	^super defaultAdditionalAccelerators 
-		, #(#(#selectAll 'Ctrl+A') #(#inspectIt 'Ctrl+I'))!
+		, #(#(#selectAll 'Ctrl+A'))!
 
 displayOn: aPuttableStream
 	"Append to the <puttableStream> first argument a String whose characters are a representation of the receiver that an end-user might want to see."

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
@@ -46,22 +46,28 @@ package setMethodNames: #(
 	#(#{Core.Process} #priorityName)
 	#(#{Kernel.ProcessorScheduler} #nameOfPriority:)
 	#(#{Smalltalk.StyledContainer class} #publishedAspectsOfInstances)
+	#(#{Tools.ClassBrowserAbstract} #toggleLocalHierarchy)
+	#(#{Tools.Debugger} #queryToggleDisassembly:)
+	#(#{Tools.Debugger} #toggleDisassembly)
 	#(#{Tools.PackageSelector} #browseDeployed)
 	#(#{Tools.PackageSelector} #browsePackageSources)
 	#(#{Tools.PackageSelector} #browseSources)
 	#(#{Tools.SmalltalkSystem} #openIdeaSpace)
 	#(#{Tools.SmalltalkSystem} #updateHelpMenus)
 	#(#{Tools.SmalltalkToolShell} #addToNewIdeaSpace)
-	#(#{Tools.SmalltalkToolShell} #browseMethodsInEnvironments:)
 	#(#{Tools.SmalltalkToolShell} #browseSystem)
 	#(#{Tools.SmalltalkToolShell} #destroy)
 	#(#{Tools.SmalltalkToolShell} #dragToolToIdeaSpace)
 	#(#{Tools.SmalltalkToolShell} #exit)
+	#(#{Tools.SmalltalkToolShell} #queryMoveToIdeaSpace:)
 	#(#{Tools.SmalltalkToolShell class} #addToNewIdeaSpace:)
 	#(#{Tools.SmalltalkToolShell class} #dragToolToIdeaSpace:)
 	#(#{Tools.SmalltalkWorkspaceDocument} #addToNewIdeaSpace)
 	#(#{Tools.SmalltalkWorkspaceDocument} #browseSources)
+	#(#{Tools.SmalltalkWorkspaceDocument} #destroy)
 	#(#{Tools.SmalltalkWorkspaceDocument} #dragToolToIdeaSpace)
+	#(#{Tools.SmalltalkWorkspaceDocument} #exit)
+	#(#{Tools.SmalltalkWorkspaceDocument} #queryMoveToIdeaSpace:)
 	#(#{UI.LinkButton class} #publishedAspectsOfInstances)
 	#(#{UI.SlideyInneyOuteyThing class} #example1)
 	#(#{UI.SlideyInneyOuteyThing class} #publishedAspectsOfInstances)
@@ -312,6 +318,54 @@ publishedAspectsOfInstances
 publishedAspectsOfInstances!constants!public! !
 !
 
+!Tools.ClassBrowserAbstract methodsFor!
+
+toggleLocalHierarchy
+	"Toggle between the entire hierarchy and showing only the current class and its subclasses."
+
+	<commandQuerySelector: #queryToggleLocalHierarchy:>
+	| instClass actualClass |
+	self promptToSaveChanges ifFalse: [^self].
+
+	"Use the selected class rather than the actual class, so always follows instance hierarchy"
+	instClass := self selectedClass.
+	actualClass := self actualClass.
+	self isLocalHierarchyMode: self isLocalHierarchyMode not.
+	self isLocalHierarchyMode
+		ifTrue: 
+			["Toggled into local hierarchy mode"
+			self displayLocalHierarchyOf: instClass.
+			self actualClass: actualClass]
+		ifFalse: 
+			["Toggled out of local hierarchy mode..."
+			classesPresenter model: self model classHierarchy.
+			actualClass notNil ifTrue: [self actualClass: actualClass]].
+	self validateUserInterface! !
+!Tools.ClassBrowserAbstract categoriesForMethods!
+toggleLocalHierarchy!commands-actions!public! !
+!
+
+!Tools.Debugger methodsFor!
+
+queryToggleDisassembly: aCommandQuery
+	aCommandQuery
+		isEnabled: true;
+		isChecked: self isDisassembled!
+
+toggleDisassembly
+	"Private - Switch between source/disassembly modes."
+
+	<commandQuerySelector: #queryToggleDisassembly:>
+	self beDisassembled: self isDisassembled not.
+	sourcePresenter
+		isReadOnly: self isDisassembled;
+		isAutoParseEnabled: (self isDisassembled not and: [sourcePresenter class isAutoParseEnabled]).
+	self displayFrame! !
+!Tools.Debugger categoriesForMethods!
+queryToggleDisassembly:!commands-queries!private! !
+toggleDisassembly!commands-actions!private! !
+!
+
 !Tools.PackageSelector methodsFor!
 
 browseDeployed
@@ -388,12 +442,8 @@ updateHelpMenus!private!utilities! !
 !Tools.SmalltalkToolShell methodsFor!
 
 addToNewIdeaSpace
+	<commandQuerySelector: #queryMoveToIdeaSpace:>
 	^self class addToNewIdeaSpace: self!
-
-browseMethodsInEnvironments: aCollectionOfBrowserEnvironment
-	^(self developmentSystem browseMethodsInEnvironments: aCollectionOfBrowserEnvironment)
-		model: self model;
-		yourself!
 
 browseSystem
 	"Open a new system browser on Object."
@@ -407,20 +457,24 @@ destroy
 	^super destroy!
 
 dragToolToIdeaSpace
+	<commandQuerySelector: #queryMoveToIdeaSpace:>
 	^self class dragToolToIdeaSpace: self!
 
 exit
 	"Attempt to close the receiver's view. If this is an IdeaSpace card then we ask the IdeaSpace to close it."
 
 	self isIdeaSpaceCard ifTrue: [^self ideaSpace closeCard: self].
-	^super exit! !
+	^super exit!
+
+queryMoveToIdeaSpace: aCommandQuery
+	aCommandQuery isEnabled: (self isIdeaSpaceCard not and: [self class canUseIdeaSpace])! !
 !Tools.SmalltalkToolShell categoriesForMethods!
 addToNewIdeaSpace!public! !
-browseMethodsInEnvironments:!browsing!public! !
-browseSystem!commands!public! !
-destroy!commands!public! !
+browseSystem!commands-actions!public! !
+destroy!commands-actions!public! !
 dragToolToIdeaSpace!public! !
-exit!commands!public! !
+exit!commands-actions!public! !
+queryMoveToIdeaSpace:!commands-queries!private! !
 !
 
 !Tools.SmalltalkToolShell class methodsFor!
@@ -446,6 +500,7 @@ dragToolToIdeaSpace:!public! !
 !Tools.SmalltalkWorkspaceDocument methodsFor!
 
 addToNewIdeaSpace
+	<commandQuerySelector: #queryMoveToIdeaSpace:>
 	^IdeaSpaceShell addToNewIdeaSpace: self!
 
 browseSources
@@ -453,12 +508,31 @@ browseSources
 	
 	self model browseSources!
 
+destroy
+	"Attempt to forcibly close the receiver's view. If this is an IdeaSpace card then we ask the IdeaSpace to destroy it."
+
+	self isIdeaSpaceCard ifTrue: [^self ideaSpace destroyCard: self].
+	^super destroy!
+
 dragToolToIdeaSpace
-	^IdeaSpaceShell dragToolToIdeaSpace: self! !
+	<commandQuerySelector: #queryMoveToIdeaSpace:>
+	^IdeaSpaceShell dragToolToIdeaSpace: self!
+
+exit
+	"Attempt to close the receiver's view. If this is an IdeaSpace card then we ask the IdeaSpace to close it."
+
+	self isIdeaSpaceCard ifTrue: [^self ideaSpace closeCard: self].
+	^super exit!
+
+queryMoveToIdeaSpace: aCommandQuery
+	aCommandQuery isEnabled: self isIdeaSpaceCard not! !
 !Tools.SmalltalkWorkspaceDocument categoriesForMethods!
 addToNewIdeaSpace!public! !
-browseSources!commands!public! !
+browseSources!commands-actions!public! !
+destroy!commands-actions!public! !
 dragToolToIdeaSpace!public! !
+exit!commands-actions!public! !
+queryMoveToIdeaSpace:!commands-queries!private! !
 !
 
 !UI.LinkButton class methodsFor!

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
@@ -216,7 +216,6 @@ package setMethodNames: #(
 	#(#{Tools.ClassBrowserAbstract} #queryPushDownInstanceVariables:)
 	#(#{Tools.ClassBrowserAbstract} #queryPushDownMethods:)
 	#(#{Tools.ClassBrowserAbstract} #queryPushUpMethods:)
-	#(#{Tools.ClassBrowserAbstract} #queryVariablesCommand:)
 	#(#{Tools.ClassBrowserAbstract} #removeInstanceVariables)
 	#(#{Tools.ClassBrowserAbstract} #renameMethod)
 	#(#{Tools.ClassBrowserAbstract} #selectedOverridableMethods)
@@ -233,7 +232,6 @@ package setMethodNames: #(
 	#(#{Tools.ClassSelector} #changeClassNamespace)
 	#(#{Tools.ClassSelector} #classRefactoringsMenu)
 	#(#{Tools.ClassSelector} #cloneClass:under:changes:)
-	#(#{Tools.ClassSelector} #commandQuerySelector:)
 	#(#{Tools.ClassSelector} #convertToSibling)
 	#(#{Tools.ClassSelector} #createClassVariableAccessors)
 	#(#{Tools.ClassSelector} #createVariableAccessors)
@@ -251,13 +249,13 @@ package setMethodNames: #(
 	#(#{Tools.ClassSelector} #pushDownInstanceVariables)
 	#(#{Tools.ClassSelector} #pushDownVariables)
 	#(#{Tools.ClassSelector} #queryAddInstanceVariable:)
+	#(#{Tools.ClassSelector} #queryHasVariablesSelected:)
 	#(#{Tools.ClassSelector} #queryPullUpClassVariables:)
 	#(#{Tools.ClassSelector} #queryPullUpInstanceVariables:)
 	#(#{Tools.ClassSelector} #queryPullUpVariables:)
 	#(#{Tools.ClassSelector} #queryPushDownInstanceVariables:)
 	#(#{Tools.ClassSelector} #queryPushDownVariables:)
 	#(#{Tools.ClassSelector} #queryRemoveImport:)
-	#(#{Tools.ClassSelector} #queryVariablesCommand:)
 	#(#{Tools.ClassSelector} #removeClassVariables)
 	#(#{Tools.ClassSelector} #removeDuplicateMethods)
 	#(#{Tools.ClassSelector} #removeImport)
@@ -297,10 +295,7 @@ package setMethodNames: #(
 	#(#{Tools.PackageBrowserShell} #performMethodRenameRefactoring:)
 	#(#{Tools.PackageBrowserShell} #performMethodsRefactoring:name:)
 	#(#{Tools.PackageBrowserShell} #promptForMethodName:caption:allowExisting:)
-	#(#{Tools.PackageBrowserShell} #queryHasClassesSelected:)
 	#(#{Tools.PackageBrowserShell} #queryHasClassSelected:)
-	#(#{Tools.PackageBrowserShell} #queryHasMethodSelected:)
-	#(#{Tools.PackageBrowserShell} #queryHasMethodsSelected:)
 	#(#{Tools.PackageBrowserShell} #queryRemoveParameter:)
 	#(#{Tools.PackageBrowserShell} #removeMethod)
 	#(#{Tools.PackageBrowserShell} #removeMethods)
@@ -2440,7 +2435,7 @@ resource_Refactoring_view!public!resources-views! !
 abstractInstanceVariables
 	"Private - Invoke the 'Abstract Instance Variable' refactoring on the currently selected variables."
 
-	<commandQuerySelector: #queryVariablesCommand:>
+	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
 	self model abstractInstanceVariables: self variables within: BrowserEnvironment new!
 
 methodRefactoringTool
@@ -2506,7 +2501,7 @@ overrideMethods
 protectInstanceVariables
 	"Private - Invoke the 'Protect/Concrete Instance Variable' refactoring on the users choice of instance variables."
 
-	<commandQuerySelector: #queryVariablesCommand:>
+	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
 	self model protectInstanceVariables: self variables!
 
 pushDownInstanceVariables
@@ -2537,7 +2532,6 @@ pushMethods: aBoolean
 pushUpMethods
 	<acceleratorKey: 'Shift+Ctrl+6'>
 	<commandQuerySelector: #queryPushUpMethods:>
-self halt.
 	self pushMethods: true!
 
 queryOverrideMethods: aCommandQuery
@@ -2566,13 +2560,10 @@ queryPushUpMethods: aCommandQuery
 	aCommandQuery isEnabled: (self methodRefactoringTool canPushUpMethods
 				and: [(self selectedMethods collect: [:each | each methodClass]) asSet size = 1])!
 
-queryVariablesCommand: aCommandQuery
-	aCommandQuery isEnabled: self variables notEmpty!
-
 removeInstanceVariables
 	"Invoke the 'Remove Instance Variable' refactoring on the currently selected variables."
 
-	<commandQuerySelector: #queryVariablesCommand:>
+	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
 	self model removeInstanceVariables: self variables within: self searchEnvironment!
 
 renameMethod
@@ -2584,20 +2575,19 @@ selectedOverridableMethods
 	class := self actualClass.
 	^self selectedMethods reject: [:each | each methodClass == class]! !
 !Tools.ClassBrowserAbstract categoriesForMethods!
-abstractInstanceVariables!commands!private!refactoring! !
-methodRefactoringTool!commands!private!refactoring! !
+abstractInstanceVariables!commands-actions!private!refactoring! !
+methodRefactoringTool!commands-actions!private!refactoring! !
 methodsToOverride!helpers!private! !
-overrideMethods!commands!private!refactoring! !
-protectInstanceVariables!commands!private!refactoring! !
-pushDownInstanceVariables!commands!public!refactoring! !
-pushDownMethods!commands!public!refactoring! !
-pushMethods:!commands!private!refactoring! !
-pushUpMethods!commands!public!refactoring! !
-queryOverrideMethods:!command queries!private!refactoring! !
-queryPushDownInstanceVariables:!command queries!private!refactoring! !
-queryPushDownMethods:!command queries!private!refactoring! !
-queryPushUpMethods:!command queries!private!refactoring! !
-queryVariablesCommand:!command queries!private!refactoring! !
+overrideMethods!commands-actions!private!refactoring! !
+protectInstanceVariables!commands-actions!private!refactoring! !
+pushDownInstanceVariables!commands-actions!public!refactoring! !
+pushDownMethods!commands-actions!public!refactoring! !
+pushMethods:!commands-actions!private!refactoring! !
+pushUpMethods!commands-actions!public!refactoring! !
+queryOverrideMethods:!commands-queries!private!refactoring! !
+queryPushDownInstanceVariables:!commands-queries!private!refactoring! !
+queryPushDownMethods:!commands-queries!private!refactoring! !
+queryPushUpMethods:!commands-queries!private!refactoring! !
 removeInstanceVariables!public!refactoring! !
 renameMethod!accessing!private! !
 selectedOverridableMethods!accessing!private! !
@@ -2634,7 +2624,7 @@ abstractInstanceVariables
 		ifNotNil: [:varNames | self developmentSystem abstractInstanceVariables: varNames within: BrowserEnvironment new]!
 
 abstractVariables
-	<commandQuerySelector: #queryVariablesCommand:>
+	<commandQuerySelector: #queryHasVariablesSelected:>
 	Sound warningBeep!
 
 addClassVariable
@@ -2718,9 +2708,6 @@ cloneClass: aClass under: superClass changes: aCompositeRefactoryChange
 		as: newName pathString
 		superclass: superClass) primitiveExecute!
 
-commandQuerySelector: a
-	!
-
 convertToSibling
 	"Invoke the 'Convert to Sibling' refactoring (inserts a new class as the common superclass of the selected
 	class and its current subclasses, copying common methods to the new superclass and adding 
@@ -2737,7 +2724,7 @@ createClassVariableAccessors
 	self createVariableAccessors: true!
 
 createVariableAccessors
-	<commandQuerySelector: #queryVariablesCommand:>
+	<commandQuerySelector: #queryHasVariablesSelected:>
 	Sound warningBeep!
 
 populateClassVarMenu: aMenu selectors: selectors
@@ -2856,7 +2843,7 @@ protectInstanceVariables
 		ifNotNil: [:varNames | self developmentSystem protectInstanceVariables: varNames]!
 
 protectVariables
-	<commandQuerySelector: #queryVariablesCommand:>
+	<commandQuerySelector: #queryHasVariablesSelected:>
 	Sound warningBeep!
 
 pullUpClassVariables
@@ -2961,6 +2948,12 @@ queryAddInstanceVariable: aCommandQuery
 					locale: Locale smalltalk);
 		isEnabled: (class notNil and: [class isPointers])!
 
+queryHasVariablesSelected: aCommandQuery
+	| class |
+	class := self actualClass.
+	aCommandQuery isEnabled: (class notNil
+				and: [class instanceVariableNames notEmpty or: [class instanceClass classBindingNames notEmpty]])!
+
 queryPullUpClassVariables: aCommandQuery
 	| class |
 	class := self actualClass.
@@ -3005,12 +2998,6 @@ queryRemoveImport: aCommandQuery
 	self selections do: [:each | imports addAll: each imports].
 	aCommandQuery isEnabled: imports notEmpty!
 
-queryVariablesCommand: aCommandQuery
-	| class |
-	class := self actualClass.
-	aCommandQuery isEnabled: (class notNil
-				and: [class instanceVariableNames notEmpty or: [class instanceClass classBindingNames notEmpty]])!
-
 removeClassVariables
 	"Invoke the 'Remove Class Variable' refactoring on the users choice of class variables.
 	Note that the view may also implement this command with a dynamic pull-out menu (of the
@@ -3049,51 +3036,50 @@ removeInstanceVariables
 		ifNotNil: [:varNames | self developmentSystem removeInstanceVariables: varNames within: self searchEnvironment]!
 
 removeVariables
-	<commandQuerySelector: #queryVariablesCommand:>
+	<commandQuerySelector: #queryHasVariablesSelected:>
 	Sound warningBeep! !
 !Tools.ClassSelector categoriesForMethods!
-abstractClassVariables!commands!public!refactoring! !
-abstractInstanceVariables!commands!public!refactoring! !
-abstractVariables!commands!private! !
-addClassVariable!commands!private!refactoring! !
-addImport!commands!public!refactoring! !
-addInstanceVariable!commands!private!refactoring! !
+abstractClassVariables!commands-actions!public!refactoring! !
+abstractInstanceVariables!commands-actions!public!refactoring! !
+abstractVariables!commands-actions!private! !
+addClassVariable!commands-actions!private!refactoring! !
+addImport!commands-actions!public!refactoring! !
+addInstanceVariable!commands-actions!private!refactoring! !
 buildInstVarMenu:selectors:!menus!private!refactoring! !
 buildPullUpVariablesMenu:!menus!private!refactoring! !
 buildVariablesMenu:instVarSelectors:classVarSelectors:!menus!private!refactoring! !
-changeClassNamespace!commands!public!refactoring! !
-classRefactoringsMenu!commands!public!refactoring! !
+changeClassNamespace!commands-actions!public!refactoring! !
+classRefactoringsMenu!commands-menus!public!refactoring! !
 cloneClass:under:changes:!private! !
-commandQuerySelector:!commands!public!refactoring! !
-convertToSibling!commands!public!refactoring! !
-createClassVariableAccessors!commands!public!refactoring! !
-createVariableAccessors!commands!private! !
+convertToSibling!commands-actions!public!refactoring! !
+createClassVariableAccessors!commands-actions!public!refactoring! !
+createVariableAccessors!commands-menus!private! !
 populateClassVarMenu:selectors:!menus!private!refactoring! !
 populateInstVarMenu:selectors:!menus!private!refactoring! !
 populatePullUpVariableMenu:forClass:command:classVariables:ifTooMany:!menus!private!refactoring! !
 populateRefactoringMenu:!menus!private!refactoring! !
-protectInstanceVariables!commands!public!refactoring! !
-protectVariables!commands!private! !
-pullUpClassVariables!commands!public!refactoring! !
-pullUpInstanceVariables!commands!public!refactoring! !
+protectInstanceVariables!commands-actions!public!refactoring! !
+protectVariables!commands-actions!private! !
+pullUpClassVariables!commands-actions!public!refactoring! !
+pullUpInstanceVariables!commands-actions!public!refactoring! !
 pullUpVariableNamePairs:for:maximum:!menus!private!refactoring! !
-pullUpVariables!commands!private! !
-pushDownClassVariables!commands!public!refactoring! !
-pushDownInstanceVariables!commands!public!refactoring! !
-pushDownVariables!commands!private! !
-queryAddInstanceVariable:!command queries!private! !
-queryPullUpClassVariables:!command queries!private! !
-queryPullUpInstanceVariables:!command queries!private! !
-queryPullUpVariables:!command queries!private! !
-queryPushDownInstanceVariables:!command queries!private! !
-queryPushDownVariables:!command queries!private! !
-queryRemoveImport:!command queries!private! !
-queryVariablesCommand:!command queries!private! !
-removeClassVariables!commands!public!refactoring! !
-removeDuplicateMethods!commands!private!refactoring! !
-removeImport!commands!public!refactoring! !
-removeInstanceVariables!commands!public!refactoring! !
-removeVariables!commands!private! !
+pullUpVariables!commands-actions!private! !
+pushDownClassVariables!commands-actions!public!refactoring! !
+pushDownInstanceVariables!commands-actions!public!refactoring! !
+pushDownVariables!commands-actions!private! !
+queryAddInstanceVariable:!commands-queries!private! !
+queryHasVariablesSelected:!commands-queries!private! !
+queryPullUpClassVariables:!commands-queries!private! !
+queryPullUpInstanceVariables:!commands-queries!private! !
+queryPullUpVariables:!commands-queries!private! !
+queryPushDownInstanceVariables:!commands-queries!private! !
+queryPushDownVariables:!commands-queries!private! !
+queryRemoveImport:!commands-queries!private! !
+removeClassVariables!commands-actions!public!refactoring! !
+removeDuplicateMethods!commands-actions!private!refactoring! !
+removeImport!commands-actions!public!refactoring! !
+removeInstanceVariables!commands-actions!public!refactoring! !
+removeVariables!commands-actions!private! !
 !
 
 !Tools.CreateSubclassDialog class methodsFor!
@@ -3118,7 +3104,7 @@ canMoveMethods
 	^false!
 
 hasRefactorableMethodSelected
-	^self isRunning not and: 
+	^self isPaused and: 
 			[| method |
 			method := self selectedMethod.
 			method notNil and: [method isUnbound not and: [self parseTree notNil]]]!
@@ -3141,7 +3127,7 @@ performMethodRenameRefactoring: aMonadicValuable
 	sender := home sender.
 	(sender notNil and: [sender isRestartable]) ifTrue: [self restartMethodFrame: sender]! !
 !Tools.Debugger categoriesForMethods!
-canMoveMethods!commands!private!refactoring! !
+canMoveMethods!commands-actions!private!refactoring! !
 hasRefactorableMethodSelected!public!refactoring!testing! !
 performMethodRefactoring:!helpers!public!refactoring! !
 performMethodRenameRefactoring:!helpers!private!refactoring! !
@@ -3282,7 +3268,7 @@ addParameter
 	the selector of the method to which the parameter is added, and constrained to operate
 	only within the selected packages."
 
-	<commandQuerySelector: #queryHasPackages:>
+	<commandQuerySelector: #queryHasPackagesSelected:>
 	(self chooseMethodForRefactoring: 'Add Parameter in Package(s)…') 
 		ifNotNil: [:method | self addParameterTo: method]
 !
@@ -3317,14 +3303,14 @@ chooseMethodsForRefactoring: aString
 	^definitions!
 
 classRefactoringsMenu
-	<commandQuerySelector: #queryHasPackages:>
+	<commandQuerySelector: #queryHasPackagesSelected:>
 	Sound warningBeep!
 
 hasRefactorableMethodSelected
 	^self hasEditableMethodSelected!
 
 methodRefactoringsMenu
-	<commandQuerySelector: #queryHasPackages:>
+	<commandQuerySelector: #queryHasPackagesSelected:>
 	Sound warningBeep!
 
 newMethodNamePrompter: aCompiledMethod caption: aString allowExisting: aBoolean
@@ -3403,17 +3389,8 @@ promptForMethodName: aCompiledMethod caption: aString allowExisting: aBoolean
 		caption: aString
 		allowExisting: aBoolean) showModal!
 
-queryHasClassesSelected: aCommandQuery
-	aCommandQuery isEnabled: classesPresenter hasSelection!
-
 queryHasClassSelected: aCommandQuery
 	aCommandQuery isEnabled: self hasClassSelected!
-
-queryHasMethodSelected: aCommandQuery
-	aCommandQuery isEnabled: self hasMethodSelected!
-
-queryHasMethodsSelected: aCommandQuery
-	aCommandQuery isEnabled: self selectedMethods notEmpty!
 
 queryRemoveParameter: aCommandQuery
 	| method |
@@ -3466,7 +3443,7 @@ removeParameter
 	"Private - Command to invoke the Remove Parameter to Method refactoring, but constrained to operate
 	only within the selected packages."
 
-	<commandQuerySelector: #queryHasPackages:>
+	<commandQuerySelector: #queryHasPackagesSelected:>
 	| method ast arg |
 	method := self chooseMethodForRefactoring: 'Remove Parameter in Package(s)…'.
 	method isNil ifTrue: [^self].
@@ -3508,7 +3485,7 @@ renameMethod
 	method selected on the methods tab. It allows the selection of an arbitrary method to be
 	renamed at package scope, not just loose methods."
 
-	<commandQuerySelector: #queryHasPackages:>
+	<commandQuerySelector: #queryHasPackagesSelected:>
 	(self chooseMethodForRefactoring: 'Rename Method in Package(s)…') 
 		ifNotNil: [:method | methodRefactoringTool renameMethod: method]!
 
@@ -3526,35 +3503,32 @@ renameMethodReferences: aCompiledMethod
 				to: methodName
 				showChanges: prompter showChanges]! !
 !Tools.PackageBrowserShell categoriesForMethods!
-addImport!commands!public!refactoring! !
-addParameter!commands!private!refactoring! !
+addImport!commands-actions!public! !
+addParameter!commands-actions!private! !
 addParameterTo:!private!refactoring! !
-addParameterToMethod!commands!public!refactoring! !
-changeClassNamespace!commands!public!refactoring! !
+addParameterToMethod!commands-actions!public! !
+changeClassNamespace!commands-actions!public! !
 chooseMethodsForRefactoring:!private!refactoring! !
-classRefactoringsMenu!commands!public!refactoring! !
+classRefactoringsMenu!commands-menus!public! !
 hasRefactorableMethodSelected!private!refactoring!testing! !
-methodRefactoringsMenu!commands!public!refactoring! !
+methodRefactoringsMenu!commands-menus!public! !
 newMethodNamePrompter:caption:allowExisting:!helpers!private!refactoring! !
 onClass:renameTo:accept:!event handling!private! !
 onRenameClass:to:showChanges:!event handling!private! !
-parseTree!commands!private! !
+parseTree!helpers!private! !
 performMethodRenameRefactoring:!helpers!private!refactoring! !
 performMethodsRefactoring:name:!private! !
 promptForMethodName:caption:allowExisting:!helpers!private!refactoring! !
-queryHasClassesSelected:!command queries!commands!private!refactoring! !
-queryHasClassSelected:!command queries!commands!private!refactoring! !
-queryHasMethodSelected:!command queries!commands!private!refactoring! !
-queryHasMethodsSelected:!command queries!commands!private!refactoring! !
-queryRemoveParameter:!command queries!commands!private!refactoring! !
-removeMethod!commands!public!refactoring! !
-removeMethods!commands!public!refactoring! !
-removeParameter!commands!private!refactoring! !
-removeParameterMenu!commands!public!refactoring! !
+queryHasClassSelected:!commands-queries!private! !
+queryRemoveParameter:!commands-queries!private! !
+removeMethod!commands-actions!public! !
+removeMethods!commands-actions!public! !
+removeParameter!commands-actions!private! !
+removeParameterMenu!commands-actions!public! !
 renameClass!public! !
-renameLooseMethod!commands!private!refactoring! !
-renameLooseMethodReferences!commands!private!refactoring! !
-renameMethod!commands!public!refactoring! !
+renameLooseMethod!commands-actions!private! !
+renameLooseMethodReferences!commands-actions!private! !
+renameMethod!commands-actions!public! !
 renameMethodReferences:!operations!private!refactoring! !
 !
 

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.EnvironmentBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.EnvironmentBrowserShell.cls
@@ -57,25 +57,6 @@ createComponents
 defaultHelpId
 	^10895!
 
-displayLocalHierarchyOf: class
-	"Private - Update the receiver to display only the local hierarchy of the <ClassDescription>,
-	class."
-
-	| instClass |
-	instClass := class instanceClass.
-	classesPresenter model: (ClassHierarchyModel withAllClasses
-				filter: [:x | (instClass allSuperclasses includes: x) or: [instClass withAllSubclasses includes: x]])!
-
-isLocalHierarchyMode
-	"Private - Answer whether the receiver is in 'local hierarchy' mode displaying a subset of the entire
-	class hierarchy."
-
-	^false
-	"^flags allMask: LocalHierarchyMask"!
-
-isLocalHierarchyMode: aBoolean 
-	"flags := flags mask: LocalHierarchyMask set: aBoolean"!
-
 isMethodVisible: aCompiledMethod 
 	^(self browserEnvironment includesMethod: aCompiledMethod) 
 		and: [super isMethodVisible: aCompiledMethod]!
@@ -83,17 +64,6 @@ isMethodVisible: aCompiledMethod
 model: aSystemModel
 	super model: aSystemModel.
 	self browserEnvironment: aSystemModel browserEnvironment!
-
-onTipTextRequired: tool
-	"Private - Tool tip text is required for the <ToolbarItem>, tool."
-
-	| cmd |
-	cmd := tool command asSymbol.
-	cmd == #toggleLocalHierarchy ifTrue: [
-		^(self isLocalHierarchyMode 
-				ifTrue: ['Browse entire hierarchy']
-				ifFalse: ['Browse local hierarchy of ', self selectedClass name])].
-	^super onTipTextRequired: tool!
 
 parseContext
 	^self method
@@ -125,26 +95,6 @@ printCaptionForClass: aClass on: aWriteStream
 printCaptionForMethod: aCompiledMethod on: aWriteStream
 	self printBasicCaptionOn: aWriteStream!
 
-queryCommand: aCommandQuery 
-	"Private - Enter details about a potential command for the receiver 
-	into the <CommandQuery>."
-
-	| cmd |
-	cmd := aCommandQuery commandSymbol.
-	#toggleLocalHierarchy == cmd 
-		ifTrue: 
-			[self isLocalHierarchyMode 
-				ifTrue: 
-					[aCommandQuery
-						isEnabled: true;
-						isChecked: true]
-				ifFalse: 
-					[aCommandQuery
-						isEnabled: (self hasClassSelected and: [self actualClass superclass notNil]);
-						isChecked: false].
-			^true].
-	^super queryCommand: aCommandQuery!
-
 resetFor: aClass 
 	"Reset the receiver to place it into a state required to display aClass"
 
@@ -169,50 +119,23 @@ saveStateOn: aWriteStream
 	aWriteStream nextPut: $]!
 
 searchEnvironment
-	^model browserEnvironment!
-
-toggleLocalHierarchy
-	"Toggle between the entire hierarchy and showing only the current class and its subclasses."
-
-	| instClass actualClass |
-	self promptToSaveChanges ifFalse: [^self].
-
-	"Use the selected class rather than the actual class, so always follows instance hierarchy"
-	instClass := self selectedClass.
-	actualClass := self actualClass.
-	self isLocalHierarchyMode: self isLocalHierarchyMode not.
-	self isLocalHierarchyMode 
-		ifTrue: 
-			["Toggled into local hierarchy mode"
-			self displayLocalHierarchyOf: instClass.
-			self actualClass: actualClass]
-		ifFalse: 
-			["Toggled out of local hierarchy mode..."
-			classesPresenter model: self model classHierarchy.
-			actualClass notNil ifTrue: [self actualClass: actualClass]].
-	self validateUserInterface! !
+	^model browserEnvironment! !
 !Tools.EnvironmentBrowserShell categoriesForMethods!
-browseExecutableManifest!commands!public! !
-browseExecutableManifestFile:!commands!public! !
+browseExecutableManifest!commands-actions!public! !
+browseExecutableManifestFile:!operations!public! !
 browserEnvironment:!initializing!private! !
-browseUnimplemented!commands!public! !
+browseUnimplemented!commands-actions!public! !
 createComponents!initializing!public! !
 defaultHelpId!constants!public! !
-displayLocalHierarchyOf:!private!updating! !
-isLocalHierarchyMode!private!testing! !
-isLocalHierarchyMode:!accessing!private! !
 isMethodVisible:!private!testing! !
 model:!accessing!public! !
-onTipTextRequired:!event handling!private! !
 parseContext!public! !
 printBasicCaptionOn:!private!updating! !
 printCaptionForClass:on:!private!updating! !
 printCaptionForMethod:on:!private!updating! !
-queryCommand:!commands!private! !
-resetFor:!commands!public! !
+resetFor:!operations!public! !
 saveStateOn:!private!saved state! !
-searchEnvironment!commands!public! !
-toggleLocalHierarchy!commands!public! !
+searchEnvironment!accessing!public! !
 !
 
 !Tools.EnvironmentBrowserShell class methodsFor!

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.SystemBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.SystemBrowserShell.cls
@@ -26,6 +26,9 @@ canSaveMethod
 		ifTrue: [self isEditableMethod: self method]
 		ifFalse: [self hasClassSelected or: [self packages size = 1]]!
 
+canShowLocalHierarchy
+	^false!
+
 createComponents
 	"Create the presenters contained by the receiver"
 
@@ -78,26 +81,6 @@ packages
 
 	^classesPresenter packages!
 
-queryCommand: aCommandQuery 
-	"Private - Enter details about a potential command for the receiver into the 
-	<CommandQuery>."
-
-	| command |
-	command := aCommandQuery commandSymbol.
-	#forgetSize == command 
-		ifTrue: 
-			[aCommandQuery isEnabled: self class defaultExtent notNil.
-			^true].
-	command == #historyBack 
-		ifTrue: 
-			[aCommandQuery isEnabled: self hasPast.
-			^true].
-	command == #historyForward 
-		ifTrue: 
-			[aCommandQuery isEnabled: self hasFuture.
-			^true].
-	^super queryCommand: aCommandQuery!
-
 resetForFoundClass: aClass
 	"Private - Reset the receiver to place it into a state required to display aClass
 	that has just been searched for. This should first navigate the receiver 
@@ -144,7 +127,8 @@ selectionEnvironment
 slideyPinNames
 	^super slideyPinNames , #('packagesSlidey')! !
 !Tools.SystemBrowserShell categoriesForMethods!
-canSaveMethod!commands!private! !
+canSaveMethod!private!testing! !
+canShowLocalHierarchy!private!testing! !
 createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
 hasPackageSelected!public!testing! !
@@ -153,8 +137,7 @@ onPackageSelected!event handling!private! !
 packageForNewMethod!operations!private! !
 packageNames!accessing!public! !
 packages!accessing!public! !
-queryCommand:!commands!private! !
-resetForFoundClass:!commands!private! !
+resetForFoundClass:!operations!private! !
 saveStateOn:!private!saved state! !
 searchForPackage:!operations!public! !
 selectionEnvironment!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.CommandQuery.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.CommandQuery.cls
@@ -70,6 +70,9 @@ commandDescription
 
 	^commandDescription!
 
+commandDescription: aCommandDescription
+	commandDescription := aCommandDescription!
+
 commandDescription: action source: aView
 	"Private - Initialize the receiver's instance variables."
 
@@ -212,6 +215,7 @@ canPerform!public!testing! !
 canPerformAgainst:!accessing!public! !
 command!accessing!public! !
 commandDescription!accessing!public! !
+commandDescription:!accessing!public! !
 commandDescription:source:!initializing!private! !
 commandSymbol!accessing!public! !
 description!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.Presenter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.Presenter.cls
@@ -693,6 +693,13 @@ queryCommandHandlers: aCommandQuery
 			whileFalse: [class := class superclass].
 	^false!
 
+queryContextCommand: aCommandQuery as: aSymbol
+	| originalCommand |
+	originalCommand := aCommandQuery commandDescription.
+	aCommandQuery commandDescription: (CommandDescription command: aSymbol).
+	^[self queryCommandHandlers: aCommandQuery]
+		ensure: [aCommandQuery commandDescription: originalCommand]!
+
 remove: aPresenter
 	"Removes aPresenter from the receiver's collection of sub-presenters.
 	Answers aPresenter"
@@ -911,6 +918,7 @@ preTranslateKeyboardInput:!dispatching!public! !
 preTranslateMouseInput:!dispatching!public! !
 queryCommand:!commands!private! !
 queryCommandHandlers:!commands!private! !
+queryContextCommand:as:!public! !
 remove:!public!subpresenters! !
 requestDragImages:!drag & drop!public! !
 requestDragObjects:!drag & drop!public! !
@@ -964,18 +972,6 @@ acceleratorKeyBindings: aDictionary
 	<Symbol>s."
 
 	self setAdditionalAccelerators: (aDictionary associations collect: [:each | {each value. each key}])!
-
-addCommandQueryHandler: aSymbol
-	"Register an additional CommandQuery handler to be invoked by the #queryCommand: processing
-	of instances of the receiver. This allows for additional commands to be added without
-	needing to modify the '#queryCommand: method. The handler is passed an instance of
-	<CommandQuery>, and should answer true if it handles the command, false if not. Handled
-	commands should be enabled/disabled in the normal way."
-
-	#deprecated.	"<commandQuerySelector: #queryBlah:> annotations should be added to the command methods and it will be added to the query selector map automatically on package load"
-	commandQueryHandlers := commandQueryHandlers
-				ifNil: [{aSymbol}]
-				ifNotNil: [commandQueryHandlers copyWith: aSymbol]!
 
 additionalAccelerators
 	"Answer a collection of additional accelerator definitions for commands not on the menu bar of the receiver's view(s). Each element of the collection should be a two element <Array>, the first element of which is the command symbol and the second the accelerator key string."
@@ -1160,14 +1156,6 @@ on: aModel
 
 	^(super new) on: aModel; yourself!
 
-removeCommandQueryHandler: aSymbol
-	"Unregister an additional CommandQuery handler to reverse out a previous
-	addCommandQueryHandler: call. This should be called by IDE extension packages that are
-	uninstalling command handlers."
-
-	#deprecated.	"see #addCommandQueryHandler:"
-	commandQueryHandlers := commandQueryHandlers copyWithout: aSymbol!
-
 resetDefaultAdditionalAccelerators
 	acceleratorKeyAnnotations := nil!
 
@@ -1240,7 +1228,6 @@ updateAdditionalAccelerators
 acceleratorKeyAnnotations!constants!private! !
 acceleratorKeyBindings!constants!public! !
 acceleratorKeyBindings:!constants!public! !
-addCommandQueryHandler:!accessing!public! !
 additionalAccelerators!accessing!public! !
 additionalKeyBindings!accessing!private! !
 annotatedMethodRemoved:!private! !
@@ -1266,7 +1253,6 @@ icon!constants!public! !
 loadViewResource:inContext:!operations!private! !
 new!instance creation!public! !
 on:!instance creation!public! !
-removeCommandQueryHandler:!accessing!public! !
 resetDefaultAdditionalAccelerators!public! !
 resource_Container_view!public!resources-views! !
 resource_Default_view!public!resources-views! !

--- a/Core/Object Arts/Dolphin/MVP/Deprecated/Dolphin MVP (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/MVP/Deprecated/Dolphin MVP (Deprecated).pax
@@ -117,6 +117,8 @@ package methodNames
 	add: 'ListPresenter class' -> #resource_Multiselection_enhanced_list_view;
 	add: 'ListPresenter class' -> #resource_Multiselection_list_box;
 	add: 'PaintEvent class' -> #handle:wParam:hdc:paintStruct:;
+	add: 'Presenter class' -> #addCommandQueryHandler:;
+	add: 'Presenter class' -> #removeCommandQueryHandler:;
 	add: 'RGB class' -> #stdColor:;
 	add: 'STBViewProxy class' -> #for:;
 	add: 'SystemColor class' -> #fromId:;
@@ -724,6 +726,26 @@ asDword
 	^self asUInt32! !
 !POINT categoriesForMethods!
 asDword!converting!public! !
+!
+
+!Presenter class methodsFor!
+
+addCommandQueryHandler: aSymbol
+	Notification deprecated.	"This mechanism is replaced by <commandQuerySelector: #queryBlah:> annotations, declared in the corresponding command methods. These are added to a query selector map automatically on package load."
+	commandQueryHandlers := commandQueryHandlers
+				ifNil: [{ aSymbol }]
+				ifNotNil: [commandQueryHandlers copyWith: aSymbol]!
+
+removeCommandQueryHandler: aSymbol
+	"Unregister an additional CommandQuery handler to reverse out a previous
+	addCommandQueryHandler: call. This should be called by IDE extension packages that are
+	uninstalling command handlers."
+
+	Notification deprecated.	"see #addCommandQueryHandler:"
+	commandQueryHandlers := commandQueryHandlers copyWithout: aSymbol! !
+!Presenter class categoriesForMethods!
+addCommandQueryHandler:!accessing!public! !
+removeCommandQueryHandler:!accessing!public! !
 !
 
 !Prompter methodsFor!

--- a/Core/Object Arts/Samples/IDE/Dolphin IDE Extension Example.pax
+++ b/Core/Object Arts/Samples/IDE/Dolphin IDE Extension Example.pax
@@ -62,7 +62,7 @@ emitClassLayoutDescription
 		do: [:ex | MessageBox errorMsg: ex description].
 	desc isNil ifFalse: [textPresenter replaceSelection: desc]! !
 !Tools.ClassCommentPlugin categoriesForMethods!
-emitClassLayoutDescription!commands!development!public! !
+emitClassLayoutDescription!commands-actions!public! !
 !
 
 !Tools.SmalltalkToolShell methodsFor!


### PR DESCRIPTION
Method history extension was using the deprecated mechanism for adding extension queryCommand: style methods, which can be replaced with the cleaner declarative association (specified using an annotation) between extension commands and a query handler.

This is an appropriate time to replace all the queryCommand: switch methods in the extended dev tools (debugger, class browser, method browser and package browser) too.

Create a common pattern for the context sensitive commands (browse-it, inspect-it, accept-it, etc) and provide the majority of this at the SmalltalkToolShell level. Individual tools implement a mapping function to return the live selector for the context sensitive command, e.g. based on subview focus. They then implement the commands to which the generic/context-sensitive command is matched, and associate these with query handlers.

A number of bugs and inconsistencies in the enablement/action of the commands became much more obvious with the new mechanism, and were fixed.

Further refinement of new command querying ClassSelector.

Remove the interim mechanism for declaring additional queryCommand: methods originally introduced to replace the legacy mechanism. This is unnecessary as it isn't required for backwards compat (the legacy mechanism still works), and it is inferior to the individual command query annotations. The legacy mechanism is now deprecated.