### PR TITLE
Command queries can be zero-arg testing methods

### DIFF
--- a/Core/Contributions/IDB/DiffBrowser.cls
+++ b/Core/Contributions/IDB/DiffBrowser.cls
@@ -50,7 +50,7 @@ about: aString
 		text: aString!
 
 character
-	<commandQuerySelector: #queryDiffMode:>
+	<commandQuery: #queryDiffMode:>
 	self mode: #character!
 
 compare: upperString id: upperIdString and: lowerString id: lowerIdString
@@ -64,7 +64,7 @@ createComponents
 	diffsPresenter := self add: DifferencesPresenter new name: 'diffs'!
 
 line
-	<commandQuerySelector: #queryDiffMode:>
+	<commandQuery: #queryDiffMode:>
 	self mode: #line!
 
 mode: aSymbol 
@@ -106,7 +106,7 @@ textStyles: anCollectionOfScintillaTextStyle
 	diffsPresenter textStyles: anCollectionOfScintillaTextStyle!
 
 word
-	<commandQuerySelector: #queryDiffMode:>
+	<commandQuery: #queryDiffMode:>
 	self mode: #word! !
 !DiffBrowser categoriesForMethods!
 about!commands-actions!public! !

--- a/Core/Contributions/IDB/IDB Method History.pax
+++ b/Core/Contributions/IDB/IDB Method History.pax
@@ -126,7 +126,7 @@ sourceDescriptorForPosition:!private!source filing-file in! !
 !ClassBrowserAbstract methodsFor!
 
 browseMethodHistory
-	<commandQuerySelector: #hasMethodSelected>
+	<commandQuery: #hasMethodSelected>
 	| method |
 	#idbAdded.
 	method := self selectedMethod.
@@ -135,7 +135,7 @@ browseMethodHistory
 browseMethodHistoryForClass
 	"Open a browser on the history of methods in the current class"
 
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	#idbAdded.
 	ClassHistoryBrowser showOnClass: self actualClass! !
 !ClassBrowserAbstract categoriesForMethods!
@@ -164,7 +164,7 @@ versionHistory!accessing!public! !
 browseMethodHistory
 	"Open a browser on the history of the current method"
 
-	<commandQuerySelector: #hasBrowsableMethod>
+	<commandQuery: #hasBrowsableMethod>
 	| method |
 	#idbAdded.
 	method := self selectedMethod.
@@ -179,7 +179,7 @@ browseMethodHistory!commands-actions!idb goodies!private! !
 !MethodBrowserShell methodsFor!
 
 browseMethodHistory
-	<commandQuerySelector: #hasMethodSelected>
+	<commandQuery: #hasMethodSelected>
 	| method |
 	#idbAdded.
 	method := self selectedMethod.

--- a/Core/Contributions/IDB/IDB Method History.pax
+++ b/Core/Contributions/IDB/IDB Method History.pax
@@ -126,7 +126,7 @@ sourceDescriptorForPosition:!private!source filing-file in! !
 !ClassBrowserAbstract methodsFor!
 
 browseMethodHistory
-	<commandQuerySelector: #queryHasMethodSelected:>
+	<commandQuerySelector: #hasMethodSelected>
 	| method |
 	#idbAdded.
 	method := self selectedMethod.
@@ -135,7 +135,7 @@ browseMethodHistory
 browseMethodHistoryForClass
 	"Open a browser on the history of methods in the current class"
 
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	#idbAdded.
 	ClassHistoryBrowser showOnClass: self actualClass! !
 !ClassBrowserAbstract categoriesForMethods!
@@ -164,7 +164,7 @@ versionHistory!accessing!public! !
 browseMethodHistory
 	"Open a browser on the history of the current method"
 
-	<commandQuerySelector: #queryHasBrowsableMethod:>
+	<commandQuerySelector: #hasBrowsableMethod>
 	| method |
 	#idbAdded.
 	method := self selectedMethod.
@@ -179,7 +179,7 @@ browseMethodHistory!commands-actions!idb goodies!private! !
 !MethodBrowserShell methodsFor!
 
 browseMethodHistory
-	<commandQuerySelector: #queryHasMethodSelected:>
+	<commandQuerySelector: #hasMethodSelected>
 	| method |
 	#idbAdded.
 	method := self selectedMethod.

--- a/Core/Contributions/MetaProg/Abbreviations/MetaProg Abbreviations.pax
+++ b/Core/Contributions/MetaProg/Abbreviations/MetaProg Abbreviations.pax
@@ -104,9 +104,9 @@ snatchAbbreviation
 					ifTrue: [^MessageBox warning: 'Do not enter an abbreviation containing a colon.'].
 				self class abbreviations at: key put: text]! !
 !SmalltalkWorkspace categoriesForMethods!
-expandAbbreviation!commands!private! !
+expandAbbreviation!commands-actions!private! !
 findSeparatorLeftAndKey:!helpers!private! !
-snatchAbbreviation!commands!private! !
+snatchAbbreviation!commands-actions!private! !
 !
 
 !SmalltalkWorkspace class methodsFor!

--- a/Core/Contributions/Odellsoft/SUnitBrowser/SUnitBrowser.pax
+++ b/Core/Contributions/Odellsoft/SUnitBrowser/SUnitBrowser.pax
@@ -159,7 +159,7 @@ SUnitAbsWrapper subclass: #SUnitTestResourceWrapper
 browseTests
 	"Open an SUnit Test Browser on the selected Test Case."
 
-	<commandQuerySelector: #hasTestCases>
+	<commandQuery: #hasTestCases>
 	self testBrowserClass sunitbShow: self buildTestSuite!
 
 buildTestSuite

--- a/Core/Contributions/Odellsoft/SUnitBrowser/SUnitBrowser.pax
+++ b/Core/Contributions/Odellsoft/SUnitBrowser/SUnitBrowser.pax
@@ -78,7 +78,7 @@ package classNames
 package methodNames
 	add: #ClassSelector -> #browseTests;
 	add: #ClassSelector -> #buildTestSuite;
-	add: #ClassSelector -> #queryBrowseTests:;
+	add: #ClassSelector -> #hasTestCases;
 	add: #ClassSelector -> #testBrowserClass;
 	add: #PackageSelector -> #browseTests;
 	add: #PackageSelector -> #buildTestSuite;
@@ -159,7 +159,7 @@ SUnitAbsWrapper subclass: #SUnitTestResourceWrapper
 browseTests
 	"Open an SUnit Test Browser on the selected Test Case."
 
-	<commandQuerySelector: #queryBrowseTests:>
+	<commandQuerySelector: #hasTestCases>
 	self testBrowserClass sunitbShow: self buildTestSuite!
 
 buildTestSuite
@@ -185,21 +185,20 @@ buildTestSuite
 						addTests: (classSuite allTests select: [:eachTest | eachClass canUnderstand: eachTest selector])]].
 	^suite!
 
-queryBrowseTests: aCommandQuery
-	aCommandQuery
-		isEnabled: (self testBrowserClass notNil and: 
-					[| class |
-					class := self selectionOrNil.
-					class notNil and: 
-							["Test if the selected class is a kind of TestCase without taking a dependency on the SUnit package, so it can be uninstalled if desired."
-							class inheritsFrom: #{TestCase} value]])!
+hasTestCases
+	^self testBrowserClass notNil and: 
+			[| class |
+			class := self selectionOrNil.
+			class notNil and: 
+					["Test if the selected class is a kind of TestCase without taking a dependency on the SUnit package, so it can be uninstalled if desired."
+					class inheritsFrom: #{TestCase} value]]!
 
 testBrowserClass
 	^SmalltalkSystem current testBrowserClass! !
 !ClassSelector categoriesForMethods!
 browseTests!commands-actions!public! !
 buildTestSuite!helpers!public! !
-queryBrowseTests:!commands-queries!private! !
+hasTestCases!private!testing! !
 testBrowserClass!constants!private! !
 !
 

--- a/Core/DolphinVM/Interprt.h
+++ b/Core/DolphinVM/Interprt.h
@@ -213,7 +213,7 @@ public:
 	static void push(char16_t);
 
 	// To be used when pushing a known non-SmallInteger (skips the SmallInteger check)
-	static void pushObject(OTE* object)
+	template<typename T> static void pushObject(TOTE<T>* object)
 	{
 		push(reinterpret_cast<Oop>(object));
 	}

--- a/Core/DolphinVM/PerformPrim.cpp
+++ b/Core/DolphinVM/PerformPrim.cpp
@@ -32,98 +32,108 @@ Oop* PRIMCALL Interpreter::primitiveValueWithArgs(Oop* const bp, primargcount_t)
 	const auto blockArgumentCount = block->m_info.argumentCount;
 
 	BehaviorOTE* arrayClass = ObjectMemory::fetchClassOf(reinterpret_cast<Oop>(argumentArray));
-	if (arrayClass != Pointers.ClassArray)
-		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter1);
-
-	const size_t arrayArgumentCount = argumentArray->pointersSize();
-	if (arrayArgumentCount != blockArgumentCount)
-		return primitiveFailure(_PrimitiveFailureCode::WrongNumberOfArgs);
-
-	pop(2);								// N.B. ref count of Block will be assumed by storing into frame
-	// Store old context details from interpreter registers
-	m_registers.StoreContextRegisters();
-
-	// Overwrite receiver block with receiver at time of closure.
-	Oop closureReceiver = block->m_receiver;
-	*(bp-1) = closureReceiver;
-	// No need to count up the receiver since we've written it into a stack slot
-
-	Array* args = argumentArray->m_location;
-
-	// Code this carefully so compiler generates optimal code (it makes a poor job on its own)
-	Oop* sp = bp;
-
-	// Push the args from the array
+	if (arrayClass == Pointers.ClassArray)
 	{
-		for (size_t i=0;i<arrayArgumentCount;i++)
+		const size_t arrayArgumentCount = argumentArray->pointersSize();
+		if (arrayArgumentCount == blockArgumentCount)
 		{
-			Oop pushee = args->m_elements[i];
-			*sp++ = pushee;
-			// No need to count up since pushing on the stack
-		}
-	}
+			pop(2);
+			// Store old context details from interpreter registers
+			m_registers.StoreContextRegisters();
 
-	const auto copiedValues = block->copiedValuesCount(oteBlock);
-	{
-		for (auto i=0u;i<copiedValues;i++)
+			// Overwrite receiver block with receiver at time of closure.
+			Oop closureReceiver = block->m_receiver;
+			*(bp - 1) = closureReceiver;
+			// No need to count up the receiver since we've written it into a stack slot
+
+			Array* args = argumentArray->m_location;
+
+			// Code this carefully so compiler generates optimal code (it makes a poor job on its own)
+			Oop* sp = bp;
+
+			// Push the args from the array
+			{
+				for (size_t i = 0; i < arrayArgumentCount; i++)
+				{
+					Oop pushee = args->m_elements[i];
+					*sp++ = pushee;
+					// No need to count up since pushing on the stack
+				}
+			}
+
+			const auto copiedValues = block->copiedValuesCount(oteBlock);
+			{
+				for (auto i = 0u; i < copiedValues; i++)
+				{
+					Oop oopCopied = block->m_copiedValues[i];
+					*sp++ = oopCopied;
+					// No need to count up since pushing on the stack
+				}
+			}
+
+			// Nil out any extra stack temp slots we need
+			const auto extraTemps = block->stackTempsCount();
+			{
+				const Oop nilPointer = Oop(Pointers.Nil);
+				for (auto i = 0; i < extraTemps; i++)
+					*sp++ = nilPointer;
+			}
+
+			// Stack frame follows args...
+			StackFrame* pFrame = reinterpret_cast<StackFrame*>(sp);
+
+			pFrame->m_bp = reinterpret_cast<Oop>(bp) + 1;
+			m_registers.m_basePointer = reinterpret_cast<Oop*>(bp);
+
+			// stack ref. removed so don't need to count down
+
+			pFrame->m_caller = m_registers.activeFrameOop();
+			// Having set caller can update the active frame Oop
+			m_registers.m_pActiveFrame = pFrame;
+
+			// Note that ref. count remains the same due dto overwritten receiver slot
+			const auto envTemps = block->envTempsCount();
+			if (envTemps > 0)
+			{
+				ContextOTE* oteContext = Context::New(envTemps, reinterpret_cast<Oop>(block->m_outer));
+				pFrame->m_environment = reinterpret_cast<Oop>(oteContext);
+				Context* context = oteContext->m_location;
+				context->m_block = oteBlock;
+				// Block has been written into a heap object slot, so must count up
+				oteBlock->countUp();
+			}
+			else
+				pFrame->m_environment = reinterpret_cast<Oop>(oteBlock);
+
+			// We don't need to store down the IP and SP into the frame until it is suspended
+			pFrame->m_ip = ZeroPointer;
+			pFrame->m_sp = ZeroPointer;
+			MethodOTE* oteMethod = block->m_method;
+			pFrame->m_method = oteMethod;
+			// Don't need to inc ref count for stack frame ref to method
+			CompiledMethod* method = oteMethod->m_location;
+			m_registers.m_pMethod = method;
+
+			m_registers.m_instructionPointer = ObjectMemory::ByteAddressOfObjectContents(method->m_byteCodes) +
+				block->initialIP() - 1;
+
+			// New stack pointer points at last field of stack frame
+			m_registers.m_stackPointer = reinterpret_cast<Oop*>(reinterpret_cast<uint8_t*>(pFrame) + sizeof(StackFrame)) - 1;
+			ASSERT(m_registers.m_stackPointer == &pFrame->m_bp);
+
+			return primitiveSuccess(0);
+		}
+		else
 		{
-			Oop oopCopied = block->m_copiedValues[i];
-			*sp++ = oopCopied;
-			// No need to count up since pushing on the stack
+			// Array size did not match block argument count
+			return primitiveFailure(_PrimitiveFailureCode::WrongNumberOfArgs);
 		}
-	}
-
-	// Nil out any extra stack temp slots we need
-	const auto extraTemps = block->stackTempsCount();
-	{
-		const Oop nilPointer = Oop(Pointers.Nil);
-		for (auto i=0;i<extraTemps;i++)
-			*sp++ = nilPointer;
-	}
-
-	// Stack frame follows args...
-	StackFrame* pFrame = reinterpret_cast<StackFrame*>(sp);
-
-	pFrame->m_bp = reinterpret_cast<Oop>(bp)+1;
-	m_registers.m_basePointer = reinterpret_cast<Oop*>(bp);
-
-	// stack ref. removed so don't need to count down
-
-	pFrame->m_caller = m_registers.activeFrameOop();
-	// Having set caller can update the active frame Oop
-	m_registers.m_pActiveFrame = pFrame;
-
-	// Note that ref. count remains the same due dto overwritten receiver slot
-	const auto envTemps = block->envTempsCount();
-	if (envTemps > 0)
-	{
-		ContextOTE* oteContext = Context::New(envTemps, reinterpret_cast<Oop>(block->m_outer));
-		pFrame->m_environment = reinterpret_cast<Oop>(oteContext);
-		Context* context = oteContext->m_location;
-		context->m_block = oteBlock;
-		// Block has been written into a heap object slot, so must count up
-		oteBlock->countUp();
 	}
 	else
-		pFrame->m_environment = reinterpret_cast<Oop>(oteBlock);
-
-	// We don't need to store down the IP and SP into the frame until it is suspended
-	pFrame->m_ip = ZeroPointer;
-	pFrame->m_sp = ZeroPointer;
-	MethodOTE* oteMethod = block->m_method;
-	pFrame->m_method = oteMethod;
-	// Don't need to inc ref count for stack frame ref to method
-	CompiledMethod* method = oteMethod->m_location;
-	m_registers.m_pMethod = method;
-
-	m_registers.m_instructionPointer = ObjectMemory::ByteAddressOfObjectContents(method->m_byteCodes) +
-											block->initialIP() - 1;
-
-	// New stack pointer points at last field of stack frame
-	m_registers.m_stackPointer = reinterpret_cast<Oop*>(reinterpret_cast<uint8_t*>(pFrame)+sizeof(StackFrame)) - 1;
-	ASSERT(m_registers.m_stackPointer == &pFrame->m_bp);
-
-	return primitiveSuccess(0);
+	{
+		// Parameter must be an Array
+		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter1);
+	}
 }
 
 Oop* PRIMCALL Interpreter::primitivePerform(Oop* const sp, primargcount_t argCount)
@@ -131,58 +141,64 @@ Oop* PRIMCALL Interpreter::primitivePerform(Oop* const sp, primargcount_t argCou
 	SymbolOTE* performSelector = m_oopMessageSelector;	// Save in case we need to restore
 
 	SymbolOTE* selectorToPerform = reinterpret_cast<SymbolOTE*>(*(sp - (argCount-1)));
-	if (ObjectMemoryIsIntegerObject(selectorToPerform))
-		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter1);
-	m_oopMessageSelector = selectorToPerform;
-	Oop newReceiver = *(sp - argCount);
-
-	// lookupMethodInClass returns the Oop of the new CompiledMethod
-	// if the selector is found, or Pointers.DoesNotUnderstand if the class 
-	// does not understand the selector. We succeed if either the argument
-	// count of the returned method matches that passed to this primitive,
-	// or if the selector is not understood, because by this time the
-	// detection of the 'does not understand' will have triggered
-	// the create of a Message object (see createActualMessage) into
-	// which all the arguments will have been moved, and which then replaces
-	// those arguments on the Smalltalk context stack. i.e. the primitive 
-	// will succeed if the message is not understood, but will result in 
-	// the execution of doesNotUnderstand: rather than the selector we've 
-	// been asked to perform. This works because
-	// after a doesNotUnderstand detection, the stack has a Message at stack
-	// top, the selector is still there, and argCount is now 1. Consequently
-	// the Message gets shuffled over the selector, and doesNotUnderstand is
-	// sent
-
-	auto oteClass = ObjectMemory::fetchClassOf(newReceiver);
-	MethodCacheEntry* pEntry = findNewMethodInClass(oteClass, (argCount - 1));
-	MethodOTE* methodPointer = pEntry->method;
-	CompiledMethod* method = methodPointer->m_location;
-	const auto methodArgCount = method->m_header.argumentCount;
-	if (methodArgCount == (argCount-1) || m_oopMessageSelector == Pointers.DoesNotUnderstandSelector)
+	if (!ObjectMemoryIsIntegerObject(selectorToPerform))
 	{
-		// Shuffle arguments down over the selector (use argumentCount of
-		// method found which may not equal argCount)
-		// #pragma message("primitivePerform: Instead of shuffling args down 1, why not just deduct 1 from calling frames suspended SP after exec?")
-		Oop* const tos = m_registers.m_stackPointer;
-		Oop* sp = tos - methodArgCount;
+		m_oopMessageSelector = selectorToPerform;
+		Oop newReceiver = *(sp - argCount);
 
-		// We don't need to count down the overwritten oop anymore, since we don't ref. count stack ops
+		// lookupMethodInClass returns the Oop of the new CompiledMethod
+		// if the selector is found, or Pointers.DoesNotUnderstand if the class 
+		// does not understand the selector. We succeed if either the argument
+		// count of the returned method matches that passed to this primitive,
+		// or if the selector is not understood, because by this time the
+		// detection of the 'does not understand' will have triggered
+		// the create of a Message object (see createActualMessage) into
+		// which all the arguments will have been moved, and which then replaces
+		// those arguments on the Smalltalk context stack. i.e. the primitive 
+		// will succeed if the message is not understood, but will result in 
+		// the execution of doesNotUnderstand: rather than the selector we've 
+		// been asked to perform. This works because
+		// after a doesNotUnderstand detection, the stack has a Message at stack
+		// top, the selector is still there, and argCount is now 1. Consequently
+		// the Message gets shuffled over the selector, and doesNotUnderstand is
+		// sent
 
-		// Not worth overhead of calling memmove here since argumentCount
-		// normally small
-		for (;sp < tos;sp++)
-			*sp = *(sp+1);
-		m_registers.m_stackPointer = sp - 1;
-		executeNewMethod(methodPointer, methodArgCount);
-		return primitiveSuccess(0);
+		auto oteClass = ObjectMemory::fetchClassOf(newReceiver);
+		MethodCacheEntry* pEntry = findNewMethodInClass(oteClass, (argCount - 1));
+		MethodOTE* methodPointer = pEntry->method;
+		CompiledMethod* method = methodPointer->m_location;
+		const auto methodArgCount = method->m_header.argumentCount;
+		if (methodArgCount == (argCount - 1) || m_oopMessageSelector == Pointers.DoesNotUnderstandSelector)
+		{
+			// Shuffle arguments down over the selector (use argumentCount of
+			// method found which may not equal argCount)
+			// #pragma message("primitivePerform: Instead of shuffling args down 1, why not just deduct 1 from calling frames suspended SP after exec?")
+			Oop* const tos = m_registers.m_stackPointer;
+			Oop* sp = tos - methodArgCount;
+
+			// We don't need to count down the overwritten oop anymore, since we don't ref. count stack ops
+
+			// Not worth overhead of calling memmove here since argumentCount
+			// normally small
+			for (; sp < tos; sp++)
+				*sp = *(sp + 1);
+			m_registers.m_stackPointer = sp - 1;
+			executeNewMethod(methodPointer, methodArgCount);
+			return primitiveSuccess(0);
+		}
+		else
+		{
+			// The argument count did not match, so drop out into the Smalltalk
+			// having restored the selector
+			ASSERT(m_oopMessageSelector != Pointers.DoesNotUnderstandSelector);
+			m_oopMessageSelector = performSelector;
+			return primitiveFailure(_PrimitiveFailureCode::WrongNumberOfArgs);
+		}
 	}
 	else
 	{
-		// The argument count did not match, so drop out into the Smalltalk
-		// having restored the selector
-		ASSERT(m_oopMessageSelector!=Pointers.DoesNotUnderstandSelector);
-		m_oopMessageSelector = performSelector;
-		return primitiveFailure(_PrimitiveFailureCode::WrongNumberOfArgs);
+		// Arg cannot be a SmallInteger
+		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter1);
 	}
 }
 
@@ -190,77 +206,84 @@ Oop* PRIMCALL Interpreter::primitivePerformWithArgs(Oop* const sp, primargcount_
 {
 	ArrayOTE* argumentArray = reinterpret_cast<ArrayOTE*>(*(sp));
 	BehaviorOTE* arrayClass = ObjectMemory::fetchClassOf(Oop(argumentArray));
-	if (arrayClass != Pointers.ClassArray)
-		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter2);
-	
-	// N.B. We're using a large stack, so don't bother checking for overflow
-	//		(standard stack overflow mechanism should catch it)
-									   
-	// We must not get the length outside, in case small integer arg
-	const auto argCount = argumentArray->pointersSize();
-	
-	// Save old message selector in case of prim failure (need to reinstate)
-	SymbolOTE* performSelector = m_oopMessageSelector;
-
-	// To ensure the argumentArray doesn't go away when we push its contents
-	// onto the stack, in case we need it for recovery from an argument
-	// count mismatch we leave its ref. count elevated
-
-	SymbolOTE* selectorToPerform = reinterpret_cast<SymbolOTE*>(*(sp-1));
-	if (ObjectMemoryIsIntegerObject(selectorToPerform))
-		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter1);
-
-	m_oopMessageSelector = selectorToPerform;	// Get selector from stack
-	// Don't need to count down the stack ref.
-	ASSERT(!selectorToPerform->isFree());
-
-	Oop newReceiver = *(sp-2);			// receiver is under selector and arg array
-
-	// Push the args from the array onto the stack. We must do this before
-	// looking up the method, because if the receiver does not understand
-	// the method then the lookup routines copy the arguments off the stack
-	// into a Message object
-	Array* args = argumentArray->m_location;
-	for (auto i=0u; i<argCount; i++)
+	if (arrayClass == Pointers.ClassArray)
 	{
-		Oop pushee = args->m_elements[i];
-		// Note no need to inc the ref. count when pushing on the stack
-		sp[i-1] = pushee;
-	}
-	// Args written over top of selector and argument array (hence -2)
-	m_registers.m_stackPointer = sp+argCount-2;
+		// N.B. We're using a large stack, so don't bother checking for overflow
+		//		(standard stack overflow mechanism should catch it)
 
-	// There is a subtle complication here when the receiver does not
-	// understand the message, by which lookupMethodInClass() converts
-	// the message we're trying to perform to a #doesNotUnderstand: with
-	// all arguments moved to a Message. We still want to execute this
-	// does not understand, so we also execute the method if the argument
-	// counts do not match, but it was not understood. Note that it is
-	// possible for a doesNotUnderstand: to be executed thru the first
-	// test if the argumentArray contained only one argument. We allow
-	// this to happen to avoid testing for not understood in the normal
-	// case - just be aware of this anomaly.
-	MethodCacheEntry* pEntry = findNewMethodInClass(ObjectMemory::fetchClassOf(newReceiver), argCount);
-	MethodOTE* methodPointer = pEntry->method;
-	CompiledMethod& method = *methodPointer->m_location;
-	const auto methodArgCount = method.m_header.argumentCount;
-	if (methodArgCount == argCount ||
-			m_oopMessageSelector == Pointers.DoesNotUnderstandSelector)
-	{
-		// WE no longer need the argument array, but don't count it down since we only have a stack ref.
-		executeNewMethod(methodPointer, methodArgCount);
-		return primitiveSuccess(0);
+		// We must not get the length outside, in case small integer arg
+		const auto argCount = argumentArray->pointersSize();
+
+		// To ensure the argumentArray doesn't go away when we push its contents
+		// onto the stack, in case we need it for recovery from an argument
+		// count mismatch we leave its ref. count elevated
+
+		SymbolOTE* selectorToPerform = reinterpret_cast<SymbolOTE*>(*(sp - 1));
+		if (!ObjectMemoryIsIntegerObject(selectorToPerform))
+		{
+			// Save old message selector in case of prim failure (need to reinstate)
+			SymbolOTE* performSelector = m_oopMessageSelector;
+		
+			m_oopMessageSelector = selectorToPerform;	// Get selector from stack
+			// Don't need to count down the stack ref.
+			ASSERT(!selectorToPerform->isFree());
+
+			Oop newReceiver = *(sp - 2);			// receiver is under selector and arg array
+
+			// Push the args from the array onto the stack. We must do this before
+			// looking up the method, because if the receiver does not understand
+			// the method then the lookup routines copy the arguments off the stack
+			// into a Message object
+			Array* args = argumentArray->m_location;
+			for (auto i = 0u; i < argCount; i++)
+			{
+				Oop pushee = args->m_elements[i];
+				// Note no need to inc the ref. count when pushing on the stack
+				sp[i - 1] = pushee;
+			}
+			// Args written over top of selector and argument array (hence -2)
+			m_registers.m_stackPointer = sp + argCount - 2;
+
+			// There is a subtle complication here when the receiver does not
+			// understand the message, by which lookupMethodInClass() converts
+			// the message we're trying to perform to a #doesNotUnderstand: with
+			// all arguments moved to a Message. We still want to execute this
+			// does not understand, so we also execute the method if the argument
+			// counts do not match, but it was not understood. Note that it is
+			// possible for a doesNotUnderstand: to be executed thru the first
+			// test if the argumentArray contained only one argument. We allow
+			// this to happen to avoid testing for not understood in the normal
+			// case - just be aware of this anomaly.
+			MethodCacheEntry* pEntry = findNewMethodInClass(ObjectMemory::fetchClassOf(newReceiver), argCount);
+			MethodOTE* methodPointer = pEntry->method;
+			CompiledMethod& method = *methodPointer->m_location;
+			const auto methodArgCount = method.m_header.argumentCount;
+			if (methodArgCount == argCount || m_oopMessageSelector == Pointers.DoesNotUnderstandSelector)
+			{
+				executeNewMethod(methodPointer, methodArgCount);
+				return primitiveSuccess(0);
+			}
+			else
+			{
+				// Receiver must have understood the message, but we had wrong 
+				// number of arguments, so reinstate the stack and fail the primitive
+				pop(argCount);
+				pushObject(m_oopMessageSelector);
+				pushObject(argumentArray);
+				m_oopMessageSelector = performSelector;
+				return primitiveFailure(_PrimitiveFailureCode::WrongNumberOfArgs);
+			}
+		}
+		else
+		{
+			// 1st arg must not be a SmallInteger
+			return primitiveFailure(_PrimitiveFailureCode::InvalidParameter1);
+		}
 	}
 	else
 	{
-		// Receiver must have understood the message, but we had wrong 
-		// number of arguments, so reinstate the stack and fail the primitive
-		pop(argCount);
-		pushObject((OTE*)m_oopMessageSelector);
-		// Argument array already has artificially increased ref. count
-		push(Oop(argumentArray));
-		m_oopMessageSelector = performSelector;
-		return primitiveFailure(_PrimitiveFailureCode::WrongNumberOfArgs);
+		// 2nd arg must be an Array
+		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter2);
 	}
 }
 
@@ -268,33 +291,46 @@ Oop* PRIMCALL Interpreter::primitivePerformWithArgs(Oop* const sp, primargcount_
 Oop* PRIMCALL Interpreter::primitivePerformMethod(Oop* const sp, primargcount_t)
 {
 	ArrayOTE* oteArg = reinterpret_cast<ArrayOTE*>(*(sp));
-	if (ObjectMemory::fetchClassOf(Oop(oteArg)) != Pointers.ClassArray)
-		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter2);		// Arguments not an Array
-	Array* arguments = oteArg->m_location;
-	Oop receiverPointer = *(sp - 1);
-	MethodOTE* oteMethod = reinterpret_cast<MethodOTE*>(*(sp - 2));
-	Oop* bp = sp - 2;
-
-	CompiledMethod* method = oteMethod->m_location;
-	if (!ObjectMemory::isKindOf(receiverPointer, method->m_methodClass))
-		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter1);		// Wrong class of receiver
-
-	const size_t argCount = oteArg->pointersSize();
-	const auto methodArgCount = method->m_header.argumentCount;
-	if (methodArgCount != argCount)
-		return primitiveFailure(_PrimitiveFailureCode::WrongNumberOfArgs);		// Wrong number of arguments
-
-	// Push receiver and arguments on stack (over the top of array and receiver)
-	bp[0] = receiverPointer;					// Write receiver over the top of the method
-	for (auto i = 0; i < methodArgCount; i++)
+	if (ObjectMemory::fetchClassOf(Oop(oteArg)) == Pointers.ClassArray)
 	{
-		Oop pushee = arguments->m_elements[i];
-		// Don't count up because we are adding a stack ref.
-		bp[i+1] = pushee;
-	}
-	m_registers.m_stackPointer = bp+ methodArgCount;
+		Array* arguments = oteArg->m_location;
+		Oop receiverPointer = *(sp - 1);
+		MethodOTE* oteMethod = reinterpret_cast<MethodOTE*>(*(sp - 2));
+		Oop* bp = sp - 2;
 
-	// Don't count down any args
-	executeNewMethod(oteMethod, methodArgCount);
-	return primitiveSuccess(0);
+		CompiledMethod* method = oteMethod->m_location;
+		if (ObjectMemory::isKindOf(receiverPointer, method->m_methodClass))
+		{
+			const size_t argCount = oteArg->pointersSize();
+			const auto methodArgCount = method->m_header.argumentCount;
+			if (methodArgCount == argCount)
+			{
+				// Push receiver and arguments on stack (over the top of array and receiver)
+				bp[0] = receiverPointer;					// Write receiver over the top of the method
+				for (auto i = 0; i < methodArgCount; i++)
+				{
+					Oop pushee = arguments->m_elements[i];
+					// Don't count up because we are adding a stack ref.
+					bp[i + 1] = pushee;
+				}
+				m_registers.m_stackPointer = bp + methodArgCount;
+
+				// Don't count down any args
+				executeNewMethod(oteMethod, methodArgCount);
+				return primitiveSuccess(0);
+			}
+			else
+			{
+				return primitiveFailure(_PrimitiveFailureCode::WrongNumberOfArgs);		// Wrong number of arguments
+			}
+		}
+		else
+		{
+			return primitiveFailure(_PrimitiveFailureCode::InvalidParameter1);		// Wrong class of receiver
+		}
+	}
+	else
+	{
+		return primitiveFailure(_PrimitiveFailureCode::InvalidParameter2);		// Arguments not an Array
+	}
 }

--- a/Core/DolphinVM/bytecde.cpp
+++ b/Core/DolphinVM/bytecde.cpp
@@ -644,7 +644,7 @@ ContextOTE* __fastcall Context::New(size_t tempCount, Oop oopOuter)
 // not objects
 void Interpreter::invalidReturn(Oop resultPointer)
 {
-	pushObject((OTE*)Pointers.Scheduler);	// Receiver of cannotReturn
+	pushObject(Pointers.Scheduler);	// Receiver of cannotReturn
 	push(resultPointer);
 	sendSelectorArgumentCount(Pointers.CannotReturnSelector, 1);
 }

--- a/Core/DolphinVM/extcall.cpp
+++ b/Core/DolphinVM/extcall.cpp
@@ -373,7 +373,7 @@ void Interpreter::push(char16_t utf16CodeUnit)
 
 	if (utf16CodeUnit <= 0x7f)
 	{
-		pushObject((OTE*)Character::NewAnsi(static_cast<unsigned char>(utf16CodeUnit)));
+		pushObject(Character::NewAnsi(static_cast<unsigned char>(utf16CodeUnit)));
 		return;
 	} 
 
@@ -383,7 +383,7 @@ void Interpreter::push(char16_t utf16CodeUnit)
 		auto ansiCodeUnit = Interpreter::m_unicodeToAnsiCharMap[utf16CodeUnit];
 		if (ansiCodeUnit != 0)
 		{
-			pushObject(reinterpret_cast<OTE*>(Character::NewAnsi(ansiCodeUnit)));
+			pushObject(Character::NewAnsi(ansiCodeUnit));
 			return;
 		}
 

