### PR TITLE
shortName of BindingReferences with unbindable environment is incorrect

### DIFF
--- a/Core/Contributions/Refactory/Refactoring Browser/Change Objects/Refactory.Browser.ClassDetails.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Change Objects/Refactory.Browser.ClassDetails.cls
@@ -248,9 +248,7 @@ sharedPoolNames
 shortName
 	"Answer the shortest <String> name of the receiver that is bindable from Smalltalk. i.e. for classes defined directly in Smalltalk, or in any of its imports, this will be an unqualified name. Otherwise it is the fully qualified name relative to Smalltalk."
 
-	^self isInBaseEnvironment
-		ifTrue: [self unqualifiedName]
-		ifFalse: [Smalltalk shortNameFor: self unqualifiedName in: self environment]!
+	^self environment shortNameFor: self unqualifiedName!
 
 sourceFilerClass
 	^(self package

--- a/Core/Contributions/Refactory/Refactoring Browser/Refactorings/Refactory.Browser.RBClass.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Refactorings/Refactory.Browser.RBClass.cls
@@ -197,6 +197,9 @@ getInstanceSpec
 guid
 	^self realClass ifNotNil: [realClass guid]!
 
+importedNamespacesDo: aMonadicValuable
+	self imports do: [:each | each valueOrNil ifNotNil: [:ns | aMonadicValuable value: ns]]!
+
 imports
 	imports
 		ifNil: 
@@ -480,9 +483,12 @@ setSuperclass: aRBClass
 shortName
 	"Answer the shortest <String> name of the receiver that is bindable from Smalltalk. i.e. for classes defined directly in Smalltalk, or in any of its imports, this will be an unqualified name. Otherwise it is the fully qualified name relative to Smalltalk."
 
-	^self isInBaseEnvironment
-		ifTrue: [name]
-		ifFalse: [self model smalltalkNamespace shortNameFor: self unqualifiedName in: self environment]!
+	^(self environment ifNil: [self model smalltalkNamespace]) shortNameFor: self unqualifiedName!
+
+shortNameFor: aString
+	"Private - Answer the short name for the receiver's variable named, aString. The short name is the shortest name that binds to variable starting from the Smalltalk namespace. This may be unqualified, partially qualified, or fully-qualified."
+
+	^self model smalltalkNamespace shortNameFor: aString in: self!
 
 subclasses
 	^subclasses
@@ -546,6 +552,7 @@ fullyQualifiedReference!accessing!namespaces!public! !
 getEnvironment!accessing!public! !
 getInstanceSpec!accessing!private! !
 guid!accessing!public! !
+importedNamespacesDo:!public! !
 imports!accessing!public! !
 imports:!accessing!public! !
 includesEnvironment:!namespaces!public!testing! !
@@ -593,6 +600,7 @@ resolveUnqualifiedName:environment:!bindings!private! !
 setModel:name:realClass:!accessing!initializing!private! !
 setSuperclass:!initializing!private! !
 shortName!accessing!public! !
+shortNameFor:!enquiries!private! !
 subclasses!accessing!public! !
 superclass!accessing!public! !
 superclass:!accessing!private! !

--- a/Core/Contributions/Refactory/Refactoring Browser/Refactorings/Refactory.Browser.RBRootNamespace.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Refactorings/Refactory.Browser.RBRootNamespace.cls
@@ -31,11 +31,17 @@ fullNameFor: aString
 	"Private - Answer the full name (i.e. a dot-separated path from Smalltalk) of a variable with the specified local identifier, assumed to be in this namespace.
 	Although this is the Root namespace, because it is the enclosing environment of Smalltalk, all of its local bindings are implicitly bindable because Root is the outer scope of Smalltalk. In other words, we don't need the Root qualifier to bind names in Root."
 
+	^aString!
+
+shortNameFor: aString
+	"Private - Answer the short name for the receiver's variable named, aString. The short name is the shortest name that binds to variable starting from the Smalltalk namespace. All of the receiver's variables are bindable by unqualified name from Smalltalk because Smalltalk is nested within Root."
+
 	^aString! !
 !Refactory.Browser.RBRootNamespace categoriesForMethods!
 allClassesDo:!enumerating!public! !
 bindingFor:!public! !
 environment!accessing!public! !
 fullNameFor:!helpers!private! !
+shortNameFor:!enquiries!private! !
 !
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Refactorings/Refactory.Browser.RBSmalltalkNamespace.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Refactorings/Refactory.Browser.RBSmalltalkNamespace.cls
@@ -12,6 +12,11 @@ Refactory.Browser.RBSmalltalkNamespace comment: ''!
 !Refactory.Browser.RBSmalltalkNamespace categoriesForClass!Refactory-Model! !
 !Refactory.Browser.RBSmalltalkNamespace methodsFor!
 
+shortNameFor: aString
+	"Private - Answer the short name for the receiver's variable named, aString. The short name is the shortest name that binds to variable starting from the Smalltalk namespace. All of the receiver's variables are of course bindable by unqualified name."
+
+	^aString!
+
 shortNameFor: aString in: aNamespace
 	^(aNamespace isNil or: 
 			[aNamespace == self or: 
@@ -21,6 +26,7 @@ shortNameFor: aString in: aNamespace
 		ifTrue: [aString]
 		ifFalse: [aNamespace fullNameFor: aString]! !
 !Refactory.Browser.RBSmalltalkNamespace categoriesForMethods!
+shortNameFor:!enquiries!private! !
 shortNameFor:in:!helpers!private! !
 !
 

--- a/Core/Contributions/Refactory/Refactoring Browser/Tests/RBTests.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Tests/RBTests.pax
@@ -108,6 +108,7 @@ package setAliasVariableNames: #(
 
 package setPrerequisites: #(
 	'..\..\..\..\Object Arts\Dolphin\Base\Dolphin'
+	'..\..\..\..\Object Arts\Dolphin\Base\Tests\Dolphin Base Tests'
 	'..\Change Objects\RBChangeObjects'
 	'..\Environments\RBEnvironments'
 	'..\Formatters\RBFormatters'

--- a/Core/Contributions/Refactory/Refactoring Browser/Tests/Refactory.Browser.Tests.ClassDetailsTest.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Tests/Refactory.Browser.Tests.ClassDetailsTest.cls
@@ -110,6 +110,21 @@ testPrintStringRootClassLegacy
 	poolDictionaries: ''''
 	classInstanceVariableNames: '''''!
 
+testShortName
+	{
+		Root.
+		Smalltalk.
+		Graphics.
+		Object.
+		ProtoObject.
+		self class.
+		Smalltalk.Scribble.
+		Core.Tests.
+		Core.Tests.ClassTest.
+		Kernel.Tests.
+		Kernel.Tests.VariableBindingTest
+	} do: [:each | self assert: (ClassDetails fromClass: each) shortName equals: each shortName]!
+
 testStoreStringFull
 	| subject rehydrated storeString |
 	subject := ClassDetails fromClass: Refactory.Browser.TestData.RefactoryTestDataApp.
@@ -168,6 +183,7 @@ testPrintStringLegacy!public! !
 testPrintStringMissingSuperclass!public! !
 testPrintStringRootClass!public! !
 testPrintStringRootClassLegacy!public! !
+testShortName!public! !
 testStoreStringFull!public! !
 testStoreStringMinimal!public! !
 testVariables!public! !

--- a/Core/Object Arts/Dolphin/Base/Core.Class.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.Class.cls
@@ -672,6 +672,9 @@ refersTo: anObject asLiteralOf: aCompiledCode
 	^(self class == anObject class and: [self = anObject])
 		or: [(anObject isKindOf: VariableBinding) and: [anObject value == self and: [anObject isClassBinding]]]!
 
+relativeShortName: aString
+	^self shortName , '.' , aString!
+
 removeBindingFor: aString
 	^(self localBindingFor: aString)
 		ifNotNil: 
@@ -908,10 +911,12 @@ setName: aSymbolOrNil environment: aNamespace
 shortName
 	"Answer the shortest <String> name of the receiver that is bindable from Smalltalk. i.e. for classes defined directly in Smalltalk, or in any of its imports, this will be an unqualified name. Otherwise it is the fully qualified name relative to Smalltalk."
 
-	^name
-		ifNil: [super name]
-		ifNotNil: 
-			[self isInBaseEnvironment ifTrue: [name] ifFalse: [Smalltalk shortNameFor: name in: environment]]!
+	^name ifNil: [super name] ifNotNil: [environment shortNameFor: name]!
+
+shortNameFor: aString
+	"Private - Answer the short name for the receiver's variable named, aString. The short name is the shortest name that binds to variable starting from the Smalltalk namespace. This may be unqualified, partially qualified, or fully-qualified."
+
+	^Smalltalk shortNameFor: aString in: self!
 
 simpleName
 	"Answer the receiver's name within it's environment.
@@ -1029,7 +1034,7 @@ subclassesDo: aMonadicValuable
 	subclasses do: aMonadicValuable!
 
 unaliasedName
-	"Answer the shortest name for the receiver that is bindable from Smalltalk without using an alias."
+	"Answer an unambiguous name for the receiver that is bindable from Smalltalk without using an alias."
 
 	^self isInBaseEnvironment
 		ifTrue: [name]
@@ -1213,6 +1218,7 @@ printNameOn:relativeTo:!printing!private! !
 printOn:!printing!public! !
 printString!printing!public! !
 refersTo:asLiteralOf:!private!testing! !
+relativeShortName:!class variables!private! !
 removeBindingFor:!bindings!public! !
 removeClassConstant:!class variables!development!public! !
 removeClassVarName:!class hierarchy-mutating!class variables!public! !
@@ -1238,6 +1244,7 @@ setGuid:!accessing!private! !
 setImports:!accessing!private! !
 setName:environment:!accessing!private! !
 shortName!accessing!public! !
+shortNameFor:!enquiries!private! !
 simpleName!accessing!public! !
 sourceDescriptor!accessing!public!source filing! !
 sourceDescriptor:!accessing!private!source filing! !
@@ -1362,7 +1369,7 @@ foldLiterals
 										ifTrue: 
 											[totalStrings := totalStrings + 1.
 											each at: i put: (literalStrings addIfAbsent: literal)]].
-							(literal isKindOf: MethodAnnotations)
+							(literal basicClass == MethodAnnotations)
 								ifTrue: 
 									[totalAnnotations := totalAnnotations + 1.
 									each at: count put: (annotations addIfAbsent: literal)]]]].