--- a/Core/DolphinVM/interfac.cpp
+++ b/Core/DolphinVM/interfac.cpp
@@ -332,26 +332,26 @@ void Interpreter::pushUnknown(Oop object)
 // Public methods for performing callbacks
 Oop	__stdcall Interpreter::perform(Oop receiver, SymbolOTE* selector TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject((OTE*)Pointers.Scheduler);
+	pushObject(Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject((OTE*)selector);
+	pushObject(selector);
 	return callback(Pointers.callbackPerformSymbol, 2 TRACEARG(traceFlag));
 }
 
 Oop	__stdcall Interpreter::performWith(Oop receiver, SymbolOTE* selector, Oop arg TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject((OTE*)Pointers.Scheduler);
+	pushObject(Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject((OTE*)selector);
+	pushObject(selector);
 	pushUnknown(arg);
 	return callback(Pointers.callbackPerformWithSymbol, 3 TRACEARG(traceFlag));
 }
 
 Oop	__stdcall Interpreter::performWithWith(Oop receiver, SymbolOTE* selector, Oop arg1, Oop arg2 TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject((OTE*)Pointers.Scheduler);
+	pushObject(Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject((OTE*)selector);
+	pushObject(selector);
 	pushUnknown(arg1);
 	pushUnknown(arg2);
 	return callback(Pointers.callbackPerformWithWithSymbol, 4 TRACEARG(traceFlag));
@@ -359,9 +359,9 @@ Oop	__stdcall Interpreter::performWithWith(Oop receiver, SymbolOTE* selector, Oo
 
 Oop	__stdcall Interpreter::performWithWithWith(Oop receiver, SymbolOTE* selector, Oop arg1, Oop arg2, Oop arg3 TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject((OTE*)Pointers.Scheduler);
+	pushObject(Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject((OTE*)selector);
+	pushObject(selector);
 	pushUnknown(arg1);
 	pushUnknown(arg2);
 	pushUnknown(arg3);
@@ -371,9 +371,9 @@ Oop	__stdcall Interpreter::performWithWithWith(Oop receiver, SymbolOTE* selector
 
 Oop	__stdcall Interpreter::performWithArguments(Oop receiver, SymbolOTE* selector, Oop anArray TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject((OTE*)Pointers.Scheduler);
+	pushObject(Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject((OTE*)selector);
+	pushObject(selector);
 	ASSERT(ObjectMemory::fetchClassOf(anArray) == Pointers.ClassArray);
 	pushUnknown(anArray);
 	return callback(Pointers.callbackPerformWithArgumentsSymbol, 3 TRACEARG(traceFlag));
@@ -405,7 +405,7 @@ SymbolOTE* __stdcall Interpreter::NewSymbol(const char8_t* name, size_t length) 
 	// to intern the symbol (Symbol intern: aString)
 	//
 
-	pushObject((OTE*)Pointers.ClassSymbol);
+	pushObject(Pointers.ClassSymbol);
 	pushNewObject((OTE*)Utf8String::New(name, length));
 	SymbolOTE* symbolPointer = reinterpret_cast<SymbolOTE*>(callback(Pointers.InternSelector, 1 TRACEARG(TRACEFLAG::TraceOff)));
 	ASSERT(symbolPointer->m_oteClass == Pointers.ClassSymbol);
@@ -620,7 +620,7 @@ inline LRESULT __stdcall Interpreter::GenericCallbackMain(SmallInteger id, uint8
 	{
 		// All accesses to stack/OT allocations must be inside the
 		// memoryExceptionFilter to implement stack and OT growth-on-demand
-		pushObject((OTE*)Pointers.Scheduler);
+		pushObject(Pointers.Scheduler);
 		pushSmallInteger(id);
 		// Add sizeof(DWORD*) to the stack pointer as it includes the return address for
 		// the call which invoked the function
@@ -830,7 +830,7 @@ LRESULT __fastcall Interpreter::VirtualCallbackMain(SmallInteger offset, COMThun
 	LRESULT result;
 	__try
 	{
-		pushObject((OTE*)Pointers.Scheduler);
+		pushObject(Pointers.Scheduler);
 		pushSmallInteger(offset+1);	// Smalltalk expects 1-based index
 		COMThunk* thisPtr = *args;
 		pushSmallInteger(thisPtr->id);

--- a/Core/DolphinVM/process.cpp
+++ b/Core/DolphinVM/process.cpp
@@ -673,7 +673,7 @@ void Interpreter::sendVMInterrupt(ProcessOTE* interruptedProcess, VMInterrupts n
 	HARDASSERT(!actualActiveProcess()->IsWaiting());
 	HARDASSERT(isNil(actualActiveProcess()->Next()));
 
-	pushObject(reinterpret_cast<POTE>(Pointers.Scheduler));
+	pushObject(Pointers.Scheduler);
 	uint8_t* pProc = reinterpret_cast<uint8_t*>(actualActiveProcess());
 	uint8_t* pFrame = reinterpret_cast<uint8_t*>(m_registers.m_pActiveFrame);
 	HARDASSERT(pFrame > pProc);

--- a/Core/Object Arts/Dolphin/Base/Core.Message.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.Message.cls
@@ -157,7 +157,7 @@ value: receiver value: argument
 	further set of parameterization cases where blocks would otherwise
 	be required."
 
-	^self forwardTo: receiver with: argument!
+	^receiver perform: selector with: argument!
 
 valueWithArguments: argArray
 	"Evaluate the receiver with an <Array> of arguments in argArray"

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassAspectPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassAspectPlugin.cls
@@ -16,7 +16,7 @@ Tools.ClassAspectPlugin comment: '`ClassAspectPlugin` is an abstract class of `<
 accept
 	"Save the text to the class."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasClassSelected>
 	| overwrite |
 	overwrite := self promptToOverwrite.
 	overwrite ifFalse: [^self].
@@ -95,6 +95,9 @@ foregroundUpdate
 	originalText := buffer value.
 	self refreshIcon!
 
+hasClassSelected
+	^self browser hasClassSelected!
+
 isModified
 	^textPresenter isModified!
 
@@ -159,9 +162,6 @@ promptToSaveClassChanges: aSelectionChangingEvent
 	textPresenter prompt: self caption asLowercase toSaveChanges: aSelectionChangingEvent.
 	^aSelectionChangingEvent value!
 
-queryClassCommand: aCommandQuery
-	aCommandQuery isEnabled: self browser hasClassSelected!
-
 refreshIcon
 	self view arrangement: self!
 
@@ -184,6 +184,7 @@ currentClassUpdated!event handling!private! !
 defaultHelpId!constants!public! !
 displayOn:!displaying!public! !
 foregroundUpdate!private!updating! !
+hasClassSelected!private!testing! !
 isModified!public!testing! !
 modifiedModel!accessing!public! !
 newAspectBufferOn:!helpers!private! !
@@ -193,7 +194,6 @@ onClassUpdated:!event handling!private! !
 onShownInBrowser!event handling!private! !
 promptToOverwrite!helpers!private! !
 promptToSaveClassChanges:!helpers!public! !
-queryClassCommand:!commands-queries!private! !
 refreshIcon!private!updating! !
 systemUpdateEvent!constants!private! !
 textPresenterClass!initializing!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassAspectPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassAspectPlugin.cls
@@ -16,7 +16,7 @@ Tools.ClassAspectPlugin comment: '`ClassAspectPlugin` is an abstract class of `<
 accept
 	"Save the text to the class."
 
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	| overwrite |
 	overwrite := self promptToOverwrite.
 	overwrite ifFalse: [^self].

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
@@ -132,7 +132,7 @@ addMethod: method toCategory: target
 addMethodCategory
 	"Private - Add a new method category to the receiver's category pane."
 
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	| actualClass newCategory |
 	actualClass := self actualClass.
 	newCategory := (CategoryPrompter choices: MethodCategory allMethodCategories
@@ -144,7 +144,7 @@ addMethodCategory
 addMethodProtocol
 	"Private - Add a new <MethodProtocol> to the selected class in the receiver."
 
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	| actualClass newProtocol protocols |
 	actualClass := self actualClass.
 	protocols := MethodProtocol allMethodProtocols asSortedCollection: [:a :b | a name < b name].
@@ -194,7 +194,7 @@ applyOptions
 	self createPlugins!
 
 browseClassHierarchy
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	self developmentSystem browseHierarchy: self actualClass!
 
 browseContainingText
@@ -217,7 +217,7 @@ browseHierarchyCommand
 browseInstVarReferences
 	"Browse methods that reference any of the selected instance variables of the selected class."
 
-	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
+	<commandQuerySelector: #hasInstanceVariablesSelected>
 	self model
 		browseReferencesToInstVars: (self variables collect: [:each | each value])
 		inHierarchyOf: self actualClass
@@ -239,7 +239,7 @@ browseMessageDefinitionsIn: aBrowserEnvironment
 	"Private - Prompt for a selector and open a method browser displaying all definitions of
 	that selector in the specified <BrowserEnvironment>."
 
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	(self developmentSystem promptForDefinitionsOf: '' in: aBrowserEnvironment)
 		ifNotNil: [:search | self browseDefinitionsMatching: search in: aBrowserEnvironment]!
 
@@ -247,20 +247,20 @@ browseMessageReferencesIn: aBrowserEnvironment
 	"Private - Prompt for a selector and open a method browser displaying the references to that
 	selector from methods defined in the specified <BrowserEnvironment>."
 
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	(self developmentSystem promptForReferencesTo: '' in: aBrowserEnvironment)
 		ifNotNil: [:search | self browseReferencesMatching: search in: aBrowserEnvironment]!
 
 browseMethodCategory
 	"Private - Browse all the methods which are in the currently selected category."
 
-	<commandQuerySelector: #queryHasMethodCategoriesSelected:>
+	<commandQuerySelector: #hasMethodCategoriesSelected>
 	self model browseMethodCategories: self categories in: self searchEnvironment!
 
 browseOverriddenMethod
 	"Reposition the browser to the method which the currently selected method is overridding."
 
-	<commandQuerySelector: #queryBrowseOverriddenMethod:>
+	<commandQuerySelector: #hasOverrideSelected>
 	| method |
 	method := self method.
 	self method: (method methodClass superclass lookupMethod: method selector)!
@@ -282,7 +282,7 @@ browseSelectorsInProtocol
 	implemented in the receiver and its superclasses, with all those which are
 	part of the protocol selected."
 
-	<commandQuerySelector: #queryHasMutableProtocolSelected:>
+	<commandQuerySelector: #hasMutableProtocolSelected>
 	| protocol newSelectors oldSelectors added removed |
 	protocol := self protocols first.
 	oldSelectors := protocol selectors.
@@ -343,6 +343,16 @@ buildPopupForCommand: aSymbol
 	aSymbol == #historyBack ifTrue: [^self buildHistoryPastMenu].
 	aSymbol == #historyForward ifTrue: [^self buildHistoryFutureMenu].
 	^super buildPopupForCommand: aSymbol!
+
+canRemoveMethodProtocols
+	| prots |
+	prots := self protocols.
+	"Can only remove selected protocols if this is the first implementor in the superclass chain"
+	^prots notEmpty and: [(prots difference: self actualClass protocols) isEmpty]!
+
+canRemoveMethodsInCategory
+	| cat |
+	^(cat := self category) notNil and: [(cat methodsInBehavior: self actualClass) notEmpty]!
 
 canSaveMethod
 	"In order to be able to save a method in the browser there must be either a single editable
@@ -422,7 +432,7 @@ createAccessors
 	Accessors' refactoring (which is undoable), otherwise it uses the base Dolphin
 	implementation (which is not undoable)."
 
-	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
+	<commandQuerySelector: #hasInstanceVariablesSelected>
 	self model 
 		createVariableAccessors: self variables
 		classVariables: false
@@ -745,16 +755,46 @@ hasEditableMethodsSelected
 	methods := self selectedMethods.
 	^methods notEmpty and: [methods allSatisfy: [:each | self isEditableMethod: each]]!
 
+hasHistory
+	^self hasPast or: [self hasFuture]!
+
+hasInstanceVariableSelected
+	^self variables size = 1!
+
+hasInstanceVariablesSelected
+	^self variables notEmpty!
+
+hasMethodCategoriesSelected
+	^self categories notEmpty!
+
 hasMethodSelected
 	"Answer true if the receiver currently has a method selected in the methodsPresenter"
 
 	^methodBrowserPresenter hasMethodSelected!
 
+hasMutableProtocolSelected
+	^self protocols size == 1 and: [self protocols first isReadOnly not]!
+
+hasNonVirtualCategorySelected
+	| cat |
+	cat := self category.
+	"Virtual categories are permanent/calculated and cannot be removed"
+	^cat notNil and: [cat isVirtual not]!
+
+hasOverrideSelected
+	^self hasMethodSelected and: [self method isOverride]!
+
+hasProtocolSelected
+	^self protocols size = 1!
+
+hasProtocolsSelected
+	^self protocols notEmpty!
+
 hierarchyOfCategory: aMethodCategory 
 	^(categoriesPresenter model withAllChildren: aMethodCategory) reject: [:each | each isIntermediate]!
 
 historyClear
-	<commandQuerySelector: #queryHistoryClear:>
+	<commandQuerySelector: #hasHistory>
 	history clear!
 
 historySkip: anInteger
@@ -788,7 +828,7 @@ inspectCollection: aCollection
 	(aCollection size = 1 ifTrue: [aCollection first] ifFalse: [aCollection]) inspect!
 
 inspectInstanceVariables
-	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
+	<commandQuerySelector: #hasInstanceVariablesSelected>
 	| vars |
 	vars := self variables.
 	self inspectCollection: (vars isEmpty ifTrue: [variablesPresenter list asArray] ifFalse: [vars])!
@@ -807,7 +847,7 @@ inspectItCommand
 	^nil!
 
 inspectMethodCategories
-	<commandQuerySelector: #queryHasMethodCategoriesSelected:>
+	<commandQuerySelector: #hasMethodCategoriesSelected>
 	self inspectCollection: self categories!
 
 inspectMethodProtocols
@@ -973,7 +1013,7 @@ modifiedModel: aValueHolder
 newMethod
 	"Sets the receiver up for creating a new method"
 
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	methodBrowserPresenter newMethod!
 
 onBrowserCardChangedFrom: previousView to: currentView
@@ -1797,43 +1837,10 @@ protocolsMethodFilter
 	(self isMethodVisible: m) 
 		and: [self protocols anySatisfy: [:each | each includesSelector: m selector]]]!
 
-queryBrowseOverriddenMethod: aCommandQuery
-	aCommandQuery isEnabled: (self hasMethodSelected and: [self method isOverride])!
-
 queryFilterObjectMethods: aCommandQuery
 	aCommandQuery
 		isChecked: self isFilterObjectMethods;
 		isEnabled: self isShowInheritedMethods!
-
-queryHasClassSelected: aCommandQuery
-	aCommandQuery isEnabled: self hasClassSelected!
-
-queryHasInstanceVariableSelected: aCommandQuery
-	aCommandQuery isEnabled: self variables size = 1!
-
-queryHasInstanceVariablesSelected: aCommandQuery
-	aCommandQuery isEnabled: self variables notEmpty!
-
-queryHasMethodCategoriesSelected: aCommandQuery
-	aCommandQuery isEnabled: self categories notEmpty!
-
-queryHasMethodSelected: aCommandQuery
-	aCommandQuery isEnabled: self hasMethodSelected!
-
-queryHasMutableProtocolSelected: aCommandQuery
-	aCommandQuery isEnabled: (self protocols size == 1 and: [self protocols first isReadOnly not])!
-
-queryHasNonVirtualCategorySelected: aCommandQuery
-	| cat |
-	cat := self category.
-	"Virtual categories are permanent/calculated and cannot be removed"
-	aCommandQuery isEnabled: (cat notNil and: [cat isVirtual not])!
-
-queryHasProtocolSelected: aCommandQuery
-	aCommandQuery isEnabled: self protocols size = 1!
-
-queryHasProtocolsSelected: aCommandQuery
-	aCommandQuery isEnabled: self protocols notEmpty!
 
 queryHistoryBack: aCommandQuery
 	self hasPast
@@ -1847,9 +1854,6 @@ queryHistoryBack: aCommandQuery
 				isEnabled: false;
 				text: 'Back']!
 
-queryHistoryClear: aCommandQuery
-	aCommandQuery isEnabled: (self hasPast or: [self hasFuture])!
-
 queryHistoryForward: aCommandQuery
 	self hasFuture
 		ifTrue: 
@@ -1861,18 +1865,6 @@ queryHistoryForward: aCommandQuery
 			[aCommandQuery
 				isEnabled: false;
 				text: 'Forward']!
-
-queryRemoveMethodProtocols: aCommandQuery
-	| prots |
-	prots := self protocols.
-	"Can only remove selected protocols if this is the first implementor in the superclass chain"
-	aCommandQuery
-		isEnabled: (prots notEmpty and: [(prots difference: self actualClass protocols) isEmpty])!
-
-queryRemoveMethodsInCategory: aCommandQuery
-	| cat |
-	aCommandQuery
-		isEnabled: ((cat := self category) notNil and: [(cat methodsInBehavior: self actualClass) notEmpty])!
 
 queryRenameItCommand: aCommandQuery
 	| selector |
@@ -1925,7 +1917,7 @@ recordMethodVisit
 		ifFalse: [history current: method]!
 
 reformatAll
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	| env |
 	env := classesPresenter selectionEnvironment.
 	(MessageBox new
@@ -1947,7 +1939,7 @@ removeMethodCategory
 	"Private - Remove the currently selected category without deleting any
 	of the methods."
 
-	<commandQuerySelector: #queryHasNonVirtualCategorySelected:>
+	<commandQuerySelector: #hasNonVirtualCategorySelected>
 	| actualClass catModel args |
 	actualClass := self actualClass.
 	args := { actualClass. self category }.
@@ -1965,7 +1957,7 @@ removeMethodCategory
 removeMethodProtocol
 	"Private - Remove the currently selected protocols from the class."
 
-	<commandQuerySelector: #queryRemoveMethodProtocols:>
+	<commandQuerySelector: #canRemoveMethodProtocols>
 	self protocols do: [:p |
 		self model removeClass: self actualClass fromProtocol: p ].
 !
@@ -1974,7 +1966,7 @@ removeMethodsInCategory
 	"Private - Remove all of the methods in the currently selected category. As this is rather
 	drastic the user will be prompted."
 
-	<commandQuerySelector: #queryRemoveMethodsInCategory:>
+	<commandQuerySelector: #canRemoveMethodsInCategory>
 	| classEnvironment categoryEnvironment searchEnvironment mb |
 	searchEnvironment := self searchEnvironment.
 	classEnvironment := searchEnvironment forClasses: { self actualClass }.
@@ -2001,7 +1993,7 @@ removeMethodsInProtocol
 	"Private - Remove all of the methods in the currently selected protocol.
 	As this is pretty drastic we give the user a second chance."
 
-	<commandQuerySelector: #queryHasProtocolsSelected:>
+	<commandQuerySelector: #hasProtocolsSelected>
 	| actualClass |
 	actualClass := self actualClass.
 	self protocols do: 
@@ -2024,7 +2016,7 @@ removePlugin: aClassBrowserPlugin
 renameInstanceVariable
 	"Private - Initiate a rename of the  first selected instance variable."
 
-	<commandQuerySelector: #queryHasInstanceVariableSelected:>
+	<commandQuerySelector: #hasInstanceVariableSelected>
 	variablesPresenter view editSelectionLabel!
 
 renameIt
@@ -2046,7 +2038,7 @@ renameItCommand
 renameMethodCategory
 	"Private - Prompter for a new name for the current category, and rename it."
 
-	<commandQuerySelector: #queryHasNonVirtualCategorySelected:>
+	<commandQuerySelector: #hasNonVirtualCategorySelected>
 	| originalCategory newName actualClass |
 	originalCategory := self category.
 	actualClass := self actualClass.
@@ -2089,7 +2081,7 @@ renameMethodCategory: aMethodCategory to: aString
 renameMethodCategoryInPlace
 	"Private - Initiate an in-place rename of the currently selected category node."
 
-	<commandQuerySelector: #queryHasNonVirtualCategorySelected:>
+	<commandQuerySelector: #hasNonVirtualCategorySelected>
 	categoriesPresenter selectableItems view editSelectionLabel!
 
 renameMethodProtocol
@@ -2111,7 +2103,7 @@ resetForFoundClass: class
 saveDefinition
 	"Private - Save the class definition currently in the definition window"
 
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 
 	| wasModified |
 	wasModified := definitionPresenter isModified.
@@ -2553,7 +2545,9 @@ buildHistoryFutureMenu!helpers!menus!private! !
 buildHistoryMenu:command:!helpers!menus!private! !
 buildHistoryPastMenu!helpers!menus!private! !
 buildPopupForCommand:!event handling!private! !
-canSaveMethod!commands-actions!private! !
+canRemoveMethodProtocols!private!testing! !
+canRemoveMethodsInCategory!private!testing! !
+canSaveMethod!private!testing! !
 canSaveState!private!saved state! !
 canShowLocalHierarchy!private!testing! !
 cardsPresenter!accessing!private! !
@@ -2584,10 +2578,19 @@ emphasiseProtocolItem:isRelevant:!helpers!private! !
 ensureDefinitionVisible!operations!private! !
 ensureSourceVisible!operations!private! !
 futureSize!accessing!public! !
-hasClassSelected!public!refactoring!testing! !
+hasClassSelected!public!testing! !
 hasEditableMethodSelected!public!testing! !
 hasEditableMethodsSelected!public!testing! !
-hasMethodSelected!public!refactoring!testing! !
+hasHistory!private!testing! !
+hasInstanceVariableSelected!private!testing! !
+hasInstanceVariablesSelected!private!testing! !
+hasMethodCategoriesSelected!private!testing! !
+hasMethodSelected!public!testing! !
+hasMutableProtocolSelected!private!testing! !
+hasNonVirtualCategorySelected!private!testing! !
+hasOverrideSelected!private!testing! !
+hasProtocolSelected!private!testing! !
+hasProtocolsSelected!private!testing! !
 hierarchyOfCategory:!helpers!private! !
 historyClear!commands-actions!public! !
 historySkip:!commands-actions!private! !
@@ -2603,7 +2606,7 @@ isDisplayingProtocols!commands-actions!private! !
 isDisplayingVariables!commands-actions!private! !
 isEditableMethod:!modes!public! !
 isFilteringObjectMethods:!commands-actions!public! !
-isFilterObjectMethods!public!refactoring!testing! !
+isFilterObjectMethods!public!testing! !
 isInheritedMethod:!modes!public! !
 isInstanceMode!modes!private! !
 isInstanceMode:!modes!private! !
@@ -2613,7 +2616,7 @@ isMethodFiltrate:!private!testing! !
 isMethodVisible:!private!testing! !
 isModified!public!testing! !
 isShowingInheritedMethods:!commands-actions!public! !
-isShowInheritedMethods!public!refactoring!testing! !
+isShowInheritedMethods!public!testing! !
 isSourceCardVisible!private!testing! !
 killVisitTimer!helpers!private! !
 loadedPlugins!accessing!public! !
@@ -2688,22 +2691,9 @@ promptToSaveChanges!commands-actions!private! !
 protocols!accessing!public! !
 protocols:!accessing!public! !
 protocolsMethodFilter!accessing!private! !
-queryBrowseOverriddenMethod:!commands-queries!private! !
 queryFilterObjectMethods:!commands-queries!private! !
-queryHasClassSelected:!commands-queries!private! !
-queryHasInstanceVariableSelected:!commands-queries!private! !
-queryHasInstanceVariablesSelected:!commands-queries!private!refactoring! !
-queryHasMethodCategoriesSelected:!commands-queries!private! !
-queryHasMethodSelected:!commands-queries!private! !
-queryHasMutableProtocolSelected:!commands-queries!private! !
-queryHasNonVirtualCategorySelected:!commands-queries!private! !
-queryHasProtocolSelected:!commands-queries!private! !
-queryHasProtocolsSelected:!commands-queries!private! !
 queryHistoryBack:!commands-queries!private! !
-queryHistoryClear:!commands-queries!private! !
 queryHistoryForward:!commands-queries!private! !
-queryRemoveMethodProtocols:!commands-queries!private! !
-queryRemoveMethodsInCategory:!commands-queries!private! !
 queryRenameItCommand:!commands-queries!private! !
 queryToggleLocalHierarchy:!commands-queries!private! !
 queryToggleProtocolReadOnly:!commands-queries!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
@@ -132,7 +132,7 @@ addMethod: method toCategory: target
 addMethodCategory
 	"Private - Add a new method category to the receiver's category pane."
 
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	| actualClass newCategory |
 	actualClass := self actualClass.
 	newCategory := (CategoryPrompter choices: MethodCategory allMethodCategories
@@ -144,7 +144,7 @@ addMethodCategory
 addMethodProtocol
 	"Private - Add a new <MethodProtocol> to the selected class in the receiver."
 
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	| actualClass newProtocol protocols |
 	actualClass := self actualClass.
 	protocols := MethodProtocol allMethodProtocols asSortedCollection: [:a :b | a name < b name].
@@ -194,7 +194,7 @@ applyOptions
 	self createPlugins!
 
 browseClassHierarchy
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	self developmentSystem browseHierarchy: self actualClass!
 
 browseContainingText
@@ -217,7 +217,7 @@ browseHierarchyCommand
 browseInstVarReferences
 	"Browse methods that reference any of the selected instance variables of the selected class."
 
-	<commandQuerySelector: #hasInstanceVariablesSelected>
+	<commandQuery: #hasInstanceVariablesSelected>
 	self model
 		browseReferencesToInstVars: (self variables collect: [:each | each value])
 		inHierarchyOf: self actualClass
@@ -239,7 +239,7 @@ browseMessageDefinitionsIn: aBrowserEnvironment
 	"Private - Prompt for a selector and open a method browser displaying all definitions of
 	that selector in the specified <BrowserEnvironment>."
 
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	(self developmentSystem promptForDefinitionsOf: '' in: aBrowserEnvironment)
 		ifNotNil: [:search | self browseDefinitionsMatching: search in: aBrowserEnvironment]!
 
@@ -247,20 +247,20 @@ browseMessageReferencesIn: aBrowserEnvironment
 	"Private - Prompt for a selector and open a method browser displaying the references to that
 	selector from methods defined in the specified <BrowserEnvironment>."
 
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	(self developmentSystem promptForReferencesTo: '' in: aBrowserEnvironment)
 		ifNotNil: [:search | self browseReferencesMatching: search in: aBrowserEnvironment]!
 
 browseMethodCategory
 	"Private - Browse all the methods which are in the currently selected category."
 
-	<commandQuerySelector: #hasMethodCategoriesSelected>
+	<commandQuery: #hasMethodCategoriesSelected>
 	self model browseMethodCategories: self categories in: self searchEnvironment!
 
 browseOverriddenMethod
 	"Reposition the browser to the method which the currently selected method is overridding."
 
-	<commandQuerySelector: #hasOverrideSelected>
+	<commandQuery: #hasOverrideSelected>
 	| method |
 	method := self method.
 	self method: (method methodClass superclass lookupMethod: method selector)!
@@ -282,7 +282,7 @@ browseSelectorsInProtocol
 	implemented in the receiver and its superclasses, with all those which are
 	part of the protocol selected."
 
-	<commandQuerySelector: #hasMutableProtocolSelected>
+	<commandQuery: #hasMutableProtocolSelected>
 	| protocol newSelectors oldSelectors added removed |
 	protocol := self protocols first.
 	oldSelectors := protocol selectors.
@@ -423,7 +423,7 @@ classMethodFilter
 clearSelection
 	"Private - Remove the selected object from the system"
 
-	<commandQuerySelector: #queryDeleteIt:>
+	<commandQuery: #queryDeleteIt:>
 	self perform: self deleteItCommand!
 
 createAccessors
@@ -432,8 +432,8 @@ createAccessors
 	Accessors' refactoring (which is undoable), otherwise it uses the base Dolphin
 	implementation (which is not undoable)."
 
-	<commandQuerySelector: #hasInstanceVariablesSelected>
-	self model 
+	<commandQuery: #hasInstanceVariablesSelected>
+	self model
 		createVariableAccessors: self variables
 		classVariables: false
 		within: self searchEnvironment!
@@ -794,7 +794,7 @@ hierarchyOfCategory: aMethodCategory
 	^(categoriesPresenter model withAllChildren: aMethodCategory) reject: [:each | each isIntermediate]!
 
 historyClear
-	<commandQuerySelector: #hasHistory>
+	<commandQuery: #hasHistory>
 	history clear!
 
 historySkip: anInteger
@@ -828,7 +828,7 @@ inspectCollection: aCollection
 	(aCollection size = 1 ifTrue: [aCollection first] ifFalse: [aCollection]) inspect!
 
 inspectInstanceVariables
-	<commandQuerySelector: #hasInstanceVariablesSelected>
+	<commandQuery: #hasInstanceVariablesSelected>
 	| vars |
 	vars := self variables.
 	self inspectCollection: (vars isEmpty ifTrue: [variablesPresenter list asArray] ifFalse: [vars])!
@@ -847,7 +847,7 @@ inspectItCommand
 	^nil!
 
 inspectMethodCategories
-	<commandQuerySelector: #hasMethodCategoriesSelected>
+	<commandQuery: #hasMethodCategoriesSelected>
 	self inspectCollection: self categories!
 
 inspectMethodProtocols
@@ -1013,7 +1013,7 @@ modifiedModel: aValueHolder
 newMethod
 	"Sets the receiver up for creating a new method"
 
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	methodBrowserPresenter newMethod!
 
 onBrowserCardChangedFrom: previousView to: currentView
@@ -1917,7 +1917,7 @@ recordMethodVisit
 		ifFalse: [history current: method]!
 
 reformatAll
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	| env |
 	env := classesPresenter selectionEnvironment.
 	(MessageBox new
@@ -1939,7 +1939,7 @@ removeMethodCategory
 	"Private - Remove the currently selected category without deleting any
 	of the methods."
 
-	<commandQuerySelector: #hasNonVirtualCategorySelected>
+	<commandQuery: #hasNonVirtualCategorySelected>
 	| actualClass catModel args |
 	actualClass := self actualClass.
 	args := { actualClass. self category }.
@@ -1957,16 +1957,14 @@ removeMethodCategory
 removeMethodProtocol
 	"Private - Remove the currently selected protocols from the class."
 
-	<commandQuerySelector: #canRemoveMethodProtocols>
-	self protocols do: [:p |
-		self model removeClass: self actualClass fromProtocol: p ].
-!
+	<commandQuery: #canRemoveMethodProtocols>
+	self protocols do: [:p | self model removeClass: self actualClass fromProtocol: p]!
 
 removeMethodsInCategory
 	"Private - Remove all of the methods in the currently selected category. As this is rather
 	drastic the user will be prompted."
 
-	<commandQuerySelector: #canRemoveMethodsInCategory>
+	<commandQuery: #canRemoveMethodsInCategory>
 	| classEnvironment categoryEnvironment searchEnvironment mb |
 	searchEnvironment := self searchEnvironment.
 	classEnvironment := searchEnvironment forClasses: { self actualClass }.
@@ -1993,7 +1991,7 @@ removeMethodsInProtocol
 	"Private - Remove all of the methods in the currently selected protocol.
 	As this is pretty drastic we give the user a second chance."
 
-	<commandQuerySelector: #hasProtocolsSelected>
+	<commandQuery: #hasProtocolsSelected>
 	| actualClass |
 	actualClass := self actualClass.
 	self protocols do: 
@@ -2016,11 +2014,11 @@ removePlugin: aClassBrowserPlugin
 renameInstanceVariable
 	"Private - Initiate a rename of the  first selected instance variable."
 
-	<commandQuerySelector: #hasInstanceVariableSelected>
+	<commandQuery: #hasInstanceVariableSelected>
 	variablesPresenter view editSelectionLabel!
 
 renameIt
-	<commandQuerySelector: #queryRenameItCommand:>
+	<commandQuery: #queryRenameItCommand:>
 	<acceleratorKey: 'F2'>
 	self perform: self renameItCommand!
 
@@ -2038,7 +2036,7 @@ renameItCommand
 renameMethodCategory
 	"Private - Prompter for a new name for the current category, and rename it."
 
-	<commandQuerySelector: #hasNonVirtualCategorySelected>
+	<commandQuery: #hasNonVirtualCategorySelected>
 	| originalCategory newName actualClass |
 	originalCategory := self category.
 	actualClass := self actualClass.
@@ -2081,7 +2079,7 @@ renameMethodCategory: aMethodCategory to: aString
 renameMethodCategoryInPlace
 	"Private - Initiate an in-place rename of the currently selected category node."
 
-	<commandQuerySelector: #hasNonVirtualCategorySelected>
+	<commandQuery: #hasNonVirtualCategorySelected>
 	categoriesPresenter selectableItems view editSelectionLabel!
 
 renameMethodProtocol
@@ -2103,19 +2101,19 @@ resetForFoundClass: class
 saveDefinition
 	"Private - Save the class definition currently in the definition window"
 
-	<commandQuerySelector: #hasClassSelected>
-
+	<commandQuery: #hasClassSelected>
 	| wasModified |
 	wasModified := definitionPresenter isModified.
 	definitionPresenter isModified: false.
-	#todo. "Use change objects so this is undoable/redoable."
+	#todo.	"Use change objects so this is undoable/redoable."
+	
 	[definitionPresenter evaluateRange: (1 to: definitionPresenter textLength)
 		ifFail: 
 			[definitionPresenter isModified: wasModified.
-			^self]] 
+			^self]]
 			on: Error
 			do: 
-				[:e | 
+				[:e |
 				definitionPresenter isModified: wasModified.
 				e okCancel]!
 
@@ -2275,14 +2273,14 @@ systemModel
 toggleFilterObjectMethods
 	"Toggle between showing <Object> methods or not"
 
-	<commandQuerySelector: #queryFilterObjectMethods:>
+	<commandQuery: #queryFilterObjectMethods:>
 	self isFilteringObjectMethods: self isFilterObjectMethods not.
 	self onClassSelected!
 
 toggleProtocolReadOnly
 	"Toggle the currenty method protocol between read-only and updatable status."
 
-	<commandQuerySelector: #queryToggleProtocolReadOnly:>
+	<commandQuery: #queryToggleProtocolReadOnly:>
 	| prot |
 	prot := self protocols first.
 	prot isReadOnly: prot isReadOnly not!
@@ -2290,7 +2288,7 @@ toggleProtocolReadOnly
 toggleShowInheritedMethods
 	"Toggle between showing inherited methods or not"
 
-	<commandQuerySelector: #queryToggleShowInheritedMethods:>
+	<commandQuery: #queryToggleShowInheritedMethods:>
 	self isShowingInheritedMethods: self isShowInheritedMethods not.
 	self onClassSelected!
 

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassSelector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassSelector.cls
@@ -60,11 +60,11 @@ actualClasses
 browseChangedMethods
 	"Browse the changed methods in the selected classes"
 
-	<commandQuerySelector: #queryClassesCommand:>
+	<commandQuerySelector: #hasSelection>
 	self developmentSystem browseChangedMethodsOfClasses: self selections!
 
 browseClass
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	self selection browse!
 
 browseClassPackage
@@ -78,7 +78,7 @@ browseClassPackage
 browseClassReferences
 	"Browse all the methods which refer to the class selected in the receiver."
 
-	<commandQuerySelector: #queryClassesCommand:>
+	<commandQuerySelector: #hasSelection>
 	| env references |
 	env := self searchEnvironment.
 	references := Array writeStream: 2.
@@ -93,7 +93,7 @@ browseClassReferences
 browseClassVariables
 	"Browse one of the class variables of the selected class."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	self developmentSystem browseClassVariables: self selection!
 
 browseHierarchy
@@ -105,7 +105,7 @@ browseHierarchy
 browseInstanceVariables
 	"Browse methods in the selected class and its subclasses that reference one of its variables."
 
-	<commandQuerySelector: #queryInstanceVariablesCommand:>
+	<commandQuerySelector: #hasClassWithInstanceVariables>
 	self developmentSystem browseInstanceVariables: self actualClass!
 
 browseIt
@@ -122,20 +122,20 @@ browseItCommand
 	^nil!
 
 browseMenu
-	<commandQuerySelector: #queryClassesCommand:>
+	<commandQuerySelector: #hasSelection>
 	!
 
 browsePackages
 	"Implement the context-sensitive browse packages command by browsing to the currently
 	selected class' package."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	self browseClassPackage!
 
 browsePublishedAspects
 	"Browse the published aspects for the current class. Copy the choice (if any) to the clipboard."
 
-	<commandQuerySelector: #queryBrowsePublishedAspects:>
+	<commandQuerySelector: #hasClassWithPublishedAspects>
 	| class pubs choice |
 	class := self selection.
 	pubs := class publishedAspectsOfInstances.
@@ -148,7 +148,7 @@ browsePublishedEvents
 	"Browse the published events that can be triggered by instances of the current class.
 	Copy the chosen symbolic event name (if any) to the clipboard."
 
-	<commandQuerySelector: #queryBrowsePublishedEvents:>
+	<commandQuerySelector: #hasClassWithPublishedEvents>
 	| pubEvents choice class |
 	class := self selection.
 	pubEvents := class publishedEventsOfInstances asSortedCollection.
@@ -160,7 +160,7 @@ browsePublishedEvents
 browseReferences
 	"Context-sensitive browse references command (Shift+F12)."
 
-	<commandQuerySelector: #queryClassesCommand:>
+	<commandQuerySelector: #hasSelection>
 	<acceleratorKey: 'Shift+F12'>
 	self browseClassReferences!
 
@@ -172,11 +172,12 @@ browserEnvironment
 browseSystem
 	"Open a new system browser on at the same point as the receiver."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	self developmentSystem browseSystem: self actualClass!
 
 browseVariablesMenu
-	<commandQuerySelector: #queryClassCommand:>!
+	<commandQuerySelector: #hasSingleSelection>
+	!
 
 buildAllVariablesMenu: aMenu
 	"Private - Build a dynamic pull-out menu which lists all of a class' existing 
@@ -235,10 +236,13 @@ buildViewsMenu: aMenu command: selector
 canRefactor
 	^self developmentSystem canRefactor!
 
+canRenameClass
+	^self developmentSystem canRenameClass: self selectionOrNil!
+
 categorizeClass
 	"Invokes a dialog to categorize the current class"
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	| chosenCategories aClass originalCategories categories |
 	aClass := self selection.
 	originalCategories := aClass categories.
@@ -276,7 +280,7 @@ classNamesSelector: aSymbol
 classPackage
 	"Prompt for the user to repackage the selected class."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	| class newPkg oldPkg |
 	class := self selection.
 	oldPkg := class owningPackage.
@@ -335,7 +339,7 @@ confirmMoveClass: aClass toPackage: aPackage
 	^true!
 
 copyClass
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	(self developmentSystem copyClass: self selection)
 		ifNotNil: [:newClass | self actualClass: newClass]!
 
@@ -343,7 +347,7 @@ createInstanceVariableAccessors
 	"Prompt to generate compiled 'get' and 'set' accessor methods for each of the immediate
 	instance variables of the current class that are not currently endowed with both."
 
-	<commandQuerySelector: #queryInstanceVariablesCommand:>
+	<commandQuerySelector: #hasClassWithInstanceVariables>
 	self createVariableAccessors: false!
 
 createSchematicWiring
@@ -443,13 +447,13 @@ editView: viewName
 fileInClass
 	"Files in the selected class via the package that owns it"
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	self developmentSystem classFileIn: self selection!
 
 fileOutClass
 	"Files out the selected class via the package that owns it"
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	self developmentSystem classFileOut: self selection!
 
 findClass
@@ -468,6 +472,42 @@ flags
 flags: anInteger
 	self subclassResponsibility!
 
+hasClassSupportingViews
+	| class |
+	class := self selectionOrNil.
+	^class notNil and: [(class includesBehavior: Presenter) or: [class includesBehavior: View]]!
+
+hasClassWithInstanceVariables
+	| class |
+	class := self actualClass.
+	^class notNil and: [class instanceVariableNames notEmpty]!
+
+hasClassWithPublishedAspects
+	| class |
+	class := self selectionOrNil.
+	^class notNil and: [class respondsTo: #publishedAspectsOfInstances]!
+
+hasClassWithPublishedEvents
+	| class |
+	class := self selectionOrNil.
+	^class notNil and: [class respondsTo: #publishedEventsOfInstances]!
+
+hasClassWithStaticVariables
+	| class |
+	class := self actualClass.
+	^class notNil and: [class instanceClass definedBindings notEmpty]!
+
+hasClassWithVariablesSelected
+	| class |
+	class := self actualClass.
+	^class notNil
+		and: [class instanceVariableNames notEmpty or: [class instanceClass classBindingNames notEmpty]]!
+
+hasViews
+	| class |
+	class := self selectionOrNil.
+	^class notNil and: [class resourceIdentifiers notEmpty]!
+
 initialize
 	"Private - Initialize the receiver"
 
@@ -481,7 +521,7 @@ initiateRename
 inspectIt
 	"Open an inspector on the currently selected class."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	self selection inspect!
 
 isInstanceMode
@@ -528,7 +568,7 @@ newView
 	selected class. If there are several possibilities allow the user to select
 	the one to edit"
 
-	<commandQuerySelector: #queryHasClassSupportingViews:>
+	<commandQuerySelector: #hasClassSupportingViews>
 	self developmentSystem openViewComposerOnNewViewFor: self selection!
 
 onAboutToDisplayMenu: aMenu 
@@ -812,32 +852,6 @@ queryBrowseIt: aCommandQuery
 			aCommandQuery isEnabled: false]
 		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
 
-queryBrowsePublishedAspects: aCommandQuery
-	| class |
-	class := self selectionOrNil.
-	aCommandQuery isEnabled: (class notNil and: [class respondsTo: #publishedAspectsOfInstances])!
-
-queryBrowsePublishedEvents: aCommandQuery
-	| class |
-	class := self selectionOrNil.
-	aCommandQuery isEnabled: (class notNil and: [class respondsTo: #publishedEventsOfInstances])!
-
-queryChangeClassNamespace: aCommandQuery
-	aCommandQuery isEnabled: (self developmentSystem canChangeClassNamespaces: self selections)!
-
-queryClassCommand: aCommandQuery
-	aCommandQuery isEnabled: self hasSingleSelection.
-	^true!
-
-queryClassesCommand: aCommandQuery
-	aCommandQuery isEnabled: self hasSelection.
-	^true!
-
-queryClassVariablesCommand: aCommandQuery
-	| class |
-	class := self actualClass.
-	aCommandQuery isEnabled: (class notNil and: [class instanceClass definedBindings notEmpty])!
-
 queryDeleteIt: aCommandQuery
 	self deleteItCommand
 		ifNil: 
@@ -845,51 +859,33 @@ queryDeleteIt: aCommandQuery
 			aCommandQuery isEnabled: false]
 		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
 
-queryHasClassSupportingViews: aCommandQuery
-	| class |
-	class := self selectionOrNil.
-	aCommandQuery isEnabled: (class notNil
-				and: [(class includesBehavior: Presenter) or: [class includesBehavior: View]])!
-
-queryInstanceVariablesCommand: aCommandQuery
-	| class |
-	class := self actualClass.
-	aCommandQuery isEnabled: (class notNil and: [class instanceVariableNames notEmpty])!
-
-queryRenameClass: aCommandQuery
-	aCommandQuery isEnabled: (self developmentSystem canRenameClass: self selectionOrNil)!
-
 queryShowFullNames: aCommandQuery
 	aCommandQuery
 		isEnabled: true;
 		isChecked: self isShowingFullNames!
 
-queryViewsEditMenu: aCommandQuery
-	| class |
-	class := self selectionOrNil.
-	aCommandQuery isEnabled: (class notNil and: [class resourceIdentifiers notEmpty])!
-
 queryViewsShowMenu: aCommandQuery
-	self queryViewsEditMenu: aCommandQuery.
-	aCommandQuery isDefault: true!
+	aCommandQuery
+		isEnabled: self hasViews;
+		isDefault: true!
 
 removeClass
 	"Removes the selected class(es) from the system. If refactoring is available, then the 'Remove Class' refactoring is employed."
 
-	<commandQuerySelector: #queryClassesCommand:>
+	<commandQuerySelector: #hasSelection>
 	self permitSelectionChange ifTrue: [self developmentSystem removeClasses: self selections]!
 
 renameClass
 	"Private - Initiate in-place label edit for the selected class."
 
-	<commandQuerySelector: #queryRenameClass:>
+	<commandQuerySelector: #canRenameClass>
 	self initiateRename!
 
 renameClassVariable
 	"Private - Initiate the rename of a class variable. Note that the view may also implement this 
 	command with a dynamic pull-out menu (of the same name)."
 
-	<commandQuerySelector: #queryClassVariablesCommand:>
+	<commandQuerySelector: #hasClassWithStaticVariables>
 	| classVar class |
 	class := self selection.
 	classVar := ChoicePrompter choices: class classBindingNames asSortedCollection
@@ -900,7 +896,7 @@ renameInstanceVariable
 	"Private - Initiate the rename of an instance variable. Note that the view may also implement this 
 	command with a dynamic pull-out menu (of the same name)."
 
-	<commandQuerySelector: #queryInstanceVariablesCommand:>
+	<commandQuerySelector: #hasClassWithInstanceVariables>
 	| instVar class |
 	class := self actualClass.
 	instVar := ChoicePrompter choices: class instanceVariableNames asSortedCollection
@@ -908,7 +904,7 @@ renameInstanceVariable
 	instVar isNil ifFalse: [self developmentSystem renameInstanceVariable: instVar in: class]!
 
 renameVariables
-	<commandQuerySelector: #queryHasVariablesSelected:>
+	<commandQuerySelector: #hasClassWithVariablesSelected>
 	Sound warningBeep!
 
 searchEnvironment
@@ -950,11 +946,11 @@ toggleShowFullNames
 	self classNamesSelector: (fullNames ifTrue: [#fullName] ifFalse: [#unqualifiedName])!
 
 viewsEditMenu
-	<commandQuerySelector: #queryViewsEditMenu:>
+	<commandQuerySelector: #hasViews>
 	!
 
 viewsMenu
-	<commandQuerySelector: #queryHasClassSupportingViews:>
+	<commandQuerySelector: #hasClassSupportingViews>
 	!
 
 viewsShowMenu
@@ -984,7 +980,8 @@ browseSystem!commands-actions!public! !
 browseVariablesMenu!commands-menus!private! !
 buildAllVariablesMenu:!menus!private! !
 buildViewsMenu:command:!menus!private! !
-canRefactor!public!testing! !
+canRefactor!public!refactoring!testing! !
+canRenameClass!private!testing! !
 categorizeClass!commands-actions!public! !
 chooseVariables:caption:!helpers!private! !
 classHierarchyPresenter!accessing!private! !
@@ -1006,6 +1003,13 @@ fileOutClass!commands-actions!public! !
 findClass!commands-actions!public! !
 flags!accessing!private! !
 flags:!accessing!private! !
+hasClassSupportingViews!private!testing! !
+hasClassWithInstanceVariables!private!testing! !
+hasClassWithPublishedAspects!private!testing! !
+hasClassWithPublishedEvents!private!testing! !
+hasClassWithStaticVariables!private!testing! !
+hasClassWithVariablesSelected!private!testing! !
+hasViews!private!testing! !
 initialize!initializing!private! !
 initiateRename!helpers!private! !
 inspectIt!commands-actions!public! !
@@ -1033,18 +1037,8 @@ populateVarMenu:class:command:variables:format:abortable:!menus!private! !
 queryBrowseClassPackage:!commands-queries!private! !
 queryBrowseHierarchy:!commands-queries!private! !
 queryBrowseIt:!commands-queries!private! !
-queryBrowsePublishedAspects:!commands-queries!private! !
-queryBrowsePublishedEvents:!commands-queries!private! !
-queryChangeClassNamespace:!commands-queries!private! !
-queryClassCommand:!commands-queries!private! !
-queryClassesCommand:!commands-queries!private! !
-queryClassVariablesCommand:!commands-queries!private! !
 queryDeleteIt:!commands-queries!private! !
-queryHasClassSupportingViews:!commands-queries!private! !
-queryInstanceVariablesCommand:!commands-queries!private! !
-queryRenameClass:!commands-queries!private! !
 queryShowFullNames:!commands-queries!private! !
-queryViewsEditMenu:!commands-queries!private! !
 queryViewsShowMenu:!commands-queries!private! !
 removeClass!commands-actions!public! !
 renameClass!commands-actions!private!refactoring! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassSelector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassSelector.cls
@@ -60,17 +60,17 @@ actualClasses
 browseChangedMethods
 	"Browse the changed methods in the selected classes"
 
-	<commandQuerySelector: #hasSelection>
+	<commandQuery: #hasSelection>
 	self developmentSystem browseChangedMethodsOfClasses: self selections!
 
 browseClass
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	self selection browse!
 
 browseClassPackage
 	"Open a package browser on the selected class' package."
 
-	<commandQuerySelector: #queryBrowseClassPackage:>
+	<commandQuery: #queryBrowseClassPackage:>
 	| pkg |
 	pkg := self selection owningPackage.
 	pkg isNil ifTrue: [self developmentSystem browsePackages] ifFalse: [pkg browse]!
@@ -78,7 +78,7 @@ browseClassPackage
 browseClassReferences
 	"Browse all the methods which refer to the class selected in the receiver."
 
-	<commandQuerySelector: #hasSelection>
+	<commandQuery: #hasSelection>
 	| env references |
 	env := self searchEnvironment.
 	references := Array writeStream: 2.
@@ -93,25 +93,25 @@ browseClassReferences
 browseClassVariables
 	"Browse one of the class variables of the selected class."
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	self developmentSystem browseClassVariables: self selection!
 
 browseHierarchy
 	"Open a new class hierarchy browser on the hierarchy at the same point as the receiver."
 
-	<commandQuerySelector: #queryBrowseHierarchy:>
+	<commandQuery: #queryBrowseHierarchy:>
 	self developmentSystem browseHierarchy: self actualClass!
 
 browseInstanceVariables
 	"Browse methods in the selected class and its subclasses that reference one of its variables."
 
-	<commandQuerySelector: #hasClassWithInstanceVariables>
+	<commandQuery: #hasClassWithInstanceVariables>
 	self developmentSystem browseInstanceVariables: self actualClass!
 
 browseIt
 	"Browse the selected item in the pane with focus."
 
-	<commandQuerySelector: #queryBrowseIt:>
+	<commandQuery: #queryBrowseIt:>
 	self perform: self browseItCommand!
 
 browseItCommand
@@ -122,20 +122,20 @@ browseItCommand
 	^nil!
 
 browseMenu
-	<commandQuerySelector: #hasSelection>
+	<commandQuery: #hasSelection>
 	!
 
 browsePackages
 	"Implement the context-sensitive browse packages command by browsing to the currently
 	selected class' package."
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	self browseClassPackage!
 
 browsePublishedAspects
 	"Browse the published aspects for the current class. Copy the choice (if any) to the clipboard."
 
-	<commandQuerySelector: #hasClassWithPublishedAspects>
+	<commandQuery: #hasClassWithPublishedAspects>
 	| class pubs choice |
 	class := self selection.
 	pubs := class publishedAspectsOfInstances.
@@ -148,7 +148,7 @@ browsePublishedEvents
 	"Browse the published events that can be triggered by instances of the current class.
 	Copy the chosen symbolic event name (if any) to the clipboard."
 
-	<commandQuerySelector: #hasClassWithPublishedEvents>
+	<commandQuery: #hasClassWithPublishedEvents>
 	| pubEvents choice class |
 	class := self selection.
 	pubEvents := class publishedEventsOfInstances asSortedCollection.
@@ -160,7 +160,7 @@ browsePublishedEvents
 browseReferences
 	"Context-sensitive browse references command (Shift+F12)."
 
-	<commandQuerySelector: #hasSelection>
+	<commandQuery: #hasSelection>
 	<acceleratorKey: 'Shift+F12'>
 	self browseClassReferences!
 
@@ -172,11 +172,11 @@ browserEnvironment
 browseSystem
 	"Open a new system browser on at the same point as the receiver."
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	self developmentSystem browseSystem: self actualClass!
 
 browseVariablesMenu
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	!
 
 buildAllVariablesMenu: aMenu
@@ -242,7 +242,7 @@ canRenameClass
 categorizeClass
 	"Invokes a dialog to categorize the current class"
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	| chosenCategories aClass originalCategories categories |
 	aClass := self selection.
 	originalCategories := aClass categories.
@@ -280,7 +280,7 @@ classNamesSelector: aSymbol
 classPackage
 	"Prompt for the user to repackage the selected class."
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	| class newPkg oldPkg |
 	class := self selection.
 	oldPkg := class owningPackage.
@@ -294,7 +294,7 @@ classPackage
 clearSelection
 	"Private - Remove the selected object from the system"
 
-	<commandQuerySelector: #queryDeleteIt:>
+	<commandQuery: #queryDeleteIt:>
 	self perform: self deleteItCommand!
 
 confirmMoveClass: aClass toPackage: aPackage
@@ -339,7 +339,7 @@ confirmMoveClass: aClass toPackage: aPackage
 	^true!
 
 copyClass
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	(self developmentSystem copyClass: self selection)
 		ifNotNil: [:newClass | self actualClass: newClass]!
 
@@ -347,7 +347,7 @@ createInstanceVariableAccessors
 	"Prompt to generate compiled 'get' and 'set' accessor methods for each of the immediate
 	instance variables of the current class that are not currently endowed with both."
 
-	<commandQuerySelector: #hasClassWithInstanceVariables>
+	<commandQuery: #hasClassWithInstanceVariables>
 	self createVariableAccessors: false!
 
 createSchematicWiring
@@ -447,13 +447,13 @@ editView: viewName
 fileInClass
 	"Files in the selected class via the package that owns it"
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	self developmentSystem classFileIn: self selection!
 
 fileOutClass
 	"Files out the selected class via the package that owns it"
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	self developmentSystem classFileOut: self selection!
 
 findClass
@@ -521,7 +521,7 @@ initiateRename
 inspectIt
 	"Open an inspector on the currently selected class."
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	self selection inspect!
 
 isInstanceMode
@@ -568,7 +568,7 @@ newView
 	selected class. If there are several possibilities allow the user to select
 	the one to edit"
 
-	<commandQuerySelector: #hasClassSupportingViews>
+	<commandQuery: #hasClassSupportingViews>
 	self developmentSystem openViewComposerOnNewViewFor: self selection!
 
 onAboutToDisplayMenu: aMenu 
@@ -872,20 +872,20 @@ queryViewsShowMenu: aCommandQuery
 removeClass
 	"Removes the selected class(es) from the system. If refactoring is available, then the 'Remove Class' refactoring is employed."
 
-	<commandQuerySelector: #hasSelection>
+	<commandQuery: #hasSelection>
 	self permitSelectionChange ifTrue: [self developmentSystem removeClasses: self selections]!
 
 renameClass
 	"Private - Initiate in-place label edit for the selected class."
 
-	<commandQuerySelector: #canRenameClass>
+	<commandQuery: #canRenameClass>
 	self initiateRename!
 
 renameClassVariable
 	"Private - Initiate the rename of a class variable. Note that the view may also implement this 
 	command with a dynamic pull-out menu (of the same name)."
 
-	<commandQuerySelector: #hasClassWithStaticVariables>
+	<commandQuery: #hasClassWithStaticVariables>
 	| classVar class |
 	class := self selection.
 	classVar := ChoicePrompter choices: class classBindingNames asSortedCollection
@@ -896,7 +896,7 @@ renameInstanceVariable
 	"Private - Initiate the rename of an instance variable. Note that the view may also implement this 
 	command with a dynamic pull-out menu (of the same name)."
 
-	<commandQuerySelector: #hasClassWithInstanceVariables>
+	<commandQuery: #hasClassWithInstanceVariables>
 	| instVar class |
 	class := self actualClass.
 	instVar := ChoicePrompter choices: class instanceVariableNames asSortedCollection
@@ -904,7 +904,7 @@ renameInstanceVariable
 	instVar isNil ifFalse: [self developmentSystem renameInstanceVariable: instVar in: class]!
 
 renameVariables
-	<commandQuerySelector: #hasClassWithVariablesSelected>
+	<commandQuery: #hasClassWithVariablesSelected>
 	Sound warningBeep!
 
 searchEnvironment
@@ -939,22 +939,22 @@ showPresenter: viewName
 toggleShowFullNames
 	"Private - Enable/disable the display of class full names (i.e. with namespace qualifier) in the class hierarchy view. There is no good reason to do this in the class list, as this already has a Namespace column showing the qualifier."
 
-	<commandQuerySelector: #queryShowFullNames:>
+	<commandQuery: #queryShowFullNames:>
 	| fullNames |
 	fullNames := self isShowingFullNames not.
 	self isShowingFullNames: fullNames.
 	self classNamesSelector: (fullNames ifTrue: [#fullName] ifFalse: [#unqualifiedName])!
 
 viewsEditMenu
-	<commandQuerySelector: #hasViews>
+	<commandQuery: #hasViews>
 	!
 
 viewsMenu
-	<commandQuerySelector: #hasClassSupportingViews>
+	<commandQuery: #hasClassSupportingViews>
 	!
 
 viewsShowMenu
-	<commandQuerySelector: #queryViewsShowMenu:>
+	<commandQuery: #queryViewsShowMenu:>
 	! !
 !Tools.ClassSelector categoriesForMethods!
 actualClass!accessing!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.Debugger.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.Debugger.cls
@@ -105,14 +105,14 @@ acceptItCommand
 acceptMethod
 	"Private - Saves the current method source, restarting the method frame if the system options so indicate."
 
-	<commandQuerySelector: #canSaveMethod>
+	<commandQuery: #canSaveMethod>
 	self accept: self class restartOnMethodSave methodSource: self source!
 
 acceptNoRestart
 	"Private - Saves the current method source without restarting the frame (i.e. the debugged
 	process becomes out of sync. with the current method)."
 
-	<commandQuerySelector: #canSaveMethod>
+	<commandQuery: #canSaveMethod>
 	self accept: false methodSource: self source!
 
 addToCommandRoute: aCommandPolicy
@@ -127,7 +127,7 @@ allFrames
 	"Private - Include all stack frames in the call stack. There cannot possibly be any more
 	than the size of the process."
 
-	<commandQuerySelector: #hasMoreFrames>
+	<commandQuery: #hasMoreFrames>
 	self depth: process size!
 
 animatePause
@@ -250,7 +250,7 @@ browseMessageDefinitions
 	"Private - Open a new method browser on the definitions of the of the currently selected
 	stack frame's selector."
 
-	<commandQuerySelector: #hasBrowsableMethod>
+	<commandQuery: #hasBrowsableMethod>
 	self browseDefinitionsMatching: (MethodSearch newSelector: self selectedMethod selector)
 		in: self searchEnvironment!
 
@@ -263,7 +263,7 @@ browseMessages
 browseMethodInheritanceChain
 	"Private - Open a method browser displaying the definitions of the currently selected stack frame's method's selector in its superclass chain."
 
-	<commandQuerySelector: #hasOverrideSelected>
+	<commandQuery: #hasOverrideSelected>
 	self model browseMethodHierarchyFrom: self selectedMethod!
 
 browseReferences
@@ -304,7 +304,7 @@ browseSystem
 		ifFalse: [self model browseSystemOnMethod: self selectedMethod]!
 
 browseVariableClass
-	<commandQuerySelector: #hasVariableSelected>
+	<commandQuery: #hasVariableSelected>
 	localAccessor value browse!
 
 buildParseTree
@@ -478,7 +478,7 @@ defaultHelpId
 	^10881!
 
 definitionsMenu
-	<commandQuerySelector: #queryMessagesMenu:>
+	<commandQuery: #queryMessagesMenu:>
 	!
 
 depth
@@ -645,7 +645,7 @@ hasVariableSelected
 	^variablesPresenter hasSelection!
 
 implementDNUMenu
-	<commandQuerySelector: #queryImplementMenu:>
+	<commandQuery: #queryImplementMenu:>
 	!
 
 initialize
@@ -659,7 +659,7 @@ initialize
 inspectFrame
 	"Private - Open an inspector on the currently selected frame."
 
-	<commandQuerySelector: #hasFrameSelected>
+	<commandQuery: #hasFrameSelected>
 	self frame inspect!
 
 inspectItCommand
@@ -682,7 +682,7 @@ inspectReferences
 inspectVariable
 	"Private - Open an inspector on the currently selected local variable (or instance variable)."
 
-	<commandQuerySelector: #hasVariableSelected>
+	<commandQuery: #hasVariableSelected>
 	localAccessor value inspect!
 
 isAnimating
@@ -788,7 +788,7 @@ markMethodAsUnbound: oldMethod
 moreFrames
 	"Private - Increase the number of stack frames displayed in the call stack."
 
-	<commandQuerySelector: #hasMoreFrames>
+	<commandQuery: #hasMoreFrames>
 	self depth: depth + StackDepthIncrement!
 
 nameForArgument: anObject 
@@ -809,7 +809,7 @@ newLocalsTreeWithRoots: anOrderedCollection
 nilVariable
 	"Private - Nil the currently selected variable or stack slot."
 
-	<commandQuerySelector: #hasMutableVariableSelected>
+	<commandQuery: #hasMutableVariableSelected>
 	variablesPresenter model collapse: localAccessor.
 	localAccessor value: nil!
 
@@ -1147,7 +1147,7 @@ queryToggleAnimation: aCommandQuery
 		isChecked: animating!
 
 referencesMenu
-	<commandQuerySelector: #queryMessagesMenu:>
+	<commandQuery: #queryMessagesMenu:>
 	!
 
 refreshFrame
@@ -1234,7 +1234,7 @@ restartFrame
 	"Private - Unwind the currently selected frame and reset the IP so that the method starts
 	executing from its beginning again."
 
-	<commandQuerySelector: #isFrameRestartable>
+	<commandQuery: #isFrameRestartable>
 	self restartFrameWithFocus: false!
 
 restartFrame: frame 
@@ -1408,7 +1408,7 @@ resumeProcess
 	"Private - Restart the debugged process from the point at which it was last suspended. This
 	might involve being resuspended on a Semaphore."
 
-	<commandQuerySelector: #isRunnable>
+	<commandQuery: #isRunnable>
 	process debugger: nil.
 	self view close ifFalse: [process debugger: self] ifTrue: [self resume]!
 
@@ -1435,7 +1435,7 @@ returnFromMessage
 	return value for which the user is prompted (may be any expression). Also resets the
 	non-resumable flag allowing debugging to continue after a non-continuable error."
 
-	<commandQuerySelector: #canReturnFromFrame>
+	<commandQuery: #canReturnFromFrame>
 	| frame expression returnValue receiver loopCookie |
 	frame := self frame.
 	receiver := frame receiver.
@@ -1482,7 +1482,7 @@ runDebuggedProcess
 runProcess
 	"Private - Run the debugged process to the next breakpoint or step interrupt."
 
-	<commandQuerySelector: #isRunnable>
+	<commandQuery: #isRunnable>
 	self debugState: 'Run to Next Breakpoint'.
 	self breakWhen: [:iFrame | false].
 	self mainView disable.
@@ -1492,7 +1492,7 @@ runToCursor
 	"Private - Step to the last breakpoint immediately before the current caret position in the
 	source pane."
 
-	<commandQuerySelector: #canRunToCursor>
+	<commandQuery: #canRunToCursor>
 	| ipInterval method frame |
 	self debugState: 'Run to Cursor'.
 	ipInterval := self cursorIPRange.
@@ -1601,7 +1601,7 @@ setVariablesList: aSequenceableCollection
 			wasExpanded ifTrue: [variablesPresenter expand: newSelection]]!
 
 showNextStatement
-	<commandQuerySelector: #isPaused>
+	<commandQuery: #isPaused>
 	self isTopFrameSelected
 		ifTrue: [self setSourceSelection]
 		ifFalse: [stackPresenter selection: topFrame]!
@@ -1645,7 +1645,7 @@ stepInto
 	"Private - Process a command to step into the next message send. This can only be done from the top
 	stack frame."
 
-	<commandQuerySelector: #canStepInto>
+	<commandQuery: #canStepInto>
 	self debugState: 'Step Into'.
 	self step!
 
@@ -1663,18 +1663,18 @@ stepIntoBlock
 stepOut
 	"Private - Step out of the currently selected frame (i.e. return to its sender)."
 
-	<commandQuerySelector: #canStep>
+	<commandQuery: #canStep>
 	| frame |
 	self debugState: 'Step Out'.
 	frame := self frame.
 	self makeDebugFrame: frame sender.
-	self breakWhen: [:iFrame | iFrame index < frame index].		"break when returned fromselected frame"
+	self breakWhen: [:iFrame | iFrame index < frame index].	"break when returned fromselected frame"
 	self runDebuggedProcess!
 
 stepOver
 	"Private - Step to the next expression in the currently selected frame. Note that this should not stop on a breakpoint in any block homed lower in the stack."
 
-	<commandQuerySelector: #canStep>
+	<commandQuery: #canStep>
 	| frame |
 	self beRunning.
 	self debugState: 'Step over'.
@@ -1760,7 +1760,7 @@ terminateProcess
 	attached debugger, so we don't need to do anything other than just request the process
 	terminate."
 
-	<commandQuerySelector: #isProcessLive>
+	<commandQuery: #isProcessLive>
 	| mb |
 	self beAnimated: false.
 	mb := MessageBox new.
@@ -1777,7 +1777,7 @@ toggleAnimation
 	fun, rather than anything of serious utility. It is also handy for stress testing the
 	debugger."
 
-	<commandQuerySelector: #queryToggleAnimation:>
+	<commandQuery: #queryToggleAnimation:>
 	| newState |
 	newState := self isAnimating not.
 	self beAnimated: newState.
@@ -1877,7 +1877,7 @@ updateTemporaries
 userBreak
 	"Private - The user deliberately broke a process running in the debugger from the menu."
 
-	<commandQuerySelector: #canBreak>
+	<commandQuery: #canBreak>
 	self assert: [process ~~ Processor activeProcess].
 	self beAnimated: false.
 	self

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.Debugger.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.Debugger.cls
@@ -105,14 +105,14 @@ acceptItCommand
 acceptMethod
 	"Private - Saves the current method source, restarting the method frame if the system options so indicate."
 
-	<commandQuerySelector: #querySaveMethod:>
+	<commandQuerySelector: #canSaveMethod>
 	self accept: self class restartOnMethodSave methodSource: self source!
 
 acceptNoRestart
 	"Private - Saves the current method source without restarting the frame (i.e. the debugged
 	process becomes out of sync. with the current method)."
 
-	<commandQuerySelector: #querySaveMethod:>
+	<commandQuerySelector: #canSaveMethod>
 	self accept: false methodSource: self source!
 
 addToCommandRoute: aCommandPolicy
@@ -127,7 +127,7 @@ allFrames
 	"Private - Include all stack frames in the call stack. There cannot possibly be any more
 	than the size of the process."
 
-	<commandQuerySelector: #queryShowMoreFrames:>
+	<commandQuerySelector: #hasMoreFrames>
 	self depth: process size!
 
 animatePause
@@ -250,7 +250,7 @@ browseMessageDefinitions
 	"Private - Open a new method browser on the definitions of the of the currently selected
 	stack frame's selector."
 
-	<commandQuerySelector: #queryHasBrowsableMethod:>
+	<commandQuerySelector: #hasBrowsableMethod>
 	self browseDefinitionsMatching: (MethodSearch newSelector: self selectedMethod selector)
 		in: self searchEnvironment!
 
@@ -263,7 +263,7 @@ browseMessages
 browseMethodInheritanceChain
 	"Private - Open a method browser displaying the definitions of the currently selected stack frame's method's selector in its superclass chain."
 
-	<commandQuerySelector: #queryBrowseMethodInheritanceChain:>
+	<commandQuerySelector: #hasOverrideSelected>
 	self model browseMethodHierarchyFrom: self selectedMethod!
 
 browseReferences
@@ -304,7 +304,7 @@ browseSystem
 		ifFalse: [self model browseSystemOnMethod: self selectedMethod]!
 
 browseVariableClass
-	<commandQuerySelector: #queryHasVariableSelected:>
+	<commandQuerySelector: #hasVariableSelected>
 	localAccessor value browse!
 
 buildParseTree
@@ -319,6 +319,9 @@ buildParseTree
 						environment: method environment]
 				ifFalse: [Parser parseExistingMethodNoError: method]]!
 
+canBreak
+	^(flags bitAnd: ##(RunMask | AnimateMask)) == RunMask!
+
 canImplementMessage
 	"Private - Answer whether the receiver can implement a stub for the message associated with 
 	the current stack frame."
@@ -331,10 +334,30 @@ canImplementMessage
 	^(selector == #doesNotUnderstand: and: [Compiler isValidSelector: frame arguments first selector])
 		or: [(Compiler isValidSelector: selector) and: [method methodClass ~= frame receiver class]]!
 
+canReturnFromFrame
+	^self isPaused and: 
+			[| frame |
+			frame := self frame.
+			frame notNil and: [frame canReturn]]!
+
+canRunToCursor
+	^self isRunnable and: 
+			[self hasLiveFrame and: 
+					["Cannot run to cursor in disassembly view"
+					self isDisassembled not]]!
+
 canSaveMethod
 	"Private - Answer whether the text of the method displayed in the receiver can be saved."
 
 	^self hasEditableMethodSelected!
+
+canStep
+	^self isRunnable and: [self hasLiveFrame]!
+
+canStepInto
+	^self isRunnable and: 
+			["Can only step-into in the top stack frame"
+			self isTopFrameSelected and: [topFrame isDead not]]!
 
 classForVariable: aStVariable
 	^aStVariable valueClass: self frame!
@@ -482,7 +505,7 @@ depth: anInteger
 displayFrame
 	"Private - Update the receiver to reflect the selected stack frame."
 
-	self frame isNil ifTrue: [^self].
+	self hasFrameSelected ifFalse: [^self].
 	self displaySource.
 	self updateTemporaries!
 
@@ -589,11 +612,17 @@ generateStubFor: aMessage inClass: aClass
 		extraFlags: 0) method
 		notNil!
 
+hasBrowsableMethod
+	^self isPaused and: [self hasMethodSelected]!
+
 hasEditableMethodSelected
 	^self isPaused and: [self isDisassembled not and: [self hasMethodSelected]]!
 
 hasEditableMethodsSelected
 	^self hasEditableMethodSelected!
+
+hasFrameSelected
+	^self frame notNil!
 
 hasLiveFrame
 	| frame |
@@ -602,6 +631,18 @@ hasLiveFrame
 
 hasMethodSelected
 	^self selectedMethod notNil and: [self selectedMethod isExpression not]!
+
+hasMoreFrames
+	^self isPaused and: [self depth <= self frames size]!
+
+hasMutableVariableSelected
+	^variablesPresenter hasSelection and: [localAccessor canSet]!
+
+hasOverrideSelected
+	^self selectedMethod ifNil: [false] ifNotNil: [:method | method isOverride]!
+
+hasVariableSelected
+	^variablesPresenter hasSelection!
 
 implementDNUMenu
 	<commandQuerySelector: #queryImplementMenu:>
@@ -618,7 +659,7 @@ initialize
 inspectFrame
 	"Private - Open an inspector on the currently selected frame."
 
-	<commandQuerySelector: #queryHasFrameSelected:>
+	<commandQuerySelector: #hasFrameSelected>
 	self frame inspect!
 
 inspectItCommand
@@ -641,7 +682,7 @@ inspectReferences
 inspectVariable
 	"Private - Open an inspector on the currently selected local variable (or instance variable)."
 
-	<commandQuerySelector: #queryHasVariableSelected:>
+	<commandQuerySelector: #hasVariableSelected>
 	localAccessor value inspect!
 
 isAnimating
@@ -657,10 +698,12 @@ isDisassembled
 !
 
 isFrameRestartable
-	"Private - Answer whether the selected frame is restartable. Some methods, such as callback
-	entry points, cannot be restarted at all, others not reliably."
+	"Private - Answer whether the receiver is paused with a selected frame that is restartable. Some methods, such as callback entry points, cannot be restarted at all, others not reliably."
 
-	^self frame isRestartable!
+	^self isPaused and: 
+			[| frame |
+			frame := self frame.
+			frame notNil and: [frame isRestartable]]!
 
 isInCompositeOp
 	"Private - Answer whether the receiver is performing a composite operation (if so then
@@ -675,6 +718,9 @@ isMain: aBoolean
 
 isPaused
 	^flags noMask: ##(RunMask | AnimateMask)!
+
+isProcessLive
+	^process isTerminated not!
 
 isResumable
 	"Private - Answer whether the process the receiver is debugging is resumable."
@@ -691,6 +737,9 @@ isRunning
 	"Private - Answer whether the process the receiver is debugging is currently running."
 
 	^flags anyMask: RunMask!
+
+isTopFrameSelected
+	^self frame = topFrame!
 
 killProcess
 	"Private - Kill the debugged process, if the user confirms that that is his wish."
@@ -739,7 +788,7 @@ markMethodAsUnbound: oldMethod
 moreFrames
 	"Private - Increase the number of stack frames displayed in the call stack."
 
-	<commandQuerySelector: #queryShowMoreFrames:>
+	<commandQuerySelector: #hasMoreFrames>
 	self depth: depth + StackDepthIncrement!
 
 nameForArgument: anObject 
@@ -760,7 +809,7 @@ newLocalsTreeWithRoots: anOrderedCollection
 nilVariable
 	"Private - Nil the currently selected variable or stack slot."
 
-	<commandQuerySelector: #queryNilVariable:>
+	<commandQuerySelector: #hasMutableVariableSelected>
 	variablesPresenter model collapse: localAccessor.
 	localAccessor value: nil!
 
@@ -1081,22 +1130,6 @@ promptToSaveChanges
 
 	^self onPromptToSaveChanges: (SelectionChangingEvent forSource: self)!
 
-queryBrowseMethodInheritanceChain: aCommandQuery
-	aCommandQuery
-		isEnabled: (self selectedMethod ifNil: [false] ifNotNil: [:method | method isOverride])!
-
-queryHasBrowsableMethod: aCommandQuery
-	aCommandQuery isEnabled: (self isPaused and: [self hasMethodSelected])!
-
-queryHasEditableMethodSelected: aCommandQuery
-	aCommandQuery isEnabled: self hasEditableMethodSelected!
-
-queryHasFrameSelected: aCommandQuery
-	aCommandQuery isEnabled: self frame notNil!
-
-queryHasVariableSelected: aCommandQuery
-	aCommandQuery isEnabled: variablesPresenter hasSelection!
-
 queryImplementMenu: aCommandQuery
 	"Note that the implement menu is not just for DNUs any more, but any message which is not directly implemented by its receiver."
 
@@ -1106,63 +1139,12 @@ queryImplementMenu: aCommandQuery
 queryMessagesMenu: aCommandQuery
 	aCommandQuery isEnabled: (self class enableDynamicMenus and: [self selectedMethod notNil])!
 
-queryNilVariable: aCommandQuery
-	aCommandQuery isEnabled: (variablesPresenter hasSelection and: [localAccessor canSet])!
-
-queryRestartFrame: aCommandQuery
-	aCommandQuery
-		isEnabled: (self isPaused and: 
-					[| frame |
-					frame := self frame.
-					frame notNil and: [frame isRestartable]])!
-
-queryReturnFromMessage: aCommandQuery
-	aCommandQuery
-		isEnabled: (self isPaused and: 
-					[| frame |
-					frame := self frame.
-					frame notNil and: [frame canReturn]])!
-
-queryRun: aCommandQuery
-	aCommandQuery isEnabled: self isRunnable!
-
-queryRunToCursor: aCommandQuery
-	aCommandQuery
-		isEnabled: (self isRunnable and: 
-					[self hasLiveFrame and: 
-							["Cannot run to cursor in disassembly view"
-							self isDisassembled not]])!
-
-querySaveMethod: aCommandQuery
-	aCommandQuery isEnabled: self canSaveMethod!
-
-queryShowMoreFrames: aCommandQuery
-	aCommandQuery isEnabled: (self isPaused and: [self depth <= self frames size])!
-
-queryShowNextStatement: aCommandQuery
-	aCommandQuery isEnabled: self isPaused!
-
-queryStep: aCommandQuery
-	aCommandQuery isEnabled: (self isRunnable and: [self hasLiveFrame])!
-
-queryStepInto: aCommandQuery
-	aCommandQuery
-		isEnabled: (self isRunnable and: 
-					["Can only step-into in the top stack frame"
-					self frame = topFrame and: [topFrame isDead not]])!
-
-queryTerminateProcess: aCommandQuery
-	aCommandQuery isEnabled: process isTerminated not!
-
 queryToggleAnimation: aCommandQuery
 	| animating |
 	animating := self isAnimating.
 	aCommandQuery
 		isEnabled: (animating or: [self isRunnable]);
 		isChecked: animating!
-
-queryUserBreak: aCommandQuery
-	aCommandQuery isEnabled: (flags bitAnd: ##(RunMask | AnimateMask)) == RunMask!
 
 referencesMenu
 	<commandQuerySelector: #queryMessagesMenu:>
@@ -1252,7 +1234,7 @@ restartFrame
 	"Private - Unwind the currently selected frame and reset the IP so that the method starts
 	executing from its beginning again."
 
-	<commandQuerySelector: #queryRestartFrame:>
+	<commandQuerySelector: #isFrameRestartable>
 	self restartFrameWithFocus: false!
 
 restartFrame: frame 
@@ -1426,7 +1408,7 @@ resumeProcess
 	"Private - Restart the debugged process from the point at which it was last suspended. This
 	might involve being resuspended on a Semaphore."
 
-	<commandQuerySelector: #queryRun:>
+	<commandQuerySelector: #isRunnable>
 	process debugger: nil.
 	self view close ifFalse: [process debugger: self] ifTrue: [self resume]!
 
@@ -1453,7 +1435,7 @@ returnFromMessage
 	return value for which the user is prompted (may be any expression). Also resets the
 	non-resumable flag allowing debugging to continue after a non-continuable error."
 
-	<commandQuerySelector: #queryReturnFromMessage:>
+	<commandQuerySelector: #canReturnFromFrame>
 	| frame expression returnValue receiver loopCookie |
 	frame := self frame.
 	receiver := frame receiver.
@@ -1500,7 +1482,7 @@ runDebuggedProcess
 runProcess
 	"Private - Run the debugged process to the next breakpoint or step interrupt."
 
-	<commandQuerySelector: #queryRun:>
+	<commandQuerySelector: #isRunnable>
 	self debugState: 'Run to Next Breakpoint'.
 	self breakWhen: [:iFrame | false].
 	self mainView disable.
@@ -1510,7 +1492,7 @@ runToCursor
 	"Private - Step to the last breakpoint immediately before the current caret position in the
 	source pane."
 
-	<commandQuerySelector: #queryRunToCursor:>
+	<commandQuerySelector: #canRunToCursor>
 	| ipInterval method frame |
 	self debugState: 'Run to Cursor'.
 	ipInterval := self cursorIPRange.
@@ -1619,8 +1601,8 @@ setVariablesList: aSequenceableCollection
 			wasExpanded ifTrue: [variablesPresenter expand: newSelection]]!
 
 showNextStatement
-	<commandQuerySelector: #queryShowNextStatement:>
-	self frame = topFrame
+	<commandQuerySelector: #isPaused>
+	self isTopFrameSelected
 		ifTrue: [self setSourceSelection]
 		ifFalse: [stackPresenter selection: topFrame]!
 
@@ -1663,7 +1645,7 @@ stepInto
 	"Private - Process a command to step into the next message send. This can only be done from the top
 	stack frame."
 
-	<commandQuerySelector: #queryStepInto:>
+	<commandQuerySelector: #canStepInto>
 	self debugState: 'Step Into'.
 	self step!
 
@@ -1681,7 +1663,7 @@ stepIntoBlock
 stepOut
 	"Private - Step out of the currently selected frame (i.e. return to its sender)."
 
-	<commandQuerySelector: #queryStep:>
+	<commandQuerySelector: #canStep>
 	| frame |
 	self debugState: 'Step Out'.
 	frame := self frame.
@@ -1692,7 +1674,7 @@ stepOut
 stepOver
 	"Private - Step to the next expression in the currently selected frame. Note that this should not stop on a breakpoint in any block homed lower in the stack."
 
-	<commandQuerySelector: #queryStep:>
+	<commandQuerySelector: #canStep>
 	| frame |
 	self beRunning.
 	self debugState: 'Step over'.
@@ -1778,7 +1760,7 @@ terminateProcess
 	attached debugger, so we don't need to do anything other than just request the process
 	terminate."
 
-	<commandQuerySelector: #queryTerminateProcess:>
+	<commandQuerySelector: #isProcessLive>
 	| mb |
 	self beAnimated: false.
 	mb := MessageBox new.
@@ -1895,7 +1877,7 @@ updateTemporaries
 userBreak
 	"Private - The user deliberately broke a process running in the debugger from the menu."
 
-	<commandQuerySelector: #queryUserBreak:>
+	<commandQuerySelector: #canBreak>
 	self assert: [process ~~ Processor activeProcess].
 	self beAnimated: false.
 	self
@@ -1934,8 +1916,13 @@ browseReferencesToLiteral:in:!browsing!private! !
 browseSystem!commands-actions!public! !
 browseVariableClass!commands-actions!private! !
 buildParseTree!commands-actions!private! !
+canBreak!private!testing! !
 canImplementMessage!private!testing! !
+canReturnFromFrame!private!testing! !
+canRunToCursor!private!testing! !
 canSaveMethod!private!testing! !
+canStep!private!testing! !
+canStepInto!private!testing! !
 classForVariable:!public! !
 clearCachedMethodInfo!helpers!private! !
 continue:with:!operations!private! !
@@ -1957,10 +1944,16 @@ frame!accessing!private! !
 frameCalledFrom:!accessing!operations!private! !
 frames!accessing!private! !
 generateStubFor:inClass:!helpers!private! !
+hasBrowsableMethod!private!testing! !
 hasEditableMethodSelected!public!testing! !
 hasEditableMethodsSelected!public!testing! !
-hasLiveFrame!commands-queries!helpers!private! !
+hasFrameSelected!public! !
+hasLiveFrame!private!testing! !
 hasMethodSelected!public!testing! !
+hasMoreFrames!private!testing! !
+hasMutableVariableSelected!private!testing! !
+hasOverrideSelected!private!testing! !
+hasVariableSelected!private!testing! !
 implementDNUMenu!commands-menus!private! !
 initialize!initializing!private! !
 inspectFrame!commands-actions!private! !
@@ -1973,9 +1966,11 @@ isFrameRestartable!private!testing! !
 isInCompositeOp!private!testing! !
 isMain:!accessing!private! !
 isPaused!private!testing! !
+isProcessLive!private!testing! !
 isResumable!private!testing! !
 isRunnable!private!testing! !
 isRunning!private!testing! !
+isTopFrameSelected!commands-actions!private! !
 killProcess!commands-actions!private! !
 mainView!accessing!private! !
 makeDebugFrame:!helpers!private! !
@@ -2007,26 +2002,9 @@ populateImplementMenu:!helpers!private! !
 populateStackModel!private!updating! !
 process:topFrame:!accessing!initializing!private! !
 promptToSaveChanges!commands-actions!private! !
-queryBrowseMethodInheritanceChain:!commands-queries!private! !
-queryHasBrowsableMethod:!commands-queries!private! !
-queryHasEditableMethodSelected:!commands-queries!private! !
-queryHasFrameSelected:!public! !
-queryHasVariableSelected:!commands-queries!private! !
 queryImplementMenu:!commands-queries!private! !
 queryMessagesMenu:!commands-queries!private! !
-queryNilVariable:!commands-queries!private! !
-queryRestartFrame:!commands-queries!private! !
-queryReturnFromMessage:!commands-queries!private! !
-queryRun:!commands-queries!private! !
-queryRunToCursor:!commands-queries!private! !
-querySaveMethod:!commands-queries!private! !
-queryShowMoreFrames:!commands-queries!private! !
-queryShowNextStatement:!commands-queries!private! !
-queryStep:!commands-queries!private! !
-queryStepInto:!commands-queries!private! !
-queryTerminateProcess:!commands-queries!private! !
 queryToggleAnimation:!commands-queries!private! !
-queryUserBreak:!commands-queries!private! !
 referencesMenu!commands-menus!private! !
 refreshFrame!private!updating! !
 restartBlock:inFrame:!operations!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowserShell.cls
@@ -68,7 +68,14 @@ hasEditableMethodsSelected
 	^self selectedMethods allSatisfy: [:each | self isEditableMethod: each]!
 
 hasMethods
-	^self browser hasMethods!
+	"Answer whether there are any methods in the browser model."
+
+	^browserPresenter hasMethods!
+
+hasMethodSelected
+	"Answer whether a single method is selected in the browser"
+
+	^browserPresenter hasMethodSelected!
 
 isEditableMethod: aCompiledMethod 
 	^true!
@@ -120,11 +127,8 @@ parseContext
 					env := package ifNil: [class environment] ifNotNil: [package environment ifNil: [class environment]].
 					ParseContext methodClass: class environment: (model modelClassFor: env)]]!
 
-queryHasMethodSelected: aCommandQuery
-	aCommandQuery isEnabled: browserPresenter hasMethodSelected!
-
 recompileDiffs
-	<commandQuerySelector: #queryHasMethodSelected:>
+	<commandQuerySelector: #hasMethodSelected>
 	self developmentSystem recompileDiffs: self selectedMethod!
 
 saveNewMethod: aString
@@ -152,9 +156,7 @@ selectedMethods
 	^self browser selectedMethods!
 
 setInitialFocus
-	browserPresenter hasMethodSelected 
-		ifTrue: [browserPresenter setInitialFocus]
-		ifFalse: [super setInitialFocus]!
+	self hasMethodSelected ifTrue: [browserPresenter setInitialFocus] ifFalse: [super setInitialFocus]!
 
 statusModel
 	^self browser errorModel!
@@ -174,7 +176,8 @@ findDetails:!accessing!public! !
 findSelector:!public!searching! !
 hasEditableMethodSelected!public!testing! !
 hasEditableMethodsSelected!public!testing! !
-hasMethods!browsing!public! !
+hasMethods!public!testing! !
+hasMethodSelected!public!testing! !
 isEditableMethod:!enquiries!public! !
 method!accessing!public! !
 methods!accessing!public! !
@@ -182,7 +185,6 @@ methods:!accessing!public! !
 onMethodSelected!event handling!private! !
 onViewOpened!event handling!public! !
 parseContext!accessing!public! !
-queryHasMethodSelected:!commands-queries!private! !
 recompileDiffs!public! !
 saveNewMethod:!helpers!private! !
 searchEnvironment:!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowserShell.cls
@@ -128,7 +128,7 @@ parseContext
 					ParseContext methodClass: class environment: (model modelClassFor: env)]]!
 
 recompileDiffs
-	<commandQuerySelector: #hasMethodSelected>
+	<commandQuery: #hasMethodSelected>
 	self developmentSystem recompileDiffs: self selectedMethod!
 
 saveNewMethod: aString

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodWorkspace.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodWorkspace.cls
@@ -33,6 +33,7 @@ accept
 	"Save the method source, updating the existing method or adding a new one depending on
 	whether the user has edited the method signature."
 
+	<commandQuery: #canSaveMethod>
 	parentPresenter saveNewMethod: self source!
 
 addToCommandRoute: route 
@@ -92,9 +93,10 @@ browseDefinitionsCommand
 	^super browseDefinitionsCommand!
 
 browseMessage
+	<commandQuery: #queryBrowseMessage:>
 	| node |
 	node := self selectedMessageNode.
-	self developmentSystem browseMethod: ((self targetOfMessage: node) lookupMethod: node selector)"Private - Answer the development system model."!
+	self developmentSystem browseMethod: ((self targetOfMessage: node) lookupMethod: node selector)!
 
 browseReferencesCommand
 	"Private - Answer the context-sensitive 'Browse References' command for the selected node."
@@ -285,52 +287,50 @@ parseTree
 promptToSaveChanges
 	^parentPresenter promptToSaveChanges!
 
+queryBrowseDefsOrRefs: aCommandQuery
+	| message |
+	message := self selectedMessage.
+	aCommandQuery
+		isEnabled: true;
+		text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: { message ?? '…' }
+					locale: Locale smalltalk)!
+
+queryBrowseMessage: aCommandQuery
+	| text node |
+self halt.
+	node := self selectedMessageNode.
+	text := nil.
+	(node isNil or: 
+			[| target |
+			target := self targetOfMessage: node.
+			target isNil or: [(text := target lookupMethod: node selector) isNil]])
+		ifTrue: 
+			[aCommandQuery isEnabled: false.
+			text := 'Message']
+		ifFalse: [aCommandQuery isEnabled: true].
+	aCommandQuery text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: { text }
+				locale: Locale smalltalk).
+	^true!
+
 queryCommand: aCommandQuery
 	"Private - Enter details about a potential command for the receiver into the
 	<CommandQuery>."
 
 	| selector |
 	selector := aCommandQuery commandSymbol.
-	#reformatMenu == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: self isReadOnly not.
-			^true].
-	(#(#accept #reformatAccept) identityIncludes: selector)
-		ifTrue: 
-			[aCommandQuery isEnabled: self canSaveMethod.
-			^true].
-	#reformatSource == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: (self isReadOnly not and: [self textLength > 0]).
-			^true].
 	(#(#browseDefinitions #browseReferences) identityIncludes: selector)
 		ifTrue: 
-			[| message |
-			message := self selectedMessage.
-			aCommandQuery
-				isEnabled: true;
-				text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: {message ?? '…'}
-							locale: Locale smalltalk).
-			^true].
-	#browseMessage == selector
-		ifTrue: 
-			[| text node |
-			node := self selectedMessageNode.
-			(node isNil or: 
-					[| target |
-					target := self targetOfMessage: node.
-					target isNil or: [(text := target lookupMethod: node selector) isNil]])
-				ifTrue: 
-					[aCommandQuery isEnabled: false.
-					text := 'Message']
-				ifFalse: [aCommandQuery isEnabled: true].
-			aCommandQuery text: (aCommandQuery commandDescription menuText expandMacrosWithArguments: {text}
-						locale: Locale smalltalk).
+			[self queryBrowseDefsOrRefs: aCommandQuery.
 			^true].
 	^super queryCommand: aCommandQuery!
 
 reformatAccept
+	<commandQuery: #canSaveMethod>
 	self reformattedSource ifNotNil: [:aString | parentPresenter saveNewMethod: aString]!
+
+reformatMenu
+	<commandQuery: #isEditable>
+	!
 
 reformatSource
 	"Reformat and syntax colour the current contents of the method source pane, but do not
@@ -488,16 +488,16 @@ widenSourceSelection
 			whileTrue: [node := node parent].
 	self selectionRange: node sourceInterval! !
 !Tools.MethodWorkspace categoriesForMethods!
-accept!commands!public! !
-addToCommandRoute:!commands!public! !
+accept!commands-actions!public! !
+addToCommandRoute:!commands-routing!public! !
 allDefinedVariablesDo:!autocompletion!enumerating!private! !
 applyOptions!operations!options!private! !
 autoParse!helpers!private! !
-browseDefinitionsCommand!commands!private! !
-browseMessage!commands!public! !
-browseReferencesCommand!commands!private! !
+browseDefinitionsCommand!commands-mappings!private! !
+browseMessage!commands-actions!public! !
+browseReferencesCommand!commands-mappings!private! !
 buildParseTree!helpers!private! !
-canSaveMethod!commands!private! !
+canSaveMethod!commands-queries!private! !
 clear!operations!public! !
 clearParseTree!helpers!private! !
 contextBindingFor:!private!refactoring! !
@@ -527,9 +527,12 @@ parseContext!accessing!private! !
 parseSourceIn:!helpers!private! !
 parseTree!accessing!private! !
 promptToSaveChanges!helpers!public! !
-queryCommand:!commands!private! !
-reformatAccept!commands!public! !
-reformatSource!commands!public! !
+queryBrowseDefsOrRefs:!commands-queries!private! !
+queryBrowseMessage:!commands-queries!private! !
+queryCommand:!commands-queries!private! !
+reformatAccept!commands-actions!public! !
+reformatMenu!commands-menus!public! !
+reformatSource!commands-actions!public! !
 reformattedSource!helpers!private! !
 repositionAtSourceLine:!operations!public! !
 resetParseTimer!helpers!private! !
@@ -548,7 +551,7 @@ source!accessing!public! !
 source:!accessing!public! !
 targetOfMessage:!helpers!private! !
 variableClassification:!helpers!private! !
-widenSourceSelection!commands!public! !
+widenSourceSelection!commands-actions!public! !
 !
 
 !Tools.MethodWorkspace class methodsFor!

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
@@ -68,7 +68,7 @@ browseClass
 	class is selected then an <EnvironmentBrowserShell> is opened and configured to display
 	those classes."
 
-	<commandQuerySelector: #queryHasClassesSelected:>
+	<commandQuerySelector: #hasClassesSelected>
 	| classes |
 	classes := self selectedClasses.
 	^classes size = 1
@@ -79,7 +79,7 @@ browseClassReferences
 	"Browse all the methods in the entire system which refer to the class selected in the
 	receiver."
 
-	<commandQuerySelector: #queryHasClassesSelected:>
+	<commandQuerySelector: #hasClassesSelected>
 	self browseClassReferencesIn: self browserEnvironment!
 
 browseClassReferencesIn: aBrowserEnvironment
@@ -106,15 +106,15 @@ browseHierarchyCommand
 		lookup: currentCard!
 
 browseHierarchyOfClass
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	self developmentSystem browseHierarchy: self selectedClass!
 
 browseHierarchyOfMethod
-	<commandQuerySelector: #queryHasMethodSelected:>
+	<commandQuerySelector: #hasMethodSelected>
 	self developmentSystem browseClassHierarchyOfMethod: self selectedMethod!
 
 browseHierarchyOfVariable
-	<commandQuerySelector: #queryHasLiveVariableSelected:>
+	<commandQuerySelector: #hasLiveVariableSelected>
 	| var |
 	var := self sharedVariable binding.
 	self developmentSystem
@@ -142,14 +142,14 @@ browseLocalMessageDefinitions
 	"Open a method browser displaying all implementors of the current selector in the currently
 	selected packages."
 
-	<commandQuerySelector: #queryHasPackagesSelected:>
+	<commandQuerySelector: #hasPackages>
 	self browseMessageDefinitionsIn: self searchEnvironment!
 
 browseLocalMessageReferences
 	"Open a method browser displaying all references to the current selector in the currently
 	selected packages."
 
-	<commandQuerySelector: #queryHasPackagesSelected:>
+	<commandQuerySelector: #hasPackages>
 	self browseMessageReferencesIn: self searchEnvironment!
 
 browseLooseMethods: aCollection
@@ -162,7 +162,7 @@ browseLooseMethods: aCollection
 browseMessageDefinitions
 	"Open a method browser displaying all implementors of the current selector in the system."
 
-	<commandQuerySelector: #queryHasMethodsSelected:>
+	<commandQuerySelector: #hasMethodsSelected>
 	self browseMessageDefinitionsIn: self browserEnvironment!
 
 browseMessageDefinitionsIn: aBrowserEnvironment
@@ -177,7 +177,7 @@ browseMessageDefinitionsIn: aBrowserEnvironment
 browseMessageReferences
 	"Open a method browser displaying all references to the current selector in the entire system."
 
-	<commandQuerySelector: #queryHasMethodsSelected:>
+	<commandQuerySelector: #hasMethodsSelected>
 	self browseMessageReferencesIn: self browserEnvironment!
 
 browseMessageReferencesIn: aBrowserEnvironment
@@ -192,7 +192,7 @@ browseMessageReferencesIn: aBrowserEnvironment
 browseMethodClass
 	"Open a default browser on the currently selected method."
 	
-	<commandQuerySelector: #queryHasMethodSelected:>
+	<commandQuerySelector: #hasMethodSelected>
 	^self selectedMethod browse!
 
 browseMethods
@@ -204,7 +204,7 @@ browseMethods
 	methods size == 1 ifTrue: [self browseMethodClass] ifFalse: [self browseLooseMethods: methods]!
 
 browsePackages
-	<commandQuerySelector: #queryHasPackagesSelected:>
+	<commandQuerySelector: #hasPackages>
 	^packagesPresenter browsePackageSources!
 
 browseReferencesCommand
@@ -233,13 +233,13 @@ browseSystem
 browseVariableClass
 	"Open a default browser on the currently selected method."
 
-	<commandQuerySelector: #queryHasLiveVariableSelected:>
+	<commandQuerySelector: #hasLiveVariableSelected>
 	^self sharedVariable browse!
 
 browseVariableReferences
 	"Browse all the methods which refer to the shared variable selected in the receiver."
 
-	<commandQuerySelector: #queryHasVariableSelected:>
+	<commandQuerySelector: #hasVariableSelected>
 	self model browseSharedVariableReferences: self sharedVariable in: self browserEnvironment!
 
 buildPopupForCommand: aSymbol 
@@ -492,21 +492,26 @@ customDrawClassList: anNMLVCUSTOMDRAW
 defaultHelpId
 	^10807!
 
+hasClassesSelected
+	^classesPresenter hasSelection!
+
 hasClassSelected
 	"Answer true if the receiver has a single (i.e. not multiple) class selected"
 
 	^classesPresenter hasSingleSelection!
 
-hasEditableMethodSelected
-	^self selectedMethod notNil!
-
-hasEditableMethodsSelected
-	^self selectedMethods notEmpty!
+hasLiveVariableSelected
+	| ref |
+	ref := self sharedVariable.
+	^ref notNil and: [ref isDefined]!
 
 hasMethodSelected
 	"Answer true if the receiver has a single (i.e. not multiple) method selected"
 
 	^self selectedMethod notNil!
+
+hasMethodsSelected
+	^self selectedMethods notEmpty!
 
 hasPackages
 	"Private - Answer whether one or more packages are currently selected."
@@ -517,6 +522,15 @@ hasPackageSelected
 	"Answer true if the receiver has a single (i.e. not multiple) package selected"
 
 	^self singlePackage notNil!
+
+hasResourcesSelected
+	^self resourceIdentifiers notEmpty!
+
+hasVariableSelected
+	^self sharedVariable notNil!
+
+hasVariablesSelected
+	^self variableNames notEmpty!
 
 initialize
 	"Private - Initialize the state of the receiver"
@@ -529,7 +543,7 @@ initialize
 inspectClasses
 	"Open an inspector on the currently selected classes."
 
-	<commandQuerySelector: #queryHasClassesSelected:>
+	<commandQuerySelector: #hasClassesSelected>
 	self inspectCollection: self selectedClasses!
 
 inspectCollection: aCollection
@@ -551,7 +565,7 @@ inspectItCommand
 inspectMethods
 	"Open an inspector on the currently selected methods."
 
-	<commandQuerySelector: #queryHasMethodsSelected:>
+	<commandQuerySelector: #hasMethodsSelected>
 	self inspectCollection: self selectedMethods!
 
 inspectResources
@@ -562,7 +576,7 @@ inspectResources
 inspectSharedVariables
 	"Open an inspector on the currently selected variables."
 
-	<commandQuerySelector: #queryHasVariablesSelected:>
+	<commandQuerySelector: #hasVariablesSelected>
 	self inspectCollection: (self variableNames collect: [:each | each bindingOrNil])!
 
 isCardUpToDate: aSymbol
@@ -920,32 +934,6 @@ queryBrowseMethods: aCommandQuery
 				expandMacrosWithArguments: { methods size = 1 ifTrue: [methods first] ifFalse: ['&Methods'] }
 				locale: Locale smalltalk)!
 
-queryHasClassesSelected: aCommandQuery
-	aCommandQuery isEnabled: classesPresenter hasSelection!
-
-queryHasLiveVariableSelected: aCommandQuery
-	| ref |
-	ref := self sharedVariable.
-	aCommandQuery isEnabled: (ref notNil and: [ref isDefined])!
-
-queryHasMethodSelected: aCommandQuery
-	aCommandQuery isEnabled: self hasMethodSelected!
-
-queryHasMethodsSelected: aCommandQuery
-	aCommandQuery isEnabled: self selectedMethods notEmpty!
-
-queryHasPackagesSelected: aCommandQuery
-	aCommandQuery isEnabled: self hasPackages!
-
-queryHasResourcesSelected: aCommandQuery
-	aCommandQuery isEnabled: self resourceIdentifiers notEmpty!
-
-queryHasVariableSelected: aCommandQuery
-	aCommandQuery isEnabled: self sharedVariable notNil!
-
-queryHasVariablesSelected: aCommandQuery
-	aCommandQuery isEnabled: self variableNames notEmpty!
-
 querySaveComment: aCommandQuery
 	(packagesPresenter hasSinglePackage and: [commentPresenter isModified])
 		ifTrue: 
@@ -979,7 +967,7 @@ release
 removeClasses
 	"Private - Remove the currently selected classes from the package."
 
-	<commandQuerySelector: #queryHasClassesSelected:>
+	<commandQuerySelector: #hasClassesSelected>
 	self selectedClasses do: [:e | e owningPackage removeClass: e]!
 
 removeLooseMethods
@@ -987,13 +975,13 @@ removeLooseMethods
 	Note that the methods are not actually removed from the system (i.e.
 	ownership is transferred to the package of their method class)."
 
-	<commandQuerySelector: #queryHasMethodsSelected:>
+	<commandQuerySelector: #hasMethodsSelected>
 	self selectedMethods do: [:each | each owningPackage removeMethod: each]!
 
 removeVariables
 	"Private - Remove the currently selected variables from their packages."
 
-	<commandQuerySelector: #queryHasVariablesSelected:>
+	<commandQuerySelector: #hasVariablesSelected>
 	self variableNames do: [:each | Package manager addVariableNamed: each to: nil]!
 
 resourceIdentifier
@@ -1252,7 +1240,7 @@ updateVariables
 upgradeResources
 	"Private - Uprade & resave the selected resources, by loading them into a ViewComposer."
 
-	<commandQuerySelector: #queryHasResourcesSelected:>
+	<commandQuerySelector: #hasResourcesSelected>
 	self resourceIdentifiers do: [:each | each reassign]!
 
 variableNames
@@ -1301,12 +1289,16 @@ createComponents!commands-actions!private! !
 createSchematicWiring!commands-actions!private! !
 customDrawClassList:!private! !
 defaultHelpId!public! !
+hasClassesSelected!private!testing! !
 hasClassSelected!public!testing! !
-hasEditableMethodSelected!public!testing! !
-hasEditableMethodsSelected!public!testing! !
+hasLiveVariableSelected!private!testing! !
 hasMethodSelected!public!testing! !
+hasMethodsSelected!public!testing! !
 hasPackages!private!testing! !
 hasPackageSelected!public!testing! !
+hasResourcesSelected!private!testing! !
+hasVariableSelected!private!testing! !
+hasVariablesSelected!private!testing! !
 initialize!initializing!private! !
 inspectClasses!commands-actions!public! !
 inspectCollection:!helpers!private! !
@@ -1346,16 +1338,8 @@ packages:!accessing!public! !
 promptToSaveChanges!helpers!private! !
 promptToSaveChanges:!helpers!private! !
 queryBrowseMethods:!commands-queries!private! !
-queryHasClassesSelected:!commands-queries!private! !
-queryHasLiveVariableSelected:!commands-queries!public! !
-queryHasMethodSelected:!commands-queries!private! !
-queryHasMethodsSelected:!commands-queries!private! !
-queryHasPackagesSelected:!commands-queries!private! !
-queryHasResourcesSelected:!commands-queries!private! !
-queryHasVariableSelected:!commands-queries!public! !
-queryHasVariablesSelected:!commands-queries!public! !
-querySaveComment:!commands-queries!public! !
-querySaveScript:!commands-queries!public! !
+querySaveComment:!commands-queries!private! !
+querySaveScript:!commands-queries!private! !
 refreshCard:!helpers!private! !
 release!dependency!public! !
 removeClasses!commands-actions!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
@@ -68,7 +68,7 @@ browseClass
 	class is selected then an <EnvironmentBrowserShell> is opened and configured to display
 	those classes."
 
-	<commandQuerySelector: #hasClassesSelected>
+	<commandQuery: #hasClassesSelected>
 	| classes |
 	classes := self selectedClasses.
 	^classes size = 1
@@ -79,7 +79,7 @@ browseClassReferences
 	"Browse all the methods in the entire system which refer to the class selected in the
 	receiver."
 
-	<commandQuerySelector: #hasClassesSelected>
+	<commandQuery: #hasClassesSelected>
 	self browseClassReferencesIn: self browserEnvironment!
 
 browseClassReferencesIn: aBrowserEnvironment
@@ -106,15 +106,15 @@ browseHierarchyCommand
 		lookup: currentCard!
 
 browseHierarchyOfClass
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	self developmentSystem browseHierarchy: self selectedClass!
 
 browseHierarchyOfMethod
-	<commandQuerySelector: #hasMethodSelected>
+	<commandQuery: #hasMethodSelected>
 	self developmentSystem browseClassHierarchyOfMethod: self selectedMethod!
 
 browseHierarchyOfVariable
-	<commandQuerySelector: #hasLiveVariableSelected>
+	<commandQuery: #hasLiveVariableSelected>
 	| var |
 	var := self sharedVariable binding.
 	self developmentSystem
@@ -142,14 +142,14 @@ browseLocalMessageDefinitions
 	"Open a method browser displaying all implementors of the current selector in the currently
 	selected packages."
 
-	<commandQuerySelector: #hasPackages>
+	<commandQuery: #hasPackages>
 	self browseMessageDefinitionsIn: self searchEnvironment!
 
 browseLocalMessageReferences
 	"Open a method browser displaying all references to the current selector in the currently
 	selected packages."
 
-	<commandQuerySelector: #hasPackages>
+	<commandQuery: #hasPackages>
 	self browseMessageReferencesIn: self searchEnvironment!
 
 browseLooseMethods: aCollection
@@ -162,7 +162,7 @@ browseLooseMethods: aCollection
 browseMessageDefinitions
 	"Open a method browser displaying all implementors of the current selector in the system."
 
-	<commandQuerySelector: #hasMethodsSelected>
+	<commandQuery: #hasMethodsSelected>
 	self browseMessageDefinitionsIn: self browserEnvironment!
 
 browseMessageDefinitionsIn: aBrowserEnvironment
@@ -177,7 +177,7 @@ browseMessageDefinitionsIn: aBrowserEnvironment
 browseMessageReferences
 	"Open a method browser displaying all references to the current selector in the entire system."
 
-	<commandQuerySelector: #hasMethodsSelected>
+	<commandQuery: #hasMethodsSelected>
 	self browseMessageReferencesIn: self browserEnvironment!
 
 browseMessageReferencesIn: aBrowserEnvironment
@@ -191,20 +191,20 @@ browseMessageReferencesIn: aBrowserEnvironment
 
 browseMethodClass
 	"Open a default browser on the currently selected method."
-	
-	<commandQuerySelector: #hasMethodSelected>
+
+	<commandQuery: #hasMethodSelected>
 	^self selectedMethod browse!
 
 browseMethods
 	"Open a default browser on the currently selected method or methods."
 
-	<commandQuerySelector: #queryBrowseMethods:>
+	<commandQuery: #queryBrowseMethods:>
 	| methods |
 	methods := self selectedMethods.
 	methods size == 1 ifTrue: [self browseMethodClass] ifFalse: [self browseLooseMethods: methods]!
 
 browsePackages
-	<commandQuerySelector: #hasPackages>
+	<commandQuery: #hasPackages>
 	^packagesPresenter browsePackageSources!
 
 browseReferencesCommand
@@ -233,13 +233,13 @@ browseSystem
 browseVariableClass
 	"Open a default browser on the currently selected method."
 
-	<commandQuerySelector: #hasLiveVariableSelected>
+	<commandQuery: #hasLiveVariableSelected>
 	^self sharedVariable browse!
 
 browseVariableReferences
 	"Browse all the methods which refer to the shared variable selected in the receiver."
 
-	<commandQuerySelector: #hasVariableSelected>
+	<commandQuery: #hasVariableSelected>
 	self model browseSharedVariableReferences: self sharedVariable in: self browserEnvironment!
 
 buildPopupForCommand: aSymbol 
@@ -543,7 +543,7 @@ initialize
 inspectClasses
 	"Open an inspector on the currently selected classes."
 
-	<commandQuerySelector: #hasClassesSelected>
+	<commandQuery: #hasClassesSelected>
 	self inspectCollection: self selectedClasses!
 
 inspectCollection: aCollection
@@ -565,7 +565,7 @@ inspectItCommand
 inspectMethods
 	"Open an inspector on the currently selected methods."
 
-	<commandQuerySelector: #hasMethodsSelected>
+	<commandQuery: #hasMethodsSelected>
 	self inspectCollection: self selectedMethods!
 
 inspectResources
@@ -576,7 +576,7 @@ inspectResources
 inspectSharedVariables
 	"Open an inspector on the currently selected variables."
 
-	<commandQuerySelector: #hasVariablesSelected>
+	<commandQuery: #hasVariablesSelected>
 	self inspectCollection: (self variableNames collect: [:each | each bindingOrNil])!
 
 isCardUpToDate: aSymbol
@@ -967,7 +967,7 @@ release
 removeClasses
 	"Private - Remove the currently selected classes from the package."
 
-	<commandQuerySelector: #hasClassesSelected>
+	<commandQuery: #hasClassesSelected>
 	self selectedClasses do: [:e | e owningPackage removeClass: e]!
 
 removeLooseMethods
@@ -975,13 +975,13 @@ removeLooseMethods
 	Note that the methods are not actually removed from the system (i.e.
 	ownership is transferred to the package of their method class)."
 
-	<commandQuerySelector: #hasMethodsSelected>
+	<commandQuery: #hasMethodsSelected>
 	self selectedMethods do: [:each | each owningPackage removeMethod: each]!
 
 removeVariables
 	"Private - Remove the currently selected variables from their packages."
 
-	<commandQuerySelector: #hasVariablesSelected>
+	<commandQuery: #hasVariablesSelected>
 	self variableNames do: [:each | Package manager addVariableNamed: each to: nil]!
 
 resourceIdentifier
@@ -1000,14 +1000,14 @@ resourceIdentifiers
 saveComment
 	"Private - Save the comment from the source text."
 
-	<commandQuerySelector: #querySaveComment:>
+	<commandQuery: #querySaveComment:>
 	self singlePackage comment: commentPresenter plainText.
 	commentPresenter isModified: false!
 
 saveScript
 	"Private - Save the script from the source text."
 
-	<commandQuerySelector: #querySaveScript:>
+	<commandQuery: #querySaveScript:>
 	self singlePackage scriptAt: self scriptName put: self scriptText.
 	self updateScriptNames!
 
@@ -1240,7 +1240,7 @@ updateVariables
 upgradeResources
 	"Private - Uprade & resave the selected resources, by loading them into a ViewComposer."
 
-	<commandQuerySelector: #hasResourcesSelected>
+	<commandQuery: #hasResourcesSelected>
 	self resourceIdentifiers do: [:each | each reassign]!
 
 variableNames

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageSelector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageSelector.cls
@@ -114,6 +114,9 @@ browseUnimplemented
 		caption: ('Unimplemented Selectors in <1p> (and prerequisites)' expandMacrosWith: sendingEnvironment)
 		environment: implementingEnvironment!
 
+canRefactor
+	^self developmentSystem canRefactor and: [self hasPackages]!
+
 checkCanUninstall: package
 	"Private - Uninstallation of the <Package>, package, has been initiated. Verify that it can be uninstalled
 	and if not inform the user accordingly and abort the operation."
@@ -1000,6 +1003,7 @@ browseIt!commands!public! !
 browseItCommand!helpers!private! !
 browsePackages!commands!public! !
 browseUnimplemented!public! !
+canRefactor!commands!private!refactoring! !
 checkCanUninstall:!helpers!private! !
 clearSelection!commands!private! !
 commonFolder:!operations!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkToolShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkToolShell.cls
@@ -185,7 +185,7 @@ fontSize: anInteger
 forgetSize
 	"Forget the default size for new instances of this tool."
 
-	<commandQuerySelector: #queryForgetSize:>
+	<commandQuerySelector: #hasRememberedSize>
 	(self class)
 		defaultSlideyPinsMap: nil;
 		defaultExtent: nil!
@@ -211,6 +211,9 @@ hasPast
 	"Answer whether there is any past history to visit."
 
 	^self pastSize > 0!
+
+hasRememberedSize
+	^self class defaultExtent notNil!
 
 help
 	"Bring up a help page for this tool."
@@ -372,9 +375,6 @@ queryDeleteIt: aCommandQuery
 			["Not handled at this level, but continue searching the chain"
 			aCommandQuery isEnabled: false]
 		ifNotNil: [:selector | self queryContextCommand: aCommandQuery as: selector]!
-
-queryForgetSize: aCommandQuery
-	aCommandQuery isEnabled: self class defaultExtent notNil!
 
 queryHistoryBack: aCommandQuery
 	aCommandQuery isEnabled: self hasPast!
@@ -547,6 +547,7 @@ futureSize!accessing!public! !
 getPinStateFor:!accessing!private! !
 hasFuture!public!testing! !
 hasPast!public!testing! !
+hasRememberedSize!private!testing! !
 help!commands-actions!public! !
 historyBack!commands-actions!private! !
 historyBack:!commands-actions!private! !
@@ -571,7 +572,6 @@ queryBrowseHierarchy:!commands-queries!private! !
 queryBrowseIt:!commands-queries!private! !
 queryBrowseReferences:!commands-queries!private! !
 queryDeleteIt:!commands-queries!private! !
-queryForgetSize:!commands-queries!private! !
 queryHistoryBack:!commands-queries!private! !
 queryHistoryFastForward:!commands-queries!private! !
 queryHistoryForward:!commands-queries!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkToolShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkToolShell.cls
@@ -33,7 +33,7 @@ Class Instance Variables:
 accept
 	"Save the source on the currently displayed source card."
 
-	<commandQuerySelector: #queryAcceptIt:>
+	<commandQuery: #queryAcceptIt:>
 	self perform: self acceptItCommand!
 
 acceptItCommand
@@ -56,7 +56,7 @@ applyOptions
 browseDefinitions
 	"Context-sensitive browse definitions command (F12)."
 
-	<commandQuerySelector: #queryBrowseDefinitions:>
+	<commandQuery: #queryBrowseDefinitions:>
 	<acceleratorKey: 'F12'>
 	self perform: self browseDefinitionsCommand!
 
@@ -68,7 +68,7 @@ browseDefinitionsCommand
 browseHierarchy
 	"Open a class hierarchy browser navigated appropriately based on initiating context."
 
-	<commandQuerySelector: #queryBrowseHierarchy:>
+	<commandQuery: #queryBrowseHierarchy:>
 	self perform: self browseHierarchyCommand!
 
 browseHierarchyCommand
@@ -79,7 +79,7 @@ browseHierarchyCommand
 browseIt
 	"Open a browser on the selected item in the window with focus."
 
-	<commandQuerySelector: #queryBrowseIt:>
+	<commandQuery: #queryBrowseIt:>
 	self perform: self browseItCommand!
 
 browseItCommand
@@ -100,7 +100,7 @@ browseMethodsInEnvironments: aCollectionOfBrowserEnvironment
 browseReferences
 	"Context-sensitive browse references command (Shift+F12)."
 
-	<commandQuerySelector: #queryBrowseReferences:>
+	<commandQuery: #queryBrowseReferences:>
 	<acceleratorKey: 'Shift+F12'>
 	self perform: self browseReferencesCommand!
 
@@ -185,8 +185,8 @@ fontSize: anInteger
 forgetSize
 	"Forget the default size for new instances of this tool."
 
-	<commandQuerySelector: #hasRememberedSize>
-	(self class)
+	<commandQuery: #hasRememberedSize>
+	self class
 		defaultSlideyPinsMap: nil;
 		defaultExtent: nil!
 
@@ -224,28 +224,28 @@ help
 historyBack
 	"Private - Return to the previously visited method."
 
-	<commandQuerySelector: #queryHistoryBack:>
+	<commandQuery: #queryHistoryBack:>
 	self historyBack: 1!
 
 historyBack: delta
 	"Private - Return to a previously visited method <integer>, delta, visits
 	in the past.."
 
-	<commandQuerySelector: #queryHistoryRewind:>
+	<commandQuery: #queryHistoryRewind:>
 	self historySkip: delta negated!
 
 historyForward
 	"Private - Return to the previously visited class which has been
 	moved back over by a jump back in time."
 
-	<commandQuerySelector: #queryHistoryForward:>
+	<commandQuery: #queryHistoryForward:>
 	self historyForward: 1!
 
 historyForward: delta
 	"Private - Return to the previously visited class which has been
 	moved back over by a jump back in time."
 
-	<commandQuerySelector: #queryHistoryFastForward:>
+	<commandQuery: #queryHistoryFastForward:>
 	self historySkip: delta!
 
 historySkip: anInteger
@@ -263,9 +263,11 @@ inspectIt
 	as class hierarchy, method browser, and workspace presenters all handle
 	it themselves."
 
+	"VW compatibility"
+
 	<acceleratorKey: 'Ctrl+I'>
-	<acceleratorKey: 'Ctrl+Q'>		"VW compatibility"
-	<commandQuerySelector: #queryInspectIt:>
+	<acceleratorKey: 'Ctrl+Q'>
+	<commandQuery: #queryInspectIt:>
 	self perform: self inspectItCommand!
 
 inspectItCommand

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspace.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspace.cls
@@ -185,6 +185,12 @@ browseReferencesCommand
 cancelAutoCompletion
 	self view cancelAutoCompletion!
 
+canReformatComment
+	^self isEditable and: [self view styleUnderCaret name == #comment]!
+
+canReformatSource
+	^self isEditable and: [self textLength > 0]!
+
 caretPosition: anInteger 
 	self view caretPosition: anInteger!
 
@@ -192,6 +198,7 @@ chooseNamespaces
 	"Display a ListPrompter to allow the user to choose the evaluation pools associated with the
 	receiver"
 
+	<commandQuery: #isEditable>
 	ChoicePrompter
 		on: (self aspectValue: #namespaces)
 		multipleChoices: (SmalltalkSystem current availableNamespaces
@@ -255,6 +262,7 @@ classForVariable: aStVariable
 clear
 	"Remove all contents in the receiver's view"
 
+	<commandQuery: #isEditable>
 	self view clear.
 	self newVariablePool!
 
@@ -273,6 +281,7 @@ cloneNew
 	contain the same contents and have the same evaluation context and workspace pools. Answers
 	the clone"
 
+	<commandQuery: #isEditable>
 	| clone |
 	clone := SmalltalkSystem current newWorkspace.
 	clone workspace
@@ -391,6 +400,7 @@ completeWord
 	The list will be displayed unless the number of choices is far too large or there are none
 	matching, in which case a warning beep will sound."
 
+	<commandQuery: #isEditable>
 	<acceleratorKey: 'Ctrl+.'>
 	| last styleName |
 	last := view caretPosition - 1.
@@ -494,6 +504,7 @@ displayIt
 	"Evaluate the currently selected text (or the current line if there is no selection). 
 	Display the result at the current insert point (i.e. immediately after the selection)."
 
+	<commandQuery: #isEditable>
 	<acceleratorKey: 'Ctrl+D'>
 	self evaluateAndDisplay: [:obj | obj displayString: self developmentSystem displayItLocale]!
 
@@ -649,6 +660,7 @@ evaluationContext: anObject
 fileItIn
 	"Files in the current selection in chunk format"
 
+	<commandQuery: #hasSelection>
 	^(self chunkFilerClass on: self selection readStream) fileIn!
 
 findDetails
@@ -848,6 +860,7 @@ inspectWorkspacePool
 	"Private - Open an inspector on the Workspace Pool containing the receiver's shared
 	variables."
 
+	<commandQuery: #isEditable>
 	self workspacePool inspect!
 
 isAutoCompletionCaseInsensitive
@@ -1088,6 +1101,7 @@ printIt
 	(i.e. show the printString of) the result at the current insert point (i.e. immediately
 	after the selection)."
 
+	<commandQuery: #isEditable>
 	<acceleratorKey: 'Ctrl+P'>
 	self evaluateAndDisplay: [:obj | obj printString]!
 
@@ -1145,56 +1159,29 @@ publishedAspects
 		add: self class indicatorStylesAspect;
 		yourself!
 
-queryCommand: aCommandQuery
-	"Private - Enter details about a potential command for the receiver into the 
-	<CommandQuery>."
+queryToggleAutoCompletion: aCommandQuery
+	(self isReadOnly not and: [self hasSmalltalkStyler and: [self isSyntaxColoringEnabled]])
+		ifTrue: 
+			[aCommandQuery
+				isChecked: self isAutoCompletionEnabled;
+				isEnabled: true]
+		ifFalse: 
+			[aCommandQuery
+				isChecked: false;
+				isEnabled: false]!
 
-	| selector |
-	selector := aCommandQuery commandSymbol.
-	#fileItIn == selector
+queryToggleStyling: aCommandQuery
+	self hasSmalltalkStyler
 		ifTrue: 
-			[aCommandQuery isEnabled: self hasSelection.
-			^true].
-	#reformatSource == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: self isEditable.
-			^true].
-	#reformatComment == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: (self isEditable and: [self view styleUnderCaret name == #comment]).
-			^true].
-	(#(#chooseNamespaces #inspectWorkspacePool #cloneNew #clear #displayIt #printIt #completeWord)
-		identityIncludes: selector)
-			ifTrue: 
-				[aCommandQuery isEnabled: self isReadOnly not.
-				^true].
-	#toggleAutoCompletion == selector
-		ifTrue: 
-			[(self isReadOnly not and: [self hasSmalltalkStyler and: [self isSyntaxColoringEnabled]])
-				ifTrue: 
-					[aCommandQuery
-						isChecked: self isAutoCompletionEnabled;
-						isEnabled: true]
-				ifFalse: 
-					[aCommandQuery
-						isChecked: false;
-						isEnabled: false].
-			^true].
-	#toggleStyling == selector
-		ifTrue: 
-			[self hasSmalltalkStyler
-				ifTrue: 
-					[aCommandQuery
-						isEnabled: true;
-						isChecked: self isSyntaxColoringEnabled]
-				ifFalse: 
-					[aCommandQuery
-						isEnabled: false;
-						isChecked: false].
-			"Ensure the command is not handled by the view"
-			aCommandQuery receiver: self.
-			^true].
-	^super queryCommand: aCommandQuery!
+			[aCommandQuery
+				isEnabled: true;
+				isChecked: self isSyntaxColoringEnabled]
+		ifFalse: 
+			[aCommandQuery
+				isEnabled: false;
+				isChecked: false].
+	"Ensure the command is not handled by the view"
+	aCommandQuery receiver: self!
 
 rangeToCompleteAt: anInteger 
 	^(self isWhitespaceAt: anInteger) 
@@ -1208,6 +1195,7 @@ reformatComment
 	"Rewrap the comment under the caret so that its lines start at the position of the 
 	comment's opening quote, and are no longer than the current  of the workspace view."
 
+	<commandQuery: #canReformatComment>
 	| range |
 	range := view tokenRangeAt: view caretPosition.
 	self wrapLinesInRange: range indent: (view columnFromPosition: range start)!
@@ -1216,6 +1204,7 @@ reformatSource
 	"Reformat and syntax colour the selected range of source in the receiver as if it is an expression. 
 	Attempts to maintain the base indentation of the first selected line."
 
+	<commandQuery: #canReformatSource>
 	| source formatter reformatted expr tabs |
 	source := self hasSelection ifTrue: [self selection] ifFalse: [self text].
 	tabs := (source findFirst: [:each | each ~~ Character tab]) - 1.
@@ -1655,9 +1644,11 @@ tipForVariable: aStVariable
 	^aStVariable infoTip!
 
 toggleAutoCompletion
+	<commandQuery: #queryToggleAutoCompletion:>
 	^self isAutoCompletionEnabled: self isAutoCompletionEnabled not!
 
 toggleStyling
+	<commandQuery: #queryToggleStyling:>
 	^self view toggleStyling!
 
 tokenBefore: anInteger 
@@ -1712,16 +1703,18 @@ applyOptions!operations!options!private! !
 areVariableTipsEnabled!public!testing! !
 areVariableTipsEnabled:!public!testing! !
 autoComplete:at:maxItems:!autocompletion!helpers!private! !
-basicFindNext!commands!public! !
-basicInspectIt!commands!public! !
-browseDefinitions!commands!public! !
-browseDefinitionsCommand!commands!private! !
-browseIt!commands!public! !
-browseReferences!commands!public! !
-browseReferencesCommand!commands!private! !
+basicFindNext!commands-actions!public! !
+basicInspectIt!commands-actions!public! !
+browseDefinitions!commands-actions!public! !
+browseDefinitionsCommand!commands-actions!private! !
+browseIt!commands-actions!public! !
+browseReferences!commands-actions!public! !
+browseReferencesCommand!commands-actions!private! !
 cancelAutoCompletion!helpers!private! !
+canReformatComment!commands-queries!private! !
+canReformatSource!commands-queries!private! !
 caretPosition:!accessing!caret!public! !
-chooseNamespaces!commands!public! !
+chooseNamespaces!commands-actions!public! !
 chunkFilerClass!constants!public! !
 classForIdentifier:!autocompletion!helpers!private! !
 classForToken:!autocompletion!helpers!private! !
@@ -1729,50 +1722,50 @@ classForVariable:!public! !
 clear!operations!public! !
 clearErrors!operations!public! !
 clearStatus!operations!public! !
-cloneNew!commands!public! !
+cloneNew!commands-actions!public! !
 compilationErrors!accessing!private! !
-compileAll!commands!public! !
+compileAll!commands-actions!public! !
 compileAllIfFail:!helpers!private! !
-compileIt!commands!public! !
+compileIt!commands-actions!public! !
 compileItIfFail:!helpers!private! !
 compileRange:ifFail:!helpers!private! !
 compileRange:ifFail:debug:!helpers!private! !
 compilerNotification:offset:!helpers!private! !
-completeWord!autocompletion!commands!public! !
+completeWord!autocompletion!commands-actions!public! !
 completeWordAt:with:!autocompletion!helpers!private! !
 completionListSortBlock!autocompletion!constants!private! !
 completionStringFor:at:!autocompletion!helpers!private! !
-copySelection!commands!public! !
+copySelection!commands-actions!public! !
 createComponents!initializing!private! !
 createSchematicWiring!initializing!private! !
-debugIt!commands!public! !
+debugIt!commands-actions!public! !
 debugItIfFail:!helpers!private! !
 defaultCompilerFlags!constants!private! !
 defaultParseContext!accessing!autocompletion!private! !
 defaultStylerClass!constants!private! !
 developmentSystem!constants!private! !
-displayIt!commands!public! !
+displayIt!commands-actions!public! !
 dragOver:!drag & drop!public! !
 drop:!drag & drop!public! !
 dropObjectRef:!helpers!private! !
 errorModel!accessing!public! !
 errorModel:!accessing!public! !
-evaluateAndDisplay:!commands!public! !
-evaluateIt!commands!public! !
+evaluateAndDisplay:!commands-actions!public! !
+evaluateIt!commands-actions!public! !
 evaluateItIfFail:!helpers!private! !
 evaluateItIfFail:debug:!helpers!private! !
 evaluateRange:ifFail:!helpers!private! !
 evaluateRange:ifFail:debug:!helpers!private! !
 evaluationContext!accessing!public! !
 evaluationContext:!accessing!public! !
-fileItIn!commands!public! !
+fileItIn!commands-actions!public! !
 findDetails!accessing!public! !
 findDetails:!accessing!public! !
 firstError!helpers!private! !
 getCompletionSignatureFor:at:!autocompletion!helpers!private! !
 hasErrors!public!testing! !
 hasSelection!public!testing! !
-hasSmalltalkStyler!commands!private! !
+hasSmalltalkStyler!commands-actions!private! !
 highlightCompilationErrors:!helpers!private! !
 identifierAt:!helpers!private! !
 identifiersStartingWith:maxItems:!autocompletion!helpers!private! !
@@ -1781,8 +1774,8 @@ indicatorStyles:!accessing!public! !
 initialize!initializing!private! !
 insertCompletion:at:!autocompletion!helpers!private! !
 insertKeywordCompletion:startingAt:!autocompletion!helpers!private! !
-inspectIt!commands!public! !
-inspectWorkspacePool!commands!private! !
+inspectIt!commands-actions!public! !
+inspectWorkspacePool!commands-actions!private! !
 isAutoCompletionCaseInsensitive!public!testing! !
 isAutoCompletionEnabled!autocompletion!private!testing! !
 isAutoCompletionEnabled:!accessing!autocompletion!private! !
@@ -1814,21 +1807,22 @@ onRightButtonReleased:!event handling!public! !
 onTimerTick:!event handling!private! !
 onTipTextRequired:!event handling!private! !
 onViewOpened!event handling!private! !
-parseContext!commands!public! !
+parseContext!commands-actions!public! !
 plainText!accessing!public! !
 plainTextRange:!accessing!public! !
-printIt!commands!public! !
+printIt!commands-actions!public! !
 prompt:toSaveChanges:!helpers!private! !
 promptForVariableName:!helpers!private! !
 publishedAspects!public! !
-queryCommand:!commands!private! !
+queryToggleAutoCompletion:!commands-actions!commands-queries!private! !
+queryToggleStyling:!commands-actions!commands-queries!private! !
 rangeToCompleteAt:!autocompletion!helpers!private! !
-reformatComment!commands!public! !
-reformatSource!commands!public! !
+reformatComment!commands-actions!public! !
+reformatSource!commands-actions!public! !
 replaceSelection:!operations!public! !
 resolveIdentifier:ifDefined:!autocompletion!helpers!private! !
 resolveVariable:!autocompletion!helpers!private! !
-searchEnvironment!commands!public! !
+searchEnvironment!commands-actions!public! !
 searchEnvironment:!accessing!public! !
 selectedWord!helpers!private! !
 selectEvaluationRange!helpers!private! !
@@ -1836,9 +1830,9 @@ selection!accessing!public! !
 selectionRange!accessing!public! !
 selectionRange:!accessing!public! !
 selectLine:!operations!public! !
-selectNext!commands!public! !
+selectNext!commands-actions!public! !
 selectorsStartingWith:maxItems:!autocompletion!helpers!private! !
-selectPrev!commands!public! !
+selectPrev!commands-actions!public! !
 selfClass!accessing!autocompletion!private! !
 setBackcolor!helpers!private! !
 setCaretColor!helpers!private! !
@@ -1869,8 +1863,8 @@ textLength!accessing!public! !
 textStyles!accessing!public! !
 textStyles:!accessing!public! !
 tipForVariable:!public! !
-toggleAutoCompletion!commands!public! !
-toggleStyling!commands!public! !
+toggleAutoCompletion!commands-actions!public! !
+toggleStyling!commands-actions!public! !
 tokenBefore:!accessing!autocompletion!private! !
 tokenRangeAt:!accessing!autocompletion!private! !
 tokenStartAt:!accessing!autocompletion!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspaceDocument.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspaceDocument.cls
@@ -146,7 +146,7 @@ fileOpen
 forgetSize
 	"Forget the default size for new instances of this tool."
 
-	<commandQuerySelector: #queryForgetSize:>
+	<commandQuerySelector: #hasRememberedSize>
 	self class defaultExtent: nil!
 
 getDocumentData
@@ -161,6 +161,12 @@ guidedTour
 
 hasContents
 	^self hasFilename or: [self getDocumentData notEmpty]!
+
+hasNonDefaultExtent
+	^self view extent ~= self class defaultExtent!
+
+hasRememberedSize
+	^DefaultExtent notNil!
 
 help
 	"Brings up a help page for the receiver"
@@ -249,16 +255,10 @@ openWorkspace
 	openFilename isNil ifTrue: [^nil].
 	^self openOn: openFilename!
 
-queryForgetSize: aCommandQuery
-	aCommandQuery isEnabled: DefaultExtent notNil!
-
-queryRememberThisSize: aCommandQuery
-	aCommandQuery isEnabled: self view extent ~= self class defaultExtent!
-
 rememberThisSize
 	"Record the size of the receiver as the default extent for its tool class."
 
-	<commandQuerySelector: #queryRememberThisSize:>
+	<commandQuerySelector: #hasNonDefaultExtent>
 	self class defaultExtent: self view extent!
 
 saveStateOn: aWriteStream
@@ -361,6 +361,8 @@ forgetSize!commands-actions!public! !
 getDocumentData!accessing!private! !
 guidedTour!commands-actions!public! !
 hasContents!public! !
+hasNonDefaultExtent!private!testing! !
+hasRememberedSize!private!testing! !
 help!commands-actions!public! !
 ideaSpace!public! !
 inspectSystemOptions!commands-actions!public! !
@@ -373,8 +375,6 @@ onDropDown:!private! !
 onViewOpened!event handling!private! !
 openViewComposer!commands-actions!public! !
 openWorkspace!public! !
-queryForgetSize:!commands-queries!private! !
-queryRememberThisSize:!commands-queries!private! !
 rememberThisSize!commands-actions!public! !
 saveStateOn:!private!saved state! !
 searchForClass:!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspaceDocument.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspaceDocument.cls
@@ -146,7 +146,7 @@ fileOpen
 forgetSize
 	"Forget the default size for new instances of this tool."
 
-	<commandQuerySelector: #hasRememberedSize>
+	<commandQuery: #hasRememberedSize>
 	self class defaultExtent: nil!
 
 getDocumentData
@@ -258,7 +258,7 @@ openWorkspace
 rememberThisSize
 	"Record the size of the receiver as the default extent for its tool class."
 
-	<commandQuerySelector: #hasNonDefaultExtent>
+	<commandQuery: #hasNonDefaultExtent>
 	self class defaultExtent: self view extent!
 
 saveStateOn: aWriteStream

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
@@ -133,7 +133,7 @@ publishedAspectsOfInstances!must strip!public! !
 browseMethodProtocol
 	"Private - Browse the currently selected protocol."
 
-	<commandQuerySelector: #queryHasProtocolSelected:>
+	<commandQuerySelector: #hasProtocolSelected>
 	| protocol |
 	protocol := self protocols first.
 	self model browseProtocols

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/Dolphin Community Edition Tools.pax
@@ -133,7 +133,7 @@ publishedAspectsOfInstances!must strip!public! !
 browseMethodProtocol
 	"Private - Browse the currently selected protocol."
 
-	<commandQuerySelector: #hasProtocolSelected>
+	<commandQuery: #hasProtocolSelected>
 	| protocol |
 	protocol := self protocols first.
 	self model browseProtocols

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/Tools.AXComponentWizard.cls
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/Tools.AXComponentWizard.cls
@@ -57,7 +57,7 @@ apply
 browseIDL
 	"Open a new workspace populated with the IDL for the currently selected library."
 
-	<commandQuerySelector: #hasLibrarySelected>
+	<commandQuery: #hasLibrarySelected>
 	| lib stm |
 	lib := self typeLib.
 	stm := ReadWriteStream on: (String new: 2048).
@@ -70,13 +70,13 @@ browseIDL
 browseTypeClass
 	"Open a new class browser on the class of the selected type."
 
-	<commandQuerySelector: #hasTypeWithClass>
+	<commandQuery: #hasTypeWithClass>
 	^types selections first programObject browse!
 
 browseTypesIDL
 	"Open a new workspace populated with the IDL for the currently selected types."
 
-	<commandQuerySelector: #hasTypesSelected>
+	<commandQuery: #hasTypesSelected>
 	| stm |
 	stm := ReadWriteStream on: (String new: 2048).
 	types selections do: 
@@ -94,7 +94,7 @@ cancel
 !
 
 chooseNamespace
-	<commandQuerySelector: #hasLibrarySelected>
+	<commandQuery: #hasLibrarySelected>
 	| choice namespaces |
 	namespaces := ClassHierarchyModel withRoots: (Namespace subclasses copyWithout: SharedPool).
 	choice := ValueConverter subject: namespaceName model
@@ -111,7 +111,7 @@ chooseNamespace
 choosePackage
 	"Sets the package name from a choice of all the available packages"
 
-	<commandQuerySelector: #hasLibrarySelected>
+	<commandQuery: #hasLibrarySelected>
 	| oldPkg |
 	oldPkg := packageName value isEmpty
 				ifTrue: [nil]
@@ -240,7 +240,7 @@ generatableStructsInTlb: aTypeLibraryAnalyzer
 generate
 	"Apply the attribute changes and attempt to generate the requested interfaces"
 
-	<commandQuerySelector: #hasTypesSelected>
+	<commandQuery: #hasTypesSelected>
 	| typeLibrary selected progress step |
 	self apply.
 	typeLibrary := self typeLib.
@@ -305,11 +305,11 @@ inspectLibrary
 	"Open an inspector on the <AXTypeLibraryAnalyzer> representing the currently
 	selected library."
 
-	<commandQuerySelector: #hasLibrarySelected>
+	<commandQuery: #hasLibrarySelected>
 	self typeLib inspect!
 
 inspectType
-	<commandQuerySelector: #hasTypesSelected>
+	<commandQuery: #hasTypesSelected>
 	| selections |
 	selections := types selections.
 	(selections size = 1 ifTrue: [selections first] ifFalse: [selections]) inspect!
@@ -317,7 +317,7 @@ inspectType
 libraryListNextCard
 	"The user has selected a library and is desirous of moving to the next card."
 
-	<commandQuerySelector: #hasInstalledTypeLib>
+	<commandQuery: #hasInstalledTypeLib>
 	^cards nextCard!
 
 loadTypeLib
@@ -398,7 +398,7 @@ standardInterfaces
 	^StandardInterfaces!
 
 toggleStandardTypes
-	<commandQuerySelector: #queryToggleStandardTypes:>
+	<commandQuery: #queryToggleStandardTypes:>
 	showStandard := showStandard not.
 	self typeLib ifNotNil: [:typeLib | self updateTypesList: typeLib]!
 
@@ -415,7 +415,7 @@ typeLib: aTypeLibraryAnalyzerOrNil
 typeLibHelp
 	"Open the selected type-libraries help file."
 
-	<commandQuerySelector: #hasTypeLibWithHelp>
+	<commandQuery: #hasTypeLibWithHelp>
 	OS.Shell32 shellOpen: self typeLib helpfile!
 
 updateTypelibVariable

--- a/Core/Object Arts/Dolphin/IDE/Community Edition/Tools.AXComponentWizard.cls
+++ b/Core/Object Arts/Dolphin/IDE/Community Edition/Tools.AXComponentWizard.cls
@@ -57,7 +57,7 @@ apply
 browseIDL
 	"Open a new workspace populated with the IDL for the currently selected library."
 
-	<commandQuerySelector: #queryHasLibrarySelected:>
+	<commandQuerySelector: #hasLibrarySelected>
 	| lib stm |
 	lib := self typeLib.
 	stm := ReadWriteStream on: (String new: 2048).
@@ -70,13 +70,13 @@ browseIDL
 browseTypeClass
 	"Open a new class browser on the class of the selected type."
 
-	<commandQuerySelector: #queryBrowseTypeClass>
+	<commandQuerySelector: #hasTypeWithClass>
 	^types selections first programObject browse!
 
 browseTypesIDL
 	"Open a new workspace populated with the IDL for the currently selected types."
 
-	<commandQuerySelector: #queryHasTypesSelected:>
+	<commandQuerySelector: #hasTypesSelected>
 	| stm |
 	stm := ReadWriteStream on: (String new: 2048).
 	types selections do: 
@@ -94,7 +94,7 @@ cancel
 !
 
 chooseNamespace
-	<commandQuerySelector: #queryHasLibrarySelected:>
+	<commandQuerySelector: #hasLibrarySelected>
 	| choice namespaces |
 	namespaces := ClassHierarchyModel withRoots: (Namespace subclasses copyWithout: SharedPool).
 	choice := ValueConverter subject: namespaceName model
@@ -111,7 +111,7 @@ chooseNamespace
 choosePackage
 	"Sets the package name from a choice of all the available packages"
 
-	<commandQuerySelector: #queryHasLibrarySelected:>
+	<commandQuerySelector: #hasLibrarySelected>
 	| oldPkg |
 	oldPkg := packageName value isEmpty
 				ifTrue: [nil]
@@ -240,7 +240,7 @@ generatableStructsInTlb: aTypeLibraryAnalyzer
 generate
 	"Apply the attribute changes and attempt to generate the requested interfaces"
 
-	<commandQuerySelector: #queryHasTypesSelected:>
+	<commandQuerySelector: #hasTypesSelected>
 	| typeLibrary selected progress step |
 	self apply.
 	typeLibrary := self typeLib.
@@ -269,6 +269,27 @@ generate
 	progress showModal.
 	types view updateAll!
 
+hasInstalledTypeLib
+	| tlb |
+	tlb := self typeLib.
+	^tlb notNil and: [tlb isInstalled]!
+
+hasLibrarySelected
+	^self typeLib notNil!
+
+hasTypeLibWithHelp
+	| tlb |
+	tlb := self typeLib.
+	^tlb notNil and: [tlb helpfile notEmpty]!
+
+hasTypesSelected
+	^types selections notEmpty!
+
+hasTypeWithClass
+	| selectedTypes |
+	selectedTypes := types selections.
+	^selectedTypes size = 1 and: [selectedTypes first isVariableDefined]!
+
 initialize
 	super initialize.
 	showStandard := false!
@@ -284,11 +305,11 @@ inspectLibrary
 	"Open an inspector on the <AXTypeLibraryAnalyzer> representing the currently
 	selected library."
 
-	<commandQuerySelector: #queryHasLibrarySelected:>
+	<commandQuerySelector: #hasLibrarySelected>
 	self typeLib inspect!
 
 inspectType
-	<commandQuerySelector: #queryHasTypesSelected:>
+	<commandQuerySelector: #hasTypesSelected>
 	| selections |
 	selections := types selections.
 	(selections size = 1 ifTrue: [selections first] ifFalse: [selections]) inspect!
@@ -296,7 +317,7 @@ inspectType
 libraryListNextCard
 	"The user has selected a library and is desirous of moving to the next card."
 
-	<commandQuerySelector: #queryLibraryListNextCard:>
+	<commandQuerySelector: #hasInstalledTypeLib>
 	^cards nextCard!
 
 loadTypeLib
@@ -349,31 +370,10 @@ parametersNextCard
 	self apply.
 	^cards nextCard!
 
-queryBrowseTypeClass: aCommandQuery
-	| selectedTypes |
-	selectedTypes := types selections.
-	aCommandQuery isEnabled: (selectedTypes size = 1 and: [selectedTypes first isVariableDefined])!
-
-queryHasLibrarySelected: aCommandQuery
-	aCommandQuery isEnabled: self typeLib notNil!
-
-queryHasTypesSelected: aCommandQuery
-	aCommandQuery isEnabled: types selections notEmpty!
-
-queryLibraryListNextCard: aCommandQuery
-	| tlb |
-	tlb := self typeLib.
-	aCommandQuery isEnabled: (tlb notNil and: [tlb isInstalled])!
-
 queryToggleStandardTypes: aCommandQuery
 	aCommandQuery
 		isEnabled: true;
 		isChecked: showStandard!
-
-queryTypeLibHelp: aCommandQuery
-	| tlb |
-	tlb := self typeLib.
-	aCommandQuery isEnabled: (tlb notNil and: [tlb helpfile notEmpty])!
 
 refresh
 	"Refresh the list of current AXTypeLibraryAnalyzers in the image"
@@ -415,7 +415,7 @@ typeLib: aTypeLibraryAnalyzerOrNil
 typeLibHelp
 	"Open the selected type-libraries help file."
 
-	<commandQuerySelector: #queryTypeLibHelp:>
+	<commandQuerySelector: #hasTypeLibWithHelp>
 	OS.Shell32 shellOpen: self typeLib helpfile!
 
 updateTypelibVariable
@@ -453,6 +453,11 @@ generatableEnumsInTlb:!private!updating! !
 generatableInterfacesInTlb:!helpers!private! !
 generatableStructsInTlb:!helpers!private! !
 generate!commands-actions!public! !
+hasInstalledTypeLib!private!testing! !
+hasLibrarySelected!private!testing! !
+hasTypeLibWithHelp!private!testing! !
+hasTypesSelected!private!testing! !
+hasTypeWithClass!private!testing! !
 initialize!initializing!private! !
 inspectItCommand!public! !
 inspectLibrary!commands-actions!public! !
@@ -462,12 +467,7 @@ loadTypeLib!commands-actions!public! !
 onTypeLibrarySelected!event handling!private! !
 onViewOpened!event handling!public! !
 parametersNextCard!commands-actions!public! !
-queryBrowseTypeClass:!commands-queries!private! !
-queryHasLibrarySelected:!commands-queries!private! !
-queryHasTypesSelected:!commands-queries!private! !
-queryLibraryListNextCard:!commands-queries!private! !
 queryToggleStandardTypes:!commands-queries!private! !
-queryTypeLibHelp:!commands-queries!private! !
 refresh!commands-actions!public! !
 selectInstalled!commands-actions!public! !
 selectUninstalled!commands-actions!public! !

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
@@ -323,7 +323,7 @@ publishedAspectsOfInstances!constants!public! !
 toggleLocalHierarchy
 	"Toggle between the entire hierarchy and showing only the current class and its subclasses."
 
-	<commandQuerySelector: #queryToggleLocalHierarchy:>
+	<commandQuery: #queryToggleLocalHierarchy:>
 	| instClass actualClass |
 	self promptToSaveChanges ifFalse: [^self].
 
@@ -355,7 +355,7 @@ queryToggleDisassembly: aCommandQuery
 toggleDisassembly
 	"Private - Switch between source/disassembly modes."
 
-	<commandQuerySelector: #queryToggleDisassembly:>
+	<commandQuery: #queryToggleDisassembly:>
 	self beDisassembled: self isDisassembled not.
 	sourcePresenter
 		isReadOnly: self isDisassembled;
@@ -442,7 +442,7 @@ updateHelpMenus!private!utilities! !
 !Tools.SmalltalkToolShell methodsFor!
 
 addToNewIdeaSpace
-	<commandQuerySelector: #canMoveToIdeaSpace>
+	<commandQuery: #canMoveToIdeaSpace>
 	^self class addToNewIdeaSpace: self!
 
 browseSystem
@@ -460,7 +460,7 @@ destroy
 	^super destroy!
 
 dragToolToIdeaSpace
-	<commandQuerySelector: #canMoveToIdeaSpace>
+	<commandQuery: #canMoveToIdeaSpace>
 	^self class dragToolToIdeaSpace: self!
 
 exit
@@ -500,7 +500,7 @@ dragToolToIdeaSpace:!public! !
 !Tools.SmalltalkWorkspaceDocument methodsFor!
 
 addToNewIdeaSpace
-	<commandQuerySelector: #canMoveToIdeaSpace>
+	<commandQuery: #canMoveToIdeaSpace>
 	^IdeaSpaceShell addToNewIdeaSpace: self!
 
 browseSources
@@ -518,7 +518,7 @@ destroy
 	^super destroy!
 
 dragToolToIdeaSpace
-	<commandQuerySelector: #canMoveToIdeaSpace>
+	<commandQuery: #canMoveToIdeaSpace>
 	^IdeaSpaceShell dragToolToIdeaSpace: self!
 
 exit

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Professional Tools.pax
@@ -56,18 +56,18 @@ package setMethodNames: #(
 	#(#{Tools.SmalltalkSystem} #updateHelpMenus)
 	#(#{Tools.SmalltalkToolShell} #addToNewIdeaSpace)
 	#(#{Tools.SmalltalkToolShell} #browseSystem)
+	#(#{Tools.SmalltalkToolShell} #canMoveToIdeaSpace)
 	#(#{Tools.SmalltalkToolShell} #destroy)
 	#(#{Tools.SmalltalkToolShell} #dragToolToIdeaSpace)
 	#(#{Tools.SmalltalkToolShell} #exit)
-	#(#{Tools.SmalltalkToolShell} #queryMoveToIdeaSpace:)
 	#(#{Tools.SmalltalkToolShell class} #addToNewIdeaSpace:)
 	#(#{Tools.SmalltalkToolShell class} #dragToolToIdeaSpace:)
 	#(#{Tools.SmalltalkWorkspaceDocument} #addToNewIdeaSpace)
 	#(#{Tools.SmalltalkWorkspaceDocument} #browseSources)
+	#(#{Tools.SmalltalkWorkspaceDocument} #canMoveToIdeaSpace)
 	#(#{Tools.SmalltalkWorkspaceDocument} #destroy)
 	#(#{Tools.SmalltalkWorkspaceDocument} #dragToolToIdeaSpace)
 	#(#{Tools.SmalltalkWorkspaceDocument} #exit)
-	#(#{Tools.SmalltalkWorkspaceDocument} #queryMoveToIdeaSpace:)
 	#(#{UI.LinkButton class} #publishedAspectsOfInstances)
 	#(#{UI.SlideyInneyOuteyThing class} #example1)
 	#(#{UI.SlideyInneyOuteyThing class} #publishedAspectsOfInstances)
@@ -442,13 +442,16 @@ updateHelpMenus!private!utilities! !
 !Tools.SmalltalkToolShell methodsFor!
 
 addToNewIdeaSpace
-	<commandQuerySelector: #queryMoveToIdeaSpace:>
+	<commandQuerySelector: #canMoveToIdeaSpace>
 	^self class addToNewIdeaSpace: self!
 
 browseSystem
 	"Open a new system browser on Object."
 
 	^self developmentSystem browseSystem!
+
+canMoveToIdeaSpace
+	^self isIdeaSpaceCard not and: [self class canUseIdeaSpace]!
 
 destroy
 	"Attempt to forcibly close the receiver's view. If this is an IdeaSpace card then we ask the IdeaSpace to destroy it."
@@ -457,24 +460,21 @@ destroy
 	^super destroy!
 
 dragToolToIdeaSpace
-	<commandQuerySelector: #queryMoveToIdeaSpace:>
+	<commandQuerySelector: #canMoveToIdeaSpace>
 	^self class dragToolToIdeaSpace: self!
 
 exit
 	"Attempt to close the receiver's view. If this is an IdeaSpace card then we ask the IdeaSpace to close it."
 
 	self isIdeaSpaceCard ifTrue: [^self ideaSpace closeCard: self].
-	^super exit!
-
-queryMoveToIdeaSpace: aCommandQuery
-	aCommandQuery isEnabled: (self isIdeaSpaceCard not and: [self class canUseIdeaSpace])! !
+	^super exit! !
 !Tools.SmalltalkToolShell categoriesForMethods!
 addToNewIdeaSpace!public! !
 browseSystem!commands-actions!public! !
+canMoveToIdeaSpace!private!testing! !
 destroy!commands-actions!public! !
 dragToolToIdeaSpace!public! !
 exit!commands-actions!public! !
-queryMoveToIdeaSpace:!commands-queries!private! !
 !
 
 !Tools.SmalltalkToolShell class methodsFor!
@@ -500,13 +500,16 @@ dragToolToIdeaSpace:!public! !
 !Tools.SmalltalkWorkspaceDocument methodsFor!
 
 addToNewIdeaSpace
-	<commandQuerySelector: #queryMoveToIdeaSpace:>
+	<commandQuerySelector: #canMoveToIdeaSpace>
 	^IdeaSpaceShell addToNewIdeaSpace: self!
 
 browseSources
 	"Open a new source browser on the entire system sources"
 	
 	self model browseSources!
+
+canMoveToIdeaSpace
+	^self isIdeaSpaceCard not!
 
 destroy
 	"Attempt to forcibly close the receiver's view. If this is an IdeaSpace card then we ask the IdeaSpace to destroy it."
@@ -515,24 +518,21 @@ destroy
 	^super destroy!
 
 dragToolToIdeaSpace
-	<commandQuerySelector: #queryMoveToIdeaSpace:>
+	<commandQuerySelector: #canMoveToIdeaSpace>
 	^IdeaSpaceShell dragToolToIdeaSpace: self!
 
 exit
 	"Attempt to close the receiver's view. If this is an IdeaSpace card then we ask the IdeaSpace to close it."
 
 	self isIdeaSpaceCard ifTrue: [^self ideaSpace closeCard: self].
-	^super exit!
-
-queryMoveToIdeaSpace: aCommandQuery
-	aCommandQuery isEnabled: self isIdeaSpaceCard not! !
+	^super exit! !
 !Tools.SmalltalkWorkspaceDocument categoriesForMethods!
 addToNewIdeaSpace!public! !
 browseSources!commands-actions!public! !
+canMoveToIdeaSpace!private!testing! !
 destroy!commands-actions!public! !
 dragToolToIdeaSpace!public! !
 exit!commands-actions!public! !
-queryMoveToIdeaSpace:!commands-queries!private! !
 !
 
 !UI.LinkButton class methodsFor!

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
@@ -204,6 +204,9 @@ package setMethodNames: #(
 	#(#{Refactory.Browser.VariableRefactoring class} #displayPrefix)
 	#(#{Tools.ChooseNamespaceDialog class} #resource_Refactoring_view)
 	#(#{Tools.ClassBrowserAbstract} #abstractInstanceVariables)
+	#(#{Tools.ClassBrowserAbstract} #canPushDownInstanceVariables)
+	#(#{Tools.ClassBrowserAbstract} #canPushDownMethods)
+	#(#{Tools.ClassBrowserAbstract} #canPushUpMethods)
 	#(#{Tools.ClassBrowserAbstract} #methodRefactoringTool)
 	#(#{Tools.ClassBrowserAbstract} #methodsToOverride)
 	#(#{Tools.ClassBrowserAbstract} #overrideMethods)
@@ -213,9 +216,6 @@ package setMethodNames: #(
 	#(#{Tools.ClassBrowserAbstract} #pushMethods:)
 	#(#{Tools.ClassBrowserAbstract} #pushUpMethods)
 	#(#{Tools.ClassBrowserAbstract} #queryOverrideMethods:)
-	#(#{Tools.ClassBrowserAbstract} #queryPushDownInstanceVariables:)
-	#(#{Tools.ClassBrowserAbstract} #queryPushDownMethods:)
-	#(#{Tools.ClassBrowserAbstract} #queryPushUpMethods:)
 	#(#{Tools.ClassBrowserAbstract} #removeInstanceVariables)
 	#(#{Tools.ClassBrowserAbstract} #renameMethod)
 	#(#{Tools.ClassBrowserAbstract} #selectedOverridableMethods)
@@ -229,12 +229,19 @@ package setMethodNames: #(
 	#(#{Tools.ClassSelector} #buildInstVarMenu:selectors:)
 	#(#{Tools.ClassSelector} #buildPullUpVariablesMenu:)
 	#(#{Tools.ClassSelector} #buildVariablesMenu:instVarSelectors:classVarSelectors:)
+	#(#{Tools.ClassSelector} #canChangeClassNamespace)
+	#(#{Tools.ClassSelector} #canPullUpClassVariables)
+	#(#{Tools.ClassSelector} #canPullUpInstanceVariables)
+	#(#{Tools.ClassSelector} #canPullUpVariables)
+	#(#{Tools.ClassSelector} #canPushDownInstanceVariables)
+	#(#{Tools.ClassSelector} #canPushDownVariables)
 	#(#{Tools.ClassSelector} #changeClassNamespace)
 	#(#{Tools.ClassSelector} #classRefactoringsMenu)
 	#(#{Tools.ClassSelector} #cloneClass:under:changes:)
 	#(#{Tools.ClassSelector} #convertToSibling)
 	#(#{Tools.ClassSelector} #createClassVariableAccessors)
 	#(#{Tools.ClassSelector} #createVariableAccessors)
+	#(#{Tools.ClassSelector} #hasImports)
 	#(#{Tools.ClassSelector} #populateClassVarMenu:selectors:)
 	#(#{Tools.ClassSelector} #populateInstVarMenu:selectors:)
 	#(#{Tools.ClassSelector} #populatePullUpVariableMenu:forClass:command:classVariables:ifTooMany:)
@@ -249,13 +256,6 @@ package setMethodNames: #(
 	#(#{Tools.ClassSelector} #pushDownInstanceVariables)
 	#(#{Tools.ClassSelector} #pushDownVariables)
 	#(#{Tools.ClassSelector} #queryAddInstanceVariable:)
-	#(#{Tools.ClassSelector} #queryHasVariablesSelected:)
-	#(#{Tools.ClassSelector} #queryPullUpClassVariables:)
-	#(#{Tools.ClassSelector} #queryPullUpInstanceVariables:)
-	#(#{Tools.ClassSelector} #queryPullUpVariables:)
-	#(#{Tools.ClassSelector} #queryPushDownInstanceVariables:)
-	#(#{Tools.ClassSelector} #queryPushDownVariables:)
-	#(#{Tools.ClassSelector} #queryRemoveImport:)
 	#(#{Tools.ClassSelector} #removeClassVariables)
 	#(#{Tools.ClassSelector} #removeDuplicateMethods)
 	#(#{Tools.ClassSelector} #removeImport)
@@ -286,6 +286,7 @@ package setMethodNames: #(
 	#(#{Tools.PackageBrowserShell} #changeClassNamespace)
 	#(#{Tools.PackageBrowserShell} #chooseMethodsForRefactoring:)
 	#(#{Tools.PackageBrowserShell} #classRefactoringsMenu)
+	#(#{Tools.PackageBrowserShell} #hasMethodWithArguments)
 	#(#{Tools.PackageBrowserShell} #hasRefactorableMethodSelected)
 	#(#{Tools.PackageBrowserShell} #methodRefactoringsMenu)
 	#(#{Tools.PackageBrowserShell} #newMethodNamePrompter:caption:allowExisting:)
@@ -295,8 +296,6 @@ package setMethodNames: #(
 	#(#{Tools.PackageBrowserShell} #performMethodRenameRefactoring:)
 	#(#{Tools.PackageBrowserShell} #performMethodsRefactoring:name:)
 	#(#{Tools.PackageBrowserShell} #promptForMethodName:caption:allowExisting:)
-	#(#{Tools.PackageBrowserShell} #queryHasClassSelected:)
-	#(#{Tools.PackageBrowserShell} #queryRemoveParameter:)
 	#(#{Tools.PackageBrowserShell} #removeMethod)
 	#(#{Tools.PackageBrowserShell} #removeMethods)
 	#(#{Tools.PackageBrowserShell} #removeParameter)
@@ -307,7 +306,6 @@ package setMethodNames: #(
 	#(#{Tools.PackageBrowserShell} #renameMethod)
 	#(#{Tools.PackageBrowserShell} #renameMethodReferences:)
 	#(#{Tools.PackageSelector} #moveAllTempsToInnerScope)
-	#(#{Tools.PackageSelector} #queryPackageRefactoring:)
 	#(#{Tools.PackageSelector} #removeDuplicateMethods)
 	#(#{Tools.SmalltalkToolShell} #chooseMethodForRefactoring:)
 	#(#{UI.Dialog} #validationDwell)
@@ -2435,8 +2433,20 @@ resource_Refactoring_view!public!resources-views! !
 abstractInstanceVariables
 	"Private - Invoke the 'Abstract Instance Variable' refactoring on the currently selected variables."
 
-	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
+	<commandQuerySelector: #hasInstanceVariablesSelected>
 	self model abstractInstanceVariables: self variables within: BrowserEnvironment new!
+
+canPushDownInstanceVariables
+	| class |
+	^(class := self actualClass) notNil and: [class subclasses notEmpty and: [self variables notEmpty]]!
+
+canPushDownMethods
+	^self methodRefactoringTool canPushDownMethods
+		and: [(self selectedMethods collect: [:each | each methodClass]) asSet size = 1]!
+
+canPushUpMethods
+	^self methodRefactoringTool canPushUpMethods
+		and: [(self selectedMethods collect: [:each | each methodClass]) asSet size = 1]!
 
 methodRefactoringTool
 	^methodBrowserPresenter refactoringTool!
@@ -2501,18 +2511,18 @@ overrideMethods
 protectInstanceVariables
 	"Private - Invoke the 'Protect/Concrete Instance Variable' refactoring on the users choice of instance variables."
 
-	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
+	<commandQuerySelector: #hasInstanceVariablesSelected>
 	self model protectInstanceVariables: self variables!
 
 pushDownInstanceVariables
 	"Invoke the 'Push Down Instance Variable' refactoring on the currently selected variables."
 
-	<commandQuerySelector: #queryPushDownInstanceVariables:>
+	<commandQuerySelector: #canPushDownInstanceVariables>
 	self model pushDownInstanceVariables: self variables!
 
 pushDownMethods
 	<acceleratorKey: 'Shift+Ctrl+7'>
-	<commandQuerySelector: #queryPushDownMethods:>
+	<commandQuerySelector: #canPushDownMethods>
 	self pushMethods: false!
 
 pushMethods: aBoolean
@@ -2531,7 +2541,7 @@ pushMethods: aBoolean
 
 pushUpMethods
 	<acceleratorKey: 'Shift+Ctrl+6'>
-	<commandQuerySelector: #queryPushUpMethods:>
+	<commandQuerySelector: #canPushUpMethods>
 	self pushMethods: true!
 
 queryOverrideMethods: aCommandQuery
@@ -2547,23 +2557,10 @@ queryOverrideMethods: aCommandQuery
 						}
 					locale: Locale smalltalk)!
 
-queryPushDownInstanceVariables: aCommandQuery
-	| class |
-	aCommandQuery isEnabled: ((class := self actualClass) notNil
-				and: [class subclasses notEmpty and: [self variables notEmpty]])!
-
-queryPushDownMethods: aCommandQuery
-	aCommandQuery isEnabled: (self methodRefactoringTool canPushDownMethods
-				and: [(self selectedMethods collect: [:each | each methodClass]) asSet size = 1])!
-
-queryPushUpMethods: aCommandQuery
-	aCommandQuery isEnabled: (self methodRefactoringTool canPushUpMethods
-				and: [(self selectedMethods collect: [:each | each methodClass]) asSet size = 1])!
-
 removeInstanceVariables
 	"Invoke the 'Remove Instance Variable' refactoring on the currently selected variables."
 
-	<commandQuerySelector: #queryHasInstanceVariablesSelected:>
+	<commandQuerySelector: #hasInstanceVariablesSelected>
 	self model removeInstanceVariables: self variables within: self searchEnvironment!
 
 renameMethod
@@ -2576,6 +2573,9 @@ selectedOverridableMethods
 	^self selectedMethods reject: [:each | each methodClass == class]! !
 !Tools.ClassBrowserAbstract categoriesForMethods!
 abstractInstanceVariables!commands-actions!private!refactoring! !
+canPushDownInstanceVariables!private!refactoring!testing! !
+canPushDownMethods!private!refactoring!testing! !
+canPushUpMethods!private!refactoring!updating! !
 methodRefactoringTool!commands-actions!private!refactoring! !
 methodsToOverride!helpers!private! !
 overrideMethods!commands-actions!private!refactoring! !
@@ -2585,9 +2585,6 @@ pushDownMethods!commands-actions!public!refactoring! !
 pushMethods:!commands-actions!private!refactoring! !
 pushUpMethods!commands-actions!public!refactoring! !
 queryOverrideMethods:!commands-queries!private!refactoring! !
-queryPushDownInstanceVariables:!commands-queries!private!refactoring! !
-queryPushDownMethods:!commands-queries!private!refactoring! !
-queryPushUpMethods:!commands-queries!private!refactoring! !
 removeInstanceVariables!public!refactoring! !
 renameMethod!accessing!private! !
 selectedOverridableMethods!accessing!private! !
@@ -2598,7 +2595,7 @@ selectedOverridableMethods!accessing!private! !
 developmentSystem
 	^SmalltalkSystem current! !
 !Tools.ClassBrowserPlugin categoriesForMethods!
-developmentSystem!commands!private! !
+developmentSystem!accessing!private! !
 !
 
 !Tools.ClassSelector methodsFor!
@@ -2609,7 +2606,7 @@ abstractClassVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #queryClassVariablesCommand:>
+	<commandQuerySelector: #hasClassWithStaticVariables>
 	(self chooseVariables: true caption: 'Abstract Class Variables…')
 		ifNotNil: [:varNames | self developmentSystem abstractClassVariables: varNames within: BrowserEnvironment new]!
 
@@ -2619,23 +2616,23 @@ abstractInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #queryInstanceVariablesCommand:>
+	<commandQuerySelector: #hasClassWithInstanceVariables>
 	(self chooseVariables: false caption: 'Abstract Instance Variables…')
 		ifNotNil: [:varNames | self developmentSystem abstractInstanceVariables: varNames within: BrowserEnvironment new]!
 
 abstractVariables
-	<commandQuerySelector: #queryHasVariablesSelected:>
+	<commandQuerySelector: #hasClassWithVariablesSelected>
 	Sound warningBeep!
 
 addClassVariable
 	"Private - Invoke the 'Add Class Variable' refactoring to add a class variable to the
 	currently selected class."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	self developmentSystem addClassVariableTo: self selection!
 
 addImport
-	<commandQuerySelector: #queryClassesCommand:>
+	<commandQuerySelector: #hasSelection>
 	self developmentSystem addImportToClasses: self selections!
 
 addInstanceVariable
@@ -2684,12 +2681,49 @@ buildVariablesMenu: aMenu instVarSelectors: instVarSelectors classVarSelectors: 
 	(aMenu notEmpty and: [self selection classPool notEmpty]) ifTrue: [aMenu addSeparator].
 	self populateClassVarMenu: aMenu selectors: classVarSelectors!
 
+canChangeClassNamespace
+	^self developmentSystem canChangeClassNamespaces: self selections!
+
+canPullUpClassVariables
+	| class |
+	class := self actualClass.
+	^class notNil
+		and: [class instanceClass allSubclasses anySatisfy: [:each | each classBindingNames notEmpty]]!
+
+canPullUpInstanceVariables
+	| class |
+	class := self actualClass.
+	^class notNil and: [class allSubclasses anySatisfy: [:each | each instanceVariableNames notEmpty]]!
+
+canPullUpVariables
+	| class |
+	class := self actualClass.
+	^class notNil and: 
+			[| isFixed |
+			isFixed := ClassBuilder isFixedLayout: class.
+			class allSubclasses anySatisfy: 
+					[:each |
+					(isFixed not and: [each instanceVariableNames notEmpty])
+						or: [each instanceClass classBindingNames notEmpty]]]!
+
+canPushDownInstanceVariables
+	| class |
+	class := self actualClass.
+	^class notNil and: [class subclasses notEmpty and: [class instanceVariableNames notEmpty]]!
+
+canPushDownVariables
+	| class |
+	class := self actualClass.
+	^class notNil and: 
+			[class subclasses notEmpty
+				and: [class instanceVariableNames notEmpty or: [class instanceClass definedBindings notEmpty]]]!
+
 changeClassNamespace
-	<commandQuerySelector: #queryChangeClassNamespace:>
+	<commandQuerySelector: #canChangeClassNamespace>
 	self developmentSystem changeNamespaceOfClasses: self selections!
 
 classRefactoringsMenu
-	<commandQuerySelector: #queryClassesCommand:>
+	<commandQuerySelector: #hasSelection>
 	Sound warningBeep!
 
 cloneClass: aClass under: superClass changes: aCompositeRefactoryChange
@@ -2713,19 +2747,25 @@ convertToSibling
 	class and its current subclasses, copying common methods to the new superclass and adding 
 	#subclassResponsibility methods as necessary)."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	self developmentSystem convertToSibling: self selection!
 
 createClassVariableAccessors
 	"Prompt to generate compiled 'get' and 'set' accessor methods for the immediate
 	class variables of the selected class."
 
-	<commandQuerySelector: #queryClassVariablesCommand:>
+	<commandQuerySelector: #hasClassWithStaticVariables>
 	self createVariableAccessors: true!
 
 createVariableAccessors
-	<commandQuerySelector: #queryHasVariablesSelected:>
+	<commandQuerySelector: #hasClassWithVariablesSelected>
 	Sound warningBeep!
+
+hasImports
+	| imports |
+	imports := Set new.
+	self selections do: [:each | imports addAll: each imports].
+	^imports notEmpty!
 
 populateClassVarMenu: aMenu selectors: selectors
 	| class varNames |
@@ -2838,12 +2878,12 @@ protectInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #queryInstanceVariablesCommand:>
+	<commandQuerySelector: #hasClassWithInstanceVariables>
 	(self chooseVariables: false caption: 'Protect Instance Variables…')
 		ifNotNil: [:varNames | self developmentSystem protectInstanceVariables: varNames]!
 
 protectVariables
-	<commandQuerySelector: #queryHasVariablesSelected:>
+	<commandQuerySelector: #hasClassWithVariablesSelected>
 	Sound warningBeep!
 
 pullUpClassVariables
@@ -2852,7 +2892,7 @@ pullUpClassVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #queryPullUpClassVariables:>
+	<commandQuerySelector: #canPullUpClassVariables>
 	| class pairs |
 	class := self selection.
 	pairs := self
@@ -2877,7 +2917,7 @@ pullUpInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #queryPullUpInstanceVariables:>
+	<commandQuerySelector: #canPullUpInstanceVariables>
 	| class pairs |
 	class := self actualClass.
 	pairs := self
@@ -2912,7 +2952,7 @@ pullUpVariableNamePairs: aBoolean for: class maximum: anInteger
 	^pairs!
 
 pullUpVariables
-	<commandQuerySelector: #queryPullUpVariables:>
+	<commandQuerySelector: #canPullUpVariables>
 	Sound warningBeep!
 
 pushDownClassVariables
@@ -2921,7 +2961,7 @@ pushDownClassVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #queryClassVariablesCommand:>
+	<commandQuerySelector: #hasClassWithStaticVariables>
 	(self chooseVariables: true caption: 'Push Down Class Variables…')
 		ifNotNil: [:varNames | self developmentSystem pushDownInstanceVariables: varNames]!
 
@@ -2931,12 +2971,12 @@ pushDownInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #queryPushDownInstanceVariables:>
+	<commandQuerySelector: #canPushDownInstanceVariables>
 	(self chooseVariables: false caption: 'Push Down Instance Variables…')
 		ifNotNil: [:varNames | self developmentSystem pushDownInstanceVariables: varNames]!
 
 pushDownVariables
-	<commandQuerySelector: #queryPushDownVariables:>
+	<commandQuerySelector: #canPushDownVariables>
 	Sound warningBeep!
 
 queryAddInstanceVariable: aCommandQuery
@@ -2948,68 +2988,18 @@ queryAddInstanceVariable: aCommandQuery
 					locale: Locale smalltalk);
 		isEnabled: (class notNil and: [class isPointers])!
 
-queryHasVariablesSelected: aCommandQuery
-	| class |
-	class := self actualClass.
-	aCommandQuery isEnabled: (class notNil
-				and: [class instanceVariableNames notEmpty or: [class instanceClass classBindingNames notEmpty]])!
-
-queryPullUpClassVariables: aCommandQuery
-	| class |
-	class := self actualClass.
-	aCommandQuery isEnabled: (class notNil
-				and: [class instanceClass allSubclasses anySatisfy: [:each | each classBindingNames notEmpty]])!
-
-queryPullUpInstanceVariables: aCommandQuery
-	| class |
-	class := self actualClass.
-	aCommandQuery isEnabled: (class notNil
-				and: [class allSubclasses anySatisfy: [:each | each instanceVariableNames notEmpty]])!
-
-queryPullUpVariables: aCommandQuery
-	| class |
-	class := self actualClass.
-	aCommandQuery
-		isEnabled: (class notNil and: 
-					[| isFixed |
-					isFixed := ClassBuilder isFixedLayout: class.
-					class allSubclasses anySatisfy: 
-							[:each |
-							(isFixed not and: [each instanceVariableNames notEmpty])
-								or: [each instanceClass classBindingNames notEmpty]]])!
-
-queryPushDownInstanceVariables: aCommandQuery
-	| class |
-	class := self actualClass.
-	aCommandQuery
-		isEnabled: (class notNil and: [class subclasses notEmpty and: [class instanceVariableNames notEmpty]])!
-
-queryPushDownVariables: aCommandQuery
-	| class |
-	class := self actualClass.
-	aCommandQuery
-		isEnabled: (class notNil and: 
-					[class subclasses notEmpty
-						and: [class instanceVariableNames notEmpty or: [class instanceClass definedBindings notEmpty]]])!
-
-queryRemoveImport: aCommandQuery
-	| imports |
-	imports := Set new.
-	self selections do: [:each | imports addAll: each imports].
-	aCommandQuery isEnabled: imports notEmpty!
-
 removeClassVariables
 	"Invoke the 'Remove Class Variable' refactoring on the users choice of class variables.
 	Note that the view may also implement this command with a dynamic pull-out menu (of the
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #queryClassVariablesCommand:>
+	<commandQuerySelector: #hasClassWithStaticVariables>
 	(self chooseVariables: true caption: 'Remove Class Variables…')
 		ifNotNil: [:pairs | self developmentSystem removeStaticVariables: pairs within: self searchEnvironment]!
 
 removeDuplicateMethods
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasSingleSelection>
 	| class |
 	class := self actualClass.
 	(self developmentSystem removeMethodsDuplicatedInSuperclassOf: class)
@@ -3022,7 +3012,7 @@ removeDuplicateMethods
 				open]!
 
 removeImport
-	<commandQuerySelector: #queryRemoveImport:>
+	<commandQuerySelector: #hasImports>
 	self developmentSystem removeImportFromClasses: self selections!
 
 removeInstanceVariables
@@ -3031,12 +3021,12 @@ removeInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #queryInstanceVariablesCommand:>
+	<commandQuerySelector: #hasClassWithInstanceVariables>
 	(self chooseVariables: false caption: 'Remove Instance Variables…')
 		ifNotNil: [:varNames | self developmentSystem removeInstanceVariables: varNames within: self searchEnvironment]!
 
 removeVariables
-	<commandQuerySelector: #queryHasVariablesSelected:>
+	<commandQuerySelector: #hasClassWithVariablesSelected>
 	Sound warningBeep! !
 !Tools.ClassSelector categoriesForMethods!
 abstractClassVariables!commands-actions!public!refactoring! !
@@ -3048,12 +3038,19 @@ addInstanceVariable!commands-actions!private!refactoring! !
 buildInstVarMenu:selectors:!menus!private!refactoring! !
 buildPullUpVariablesMenu:!menus!private!refactoring! !
 buildVariablesMenu:instVarSelectors:classVarSelectors:!menus!private!refactoring! !
+canChangeClassNamespace!private!testing! !
+canPullUpClassVariables!private!refactoring!testing! !
+canPullUpInstanceVariables!private!refactoring!testing! !
+canPullUpVariables!private!refactoring!testing! !
+canPushDownInstanceVariables!private!refactoring!testing! !
+canPushDownVariables!private!refactoring!testing! !
 changeClassNamespace!commands-actions!public!refactoring! !
 classRefactoringsMenu!commands-menus!public!refactoring! !
 cloneClass:under:changes:!private! !
 convertToSibling!commands-actions!public!refactoring! !
 createClassVariableAccessors!commands-actions!public!refactoring! !
 createVariableAccessors!commands-menus!private! !
+hasImports!private!refactoring!testing! !
 populateClassVarMenu:selectors:!menus!private!refactoring! !
 populateInstVarMenu:selectors:!menus!private!refactoring! !
 populatePullUpVariableMenu:forClass:command:classVariables:ifTooMany:!menus!private!refactoring! !
@@ -3068,13 +3065,6 @@ pushDownClassVariables!commands-actions!public!refactoring! !
 pushDownInstanceVariables!commands-actions!public!refactoring! !
 pushDownVariables!commands-actions!private! !
 queryAddInstanceVariable:!commands-queries!private! !
-queryHasVariablesSelected:!commands-queries!private! !
-queryPullUpClassVariables:!commands-queries!private! !
-queryPullUpInstanceVariables:!commands-queries!private! !
-queryPullUpVariables:!commands-queries!private! !
-queryPushDownInstanceVariables:!commands-queries!private! !
-queryPushDownVariables:!commands-queries!private! !
-queryRemoveImport:!commands-queries!private! !
 removeClassVariables!commands-actions!public!refactoring! !
 removeDuplicateMethods!commands-actions!private!refactoring! !
 removeImport!commands-actions!public!refactoring! !
@@ -3260,7 +3250,7 @@ renameVariable:operation:validationBlock:!operations!private!refactoring! !
 !Tools.PackageBrowserShell methodsFor!
 
 addImport
-	<commandQuerySelector: #queryHasClassesSelected:>
+	<commandQuerySelector: #hasClassesSelected>
 	self developmentSystem addImportToClasses: self selectedClasses!
 
 addParameter
@@ -3268,7 +3258,7 @@ addParameter
 	the selector of the method to which the parameter is added, and constrained to operate
 	only within the selected packages."
 
-	<commandQuerySelector: #queryHasPackagesSelected:>
+	<commandQuerySelector: #hasPackages>
 	(self chooseMethodForRefactoring: 'Add Parameter in Package(s)…') 
 		ifNotNil: [:method | self addParameterTo: method]
 !
@@ -3281,11 +3271,11 @@ addParameterToMethod
 	'Add Parameter to Method refactoring' against a selected loose method, 
 	constrained within the selected packages."
 
-	<commandQuerySelector: #queryHasMethodSelected:>
+	<commandQuerySelector: #hasMethodSelected>
 	self addParameterTo: self selectedMethod!
 
 changeClassNamespace
-	<commandQuerySelector: #queryHasClassesSelected:>
+	<commandQuerySelector: #hasClassesSelected>
 	self developmentSystem changeNamespaceOfClasses: self selectedClasses!
 
 chooseMethodsForRefactoring: aString
@@ -3303,14 +3293,19 @@ chooseMethodsForRefactoring: aString
 	^definitions!
 
 classRefactoringsMenu
-	<commandQuerySelector: #queryHasPackagesSelected:>
+	<commandQuerySelector: #hasPackages>
 	Sound warningBeep!
 
+hasMethodWithArguments
+	| method |
+	method := self selectedMethod.
+	^method notNil and: [method argumentCount > 0]!
+
 hasRefactorableMethodSelected
-	^self hasEditableMethodSelected!
+	^self hasMethodSelected!
 
 methodRefactoringsMenu
-	<commandQuerySelector: #queryHasPackagesSelected:>
+	<commandQuerySelector: #hasPackages:>
 	Sound warningBeep!
 
 newMethodNamePrompter: aCompiledMethod caption: aString allowExisting: aBoolean
@@ -3389,14 +3384,6 @@ promptForMethodName: aCompiledMethod caption: aString allowExisting: aBoolean
 		caption: aString
 		allowExisting: aBoolean) showModal!
 
-queryHasClassSelected: aCommandQuery
-	aCommandQuery isEnabled: self hasClassSelected!
-
-queryRemoveParameter: aCommandQuery
-	| method |
-	method := self selectedMethod.
-	aCommandQuery isEnabled: (self hasPackages and: [method notNil and: [method argumentCount > 0]])!
-
 removeMethod
 	"Private - Prompt the user for a selector and invoke the 'Safe Remove Method' refactoring to 
 	remove the specified methods from the system if defined but not referenced from within 
@@ -3407,7 +3394,7 @@ removeMethod
 	methods selected on the methods tab. It allows the selection of an arbitrary method to be
 	renamed at package scope, not just loose methods."
 
-	<commandQuerySelector: #queryHasMethodsSelected:>
+	<commandQuerySelector: #hasMethodsSelected>
 	| methods |
 	methods := self chooseMethodsForRefactoring: 'Safe Remove Methods from Package(s)…'.
 	methods isEmpty
@@ -3443,7 +3430,7 @@ removeParameter
 	"Private - Command to invoke the Remove Parameter to Method refactoring, but constrained to operate
 	only within the selected packages."
 
-	<commandQuerySelector: #queryHasPackagesSelected:>
+	<commandQuerySelector: #hasPackages>
 	| method ast arg |
 	method := self chooseMethodForRefactoring: 'Remove Parameter in Package(s)…'.
 	method isNil ifTrue: [^self].
@@ -3454,13 +3441,13 @@ removeParameter
 	arg notNil ifTrue: [methodRefactoringTool removeParameter: arg from: method]!
 
 removeParameterMenu
-	<commandQuerySelector: #queryRemoveParameter:>
+	<commandQuerySelector: #hasMethodWithArguments>
 	Sound warningBeep!
 
 renameClass
 	"Private - Initiate in-place label edit for the selected class."
 
-	<commandQuerySelector: #queryHasClassSelected:>
+	<commandQuerySelector: #hasClassSelected>
 	classesPresenter view editSelectionLabel!
 
 renameLooseMethod
@@ -3485,7 +3472,7 @@ renameMethod
 	method selected on the methods tab. It allows the selection of an arbitrary method to be
 	renamed at package scope, not just loose methods."
 
-	<commandQuerySelector: #queryHasPackagesSelected:>
+	<commandQuerySelector: #hasPackages>
 	(self chooseMethodForRefactoring: 'Rename Method in Package(s)…') 
 		ifNotNil: [:method | methodRefactoringTool renameMethod: method]!
 
@@ -3510,6 +3497,7 @@ addParameterToMethod!commands-actions!public! !
 changeClassNamespace!commands-actions!public! !
 chooseMethodsForRefactoring:!private!refactoring! !
 classRefactoringsMenu!commands-menus!public! !
+hasMethodWithArguments!private!testing! !
 hasRefactorableMethodSelected!private!refactoring!testing! !
 methodRefactoringsMenu!commands-menus!public! !
 newMethodNamePrompter:caption:allowExisting:!helpers!private!refactoring! !
@@ -3519,8 +3507,6 @@ parseTree!helpers!private! !
 performMethodRenameRefactoring:!helpers!private!refactoring! !
 performMethodsRefactoring:name:!private! !
 promptForMethodName:caption:allowExisting:!helpers!private!refactoring! !
-queryHasClassSelected:!commands-queries!private! !
-queryRemoveParameter:!commands-queries!private! !
 removeMethod!commands-actions!public! !
 removeMethods!commands-actions!public! !
 removeParameter!commands-actions!private! !
@@ -3542,16 +3528,8 @@ moveAllTempsToInnerScope
 Are you sure that you would like to proceed?')
 			ifTrue: [self developmentSystem moveAllTempsToInnerScope: self selectionEnvironment]!
 
-queryPackageRefactoring: aCommandQuery
-	"Private - Enters details about a potential refactoring command for the receiver into the 
-	<CommandQuery> argument."
-
-	| canRefactor |
-	canRefactor := self developmentSystem canRefactor and: [self hasPackages].
-	aCommandQuery isEnabled: canRefactor!
-
 removeDuplicateMethods
-	<commandQuerySelector: #queryPackageRefactoring:>
+	<commandQuerySelector: #canRefactor>
 	| count pkgs |
 	pkgs := self packages.
 	count := pkgs inject: 0 into: [:sum :eachPackage | sum + eachPackage classNames size].
@@ -3572,7 +3550,6 @@ removeDuplicateMethods
 		showModal! !
 !Tools.PackageSelector categoriesForMethods!
 moveAllTempsToInnerScope!commands!private!refactoring! !
-queryPackageRefactoring:!commands!private!refactoring! !
 removeDuplicateMethods!development!private! !
 !
 

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
@@ -2433,7 +2433,7 @@ resource_Refactoring_view!public!resources-views! !
 abstractInstanceVariables
 	"Private - Invoke the 'Abstract Instance Variable' refactoring on the currently selected variables."
 
-	<commandQuerySelector: #hasInstanceVariablesSelected>
+	<commandQuery: #hasInstanceVariablesSelected>
 	self model abstractInstanceVariables: self variables within: BrowserEnvironment new!
 
 canPushDownInstanceVariables
@@ -2469,7 +2469,7 @@ methodsToOverride
 			ifNotNil: [:selectors | selectors collect: [:each | selectedClass lookupMethod: each]]!
 
 overrideMethods
-	<commandQuerySelector: #queryOverrideMethods:>
+	<commandQuery: #queryOverrideMethods:>
 	| stream class changes name methods devsys |
 	class := self actualClass.
 	stream := String writeStream.
@@ -2511,18 +2511,18 @@ overrideMethods
 protectInstanceVariables
 	"Private - Invoke the 'Protect/Concrete Instance Variable' refactoring on the users choice of instance variables."
 
-	<commandQuerySelector: #hasInstanceVariablesSelected>
+	<commandQuery: #hasInstanceVariablesSelected>
 	self model protectInstanceVariables: self variables!
 
 pushDownInstanceVariables
 	"Invoke the 'Push Down Instance Variable' refactoring on the currently selected variables."
 
-	<commandQuerySelector: #canPushDownInstanceVariables>
+	<commandQuery: #canPushDownInstanceVariables>
 	self model pushDownInstanceVariables: self variables!
 
 pushDownMethods
 	<acceleratorKey: 'Shift+Ctrl+7'>
-	<commandQuerySelector: #canPushDownMethods>
+	<commandQuery: #canPushDownMethods>
 	self pushMethods: false!
 
 pushMethods: aBoolean
@@ -2541,7 +2541,7 @@ pushMethods: aBoolean
 
 pushUpMethods
 	<acceleratorKey: 'Shift+Ctrl+6'>
-	<commandQuerySelector: #canPushUpMethods>
+	<commandQuery: #canPushUpMethods>
 	self pushMethods: true!
 
 queryOverrideMethods: aCommandQuery
@@ -2560,7 +2560,7 @@ queryOverrideMethods: aCommandQuery
 removeInstanceVariables
 	"Invoke the 'Remove Instance Variable' refactoring on the currently selected variables."
 
-	<commandQuerySelector: #hasInstanceVariablesSelected>
+	<commandQuery: #hasInstanceVariablesSelected>
 	self model removeInstanceVariables: self variables within: self searchEnvironment!
 
 renameMethod
@@ -2606,7 +2606,7 @@ abstractClassVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #hasClassWithStaticVariables>
+	<commandQuery: #hasClassWithStaticVariables>
 	(self chooseVariables: true caption: 'Abstract Class Variables…')
 		ifNotNil: [:varNames | self developmentSystem abstractClassVariables: varNames within: BrowserEnvironment new]!
 
@@ -2616,30 +2616,30 @@ abstractInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #hasClassWithInstanceVariables>
+	<commandQuery: #hasClassWithInstanceVariables>
 	(self chooseVariables: false caption: 'Abstract Instance Variables…')
 		ifNotNil: [:varNames | self developmentSystem abstractInstanceVariables: varNames within: BrowserEnvironment new]!
 
 abstractVariables
-	<commandQuerySelector: #hasClassWithVariablesSelected>
+	<commandQuery: #hasClassWithVariablesSelected>
 	Sound warningBeep!
 
 addClassVariable
 	"Private - Invoke the 'Add Class Variable' refactoring to add a class variable to the
 	currently selected class."
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	self developmentSystem addClassVariableTo: self selection!
 
 addImport
-	<commandQuerySelector: #hasSelection>
+	<commandQuery: #hasSelection>
 	self developmentSystem addImportToClasses: self selections!
 
 addInstanceVariable
 	"Private - Invoke the 'Add Instance Variable' refactoring to add an instance variable to the
 	currently selected class."
 
-	<commandQuerySelector: #queryAddInstanceVariable:>
+	<commandQuery: #queryAddInstanceVariable:>
 	self developmentSystem addInstanceVariableTo: self actualClass!
 
 buildInstVarMenu: aMenu selectors: selectors
@@ -2719,11 +2719,11 @@ canPushDownVariables
 				and: [class instanceVariableNames notEmpty or: [class instanceClass definedBindings notEmpty]]]!
 
 changeClassNamespace
-	<commandQuerySelector: #canChangeClassNamespace>
+	<commandQuery: #canChangeClassNamespace>
 	self developmentSystem changeNamespaceOfClasses: self selections!
 
 classRefactoringsMenu
-	<commandQuerySelector: #hasSelection>
+	<commandQuery: #hasSelection>
 	Sound warningBeep!
 
 cloneClass: aClass under: superClass changes: aCompositeRefactoryChange
@@ -2747,18 +2747,18 @@ convertToSibling
 	class and its current subclasses, copying common methods to the new superclass and adding 
 	#subclassResponsibility methods as necessary)."
 
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	self developmentSystem convertToSibling: self selection!
 
 createClassVariableAccessors
 	"Prompt to generate compiled 'get' and 'set' accessor methods for the immediate
 	class variables of the selected class."
 
-	<commandQuerySelector: #hasClassWithStaticVariables>
+	<commandQuery: #hasClassWithStaticVariables>
 	self createVariableAccessors: true!
 
 createVariableAccessors
-	<commandQuerySelector: #hasClassWithVariablesSelected>
+	<commandQuery: #hasClassWithVariablesSelected>
 	Sound warningBeep!
 
 hasImports
@@ -2878,12 +2878,12 @@ protectInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #hasClassWithInstanceVariables>
+	<commandQuery: #hasClassWithInstanceVariables>
 	(self chooseVariables: false caption: 'Protect Instance Variables…')
 		ifNotNil: [:varNames | self developmentSystem protectInstanceVariables: varNames]!
 
 protectVariables
-	<commandQuerySelector: #hasClassWithVariablesSelected>
+	<commandQuery: #hasClassWithVariablesSelected>
 	Sound warningBeep!
 
 pullUpClassVariables
@@ -2892,7 +2892,7 @@ pullUpClassVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #canPullUpClassVariables>
+	<commandQuery: #canPullUpClassVariables>
 	| class pairs |
 	class := self selection.
 	pairs := self
@@ -2917,7 +2917,7 @@ pullUpInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #canPullUpInstanceVariables>
+	<commandQuery: #canPullUpInstanceVariables>
 	| class pairs |
 	class := self actualClass.
 	pairs := self
@@ -2952,7 +2952,7 @@ pullUpVariableNamePairs: aBoolean for: class maximum: anInteger
 	^pairs!
 
 pullUpVariables
-	<commandQuerySelector: #canPullUpVariables>
+	<commandQuery: #canPullUpVariables>
 	Sound warningBeep!
 
 pushDownClassVariables
@@ -2961,7 +2961,7 @@ pushDownClassVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #hasClassWithStaticVariables>
+	<commandQuery: #hasClassWithStaticVariables>
 	(self chooseVariables: true caption: 'Push Down Class Variables…')
 		ifNotNil: [:varNames | self developmentSystem pushDownInstanceVariables: varNames]!
 
@@ -2971,12 +2971,12 @@ pushDownInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #canPushDownInstanceVariables>
+	<commandQuery: #canPushDownInstanceVariables>
 	(self chooseVariables: false caption: 'Push Down Instance Variables…')
 		ifNotNil: [:varNames | self developmentSystem pushDownInstanceVariables: varNames]!
 
 pushDownVariables
-	<commandQuerySelector: #canPushDownVariables>
+	<commandQuery: #canPushDownVariables>
 	Sound warningBeep!
 
 queryAddInstanceVariable: aCommandQuery
@@ -2994,12 +2994,12 @@ removeClassVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #hasClassWithStaticVariables>
+	<commandQuery: #hasClassWithStaticVariables>
 	(self chooseVariables: true caption: 'Remove Class Variables…')
 		ifNotNil: [:pairs | self developmentSystem removeStaticVariables: pairs within: self searchEnvironment]!
 
 removeDuplicateMethods
-	<commandQuerySelector: #hasSingleSelection>
+	<commandQuery: #hasSingleSelection>
 	| class |
 	class := self actualClass.
 	(self developmentSystem removeMethodsDuplicatedInSuperclassOf: class)
@@ -3012,7 +3012,7 @@ removeDuplicateMethods
 				open]!
 
 removeImport
-	<commandQuerySelector: #hasImports>
+	<commandQuery: #hasImports>
 	self developmentSystem removeImportFromClasses: self selections!
 
 removeInstanceVariables
@@ -3021,12 +3021,12 @@ removeInstanceVariables
 	same name) which has the advantage of not requiring a dialog, but which enables the user to 
 	choose only one instance variable at a time."
 
-	<commandQuerySelector: #hasClassWithInstanceVariables>
+	<commandQuery: #hasClassWithInstanceVariables>
 	(self chooseVariables: false caption: 'Remove Instance Variables…')
 		ifNotNil: [:varNames | self developmentSystem removeInstanceVariables: varNames within: self searchEnvironment]!
 
 removeVariables
-	<commandQuerySelector: #hasClassWithVariablesSelected>
+	<commandQuery: #hasClassWithVariablesSelected>
 	Sound warningBeep! !
 !Tools.ClassSelector categoriesForMethods!
 abstractClassVariables!commands-actions!public!refactoring! !
@@ -3250,7 +3250,7 @@ renameVariable:operation:validationBlock:!operations!private!refactoring! !
 !Tools.PackageBrowserShell methodsFor!
 
 addImport
-	<commandQuerySelector: #hasClassesSelected>
+	<commandQuery: #hasClassesSelected>
 	self developmentSystem addImportToClasses: self selectedClasses!
 
 addParameter
@@ -3258,10 +3258,9 @@ addParameter
 	the selector of the method to which the parameter is added, and constrained to operate
 	only within the selected packages."
 
-	<commandQuerySelector: #hasPackages>
-	(self chooseMethodForRefactoring: 'Add Parameter in Package(s)…') 
-		ifNotNil: [:method | self addParameterTo: method]
-!
+	<commandQuery: #hasPackages>
+	(self chooseMethodForRefactoring: 'Add Parameter in Package(s)…')
+		ifNotNil: [:method | self addParameterTo: method]!
 
 addParameterTo: aCompiledMethod
 	self model addParameterToMethod: aCompiledMethod inPackages: self packages!
@@ -3271,11 +3270,11 @@ addParameterToMethod
 	'Add Parameter to Method refactoring' against a selected loose method, 
 	constrained within the selected packages."
 
-	<commandQuerySelector: #hasMethodSelected>
+	<commandQuery: #hasMethodSelected>
 	self addParameterTo: self selectedMethod!
 
 changeClassNamespace
-	<commandQuerySelector: #hasClassesSelected>
+	<commandQuery: #hasClassesSelected>
 	self developmentSystem changeNamespaceOfClasses: self selectedClasses!
 
 chooseMethodsForRefactoring: aString
@@ -3293,7 +3292,7 @@ chooseMethodsForRefactoring: aString
 	^definitions!
 
 classRefactoringsMenu
-	<commandQuerySelector: #hasPackages>
+	<commandQuery: #hasPackages>
 	Sound warningBeep!
 
 hasMethodWithArguments
@@ -3305,7 +3304,7 @@ hasRefactorableMethodSelected
 	^self hasMethodSelected!
 
 methodRefactoringsMenu
-	<commandQuerySelector: #hasPackages:>
+	<commandQuery: #hasPackages:>
 	Sound warningBeep!
 
 newMethodNamePrompter: aCompiledMethod caption: aString allowExisting: aBoolean
@@ -3394,7 +3393,7 @@ removeMethod
 	methods selected on the methods tab. It allows the selection of an arbitrary method to be
 	renamed at package scope, not just loose methods."
 
-	<commandQuerySelector: #hasMethodsSelected>
+	<commandQuery: #hasMethodsSelected>
 	| methods |
 	methods := self chooseMethodsForRefactoring: 'Safe Remove Methods from Package(s)…'.
 	methods isEmpty
@@ -3430,7 +3429,7 @@ removeParameter
 	"Private - Command to invoke the Remove Parameter to Method refactoring, but constrained to operate
 	only within the selected packages."
 
-	<commandQuerySelector: #hasPackages>
+	<commandQuery: #hasPackages>
 	| method ast arg |
 	method := self chooseMethodForRefactoring: 'Remove Parameter in Package(s)…'.
 	method isNil ifTrue: [^self].
@@ -3441,13 +3440,13 @@ removeParameter
 	arg notNil ifTrue: [methodRefactoringTool removeParameter: arg from: method]!
 
 removeParameterMenu
-	<commandQuerySelector: #hasMethodWithArguments>
+	<commandQuery: #hasMethodWithArguments>
 	Sound warningBeep!
 
 renameClass
 	"Private - Initiate in-place label edit for the selected class."
 
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	classesPresenter view editSelectionLabel!
 
 renameLooseMethod
@@ -3472,8 +3471,8 @@ renameMethod
 	method selected on the methods tab. It allows the selection of an arbitrary method to be
 	renamed at package scope, not just loose methods."
 
-	<commandQuerySelector: #hasPackages>
-	(self chooseMethodForRefactoring: 'Rename Method in Package(s)…') 
+	<commandQuery: #hasPackages>
+	(self chooseMethodForRefactoring: 'Rename Method in Package(s)…')
 		ifNotNil: [:method | methodRefactoringTool renameMethod: method]!
 
 renameMethodReferences: aCompiledMethod
@@ -3529,7 +3528,7 @@ Are you sure that you would like to proceed?')
 			ifTrue: [self developmentSystem moveAllTempsToInnerScope: self selectionEnvironment]!
 
 removeDuplicateMethods
-	<commandQuerySelector: #canRefactor>
+	<commandQuery: #canRefactor>
 	| count pkgs |
 	pkgs := self packages.
 	count := pkgs inject: 0 into: [:sum :eachPackage | sum + eachPackage classNames size].

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.CodeMentorPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.CodeMentorPlugin.cls
@@ -199,8 +199,8 @@ filterInRules: rules
 filterOutRule
 	"Add the current method to the filters for the current failed rule(s) so that it won't be classed as a failure next time around"
 
-	self filterOutRules: self failedRule failedRules.
-!
+	<commandQuerySelector: #queryFilterOutRule:>
+	self filterOutRules: self failedRule failedRules!
 
 filterOutRules: rules
 	"Private - Add filters for the supplied rules"
@@ -339,6 +339,9 @@ isFilterActive
 	"Private - Answer true if one or more rule failures are omitted due to active filters"
 
 	^self filteredRules notEmpty!
+
+isRefreshable
+	^isRefreshPending or: [self refreshMode == #manual]!
 
 lintRuleFailuresBrowserClass
 	^LintRuleFailuresBrowserShell!
@@ -505,36 +508,20 @@ printTransformationRuleHtmlFor: anIXMLDOMElement on: aStream
 				print: node innerXML;
 				nextPutAll: '"> automatic transformation</a> available to address this issue.</i></p>']!
 
-queryCommand: aCommandQuery
-	"Private - Enter details about a potential command for the receiver 
-	into the <CommandQuery> argument."
-
-	| selector |
-	selector := aCommandQuery commandSymbol.
-	#filterOutRule == selector
-		ifTrue: 
-			[| failedRule text |
-			failedRule := self failedRule.
-			text := (failedRule notNil and: [failedRule problemCount > 1])
-						ifTrue: ['Ignore these <1p> rule failures' expandMacrosWith: failedRule problemCount]
-						ifFalse: ['Ignore this rule failure'].
-			aCommandQuery
-				isEnabled: (failedRule notNil and: [failedRule notEmpty]);
-				text: text.
-			^true].
-	#selectIgnoredRules == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: self isFilterActive.
-			^true].
-	#refresh == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: (isRefreshPending or: [self refreshMode == #manual]).
-			^true].
-	^super queryCommand: aCommandQuery!
+queryFilterOutRule: aCommandQuery
+	| text failedRule |
+	failedRule := self failedRule.
+	text := (failedRule notNil and: [failedRule problemCount > 1])
+				ifTrue: ['Ignore these <1p> rule failures' expandMacrosWith: failedRule problemCount]
+				ifFalse: ['Ignore this rule failure'].
+	aCommandQuery
+		isEnabled: (failedRule notNil and: [failedRule notEmpty]);
+		text: text!
 
 refresh
 	"Refresh the receiver's display after first re-running the checks"
 
+	<commandQuerySelector: #isRefreshable>
 	self clearFailures.
 	self startCheckerProcess.
 	isRefreshPending := false.
@@ -606,11 +593,12 @@ runLintChecks
 			postToMessageQueue!
 
 selectFilteredRules
+	<commandQuerySelector: #isFilterActive>
 	| filteredRules originalFilteredRules addFilters removeFilters |
 	originalFilteredRules := self filteredRules.
-	filteredRules := ChoicePrompter 
+	filteredRules := ChoicePrompter
 				on: originalFilteredRules
-				multipleChoices: ((self filteredRules , self allRules failedRules) asSet 
+				multipleChoices: ((self filteredRules , self allRules failedRules) asSet
 						asSortedCollection: [:x :y | x name <= y name])
 				caption: 'Select Rules to Ignore'.
 	filteredRules isNil ifTrue: [^self].
@@ -668,36 +656,37 @@ addFailedRule:!helpers!private! !
 allRules!operations!private! !
 applyTransform:!helpers!private! !
 autoRefresh!operations!private! !
-browseAllFailedMethods!commands!private! !
-browseFailedClass:!commands!private! !
-browseFailedMethod:!commands!public! !
-browseFailedMethods:!commands!private! !
+browseAllFailedMethods!commands-actions!private! !
+browseFailedClass:!operations!private! !
+browseFailedMethod:!operations!public! !
+browseFailedMethods:!operations!private! !
 clearFailures!operations!private! !
-clearIgnoredRules!commands!public! !
+clearIgnoredRules!commands-actions!public! !
 createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
 defaultHelpId!constants!public! !
 displayOn:!displaying!public! !
-exportIgnoredRules!commands!public! !
+exportIgnoredRules!commands-actions!public! !
 failedClassesFor:!accessing!private! !
-failedRule!commands!private! !
+failedRule!commands-actions!private! !
 filteredRuleNames!accessing!private! !
 filteredRules!accessing!public! !
-filterInRules:!commands!private! !
-filterOutRule!commands!public! !
-filterOutRules:!commands!private! !
+filterInRules:!operations!private! !
+filterOutRule!commands-actions!public! !
+filterOutRules:!operations!private! !
 getRuleInfo:!helpers!private! !
 htmlDescriptionFor:!helpers!private! !
 htmlStyle!helpers!private! !
 icon!accessing!public! !
-importIgnoredRules!commands!public! !
+importIgnoredRules!commands-actions!public! !
 indicateFailures:!operations!private! !
 indicateStatus!operations!private! !
 indicateSuccess!operations!private! !
 infoBrowserPresenter!accessing!private! !
 initialize!initializing!private! !
 isBusy!accessing!public! !
-isFilterActive!commands!private! !
+isFilterActive!private!testing! !
+isRefreshable!private!testing! !
 lintRuleFailuresBrowserClass!constants!private! !
 lintRules!accessing!private! !
 onBrowserEnvironmentSelected!event handling!private! !
@@ -716,16 +705,16 @@ parentRuleOf:!helpers!private! !
 printClassFailuresHtmlFor:on:!helpers!printing!private! !
 printMethodFailuresHtmlFor:on:!helpers!printing!private! !
 printTransformationRuleHtmlFor:on:!helpers!printing!private! !
-queryCommand:!commands!private! !
-refresh!commands!public! !
+queryFilterOutRule:!commands-queries!private! !
+refresh!commands-actions!public! !
 refreshIcon!operations!private! !
 refreshMode!accessing!public! !
 refreshMode:!accessing!public! !
-refreshResults!commands!public! !
+refreshResults!commands-actions!public! !
 resetProgressBar!operations!private! !
 rulesTreeModel!accessing!private! !
 runLintChecks!operations!public! !
-selectFilteredRules!commands!public! !
+selectFilteredRules!commands-actions!public! !
 showDescriptionFor:!operations!private! !
 smalltalkUrlTag!constants!private! !
 splitName:!helpers!private! !

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.CodeMentorPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.CodeMentorPlugin.cls
@@ -199,7 +199,7 @@ filterInRules: rules
 filterOutRule
 	"Add the current method to the filters for the current failed rule(s) so that it won't be classed as a failure next time around"
 
-	<commandQuerySelector: #queryFilterOutRule:>
+	<commandQuery: #queryFilterOutRule:>
 	self filterOutRules: self failedRule failedRules!
 
 filterOutRules: rules
@@ -521,7 +521,7 @@ queryFilterOutRule: aCommandQuery
 refresh
 	"Refresh the receiver's display after first re-running the checks"
 
-	<commandQuerySelector: #isRefreshable>
+	<commandQuery: #isRefreshable>
 	self clearFailures.
 	self startCheckerProcess.
 	isRefreshPending := false.
@@ -593,7 +593,7 @@ runLintChecks
 			postToMessageQueue!
 
 selectFilteredRules
-	<commandQuerySelector: #isFilterActive>
+	<commandQuery: #isFilterActive>
 	| filteredRules originalFilteredRules addFilters removeFilters |
 	originalFilteredRules := self filteredRules.
 	filteredRules := ChoicePrompter

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.CodeRewriterPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.CodeRewriterPlugin.cls
@@ -86,22 +86,6 @@ model: anObject
 	super model: anObject.
 	searchTextPresenter errorModel: self model statusModel.!
 
-queryCommand: aCommandQuery
-	"Private - Enter details about a potential command for the receiver 
-	into the <CommandQuery> argument."
-
-	| selector |
-	selector := aCommandQuery commandSymbol.
-	#search == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: self hasSearchText.
-			^true].
-	#replace == selector
-		ifTrue: 
-			[aCommandQuery isEnabled: self hasSearchText.
-			^true].
-	^super queryCommand: aCommandQuery!
-
 renameMethodArgument
 	| pair |
 	pair := 'anObject' -> ''.
@@ -113,12 +97,14 @@ renameMethodArgument
 	self runTransformation: (TransformationRule renameArgument: pair key to: pair value)!
 
 replace
+	<commandQuerySelector: #hasSearchText>
 	self buildReplaceRule ifNotNil: [:rule | self runTransformation: rule]!
 
 replaceText
 	^replaceTextPresenter text!
 
 search
+	<commandQuerySelector: #hasSearchText>
 	searchTextPresenter clearStatus.
 	self buildSearchRule
 		ifNotNil: [:searchRule | (self runRule: searchRule) isNil ifFalse: [self browseRuleResults: searchRule]]!
@@ -135,21 +121,20 @@ transform
 		ifNotNil: [:rule | self runTransformation: rule]! !
 !Tools.CodeRewriterPlugin categoriesForMethods!
 browseRuleResults:!helpers!private! !
-buildReplaceRule!commands!private! !
+buildReplaceRule!helpers!private! !
 buildSearchRule!helpers!private! !
 captionText:!helpers!private! !
 createComponents!initializing!public! !
 defaultHelpId!public! !
 displayOn:!displaying!public! !
-hasSearchText!commands!private! !
+hasSearchText!private!testing! !
 model:!accessing!public! !
-queryCommand:!commands!private! !
-renameMethodArgument!commands!public! !
-replace!commands!public! !
+renameMethodArgument!commands-actions!public! !
+replace!commands-actions!public! !
 replaceText!accessing!private! !
-search!commands!public! !
+search!commands-actions!public! !
 searchText!accessing!private! !
-transform!commands!public! !
+transform!commands-actions!public! !
 !
 
 !Tools.CodeRewriterPlugin class methodsFor!

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.CodeRewriterPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.CodeRewriterPlugin.cls
@@ -97,14 +97,14 @@ renameMethodArgument
 	self runTransformation: (TransformationRule renameArgument: pair key to: pair value)!
 
 replace
-	<commandQuerySelector: #hasSearchText>
+	<commandQuery: #hasSearchText>
 	self buildReplaceRule ifNotNil: [:rule | self runTransformation: rule]!
 
 replaceText
 	^replaceTextPresenter text!
 
 search
-	<commandQuerySelector: #hasSearchText>
+	<commandQuery: #hasSearchText>
 	searchTextPresenter clearStatus.
 	self buildSearchRule
 		ifNotNil: [:searchRule | (self runRule: searchRule) isNil ifFalse: [self browseRuleResults: searchRule]]!

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.ResourceListPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.ResourceListPlugin.cls
@@ -126,13 +126,13 @@ showClassResources
 toggleShowInheritedResources
 	"Toggle between showing resources owned by subclasses or not"
 
-	<commandQuerySelector: #queryToggleShowInheritedResources:>
+	<commandQuery: #queryToggleShowInheritedResources:>
 	self isShowingInheritedResources: self isShowingInheritedResources not!
 
 toggleShowSubclassResources
 	"Toggle between showing resources inherited from superclasses or not"
 
-	<commandQuerySelector: #queryToggleShowSubclassResources:>
+	<commandQuery: #queryToggleShowSubclassResources:>
 	self isShowingSubclassResources: self isShowingSubclassResources not! !
 !Tools.ResourceListPlugin categoriesForMethods!
 createComponents!initializing!operations!private! !

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.ResourceListPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.ResourceListPlugin.cls
@@ -90,21 +90,15 @@ onShownInBrowser
 	super onShownInBrowser.
 	self showClassResources!
 
-queryCommand: aCommandQuery 
-	"Private - Enter details about a potential command for the receiver 
-	into the <CommandQuery> argument."
+queryToggleShowInheritedResources: aCommandQuery
+	aCommandQuery
+		isEnabled: true;
+		isChecked: self isShowingInheritedResources!
 
-	| selector |
-	selector := aCommandQuery commandSymbol.
-	#toggleShowInheritedResources == selector 
-		ifTrue: 
-			[aCommandQuery isEnabled: true; isChecked: self isShowingInheritedResources.
-			^true].
-	#toggleShowSubclassResources == selector 
-		ifTrue: 
-			[aCommandQuery isEnabled: true; isChecked: self isShowingSubclassResources.
-			^true].
-	^super queryCommand: aCommandQuery!
+queryToggleShowSubclassResources: aCommandQuery
+	aCommandQuery
+		isEnabled: true;
+		isChecked: self isShowingSubclassResources!
 
 showClassResources
 	| classes filter |
@@ -132,14 +126,16 @@ showClassResources
 toggleShowInheritedResources
 	"Toggle between showing resources owned by subclasses or not"
 
+	<commandQuerySelector: #queryToggleShowInheritedResources:>
 	self isShowingInheritedResources: self isShowingInheritedResources not!
 
 toggleShowSubclassResources
 	"Toggle between showing resources inherited from superclasses or not"
 
+	<commandQuerySelector: #queryToggleShowSubclassResources:>
 	self isShowingSubclassResources: self isShowingSubclassResources not! !
 !Tools.ResourceListPlugin categoriesForMethods!
-createComponents!commands!initializing!private! !
+createComponents!initializing!operations!private! !
 createSchematicWiring!initializing!public! !
 defaultHelpId!constants!public! !
 displayOn:!displaying!public! !
@@ -151,10 +147,11 @@ isShowingSubclassResources:!accessing!private! !
 onBrowserClassSelected!event handling!public! !
 onBrowserMethodSelected!event handling!private! !
 onShownInBrowser!event handling!public! !
-queryCommand:!commands!private! !
+queryToggleShowInheritedResources:!commands-queries!private! !
+queryToggleShowSubclassResources:!commands-queries!private! !
 showClassResources!private!updating! !
-toggleShowInheritedResources!commands!public! !
-toggleShowSubclassResources!commands!public! !
+toggleShowInheritedResources!commands-actions!public! !
+toggleShowSubclassResources!commands-actions!public! !
 !
 
 !Tools.ResourceListPlugin class methodsFor!

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.UnitTestPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.UnitTestPlugin.cls
@@ -96,7 +96,7 @@ createSchematicWiring
 debugTest
 	"Debug the currently selected defect. If no defects are selected then select and ebug the first one"
 
-	<commandQuerySelector: #hasDefects>
+	<commandQuery: #hasDefects>
 	defectsPresenter hasSelection ifFalse: [defectsPresenter selectionByIndex: 1].
 	self debugTest: defectsPresenter selection!
 
@@ -299,7 +299,7 @@ profileSuite: aTestSuite
 	self updateWindow!
 
 profileTests
-	<commandQuerySelector: #hasTests>
+	<commandQuery: #hasTests>
 	| suite |
 	suite := self testSuite.
 	(#{Smalltalk.Profiler} isDefined and: [suite notNil])
@@ -322,7 +322,7 @@ runSuite: aTestSuite
 	self updateWindow!
 
 runTests
-	<commandQuerySelector: #hasTests>
+	<commandQuery: #hasTests>
 	self testSuite ifNil: [self displayReset] ifNotNil: [:suite | self runSuite: suite]!
 
 startAutoSwitchProcess
@@ -380,7 +380,7 @@ testSuite
 toggleToTests
 	"Switch the associated browser between the class under test and the corresponding test class"
 
-	<commandQuerySelector: #queryToggleToTests:>
+	<commandQuery: #queryToggleToTests:>
 	| toggleToClass |
 	toggleToClass := self toggleToTestsClass.
 	toggleToClass ifNil: [^Error beep].

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.UnitTestPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.UnitTestPlugin.cls
@@ -96,7 +96,7 @@ createSchematicWiring
 debugTest
 	"Debug the currently selected defect. If no defects are selected then select and ebug the first one"
 
-	<commandQuerySelector: #queryHasDefects:>
+	<commandQuerySelector: #hasDefects>
 	defectsPresenter hasSelection ifFalse: [defectsPresenter selectionByIndex: 1].
 	self debugTest: defectsPresenter selection!
 
@@ -299,18 +299,12 @@ profileSuite: aTestSuite
 	self updateWindow!
 
 profileTests
-	<commandQuerySelector: #queryHasTests:>
+	<commandQuerySelector: #hasTests>
 	| suite |
 	suite := self testSuite.
 	(#{Smalltalk.Profiler} isDefined and: [suite notNil])
 		ifTrue: [self profileSuite: suite]
 		ifFalse: [self displayReset]!
-
-queryHasDefects: aCommandQuery
-	aCommandQuery isEnabled: self hasDefects!
-
-queryHasTests: aCommandQuery
-	aCommandQuery isEnabled: self hasTests!
 
 queryToggleToTests: query
 	^query
@@ -328,7 +322,7 @@ runSuite: aTestSuite
 	self updateWindow!
 
 runTests
-	<commandQuerySelector: #queryHasTests:>
+	<commandQuerySelector: #hasTests>
 	self testSuite ifNil: [self displayReset] ifNotNil: [:suite | self runSuite: suite]!
 
 startAutoSwitchProcess
@@ -454,8 +448,6 @@ onViewOpened!event handling!private! !
 prepareToRun:!operations!private! !
 profileSuite:!operations!private! !
 profileTests!commands-actions!public! !
-queryHasDefects:!commands-queries!private! !
-queryHasTests:!commands-queries!private! !
 queryToggleToTests:!helpers!private! !
 refreshIcon!operations!private! !
 runSuite:!operations!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -1436,14 +1436,14 @@ Core.Object
 	instanceVariableNames: 'model view parentPresenter events subPresenters names helpId'
 	classVariableNames: ''
 	imports: #(#{OS.Win32Constants})
-	classInstanceVariableNames: 'acceleratorKeyAnnotations commandQuerySelectors commandQueryHandlers'
+	classInstanceVariableNames: 'acceleratorKeyAnnotations commandQueries queryCommandHandlers'
 	classConstants: {}!
 Core.Object
 	subclass: #'UI.View'
 	instanceVariableNames: 'handle creationParent creationStyle presenter model backcolor preferredExtent flags contextMenu font events interactor'
 	classVariableNames: 'MessageMap NextId ViewClosedError WndClassAtom'
 	imports: #(#{OS.Win32Constants} #{OS.Win32Errors})
-	classInstanceVariableNames: 'theme commandQuerySelectors'
+	classInstanceVariableNames: 'theme commandQueries'
 	classConstants: {
 			'CreateCenteredMask' -> 16r40.
 			'DragSourceMask' -> 16r4.

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.CommandQuery.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.CommandQuery.cls
@@ -261,7 +261,7 @@ findQueryHandlersIn: aClass
 					[:annotations |
 					annotations selectorsAndArgumentsDo: 
 							[:annotationSelector :annotationArgs |
-							annotationSelector == #commandQuerySelector:
+							annotationSelector == #commandQuery:
 								ifTrue: 
 									[| querySelector argc |
 									querySelector := annotationArgs single.
@@ -283,13 +283,13 @@ new
 validateQueriesIn: aCompilationResult
 	| method affectsQueries annotations |
 	method := aCompilationResult oldMethod.
-	affectsQueries := method notNil and: [method hasAnnotation: #commandQuerySelector:].
+	affectsQueries := method notNil and: [method hasAnnotation: #commandQuery:].
 	method := aCompilationResult method.
 	(method notNil and: [(annotations := method annotations) notNil])
 		ifTrue: 
 			[| class |
 			class := method methodClass.
-			annotations withSelector: #commandQuerySelector:
+			annotations withSelector: #commandQuery:
 				do: 
 					[:each |
 					| selector |

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.CommandQuery.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.CommandQuery.cls
@@ -249,12 +249,75 @@ commandDescription: item source: aView
 	^(super new initialize) 
 		commandDescription: item source: aView!
 
+findQueryHandlersIn: aClass
+	"Find all the command query annotations in the <Class> argument, and use them to build a map between command symbols (the selectors of the annotated methods), and selectors to perform to run the command query. The command query selectors can be unary, in which case the expectation is that the performed method is a testing method that will answer a <boolean> enablement status for the command, or can be a one-argument selector. Command queries that expect an argument are passed a <CommandQuery> object, and can update the enablement, checked status, and even change the command description text that will be displayed on a menu (where relevant)."
+
+	| queries |
+	queries := IdentityDictionary new.
+	aClass methodsDo: 
+			[:eachMethod |
+			eachMethod annotations
+				ifNotNil: 
+					[:annotations |
+					annotations selectorsAndArgumentsDo: 
+							[:annotationSelector :annotationArgs |
+							annotationSelector == #commandQuerySelector:
+								ifTrue: 
+									[| querySelector argc |
+									querySelector := annotationArgs single.
+									argc := querySelector argumentCount.
+									argc == 1
+										ifTrue: [queries at: eachMethod selector put: (Message selector: querySelector arguments: #('placeholder for aCommandQuery'))]
+										ifFalse: 
+											[argc == 0
+												ifTrue: 
+													[queries at: eachMethod selector put: [:rcvr :query | query isEnabled: (rcvr perform: querySelector)]]
+												ifFalse: [Notification signal: 'Ignoring invalid command query selector #' , querySelector]]]]]].
+	^queries!
+
 new
 	"Answers an instance of the receiver on a nil message"
 
-	^self commandDescription: CommandDescription new source: nil! !
+	^self commandDescription: CommandDescription new source: nil!
+
+validateQueriesIn: aCompilationResult
+	| method affectsQueries annotations |
+	method := aCompilationResult oldMethod.
+	affectsQueries := method notNil and: [method hasAnnotation: #commandQuerySelector:].
+	method := aCompilationResult method.
+	(method notNil and: [(annotations := method annotations) notNil])
+		ifTrue: 
+			[| class |
+			class := method methodClass.
+			annotations withSelector: #commandQuerySelector:
+				do: 
+					[:each |
+					| selector |
+					selector := each first.
+					(self validateQuerySelector: selector in: class)
+						ifFalse: 
+							["As there are validation issues, we want the change to be ignored, rather than used to build an invalid set of command queries"
+							^false]]].
+	^affectsQueries!
+
+validateQuerySelector: aSymbol in: aClass
+	| argc |
+	argc := aSymbol argumentCount.
+	argc > 1
+		ifTrue: 
+			[Warning signal: 'Command query selectors must have at most 1 argument, not the <2d> of <1p>'
+						<< { aSymbol. argc }.
+			^false].
+	(aClass canUnderstand: aSymbol)
+		ifFalse: 
+			[Warning signal: '<1p> does not understand the command query selector <2p>' << { aClass. aSymbol }.
+			^false].
+	^true! !
 !UI.CommandQuery class categoriesForMethods!
 commandDescription:source:!instance creation!public! !
+findQueryHandlersIn:!public! !
 new!instance creation!public! !
+validateQueriesIn:!private! !
+validateQuerySelector:in:!private! !
 !
 

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.Presenter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.Presenter.cls
@@ -992,7 +992,7 @@ annotatedMethodRemoved: aCompiledMethod
 	"Private - An annotated method of the receiver has been removed. This is an opportunity to update any metadata that might be based on method annotations."
 
 	(aCompiledMethod hasAnnotation: #acceleratorKey:) ifTrue: [self updateAdditionalAccelerators].
-	(aCompiledMethod hasAnnotation: #commandQuerySelector:) ifTrue: [self resetCommandQueries]!
+	(aCompiledMethod hasAnnotation: #commandQuery:) ifTrue: [self resetCommandQueries]!
 
 annotationsUpdated: aCompilationResult
 	"Private - Annotations may have been added or removed in the receiver's methods. This is an opportunity to update any metadata that might be based on method annotations."

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.Presenter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.Presenter.cls
@@ -5,7 +5,7 @@ Core.Object
 	instanceVariableNames: 'model view parentPresenter events subPresenters names helpId'
 	classVariableNames: ''
 	imports: #(#{OS.Win32Constants})
-	classInstanceVariableNames: 'acceleratorKeyAnnotations commandQuerySelectors commandQueryHandlers'
+	classInstanceVariableNames: 'acceleratorKeyAnnotations commandQueries queryCommandHandlers'
 	classConstants: {}!
 UI.Presenter guid: (Core.GUID fromString: '{87b4c4a9-026e-11d3-9fd7-00a0cc3e4a32}')!
 UI.Presenter comment: 'Presenter is an abstract class whose subclasses conform to <presenter> and represent components in the Model-View-Presenter framework. A presenter is the equivalent of a "user interface component" in the Dolphin MVP framework. It achieves flexibility over other component based architectures by allowing its data (its model) and its screen representation (its view) to be pluggable. Thus, one can change the way a user sees and manipulates a component by changing its view and one can change the data that the component is representing  by changing the model. Substituting a presenter''s model also allows several  presenter and view pairs to share and interact with the same data.  
@@ -681,14 +681,13 @@ queryCommandHandlers: aCommandQuery
 	class := self class.
 	command := aCommandQuery commandSymbol.
 	
-	[(class commandQuerySelectors lookup: command)
+	[(class commandQueries lookup: command)
 		ifNotNil: 
-			[:selector |
+			[:handler |
 			"Unless the handler specifically returns false, assume the command query was handled and terminate the search"
-			(self perform: selector with: aCommandQuery) == false ifFalse: [^true]].
+			(handler value: self value: aCommandQuery) == false ifFalse: [^true]].
 	"Try the legacy extension handlers - this mechanism is deprecated as of Dolphin 8.1"
-	class commandQueryHandlers
-		do: [:each | (self perform: each with: aCommandQuery) ifTrue: [^true]].
+	class queryCommandHandlers do: [:each | (self perform: each with: aCommandQuery) ifTrue: [^true]].
 	class == ##(self)]
 			whileFalse: [class := class superclass].
 	^false!
@@ -993,21 +992,17 @@ annotatedMethodRemoved: aCompiledMethod
 	"Private - An annotated method of the receiver has been removed. This is an opportunity to update any metadata that might be based on method annotations."
 
 	(aCompiledMethod hasAnnotation: #acceleratorKey:) ifTrue: [self updateAdditionalAccelerators].
-	(aCompiledMethod hasAnnotation: #commandQuerySelector:) ifTrue: [commandQuerySelectors := nil]!
+	(aCompiledMethod hasAnnotation: #commandQuerySelector:) ifTrue: [self resetCommandQueries]!
 
 annotationsUpdated: aCompilationResult
 	"Private - Annotations may have been added or removed in the receiver's methods. This is an opportunity to update any metadata that might be based on method annotations."
 
 	(aCompilationResult affectsAnnotation: #acceleratorKey:)
 		ifTrue: [self updateAdditionalAccelerators].
-	(aCompilationResult affectsAnnotation: #commandQuerySelector:)
-		ifTrue: [commandQuerySelectors := nil]!
+	(CommandQuery validateQueriesIn: aCompilationResult) ifTrue: [self resetCommandQueries]!
 
-commandQueryHandlers
-	^commandQueryHandlers ?? #()!
-
-commandQuerySelectors
-	^commandQuerySelectors ifNil: [commandQuerySelectors := self findCommandQuerySelectors]!
+commandQueries
+	^commandQueries ifNil: [commandQueries := CommandQuery findQueryHandlersIn: self]!
 
 create
 	"Answers an instance of the receiver with a default view"
@@ -1115,20 +1110,6 @@ findAcceleratorKeyAnnotations
 						do: [:args | stream nextPut: {each selector. AcceleratorTable canonicalizeKeyString: (args at: 1)}]]].
 	^stream contents!
 
-findCommandQuerySelectors
-	| selectors |
-	selectors := IdentityDictionary new.
-	self methodsDo: 
-			[:eachMethod |
-			eachMethod annotations
-				ifNotNil: 
-					[:annotations |
-					annotations selectorsAndArgumentsDo: 
-							[:annotationSelector :annotationArgs |
-							annotationSelector == #commandQuerySelector:
-								ifTrue: [selectors at: eachMethod selector put: annotationArgs single]]]].
-	^selectors!
-
 getAdditionalKeyBindings
 	^nil!
 
@@ -1155,6 +1136,12 @@ on: aModel
 	but connected to aModel."
 
 	^(super new) on: aModel; yourself!
+
+queryCommandHandlers
+	^queryCommandHandlers ?? #()!
+
+resetCommandQueries
+	commandQueries := nil!
 
 resetDefaultAdditionalAccelerators
 	acceleratorKeyAnnotations := nil!
@@ -1232,8 +1219,7 @@ additionalAccelerators!accessing!public! !
 additionalKeyBindings!accessing!private! !
 annotatedMethodRemoved:!private! !
 annotationsUpdated:!private! !
-commandQueryHandlers!accessing!private! !
-commandQuerySelectors!accessing!private! !
+commandQueries!accessing!private! !
 create!instance creation!public! !
 create:!instance creation!public! !
 create:in:!instance creation!public! !
@@ -1247,12 +1233,13 @@ defaultModel!models!public! !
 defaultResourceIdentifier!constants!public! !
 defaultView!constants!public! !
 findAcceleratorKeyAnnotations!constants!private! !
-findCommandQuerySelectors!accessing!private! !
 getAdditionalKeyBindings!accessing!private! !
 icon!constants!public! !
 loadViewResource:inContext:!operations!private! !
 new!instance creation!public! !
 on:!instance creation!public! !
+queryCommandHandlers!accessing!private! !
+resetCommandQueries!initializing!private! !
 resetDefaultAdditionalAccelerators!public! !
 resource_Container_view!public!resources-views! !
 resource_Default_view!public!resources-views! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.Shell.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.Shell.cls
@@ -225,7 +225,7 @@ redo
 	"Redo the last command that is forward in the command history list. During the redo operation
 	we place the receiver in a state where it will not accept any further command histories."
 
-	<commandQuerySelector: #queryRedo:>
+	<commandQuery: #queryRedo:>
 	| history |
 	self hasCommandHistory ifFalse: [^self].
 	"Save the original history list"
@@ -255,7 +255,7 @@ undo
 	"Undo the current command in the command history list. During the undo operation
 	we place the receiver in a state where it will not accept any further command histories."
 
-	<commandQuerySelector: #queryUndo:>
+	<commandQuery: #queryUndo:>
 	| history command |
 	self hasCommandHistory ifFalse: [^self].
 	"Save the original history list"

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.View.cls
@@ -5,7 +5,7 @@ Core.Object
 	instanceVariableNames: 'handle creationParent creationStyle presenter model backcolor preferredExtent flags contextMenu font events interactor'
 	classVariableNames: 'MessageMap NextId ViewClosedError WndClassAtom'
 	imports: #(#{OS.Win32Constants} #{OS.Win32Errors})
-	classInstanceVariableNames: 'theme commandQuerySelectors'
+	classInstanceVariableNames: 'theme commandQueries'
 	classConstants: {
 			'CreateCenteredMask' -> 16r40.
 			'DragSourceMask' -> 16r4.
@@ -2902,11 +2902,11 @@ queryCommandHandlers: aCommandQuery
 	class := self class.
 	command := aCommandQuery commandSymbol.
 	
-	[(class commandQuerySelectors lookup: command)
+	[(class commandQueries lookup: command)
 		ifNotNil: 
-			[:selector |
+			[:handler |
 			"Unless the handler specifically returns false, assume the command query was handled and terminate the search"
-			(self perform: selector with: aCommandQuery) == false ifFalse: [^true]].
+			(handler value: self value: aCommandQuery) == false ifFalse: [^true]].
 	class == ##(self)]
 			whileFalse: [class := class superclass].
 	^false!
@@ -5169,13 +5169,12 @@ activeOrDesktop
 annotatedMethodRemoved: aCompiledMethod
 	"Private - An annotated method of the receiver has been removed. This is an opportunity to update any metadata that might be based on method annotations."
 
-	(aCompiledMethod hasAnnotation: #commandQuerySelector:) ifTrue: [commandQuerySelectors := nil]!
+	(aCompiledMethod hasAnnotation: #commandQuerySelector:) ifTrue: [self resetCommandQueries]!
 
 annotationsUpdated: aCompilationResult
 	"Private - Annotations may have been added or removed in the receiver's methods. This is an opportunity to update any metadata that might be based on method annotations."
 
-	(aCompilationResult affectsAnnotation: #commandQuerySelector:)
-		ifTrue: [commandQuerySelectors := nil]!
+	(CommandQuery validateQueriesIn: aCompilationResult) ifTrue: [self resetCommandQueries]!
 
 buildMessageMap
 	"Private - Initialize the map of Windows message numbers to the selectors of the low-level event handlers in the receiver.
@@ -5261,8 +5260,8 @@ closeAll
 
 	^(self topLevelViews reject: [ :w | w close ]) isEmpty!
 
-commandQuerySelectors
-	^commandQuerySelectors ifNil: [commandQuerySelectors := self findCommandQuerySelectors]!
+commandQueries
+	^commandQueries ifNil: [commandQueries := CommandQuery findQueryHandlersIn: self]!
 
 cursor
 	"Answers the default cursor to be used for the mouse pointer when over instances of the receiver.
@@ -5320,20 +5319,6 @@ destroyAll
 
 	self topLevelViews do: [:w | w destroy].
 	SessionManager.Current inputState purgeDeadWindows!
-
-findCommandQuerySelectors
-	| selectors |
-	selectors := IdentityDictionary new.
-	self methodsDo: 
-			[:eachMethod |
-			eachMethod annotations
-				ifNotNil: 
-					[:annotations |
-					annotations selectorsAndArgumentsDo: 
-							[:annotationSelector :annotationArgs |
-							annotationSelector == #commandQuerySelector:
-								ifTrue: [selectors at: eachMethod selector put: annotationArgs single]]]].
-	^selectors!
 
 focus
 	"Answers the View with focus or nil if there is none.
@@ -5513,6 +5498,9 @@ reregisterClass
 		unregisterClass;
 		registerClass
 !
+
+resetCommandQueries
+	commandQueries := nil!
 
 resetTheme
 	theme := nil!
@@ -5791,7 +5779,7 @@ annotationsUpdated:!private! !
 buildMessageMap!constants!must not strip!private! !
 capture!accessing!public! !
 closeAll!operations!private! !
-commandQuerySelectors!accessing!private! !
+commandQueries!accessing!private! !
 cursor!accessing!public! !
 defaultGetImageBlock!adapters!constants!public! !
 defaultGetTextBlock!adapters!constants!public! !
@@ -5801,7 +5789,6 @@ defaultView!constants!public! !
 desktop!accessing!public! !
 desktopHandle!enquiries!private! !
 destroyAll!operations!private! !
-findCommandQuerySelectors!accessing!private! !
 focus!accessing!public! !
 focusHandle!accessing!private! !
 foreground!enquiries!public! !
@@ -5821,6 +5808,7 @@ registerMessage:!dispatching!public! !
 registerMessageMappings:!class initialization!public! !
 releaseCapture!operations!public! !
 reregisterClass!operations!private! !
+resetCommandQueries!initializing!private! !
 resetTheme!private!theming! !
 resource_Default_view!public!resources-views! !
 selectorForMessage:!dispatching!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.View.cls
@@ -5169,7 +5169,7 @@ activeOrDesktop
 annotatedMethodRemoved: aCompiledMethod
 	"Private - An annotated method of the receiver has been removed. This is an opportunity to update any metadata that might be based on method annotations."
 
-	(aCompiledMethod hasAnnotation: #commandQuerySelector:) ifTrue: [self resetCommandQueries]!
+	(aCompiledMethod hasAnnotation: #commandQuery:) ifTrue: [self resetCommandQueries]!
 
 annotationsUpdated: aCompilationResult
 	"Private - Annotations may have been added or removed in the receiver's methods. This is an opportunity to update any metadata that might be based on method annotations."

--- a/Core/Object Arts/Dolphin/MVP/Deprecated/Dolphin MVP (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/MVP/Deprecated/Dolphin MVP (Deprecated).pax
@@ -733,9 +733,9 @@ asDword!converting!public! !
 
 addCommandQueryHandler: aSymbol
 	Notification deprecated.	"This mechanism is replaced by <commandQuerySelector: #queryBlah:> annotations, declared in the corresponding command methods. These are added to a query selector map automatically on package load."
-	commandQueryHandlers := commandQueryHandlers
+	queryCommandHandlers := queryCommandHandlers
 				ifNil: [{ aSymbol }]
-				ifNotNil: [commandQueryHandlers copyWith: aSymbol]!
+				ifNotNil: [queryCommandHandlers copyWith: aSymbol]!
 
 removeCommandQueryHandler: aSymbol
 	"Unregister an additional CommandQuery handler to reverse out a previous
@@ -743,7 +743,7 @@ removeCommandQueryHandler: aSymbol
 	uninstalling command handlers."
 
 	Notification deprecated.	"see #addCommandQueryHandler:"
-	commandQueryHandlers := commandQueryHandlers copyWithout: aSymbol! !
+	queryCommandHandlers := queryCommandHandlers copyWithout: aSymbol! !
 !Presenter class categoriesForMethods!
 addCommandQueryHandler:!accessing!public! !
 removeCommandQueryHandler:!accessing!public! !
@@ -947,7 +947,7 @@ supportsAlphaBlending!capability enquiries!public! !
 clear
 	"Clears the contents of the receiver"
 
-	<commandQuerySelector: #queryCanCut:>
+	<commandQuerySelector: #canCut>
 	Notification deprecated.	"Use #clearAll"
 	self clearAll!
 

--- a/Core/Object Arts/Dolphin/MVP/Deprecated/Dolphin MVP (Deprecated).pax
+++ b/Core/Object Arts/Dolphin/MVP/Deprecated/Dolphin MVP (Deprecated).pax
@@ -947,7 +947,7 @@ supportsAlphaBlending!capability enquiries!public! !
 clear
 	"Clears the contents of the receiver"
 
-	<commandQuerySelector: #canCut>
+	<commandQuery: #canCut>
 	Notification deprecated.	"Use #clearAll"
 	self clearAll!
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Collection/UI.CollectionPresenter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Collection/UI.CollectionPresenter.cls
@@ -19,7 +19,8 @@ Instance Variables:
 addItem
 	"Uses the receiver's addItemBlock to answer a new item to add to the collection"
 
-	self canGrow
+	<commandQuery: #canAddOrRemoveItems>
+	self canAddOrRemoveItems
 		ifTrue: 
 			[| item |
 			item := addItemBlock notNil ifTrue: [addItemBlock value] ifFalse: [self defaultAddItem].
@@ -32,12 +33,14 @@ addItem: anObject
 	self listModel add: anObject
 	!
 
-canGrow
+canAddOrRemoveItems
 	"Private - Answer true if it is valid to add and remove elements of the receiver's collection"
 
 	^self isReadOnly not and: 
-			[self model canSet 
-				and: [self model value class conformsToProtocol: #sequencedContractibleCollection]]!
+			[self model canSet and: [self model value class conformsToProtocol: #sequencedContractibleCollection]]!
+
+canRemoveItem
+	^self canAddOrRemoveItems and: [listPresenter hasSelection]!
 
 createComponents
 	"Create the presenters contained by the receiver"
@@ -151,25 +154,10 @@ promptForExpression: promptString caption: captionString
 			whileTrue.
 	^result!
 
-queryCommand: query
-	"Private - Enters details about a potential command for the receiver into 
-	the <CommandQuery>, query"
-
-	| command |
-	command := query commandSymbol.
-	(#(#addItem) identityIncludes: command) 
-		ifTrue: 
-			[query isEnabled: self canGrow.
-			^true].
-	(#(#removeItem) identityIncludes: command) 
-		ifTrue: 
-			[query isEnabled: (self canGrow and: [listPresenter hasSelection]).
-			^true].
-	^super queryCommand: query!
-
 removeItem
 	"Removes the current selection from the receiver's list"
 
+	<commandQuery: #canRemoveItem>
 	| index |
 	index:= listPresenter selectionByIndex.
 	self listModel removeAtIndex: index.
@@ -192,9 +180,10 @@ setAddItemBlock: aNiladicValuable
 
 	addItemBlock := aNiladicValuable! !
 !UI.CollectionPresenter categoriesForMethods!
-addItem!commands!public! !
+addItem!commands-actions!public! !
 addItem:!operations!public! !
-canGrow!private!testing! !
+canAddOrRemoveItems!private!testing! !
+canRemoveItem!private!testing! !
 createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
 defaultAddItem!helpers!private! !
@@ -208,8 +197,7 @@ onListChanged!event handling!private! !
 onSelectionChanged!public! !
 onValueChanged!event handling!private! !
 promptForExpression:caption:!helpers!private! !
-queryCommand:!commands!private! !
-removeItem!commands!operations!public! !
+removeItem!commands-actions!operations!public! !
 selectionOrNil!public!selection! !
 selectionOrNil:!public!selection! !
 setAddItemBlock:!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Collection/UI.HashedCollectionPresenter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Collection/UI.HashedCollectionPresenter.cls
@@ -24,7 +24,7 @@ addItem: anObject
 	self onValueChanged.
 	listPresenter selection: anObject!
 
-canGrow
+canAddOrRemoveItems
 	"Private - Answer true if it is valid to add and remove elements of the receiver's collection"
 
 	^self isReadOnly not and: [self model canSet]!
@@ -60,11 +60,11 @@ removeItem
 !UI.HashedCollectionPresenter categoriesForMethods!
 addElement:!adding!private! !
 addItem:!operations!public! !
-canGrow!private!testing! !
+canAddOrRemoveItems!private!testing! !
 elements!accessing!public! !
 onListChanged!event handling!public! !
 onValueChanged!event handling!public! !
 removeElement:!private!removing! !
-removeItem!commands!public!removing! !
+removeItem!commands-actions!public!removing! !
 !
 

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Collection/UI.SequenceableCollectionPresenter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Collection/UI.SequenceableCollectionPresenter.cls
@@ -14,6 +14,12 @@ UI.SequenceableCollectionPresenter comment: 'SequenceableCollectionPresenter is 
 !UI.SequenceableCollectionPresenter categoriesForClass!MVP-Presenters! !
 !UI.SequenceableCollectionPresenter methodsFor!
 
+canMoveDown
+	^self canReorder and: [listPresenter selectionByIndex between: 1 and: self listModel size - 1]!
+
+canMoveUp
+	^self canReorder and: [listPresenter selectionByIndex > 1]!
+
 canReorder
 	"Private - Answer true if it is valid to reorder the receiver's collection"
 
@@ -23,6 +29,7 @@ canReorder
 moveDown
 	"Moves the current selection closer to the end of the receiver's list"
 
+	<commandQuery: #canMoveDown>
 	| index list |
 	index := listPresenter selectionByIndex.
 	list := self listModel.
@@ -36,13 +43,18 @@ moveDown
 moveFirst
 	"Moves the current selection to be the first item in the receiver's list"
 
+	<commandQuery: #canMoveUp>
 	| list index |
 	index := listPresenter selectionByIndex.
 	list := self listModel.
 	list noEventsDo: 
 			[| item |
 			item := list at: index.
-			list replaceFrom: 2 to: index with: list startingAt: 1.
+			list
+				replaceFrom: 2
+				to: index
+				with: list
+				startingAt: 1.
 			list at: 1 put: item].
 	list notifyListChanged.
 	listPresenter selectionByIndex: 1!
@@ -50,6 +62,7 @@ moveFirst
 moveLast
 	"Moves the current selection to be the last item in the receiver's list"
 
+	<commandQuery: #canMoveDown>
 	| list index last |
 	index := listPresenter selectionByIndex.
 	list := self listModel.
@@ -69,6 +82,7 @@ moveLast
 moveUp
 	"Moves the current selection closer to the head of the receiver's list"
 
+	<commandQuery: #canMoveUp>
 	| index list |
 	index := listPresenter selectionByIndex.
 	list := self listModel.
@@ -80,35 +94,16 @@ onValueChanged
 	"Private - The value has been changed in the receiver's model.
 	Transfer the value to the listModel"
 
-	listPresenter list: self value!
-
-queryCommand: query
-	"Private - Enters details about a potential command for the receiver into 
-	the <CommandQuery>, query"
-
-	| command |
-	command := query commandSymbol.
-	(#(#moveUp #moveFirst) identityIncludes: command) 
-		ifTrue: 
-			[query isEnabled: (self canReorder and: [listPresenter selectionByIndex > 1]).
-			^true].
-	(#(#moveDown #moveLast) identityIncludes: command) 
-		ifTrue: 
-			[query 
-				isEnabled: (self canReorder and: 
-							[| selected |
-							selected := listPresenter selectionByIndex.
-							selected > 0 and: [selected < self listModel size]]).
-			^true].
-	^super queryCommand: query! !
+	listPresenter list: self value! !
 !UI.SequenceableCollectionPresenter categoriesForMethods!
+canMoveDown!private!testing! !
+canMoveUp!private!testing! !
 canReorder!private!testing! !
-moveDown!commands!operations!public! !
-moveFirst!commands!operations!public! !
-moveLast!commands!operations!public! !
-moveUp!commands!operations!public! !
+moveDown!commands-actions!operations!public! !
+moveFirst!commands-actions!operations!public! !
+moveLast!commands-actions!operations!public! !
+moveUp!commands-actions!operations!public! !
 onValueChanged!event handling!private! !
-queryCommand:!commands!private! !
 !
 
 !UI.SequenceableCollectionPresenter class methodsFor!

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/UI.MultilineTextEdit.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/UI.MultilineTextEdit.cls
@@ -105,11 +105,10 @@ canVScroll: aBoolean
 copyLine
 	"Copy the current line. The selection is unaffected."
 
-	<commandQuerySelector: #queryCanCopy:>
+	<commandQuerySelector: #hasSelection>
 	self basicCopyLine!
 
 copySelectionOrLine
-	<commandQuerySelector: #queryCanCopy:>
 	self basicCopySelectionOrLine!
 
 currentLine
@@ -122,7 +121,7 @@ cutLine
 	"Delete the line on which the caret is located into the clipboard, including the line delimiter (i.e. subsequent lines shift
 	up by one). If it is the last line just cuts the text on that line, if any."
 
-	<commandQuerySelector: #queryCanCut:>
+	<commandQuerySelector: #canCut>
 	self basicCutLine!
 
 defaultExtent
@@ -140,7 +139,7 @@ deleteLine
 	"Delete the line on which the caret is located, including the line delimiter (i.e. subsequent lines shift
 	up by one). If it is the last line just deletes the text on that line, if any."
 
-	<commandQuerySelector: #queryCanCut:>
+	<commandQuerySelector: #canCut>
 	self basicDeleteLine!
 
 displayOnFormats
@@ -166,13 +165,13 @@ dlgCode
 duplicateLine
 	"Duplicate the current line."
 
-	<commandQuerySelector: #queryCanDuplicate:>
+	<commandQuerySelector: #isWriteable>
 	self basicDuplicateLine!
 
 duplicateSelection
 	"Duplicate the current selection (or line if the selection is empty)."
 
-	<commandQuerySelector: #queryCanDuplicate:>
+	<commandQuerySelector: #isWriteable>
 	self basicDuplicateSelection!
 
 goto: anInteger 
@@ -223,9 +222,6 @@ lineLength: anIntegerLineNumber
 
 	^self lineLengthFromPosition: (self positionAtLine: anIntegerLineNumber).
 !
-
-queryCanDuplicate: aCommandQuery
-	aCommandQuery isEnabled: self isReadOnly not!
 
 queryToggleWordWrap: aCommandQuery
 	aCommandQuery
@@ -415,7 +411,6 @@ insertText:at:!public!text retrieval & modification! !
 lineCount!accessing!public! !
 lineHeight:!public! !
 lineLength:!accessing!public! !
-queryCanDuplicate:!commands-queries!private! !
 queryToggleWordWrap:!commands-queries!private! !
 resetCharFormat!operations!public! !
 selectCurrentLine!public!selection! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/UI.MultilineTextEdit.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/UI.MultilineTextEdit.cls
@@ -105,7 +105,7 @@ canVScroll: aBoolean
 copyLine
 	"Copy the current line. The selection is unaffected."
 
-	<commandQuerySelector: #hasSelection>
+	<commandQuery: #hasSelection>
 	self basicCopyLine!
 
 copySelectionOrLine
@@ -121,7 +121,7 @@ cutLine
 	"Delete the line on which the caret is located into the clipboard, including the line delimiter (i.e. subsequent lines shift
 	up by one). If it is the last line just cuts the text on that line, if any."
 
-	<commandQuerySelector: #canCut>
+	<commandQuery: #canCut>
 	self basicCutLine!
 
 defaultExtent
@@ -139,7 +139,7 @@ deleteLine
 	"Delete the line on which the caret is located, including the line delimiter (i.e. subsequent lines shift
 	up by one). If it is the last line just deletes the text on that line, if any."
 
-	<commandQuerySelector: #canCut>
+	<commandQuery: #canCut>
 	self basicDeleteLine!
 
 displayOnFormats
@@ -165,13 +165,13 @@ dlgCode
 duplicateLine
 	"Duplicate the current line."
 
-	<commandQuerySelector: #isWriteable>
+	<commandQuery: #isWriteable>
 	self basicDuplicateLine!
 
 duplicateSelection
 	"Duplicate the current selection (or line if the selection is empty)."
 
-	<commandQuerySelector: #isWriteable>
+	<commandQuery: #isWriteable>
 	self basicDuplicateSelection!
 
 goto: anInteger 
@@ -320,12 +320,11 @@ toggleWordWrap
 	which will go into an infinite loop if a keyboard shortcut or navigation key is pressed when the active
 	view does not have focus anywhere."
 
-	<commandQuerySelector: #queryToggleWordWrap:>
+	<commandQuery: #queryToggleWordWrap:>
 	| focus |
-	focus := self class focus.	
+	focus := self class focus.
 	self wordWrap: self wordWrap not.
-	focus == self ifTrue: [self setFocus]
-	!
+	focus == self ifTrue: [self setFocus]!
 
 wmKeyDown: message wParam: wParam lParam: lParam 
 	"Private - Handle WM_KEYDOWN.

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/UI.TextEdit.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/UI.TextEdit.cls
@@ -55,7 +55,7 @@ apply
 	"Apply the changes made to the edit to the receiver's model. Answer whether
 	any update actually occurred to the model."
 
-	<commandQuerySelector: #queryApply:>
+	<commandQuerySelector: #isTextModified>
 	| modified |
 	modified := self isTextModified.
 	modified ifTrue: [self updateModel].
@@ -146,6 +146,15 @@ calculateExtent: aLayoutContext
 
 	^self extentForText: self plainText!
 
+canCut
+	^self isWriteable and: [self hasSelection]!
+
+canFind
+	^self isFindEnabled and: [self hasText]!
+
+canFindReplace
+	^self isWriteable and: [self canFind]!
+
 canHScroll
 	"Answer true if the receiver is in horizontal scrolling mode"
 
@@ -169,7 +178,7 @@ canPaste
 	"Answer whether the window can paste from the current contents of
 	the clipboard."
 
-	^self isReadOnly not and: [User32 isClipboardFormatAvailable: CF_UNICODETEXT]!
+	^self isWriteable and: [User32 isClipboardFormatAvailable: CF_UNICODETEXT]!
 
 canRedo
 	"Answer whether the window can redo the last undone operation."
@@ -209,7 +218,7 @@ charNearestPosition: aPoint
 clearAll
 	"Clears the contents of the receiver"
 
-	<commandQuerySelector: #queryCanCut:>
+	<commandQuerySelector: #canCut>
 	self basicClearAll!
 
 clearSelection
@@ -217,7 +226,7 @@ clearSelection
 	N.B. If there is no selection, deletes the character immediately after the
 	caret (i.e. behaves like Del key)."
 
-	<commandQuerySelector: #queryCanCut:>
+	<commandQuerySelector: #canCut>
 	| range |
 	range := self selectionRange.
 	range isEmpty ifTrue: [self selectionStart: range start end: range start].
@@ -237,7 +246,7 @@ command: anInteger id: id
 copySelection
 	"Copy the current selection to the clipboard."
 
-	<commandQuerySelector: #queryCanCopy:>
+	<commandQuerySelector: #hasSelection>
 	self basicCopySelection!
 
 cueBanner
@@ -264,7 +273,7 @@ cueBanner: aString
 cutSelection
 	"Cut the current selection and place on the clipboard."
 
-	<commandQuerySelector: #queryCanCut:>
+	<commandQuerySelector: #canCut>
 	self basicCutSelection!
 
 defaultSelectionRange
@@ -330,7 +339,7 @@ dragOver: session
 editFind
 	"Launch the common Find dialog."
 
-	<commandQuerySelector: #queryFind:>
+	<commandQuerySelector: #canFind>
 	self findPrompt: self suggestedFindText!
 
 emptyUndoBuffer
@@ -391,7 +400,7 @@ extentForText: aString
 find
 	"Launch the FindText dialog in response to a generic toolbar find command."
 
-	<commandQuerySelector: #queryFind:>
+	<commandQuerySelector: #canFind>
 	self editFind!
 
 find: aFindDetails range: anInterval 
@@ -419,7 +428,7 @@ findDialogClass
 findNext
 	"Hilight the next occurrence which satisfies the find operation held in findDetails."
 
-	<commandQuerySelector: #queryFindNext:>
+	<commandQuerySelector: #hasFindDetails>
 	self findDetails isNil
 		ifTrue: [self find]
 		ifFalse: [self basicFindNext ifFalse: [Sound defaultBeep]]!
@@ -468,7 +477,7 @@ findPrompt: aString
 findReplace
 	"Launch the FindReplaceText dialog."
 
-	<commandQuerySelector: #queryFindReplace:>
+	<commandQuerySelector: #canFindReplace>
 	self findReplacePrompt: self suggestedFindText!
 
 findReplacePrompt: aString
@@ -508,6 +517,9 @@ formatRectangle
 		lpParam: rect.
 	^rect asRectangle!
 
+hasFindDetails
+	^self findDetails notNil!
+
 hasSelection
 	"Answer true if the receiver has a selected range of text.
 	Implementation Note: The simplest implementation of this would be
@@ -533,6 +545,9 @@ hasSelection
 					(selEnd := range stop) > len ifTrue: [selEnd := len].
 					(selStart := range start) > len ifTrue: [selStart := len].
 					(selStart + 1 to: selEnd) notEmpty]]!
+
+hasText
+	^self textLength > 0!
 
 highlightFindMatch: anInterval 
 	self selectionRange: anInterval!
@@ -650,6 +665,9 @@ isUpdatePerChar: aBoolean
 
 	self updatePerChar: aBoolean
 !
+
+isWriteable
+	^self isReadOnly not!
 
 lineCount
 	"Answers the number of lines in the receiver."
@@ -846,13 +864,13 @@ passwordCharacter: aCharacter
 pasteClipboard
 	"Paste the clipboard text into the receiver's window."
 
-	<commandQuerySelector: #queryCanPaste:>
+	<commandQuerySelector: #canPaste>
 	self basicPasteClipboard!
 
 pastePlainText
 	"Paste the clipboard text into the receiver's window."
 
-	<commandQuerySelector: #queryCanPaste:>
+	<commandQuerySelector: #canPaste>
 	self basicPasteClipboard!
 
 plainTextAtLine: anInteger 
@@ -906,42 +924,10 @@ preTranslateKeyboardInput: aMSG
 			^true].
 	^false!
 
-queryApply: aCommandQuery
-	aCommandQuery isEnabled: self isTextModified!
-
-queryCanCopy: aCommandQuery
-
-	aCommandQuery
-		receiver: self;
-		isEnabled: self hasSelection!
-
-queryCanCut: aCommandQuery
-	aCommandQuery
-		receiver: self;
-		isEnabled: (self isReadOnly not and: [self hasSelection])!
-
-queryCanPaste: aCommandQuery
-	aCommandQuery isEnabled: self canPaste!
-
-queryCanRedo: aCommandQuery
-	aCommandQuery isEnabled: self canRedo!
-
-queryCanUndo: aCommandQuery
-	aCommandQuery isEnabled: self canUndo!
-
-queryFind: aCommandQuery
-	aCommandQuery isEnabled: (self isFindEnabled and: [self textLength > 0])!
-
-queryFindNext: aCommandQuery
-	aCommandQuery isEnabled: self findDetails notNil!
-
-queryFindReplace: aCommandQuery
-	aCommandQuery isEnabled: (self isFindEnabled and: [self isReadOnly not and: [self textLength > 0]])!
-
 redo
 	"Redo the last undone edit action."
 
-	<commandQuerySelector: #queryCanRedo:>
+	<commandQuerySelector: #canRedo>
 	self basicRedo!
 
 refreshContents
@@ -1188,7 +1174,7 @@ textRange
 undo
 	"Undo the last undoable edit action."
 
-	<commandQuerySelector: #queryCanUndo:>
+	<commandQuerySelector: #canUndo>
 	self basicUndo!
 
 updateModel
@@ -1324,6 +1310,9 @@ basicSelectionStart:end:!accessing!private! !
 basicUndo!private!undo & redo! !
 calcRectangleFromClientRectangle:!geometry!private! !
 calculateExtent:!geometry!private! !
+canCut!private!testing! !
+canFind!private!testing! !
+canFindReplace!private!testing! !
 canHScroll!accessing-styles!public! !
 canHScroll:!accessing-styles!public! !
 canPaste!clipboard operations!public!testing! !
@@ -1370,7 +1359,9 @@ findReplacePrompt:!public!searching & replacing! !
 format!public!testing! !
 format:!accessing!public! !
 formatRectangle!accessing!public! !
+hasFindDetails!private!testing! !
 hasSelection!public!selection! !
+hasText!private!testing! !
 highlightFindMatch:!private!searching & replacing! !
 initialize!initializing!private! !
 initializeNewTypeConverter:!accessing!private! !
@@ -1390,6 +1381,7 @@ isTextModified!private!testing! !
 isTextModified:!modes!private! !
 isUpdatePerChar!public!testing! !
 isUpdatePerChar:!accessing!public! !
+isWriteable!public!testing! !
 lineCount!accessing!public! !
 lineFromPosition:!accessing!public! !
 lineLengthFromPosition:!accessing!private! !
@@ -1416,15 +1408,6 @@ positionAtLine:!accessing!public! !
 positionForKeyboardContextMenu!enquiries!public! !
 positionOfChar:!accessing!public! !
 preTranslateKeyboardInput:!dispatching!public! !
-queryApply:!commands-queries!private! !
-queryCanCopy:!commands-queries!private! !
-queryCanCut:!commands-queries!private! !
-queryCanPaste:!commands-queries!private! !
-queryCanRedo:!commands-queries!private! !
-queryCanUndo:!commands-queries!private! !
-queryFind:!commands-queries!private! !
-queryFindNext:!commands-queries!private! !
-queryFindReplace:!commands-queries!private! !
 redo!commands-actions!public! !
 refreshContents!operations!public! !
 replace:!private!searching & replacing! !

--- a/Core/Object Arts/Dolphin/MVP/Presenters/Text/UI.TextEdit.cls
+++ b/Core/Object Arts/Dolphin/MVP/Presenters/Text/UI.TextEdit.cls
@@ -55,7 +55,7 @@ apply
 	"Apply the changes made to the edit to the receiver's model. Answer whether
 	any update actually occurred to the model."
 
-	<commandQuerySelector: #isTextModified>
+	<commandQuery: #isTextModified>
 	| modified |
 	modified := self isTextModified.
 	modified ifTrue: [self updateModel].
@@ -218,7 +218,7 @@ charNearestPosition: aPoint
 clearAll
 	"Clears the contents of the receiver"
 
-	<commandQuerySelector: #canCut>
+	<commandQuery: #canCut>
 	self basicClearAll!
 
 clearSelection
@@ -226,7 +226,7 @@ clearSelection
 	N.B. If there is no selection, deletes the character immediately after the
 	caret (i.e. behaves like Del key)."
 
-	<commandQuerySelector: #canCut>
+	<commandQuery: #canCut>
 	| range |
 	range := self selectionRange.
 	range isEmpty ifTrue: [self selectionStart: range start end: range start].
@@ -246,7 +246,7 @@ command: anInteger id: id
 copySelection
 	"Copy the current selection to the clipboard."
 
-	<commandQuerySelector: #hasSelection>
+	<commandQuery: #hasSelection>
 	self basicCopySelection!
 
 cueBanner
@@ -273,7 +273,7 @@ cueBanner: aString
 cutSelection
 	"Cut the current selection and place on the clipboard."
 
-	<commandQuerySelector: #canCut>
+	<commandQuery: #canCut>
 	self basicCutSelection!
 
 defaultSelectionRange
@@ -339,7 +339,7 @@ dragOver: session
 editFind
 	"Launch the common Find dialog."
 
-	<commandQuerySelector: #canFind>
+	<commandQuery: #canFind>
 	self findPrompt: self suggestedFindText!
 
 emptyUndoBuffer
@@ -400,7 +400,7 @@ extentForText: aString
 find
 	"Launch the FindText dialog in response to a generic toolbar find command."
 
-	<commandQuerySelector: #canFind>
+	<commandQuery: #canFind>
 	self editFind!
 
 find: aFindDetails range: anInterval 
@@ -428,7 +428,7 @@ findDialogClass
 findNext
 	"Hilight the next occurrence which satisfies the find operation held in findDetails."
 
-	<commandQuerySelector: #hasFindDetails>
+	<commandQuery: #hasFindDetails>
 	self findDetails isNil
 		ifTrue: [self find]
 		ifFalse: [self basicFindNext ifFalse: [Sound defaultBeep]]!
@@ -477,7 +477,7 @@ findPrompt: aString
 findReplace
 	"Launch the FindReplaceText dialog."
 
-	<commandQuerySelector: #canFindReplace>
+	<commandQuery: #canFindReplace>
 	self findReplacePrompt: self suggestedFindText!
 
 findReplacePrompt: aString
@@ -864,13 +864,13 @@ passwordCharacter: aCharacter
 pasteClipboard
 	"Paste the clipboard text into the receiver's window."
 
-	<commandQuerySelector: #canPaste>
+	<commandQuery: #canPaste>
 	self basicPasteClipboard!
 
 pastePlainText
 	"Paste the clipboard text into the receiver's window."
 
-	<commandQuerySelector: #canPaste>
+	<commandQuery: #canPaste>
 	self basicPasteClipboard!
 
 plainTextAtLine: anInteger 
@@ -927,7 +927,7 @@ preTranslateKeyboardInput: aMSG
 redo
 	"Redo the last undone edit action."
 
-	<commandQuerySelector: #canRedo>
+	<commandQuery: #canRedo>
 	self basicRedo!
 
 refreshContents
@@ -1174,7 +1174,7 @@ textRange
 undo
 	"Undo the last undoable edit action."
 
-	<commandQuerySelector: #canUndo>
+	<commandQuery: #canUndo>
 	self basicUndo!
 
 updateModel

--- a/Core/Object Arts/Dolphin/MVP/Views/Cards/UI.AbstractCardContainer.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Cards/UI.AbstractCardContainer.cls
@@ -55,14 +55,24 @@ firstCard
 	associated container. It is an error to ask for the first card
 	when there is none. Answers the view that is the first card."
 
+	<commandQuery: #isNotFirstCard>
 	self cardLayout firstCard.
 	^self tabOntoCurrentCard!
+
+isNotFirstCard
+	| cards |
+	cards := self cardLayout cards.
+	^cards notEmpty and: [self currentCard ~= cards first]!
+
+isNotLastCard
+	^self currentCard ~= self cardLayout cards last!
 
 lastCard
 	"Show the card which is last in the z-order sequence of the 
 	associated container. It is an error to ask for the first card
 	when there is none. Answers the view that is the last card."
 
+	<commandQuery: #isNotLastCard>
 	self cardLayout lastCard.
 	^self tabOntoCurrentCard!
 
@@ -71,6 +81,7 @@ nextCard
 	associated container after the current card that is visible. 
 	Answers the view that is the next card or nil if there is none"
 
+	<commandQuery: #isNotLastCard>
 	self cardLayout nextCard.
 	^self tabOntoCurrentCard!
 
@@ -109,24 +120,9 @@ previousCard
 	associated container before the current card that is visible. 
 	Answers the view that is the previous card or nil if there is none"
 
+	<commandQuery: #isNotFirstCard>
 	self cardLayout previousCard.
 	^self tabOntoCurrentCard!
-
-queryCommand: aCommandQuery 
-	"Private - Enter details about a potential command for the receiver into the <CommandQuery>
-	argument."
-
-	| cmd |
-	cmd := aCommandQuery commandSymbol.
-	cmd == #nextCard 
-		ifTrue: 
-			[aCommandQuery isEnabled: self currentCard ~= self cardLayout cards last.
-			^true].
-	cmd == #previousCard 
-		ifTrue: 
-			[aCommandQuery isEnabled: self currentCard ~= self cardLayout cards first.
-			^true].
-	^super queryCommand: aCommandQuery!
 
 tabOntoCurrentCard
 	"Private - The receiver has just displayed a new card.
@@ -153,18 +149,19 @@ validateSubViewLayouts: aLayoutContext
 cardLayout!accessing!private! !
 cards!accessing!public! !
 currentCard!accessing!public! !
-cycleNextCard!commands!public! !
-cyclePreviousCard!commands!public! !
+cycleNextCard!commands-actions!public! !
+cyclePreviousCard!commands-actions!public! !
 defaultLayoutManager!initializing!private! !
 ensureSubViewVisible:!public!sub views! !
-firstCard!commands!public! !
-lastCard!commands!public! !
-nextCard!commands!public! !
+firstCard!commands-actions!public! !
+isNotFirstCard!private!testing! !
+isNotLastCard!private!testing! !
+lastCard!commands-actions!public! !
+nextCard!commands-actions!public! !
 onCardChangedFrom:to:!event handling!private! !
 onSubViewAdded:!event handling!private! !
 onViewCreated!event handling!private! !
-previousCard!commands!public! !
-queryCommand:!commands!private! !
+previousCard!commands-actions!public! !
 tabOntoCurrentCard!operations!private! !
 validateSubViewLayouts:!geometry!private! !
 !

--- a/Core/Object Arts/Dolphin/MVP/Views/Cards/UI.CardContainer.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Cards/UI.CardContainer.cls
@@ -258,20 +258,15 @@ preTranslateKeyboardInput: aMSG
 
 	^tabs preTranslateKeyboardInput: aMSG!
 
-queryCommand: aCommandQuery 
-	"Update aCommandQuery to indicate how a command would be processed
-	if sent to the receiver. Answers whether the receiver recognised the command
-	as one of its own (this may be ignored by the command router). This need not
-	be supersent if the #isEnabled: is sent to the <CommandQuery> to explicitly
-	enable or disable a particular command."
+queryTabOrientation: aCommandQuery
+	aCommandQuery
+		isEnabled: true;
+		isChecked: self tabOrientation == aCommandQuery command arguments first!
 
-	| cmd |
-	cmd := aCommandQuery commandSymbol.
-	#viewMode: == cmd 
-		ifTrue: [aCommandQuery isChecked: self viewMode == aCommandQuery command arguments first].
-	#tabOrientation: == cmd 
-		ifTrue: [aCommandQuery isChecked: self tabOrientation == aCommandQuery command arguments first].
-	^super queryCommand: aCommandQuery!
+queryViewMode: aCommandQuery
+	aCommandQuery
+		isEnabled: true;
+		isChecked: self viewMode == aCommandQuery command arguments first!
 
 refreshTabs
 	"Rebuild the associated tab view to include all the managed subviews
@@ -304,6 +299,7 @@ tabOrientation: aSymbol
 	displayed. The <Symbol> argument can be one of #left, #right, #top (the default) or
 	#bottom."
 
+	<commandQuery: #queryTabOrientation:>
 	tabs tabOrientation: aSymbol!
 
 tabs
@@ -331,6 +327,7 @@ viewMode: aSymbol
 		#smallIcons
 		#largeIcons"
 
+	<commandQuery: #queryViewMode:>
 	tabs viewMode: aSymbol!
 
 wmPrint: message wParam: wParam lParam: lParam
@@ -393,7 +390,8 @@ onTabChanging:!event handling!private! !
 onViewCreated!event handling!private! !
 onZOrderChanged!event handling!private! !
 preTranslateKeyboardInput:!public! !
-queryCommand:!commands!public! !
+queryTabOrientation:!commands-queries!private! !
+queryViewMode:!commands-queries!private! !
 refreshTabs!public!updating! !
 removeSubView:!public! !
 tabOrientation!accessing-styles!public! !

--- a/Core/Object Arts/Dolphin/MVP/Views/MoenTree/UI.MoenTreeView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/MoenTree/UI.MoenTreeView.cls
@@ -268,10 +268,23 @@ calculateNodeExtents: aMoenTreeNode forCanvas: aCanvas
 								ifTrue: [(textInset x + nodeExtent x) @ (iconExtent y max: nodeExtent y)]
 								ifFalse: [nodeExtent]])]!
 
+canCollapse
+	^selection notNil and: [selection isExpanded not and: [self hasChildren: selection]]!
+
+canCollapseAll
+	^selection isNil or: [selection isExpanded and: [self hasChildren: selection]]!
+
+canExpand
+	^selection notNil and: [selection isExpanded and: [self hasChildren: selection]]!
+
+canExpandAll
+	^selection isNil or: [self hasChildren: selection]!
+
 collapse
 	"Collapse the selected node, hiding any children and displaying a '+' button
 	if there are any."
 
+	<commandQuery: #canCollapse>
 	Cursor wait showWhile: [self collapseNode: self selectedNode cause: #keyboard]!
 
 collapse: anObject
@@ -280,6 +293,7 @@ collapse: anObject
 	self collapseNode: (self nodeForObject: anObject) cause: #unknown!
 
 collapseAll
+	<commandQuery: #canCollapseAll>
 	Cursor wait showWhile: [self collapseAll: self selectionOrNil]!
 
 collapseAll: anObject
@@ -410,6 +424,7 @@ expand
 	"Expand the selected node, showing any children and displaying a '-' button.
 	Implementation Note: This may take a while, so display the wait cursor."
 
+	<commandQuery: #canExpand>
 	Cursor wait showWhile: [self expandNode: self selectedNode]!
 
 expand: anObject
@@ -421,6 +436,7 @@ expand: anObject
 expandAll
 	"Expand the entire tree below the current selection."
 
+	<commandQuery: #canExpandAll>
 	Cursor wait showWhile: [self expandAll: self selectionOrNil]!
 
 expandAll: anObject
@@ -1463,34 +1479,6 @@ previousSibling: aMoenTreeNode
 					siblingNode := siblingNode sibling].
 			childNode]!
 
-queryCommand: aCommandQuery
-	"Private - Enters details about a potential command for the receiver into the 
-	<CommandQuery>."
-
-	| command |
-	command := aCommandQuery commandSymbol.
-	#expand == command 
-		ifTrue: 
-			[aCommandQuery isEnabled: (selection notNil 
-						and: [selection isExpanded not and: [self hasChildren: selection]]).
-			^true].
-	#collapse == command 
-		ifTrue: 
-			[aCommandQuery isEnabled: (selection notNil 
-						and: [selection isExpanded and: [self hasChildren: selection]]).
-			^true].
-	#collapseAll == command 
-		ifTrue: 
-			[aCommandQuery isEnabled: (selection isNil 
-						or: [selection isExpanded and: [self hasChildren: selection]]).
-			^true].
-	#expandAll == command 
-		ifTrue: 
-			[aCommandQuery 
-				isEnabled: (selection isNil or: [self hasChildren: selection]).
-			^true].
-	^super queryCommand: aCommandQuery!
-
 rectanglesChanged
 	self
 		generateAbsolutes;
@@ -1821,9 +1809,13 @@ calculateExtent:!accessing!private! !
 calculateNodeExtents!geometry!private! !
 calculateNodeExtents:!geometry!private! !
 calculateNodeExtents:forCanvas:!geometry!private! !
-collapse!commands!public! !
+canCollapse!private!testing! !
+canCollapseAll!private!testing! !
+canExpand!private!testing! !
+canExpandAll!private!testing! !
+collapse!commands-actions!public! !
 collapse:!operations!public! !
-collapseAll!commands!public! !
+collapseAll!commands-actions!public! !
 collapseAll:!expanding/collapsing!public! !
 collapseNode:cause:!operations!private! !
 collapseSubtree:!operations!private! !
@@ -1837,9 +1829,9 @@ editSelectionLabel!operations!public! !
 ensureNodeVisible:!operations!private! !
 ensureSelectionVisible!helpers!public! !
 errorNoSelection!exceptions!private! !
-expand!commands!public! !
+expand!commands-actions!public! !
 expand:!operations!public! !
-expandAll!commands!public! !
+expandAll!commands-actions!public! !
 expandAll:!expanding/collapsing!public! !
 expandNode:!operations!private! !
 expandSubtree:!operations!private! !
@@ -1929,7 +1921,6 @@ parentSpacing!accessing!public! !
 parentSpacing:!accessing!public! !
 populateNode:!operations!private! !
 previousSibling:!accessing!private! !
-queryCommand:!commands!private! !
 rectanglesChanged!event handling!public! !
 refreshContents!public!updating! !
 removeNode:!event handling!public! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.ScintillaView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.ScintillaView.cls
@@ -1231,7 +1231,7 @@ charNearestPosition: aPoint
 clearAll
 	"Delete all text in the document."
 
-	<commandQuerySelector: #queryCanCut:>
+	<commandQuerySelector: #canCut>
 	self modifyText: [self basicClearAll]!
 
 clearContainerIndicators
@@ -9555,7 +9555,7 @@ twiddleLines
 undo
 	"Undo one action in the undo history."
 
-	<commandQuerySelector: #queryCanUndo:>
+	<commandQuerySelector: #canUndo>
 	self cancelModes.
 	self basicUndo!
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.ScintillaView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.ScintillaView.cls
@@ -1231,7 +1231,7 @@ charNearestPosition: aPoint
 clearAll
 	"Delete all text in the document."
 
-	<commandQuerySelector: #canCut>
+	<commandQuery: #canCut>
 	self modifyText: [self basicClearAll]!
 
 clearContainerIndicators
@@ -9455,19 +9455,19 @@ toggleFoldMargin
 toggleIndentationGuides
 	"Show or hide the indentation guides."
 
-	<commandQuerySelector: #queryToggleIndentationGuides:>
+	<commandQuery: #queryToggleIndentationGuides:>
 	self hasIndentationGuides: self hasIndentationGuides not!
 
 toggleLineEndings
 	"Show or hide the end-of-line characters."
 
-	<commandQuerySelector: #queryToggleLineEndings:>
+	<commandQuery: #queryToggleLineEndings:>
 	self hasVisibleLineEndings: self hasVisibleLineEndings not!
 
 toggleLineNumbers
 	"Show or hide the first line number margin, inverting the current state."
 
-	<commandQuerySelector: #queryToggleLineNumbers:>
+	<commandQuery: #queryToggleLineNumbers:>
 	self hasLineNumbers: self hasLineNumbers not!
 
 toggleOvertype
@@ -9482,21 +9482,21 @@ toggleOvertype
 toggleStyling
 	"Enable/disable dynamic styling of text in the receiver."
 
-	<commandQuerySelector: #queryToggleStyling:>
+	<commandQuery: #queryToggleStyling:>
 	self isStylingEnabled: self isStylingEnabled not!
 
 toggleWhitespace
 	"Show or hide the whitespace markers in the view."
 
-	<commandQuerySelector: #queryToggleWhitespace:>
-	self whitespaceVisibility: (self whitespaceVisibility == #invisible 
+	<commandQuery: #queryToggleWhitespace:>
+	self whitespaceVisibility: (self whitespaceVisibility == #invisible
 				ifTrue: [#visibleAlways]
 				ifFalse: [#invisible])!
 
 toggleWordWrap
 	"Toggle the receiver into/out-of word wrap mode."
 
-	<commandQuerySelector: #queryToggleWordWrap:>
+	<commandQuery: #queryToggleWordWrap:>
 	self wordWrap: self wordWrap not!
 
 tokenEndAt: anInteger 
@@ -9555,7 +9555,7 @@ twiddleLines
 undo
 	"Undo one action in the undo history."
 
-	<commandQuerySelector: #canUndo>
+	<commandQuery: #canUndo>
 	self cancelModes.
 	self basicUndo!
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/UI.SlidingCardTray.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Sliding Tray/UI.SlidingCardTray.cls
@@ -259,6 +259,14 @@ pinStateId
 				ifTrue: [self isPinPressed ifTrue: [EBHP_PRESSED] ifFalse: [EBHP_HOT]]
 				ifFalse: [EBHP_NORMAL]]!
 
+queryTogglePin: aCommandQuery
+	slider
+		ifNil: [aCommandQuery isEnabled: false]
+		ifNotNil: 
+			[aCommandQuery
+				isEnabled: true;
+				isChecked: slider isPinned]!
+
 setSlider: aSlideyInneyOuteyThing
 	slider := aSlideyInneyOuteyThing.
 	tabs := slider tabs.
@@ -299,6 +307,7 @@ tabOrientation: aSymbol
 	self captionGeometryChanged!
 
 togglePin
+	<commandQuery: #queryTogglePin:>
 	slider ifNotNil: [slider isPinned: slider isPinned not]!
 
 trackMouseOverPin: aMouseEvent 
@@ -383,10 +392,11 @@ pinImageList!accessing!private! !
 pinInset!constants!private! !
 pinRectangle!accessing!private! !
 pinStateId!accessing!private! !
+queryTogglePin:!commands-actions!private! !
 setSlider:!initializing!private! !
 sizingEdgeInfo!helpers!private! !
 tabOrientation:!accessing-styles!public! !
-togglePin!commands!public! !
+togglePin!commands-actions!public! !
 trackMouseOverPin:!helpers!private! !
 wmNcCalcSize:wParam:lParam:!event handling-win32!private! !
 wmNcHitTest:wParam:lParam:!event handling-win32!private! !

--- a/Core/Object Arts/Samples/IDE/Dolphin IDE Extension Example.pax
+++ b/Core/Object Arts/Samples/IDE/Dolphin IDE Extension Example.pax
@@ -53,7 +53,7 @@ emitClassLayoutDescription
 	"Emits a description of the instance variables for the context class at the
 	insertion point in the receiver."
 
-	<commandQuerySelector: #hasClassSelected>
+	<commandQuery: #hasClassSelected>
 	| desc |
 	[desc := OAIDEExtensions current variableDescriptionsFor: self browser selectedClass]
 		on: OperationAborted

--- a/Core/Object Arts/Samples/IDE/Dolphin IDE Extension Example.pax
+++ b/Core/Object Arts/Samples/IDE/Dolphin IDE Extension Example.pax
@@ -53,7 +53,7 @@ emitClassLayoutDescription
 	"Emits a description of the instance variables for the context class at the
 	insertion point in the receiver."
 
-	<commandQuerySelector: #queryClassCommand:>
+	<commandQuerySelector: #hasClassSelected>
 	| desc |
 	[desc := OAIDEExtensions current variableDescriptionsFor: self browser selectedClass]
 		on: OperationAborted


### PR DESCRIPTION
Many command queries do nothing other than set the enablement of the command, in which case the code is simpler and smaller if a command query method can be a simple testing method that takes no arguments and returns true if the command is to be enabled, or false if disabled.

This seems to apply to the majority of cases visited so far, and in quite a few cases allows for the use of existing testing methods to be used, reducing the proliferation of individual query methods specific to individual commands or related groups of commands.

Also perform some validation of the query annotations, since it is easy to make a small mistake, such as mispelling a selector, and end up breaking the command handling in the development tools. As the command queries are often called repeatedly as a background/idle task to revalidate the UI state (e.g. for toolbar buttons), this can cause repetitive errors that are at best annoying, and at worst terminal.

Replace old #queryCommand: methods in MoenTreeView, Card containers, collection presenters and workspace classes.