--- a/Core/Object Arts/Dolphin/Base/Deprecated/PoolConstantsDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/Deprecated/PoolConstantsDictionary.cls
@@ -106,6 +106,11 @@ preResize: newMe
 
 	name isNil ifFalse: [newMe name: name]!
 
+shortNameFor: aString
+	"Private - Answer the short name for the receiver's variable named, aString. The short name is the shortest name that binds to variable starting from the Smalltalk namespace. This may be unqualified, partially qualified, or fully-qualified."
+
+	^Smalltalk shortNameFor: aString in: self!
+
 sourceFilerClass
 	^LegacyChunkSourceFiler! !
 !PoolConstantsDictionary categoriesForMethods!
@@ -124,6 +129,7 @@ name:!accessing!private! !
 newAssociation:value:!helpers!private! !
 owningPackage!public!source filing! !
 preResize:!adding!private! !
+shortNameFor:!enquiries!private! !
 sourceFilerClass!public!source filing! !
 !
 

--- a/Core/Object Arts/Dolphin/Base/Kernel.BindingReference.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.BindingReference.cls
@@ -315,7 +315,15 @@ scope: anObject
 shortName
 	"Answer the shortest <String> name equivalent to the receiver's pathString that is bindable from Smalltalk. i.e. for variables defined directly in Smalltalk, or in any of its imports, this will be an unqualified name. Otherwise it is the fully qualified name relative to Smalltalk."
 
-	^Smalltalk shortNameFor: self basicUnqualifiedName in: self environment!
+	^self bindingOrNil
+		ifNil: 
+			["Not bindable, so try to bind environment to answer short name relative to that"
+			self environment
+				ifNil: 
+					["Environment not bindable either, so just answer the full name"
+					self pathString]
+				ifNotNil: [:ns | ns shortNameFor: self basicUnqualifiedName]]
+		ifNotNil: [:binding | binding shortName]!
 
 simpleName
 	"Answer the unqualified name part of the receiver (the final component of the name).

--- a/Core/Object Arts/Dolphin/Base/Kernel.PoolDictionary.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.PoolDictionary.cls
@@ -98,14 +98,19 @@ resolvePublicBinding: aBindingContext
 
 	^self bindingFor: aBindingContext identifier!
 
+shortNameFor: aString
+	"Private - Answer the short name for the receiver's variable named, aString. The short name is the shortest name that binds to the variable from a workspace for which the receiver is activing as a variable pool. Workspace variables are always unqualified."
+
+	^aString!
+
 unqualifiedName
 	^self anonymousName! !
 !Kernel.PoolDictionary categoriesForMethods!
 anonymousName!constants!private! !
-asQualifiedReference!private! !
+asQualifiedReference!converting!private! !
 associationClass!constants!private! !
 convertToSharedPool!development!private! !
-displayOn:!public! !
+displayOn:!displaying!public! !
 environment!accessing!public! !
 fullName!accessing!public! !
 fullNameFor:!helpers!private! !
@@ -114,7 +119,8 @@ name!accessing!public! !
 name:!accessing!private! !
 newAssociation:value:!helpers!private! !
 resolveLocalBindingPath:!bindings!private! !
-resolvePublicBinding:!private! !
+resolvePublicBinding:!bindings!private! !
+shortNameFor:!enquiries!private! !
 unqualifiedName!accessing!private! !
 !
 

--- a/Core/Object Arts/Dolphin/Base/Kernel.VariableBinding.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.VariableBinding.cls
@@ -52,10 +52,10 @@ asQualifiedReference
 displayOn: aPuttableStream
 	"Append to the <puttableStream> argument a String whose characters are a representation of the receiver that an end-user might want to see."
 
-	aPuttableStream nextPutAll: key!
+	aPuttableStream nextPutAll: self shortName!
 
 displayString
-	^key!
+	^self shortName!
 
 environment
 	^environment!
@@ -144,6 +144,11 @@ setFlags: anInteger
 	<mutable>
 	flags := anInteger!
 
+shortName
+	"Answer the <String> fully qualified name of this variable, which is a dot-separated path from (but not including) Smalltalk."
+
+	^environment shortNameFor: key!
+
 targetVariable
 	^self!
 
@@ -174,6 +179,7 @@ owningPackage!accessing!development!public! !
 owningPackage:!accessing!development!public! !
 refersTo:asLiteralOf:!private!testing! !
 setFlags:!accessing!private! !
+shortName!accessing!public! !
 targetVariable!accessing!public! !
 unqualifiedName!accessing!public! !
 !

--- a/Core/Object Arts/Dolphin/Base/Root.cls
+++ b/Core/Object Arts/Dolphin/Base/Root.cls
@@ -35,12 +35,22 @@ imports: anArray
 	anArray isEmpty ifFalse: [self error: 'Root must not have imports']!
 
 nestedClasses
-	^super nestedClasses copyWithout: self! !
+	^super nestedClasses copyWithout: self!
+
+shortName
+	^#Root!
+
+shortNameFor: aString
+	"Private - Answer the short name for the receiver's variable named, aString. The short name is the shortest name that binds to variable starting from the Smalltalk namespace. All of the receiver's variables are bindable by unqualified name from Smalltalk because Smalltalk is nested within Root."
+
+	^aString! !
 !Root class categoriesForMethods!
 bindingFor:!bindings!public! !
 environment!public! !
 fullNameFor:!helpers!private! !
 imports:!pool variables!public! !
 nestedClasses!accessing!public! !
+shortName!accessing!public! !
+shortNameFor:!enquiries!private! !
 !
 

--- a/Core/Object Arts/Dolphin/Base/Smalltalk.cls
+++ b/Core/Object Arts/Dolphin/Base/Smalltalk.cls
@@ -115,14 +115,18 @@ setEvents: anEventsCollectionOrNil
 
 	events := anEventsCollectionOrNil!
 
+shortNameFor: aString
+	"Private - Answer the short name for the receiver's variable named, aString. The short name is the shortest name that binds to variable starting from the Smalltalk namespace. All of the receiver's variables are of course bindable by unqualified name."
+
+	^aString!
+
 shortNameFor: aString in: aNamespace
 	^(aNamespace isNil or: 
-			[aNamespace == self or: 
-					[(self fullBindingFor: aString)
-						ifNil: [self imports anySatisfy: [:each | each valueOrNil == aNamespace]]
-						ifNotNil: [:binding | binding environment == aNamespace or: [binding environment == self]]]])
+			[(self fullBindingFor: aString)
+				ifNil: [self imports anySatisfy: [:each | each valueOrNil == aNamespace]]
+				ifNotNil: [:binding | binding environment == aNamespace or: [binding environment == self]]])
 		ifTrue: [aString]
-		ifFalse: [aNamespace shortName , '.' , aString]!
+		ifFalse: [aNamespace relativeShortName: aString]!
 
 staticVariableRemoved: aVariableBinding
 	self
@@ -143,6 +147,7 @@ getEvents!events!private! !
 oldNames!accessing!public! !
 removeClass:!operations!public! !
 setEvents:!events!private! !
+shortNameFor:!enquiries!private! !
 shortNameFor:in:!helpers!private! !
 staticVariableRemoved:!class hierarchy-mutating!class variables!private! !
 !

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.ClassTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.ClassTest.cls
@@ -150,7 +150,25 @@ testPoolBinding
 
 	self assert: (Exception fullBindingFor: 'WS_CHILD') notNil.
 	"But the imports are private, and so not be exported as externally resolvable names"
-	self assert: (Smalltalk fullBindingFor: 'Exception.WS_CHILD') isNil! !
+	self assert: (Smalltalk fullBindingFor: 'Exception.WS_CHILD') isNil!
+
+testShortName
+	"The short name of a class is the minimally qualified name required to bind it starting from the Smalltalk namespace"
+
+	"Object, a root class, is in Core, which is imported into Smalltalk, so bindable using its unqualified name"
+
+	self assert: Object shortName equals: 'Object'.
+	"Non-root imported classes"
+	self assert: Kernel.CompiledMethod shortName equals: #CompiledMethod.
+	self assert: External.DynamicLinkLibraryStub shortName equals: #DynamicLinkLibraryStub.
+	"Class requireing a fully-qualified short name"
+	self assert: TestRunConsoleLogger shortName equals: 'XProgramming.SUnit.TestRunConsoleLogger'.
+	"Aliased class"
+	self assert: Smalltalk.ExternalAddress shortName equals: #Address.
+	"The short name of a class in a nested namespace should be qualified with the short name of its namespace, not necessarily the full name"
+	self assert: self class shortName equals: 'Tests.ClassTest'.
+	"Core is imported before Kernel, so Tests in Core is bindable unqualified, but Kernel.Tests is not"
+	self assert: Kernel.Tests.NamespaceTest shortName equals: 'Kernel.Tests.NamespaceTest'! !
 !Core.Tests.ClassTest categoriesForMethods!
 allClassHierarchyInstancesDo:!helpers!private! !
 testAllRoots!public!unit tests! !
@@ -163,5 +181,6 @@ testIncludesNamespace!public!unit tests! !
 testLessOrEqual!public!unit tests! !
 testNestedClasses!public!unit tests! !
 testPoolBinding!public!unit tests! !
+testShortName!public!unit tests! !
 !
 

--- a/Core/Object Arts/Dolphin/Base/Tests/Dolphin Base Tests.pax
+++ b/Core/Object Arts/Dolphin/Base/Tests/Dolphin Base Tests.pax
@@ -202,6 +202,7 @@ package setPrerequisites: #(
 	'..\Dolphin'
 	'..\Dolphin Additional Sort Algorithms'
 	'..\Dolphin Anonymous Classes'
+	'..\Deprecated\Dolphin Base (Old Names)'
 	'..\..\MVP\Base\Dolphin Basic Geometry'
 	'..\Dolphin Command-line Parser'
 	'..\..\System\Random\Dolphin CRT Random Stream'

--- a/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.BindingReferenceTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.BindingReferenceTest.cls
@@ -360,18 +360,31 @@ testRelativeNoScope
 	self should: [self newSubjectWithPath: #('_' 'Object')] raise: Error!
 
 testShortName
-	#(#Root #Smalltalk #Core #'Core.Class' #'Kernel.BindingContext') do: 
+	#(#Root #Smalltalk #Core 'Core.Class' 'Kernel.BindingContext' 'Kernel.Missing' 'Core.Tests' 'Core.Object' 'Object' 'Smalltalk.String') do: 
 			[:each |
 			| subject |
 			subject := self newSubjectWithPathString: each.
 			self assert: subject shortName equals: ($. split: each) last , self nameSuffix.
 			self assert: subject shortName equals: subject simpleName].
-	#('XProgramming.SUnit' 'XProgramming.SUnit.TestRunConsoleLogger') do: 
+	self assert: (self newSubjectWithPathString: 'Core.Tests.ClassTest') shortName
+		equals: 'Tests.ClassTest' , self nameSuffix.
+	#('XProgramming.SUnit' 'XProgramming.SUnit.TestRunConsoleLogger' 'Kernel.Tests.BindingReferenceTest')
+		do: 
 			[:each |
 			| subject |
 			subject := self newSubjectWithPathString: each.
 			self assert: subject shortName equals: subject pathString , self nameSuffix.
-			self deny: subject shortName equals: subject simpleName]!
+			self deny: subject shortName equals: subject simpleName].
+	"If the environment does not exist, then the short name should just be the path"
+	self deny: #{Foo} isDefined.
+	#('Foo' 'Foo.Bar')
+		do: [:each | self assert: (self newSubjectWithPathString: each) shortName equals: each , self nameSuffix]!
+
+testShortNameViaImport
+	"Test the case of a name that is bindable, but only by following an import path."
+	| subject |
+	subject := self newSubjectWithPathString: 'External.Array'.
+	self assert: subject shortName equals: 'Array' , self nameSuffix!
 
 testStoreString
 	self printStringTestCases do: 
@@ -455,6 +468,7 @@ testRefersToLiteralClass!public!unit tests! !
 testRefersToLiteralNotFound!public!unit tests! !
 testRelativeNoScope!public!unit tests! !
 testShortName!public!unit tests! !
+testShortNameViaImport!public!unit tests! !
 testStoreString!public!unit tests! !
 testUnqualifiedName!public!unit tests! !
 testValue!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.NamespaceImportTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.NamespaceImportTest.cls
@@ -65,7 +65,14 @@ testMissingSmalltalkImport
 	
 	[Smalltalk setImports: (original copyWith: importBlah).
 	self assertIsNil: #Foo asQualifiedReference bindingOrNil]
-			ensure: [Smalltalk setImports: original]! !
+			ensure: [Smalltalk setImports: original]!
+
+testShortNameViaImport
+	"Test the case of a name that is bindable, but only by following an import path. This won't resolve for a NamespaceImport as these must always be the full unambiguous path from Root."
+
+	| subject |
+	subject := self newSubjectWithPathString: 'External.Array'.
+	self assert: subject shortName equals: 'External.Array'! !
 !Kernel.Tests.NamespaceImportTest categoriesForMethods!
 bindingTestCases!constants!private! !
 pathTestCases!private!unit tests! !
@@ -76,5 +83,6 @@ testBindingScope!public!unit tests! !
 testHome!public!unit tests! !
 testIsRelative!public!unit tests! !
 testMissingSmalltalkImport!public!unit tests! !
+testShortNameViaImport!public!unit tests! !
 !
 

--- a/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.NamespaceTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.NamespaceTest.cls
@@ -253,17 +253,13 @@ testResolveImportIntoCustomEnvironment
 
 testShortName
 	"The short name of a namespace is it's unqualified name if it is defined in Smalltalk, or in one of Smalltalk's imports, otherwise it is the full name."
-
-	self assert: Behavior shortName equals: 'Behavior'.
 	self assert: XProgramming shortName equals: 'XProgramming'.
 	self assert: XProgramming.SUnit shortName equals: 'XProgramming.SUnit'.
-	self assert: TestRunConsoleLogger shortName equals: 'XProgramming.SUnit.TestRunConsoleLogger'.
+
 	"Where there is ambiguity in imported namespaces, the order of imports takes precedence (Core is imported into Smaltlalk before Kernel)."
 	self assert: Core.Tests shortName equals: 'Tests'.
 	self assert: Kernel.Tests shortName equals: 'Kernel.Tests'.
-	"The short name of a class in a nested namespace should be qualified with the short name of its namespace, not necessarily the full name"
-	self assert: Core.Tests.ObjectTest shortName equals: 'Tests.ObjectTest'.
-	self assert: Kernel.Tests.NamespaceTest shortName equals: 'Kernel.Tests.NamespaceTest'!
+!
 
 testSimpleName
 	"#simpleName is defined for compatibility. It is the same as the #unqualifiedName (or indeed the #name)."

--- a/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.SystemNamespaceTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.SystemNamespaceTest.cls
@@ -49,6 +49,8 @@ testFullyQualifiedReference
 	self deny: ref isRelative!
 
 testShortName
+	"Root and Smalltalk's short names do not need qualification"
+
 	self assert: self subject shortName equals: self subject name! !
 !Kernel.Tests.SystemNamespaceTest categoriesForMethods!
 canonicalSubject!private! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.VariableBindingTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.VariableBindingTest.cls
@@ -66,12 +66,37 @@ testRefersToLiteral
 	self assert: (method refersToLiteral: subject).
 	self assert: (method refersToLiteral: subject environment).
 	self assert: (method refersToLiteral: subject environment environment).
-	self assert: (method refersToLiteral: subject environment environment environment)! !
+	self assert: (method refersToLiteral: subject environment environment environment)!
+
+testShortName
+	self assert: (Smalltalk bindings select: [:each | BindingReference isQualifiedName: each shortName])
+		equals: #().
+
+	"Root vars are bindable unqualified"
+	self assert: (Root bindings select: [:each | BindingReference isQualifiedName: each shortName])
+		equals: #().
+
+	"Class in Core, imported into Smalltalk so bindable using an unqualified name"
+	self assert: Object binding shortName equals: #Object.
+
+	"Ditto namespace variable in Core"
+	self assert: (Core bindingFor: #Processor) shortName equals: #Processor.
+
+	"Class var or a class in Kernel, which is imported, so partially qualified name is bindable"
+	self assert: (_PrimitiveFailureCode bindingFor: 'InvalidParameter') shortName
+		equals: '_PrimitiveFailureCode.InvalidParameter'.
+
+	"Class in child namespace of a Smalltalk imported namespace where the imported binding is ambiguous"
+	self assert: Core.Tests binding shortName equals: #Tests.
+	self assert: Core.Tests.ClassTest binding shortName equals: 'Tests.ClassTest'.
+	self assert: self class environment binding shortName equals: 'Kernel.Tests'.
+	self assert: self class binding shortName equals: 'Kernel.Tests.VariableBindingTest'! !
 !Kernel.Tests.VariableBindingTest categoriesForMethods!
 testAbsoluteName!public!unit tests! !
 testFullName!public! !
 testFullyQualifiedReference!public! !
 testIsClassBinding!public! !
 testRefersToLiteral!public!unit tests! !
+testShortName!public! !
 !
 


### PR DESCRIPTION
For an unbindable BindingReference the shortName should be the path string, not the unqualified name.

Can simplify away the #isInBaseEnvironment test too.