### PR TITLE
Improve clarity of message box shown for unhandled warning

### DIFF
--- a/Core/Object Arts/Dolphin/Base/External.Structure.cls
+++ b/Core/Object Arts/Dolphin/Base/External.Structure.cls
@@ -662,6 +662,9 @@ fieldNamesFromTemplate
 fieldOffsetConstantPrefix
 	^'_OffsetOf_'!
 
+flags
+	^flags!
+
 fromAddress: anAddress
 	"Answer a new instance that points to the ExternalAddress 
 	respresented by anAddress (which responds to the protocol
@@ -699,6 +702,7 @@ hasUncompiledFields: aBoolean
 inheritTemplate
 	| ancestor |
 	ancestor := self superclass.
+	flags := ancestor flags.
 	template := ancestor template.
 	self byteSize: ancestor byteSize.
 	alignment := ancestor alignment!
@@ -1010,6 +1014,7 @@ elementSize!accessing!public! !
 ensureDefined!instance creation!private! !
 fieldNamesFromTemplate!accessing!private! !
 fieldOffsetConstantPrefix!constants!private!template definition! !
+flags!accessing!private! !
 fromAddress:!instance creation!public! !
 fromBytes:!instance creation!public! !
 getFieldNames!accessing!private! !

--- a/Core/Object Arts/Dolphin/Base/Kernel.CompiledExpression.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.CompiledExpression.cls
@@ -77,6 +77,9 @@ storeSourceString: aString evaluationPools: anArray
 					nonEmptyPools notEmpty ifTrue: [nonEmptyPools]].
 	self sourceDescriptor: (pools isNil ifTrue: [aString] ifFalse: [{aString. pools}])!
 
+suppressionId
+	^sourceDescriptor hash!
+
 value
 	"Evaluate the expression with nil as 'self'."
 
@@ -95,6 +98,7 @@ getSource!accessing!development!public! !
 isExpression!private!testing! !
 owningPackage!accessing!public! !
 storeSourceString:evaluationPools:!accessing!private! !
+suppressionId!accessing!private! !
 value!evaluating!public! !
 value:!evaluating!public! !
 !

--- a/Core/Object Arts/Dolphin/Base/Kernel.CompiledMethod.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.CompiledMethod.cls
@@ -197,7 +197,10 @@ recompile
 storeSourceString: aString
 	"Private - Record aString as the source for the receiver. Delegate to the receiver's source manager"
 
-	self class sourceManager storeSourceString: aString forMethod: self! !
+	self class sourceManager storeSourceString: aString forMethod: self!
+
+suppressionId
+	^self! !
 !Kernel.CompiledMethod categoriesForMethods!
 <=!comparing!public! !
 categories!categories-accessing!development!public! !
@@ -229,6 +232,7 @@ protocols!categories-accessing!development!public! !
 realCategories!categories-accessing!public! !
 recompile!compiling!development!private! !
 storeSourceString:!private!source filing-methods! !
+suppressionId!accessing!private! !
 !
 
 !Kernel.CompiledMethod class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/Kernel.Package.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.Package.cls
@@ -493,7 +493,8 @@ environment
 environment: aNamespace
 	"Set the default environment for the package, in the context of which any loose (extension) methods should be compiled, or nil if there is no default environment for loose methods and the extended class' own environment should be used for resolving static variable references in the method source."
 
-	| ref currentEnvironment preamble failures |
+	| ref failures |
+	"Cannot be here if current namespace is nil and new namespace is nil, due to earlier guard"
 	self environment == aNamespace ifTrue: [^self].
 	(self isLegacySourceFormat and: [aNamespace ~~ Smalltalk])
 		ifTrue: 
@@ -504,23 +505,8 @@ environment: aNamespace
 					[aNamespace owningPackage = self
 						ifTrue: [self error: 'The default namespace for a package cannot be one of its own classes'].
 					aNamespace fullyQualifiedReference].
-	currentEnvironment := self environment.
-	preamble := currentEnvironment isNil
-				ifTrue: 
-					["Cannot be here if current namespace is nil and new namespace is nil, due to earlier guard"
-					'The namespace for extension methods of ''<1d>'' will be set to <3p>, requiring that the methods be recompiled.']
-				ifFalse: 
-					[aNamespace isNil
-						ifTrue: 
-							['The namespace for extension methods of ''<1d>'' will be reset, requiring that those methods be recompiled in the scope of the classes they extend.']
-						ifFalse: 
-							['The namespace for extension methods of ''<1d>'' will be changed from <2p> to <3p>, requiring that the methods be recompiled.']].
-	Warning
-		signal: (preamble
-				, '<n><n>Methods may fail to recompile if they contain static variable references that are not resolvable in their new scope. This may render the system unstable if the methods that fail to compile are critical to system operation.<n><n>Press Abort to cancel the change, Retry to open a debugger, or Ignore to continue with the change.'
-					expandMacrosWith: self
-					with: currentEnvironment
-					with: aNamespace).
+	#todo. "Add a refactoring to update the namespace safely. The capability exists add extra qualification, or remove unnecessary qualification, from class/static variable refs, as used in rename class/namespace refactoring. Until then, warn that it might generate compilation errors."
+	self warnChangingDefaultNamespaceFrom: self environment to: aNamespace.
 	self environmentName: ref.
 	failures := SortedCollection new.
 	self methodsDo: 
@@ -1942,7 +1928,26 @@ vmVersionCheck: verWhenSaved
 It will probably load, but it may not operate correctly. 
 If you experience subsequent problems please contact the package supplier for an updated version.'
 				expandMacrosWith: self name
-				with: versionString)! !
+				with: versionString)!
+
+warnChangingDefaultNamespaceFrom: currentNamespace to: newNamespace
+	| preamble |
+	preamble := currentNamespace isNil
+				ifTrue: 
+					["Cannot be here if current namespace is nil and new namespace is nil, due to earlier guard"
+					'The namespace for extension methods of ''<1d>'' will be set to <3p><n>Setting a package''s default namespace requires that extension methods be recompiled.']
+				ifFalse: 
+					[newNamespace isNil
+						ifTrue: 
+							['The namespace for extension methods of ''<1d>'' will be reset<n>Resetting a package''s default namespace requires that its extension methods be recompiled in the scope of the classes they extend.']
+						ifFalse: 
+							['The namespace for extension methods of ''<1d>'' will be changed from <2p> to <3p><n>Changing a package''s default namespace requires that its extension methods be recompiled.']].
+	Warning
+		signal: (preamble
+				, '<n><n>Methods may fail to recompile if they contain static variable references that are not resolvable in their new scope. This may render the system unstable if the methods that fail to compile are critical to system operation.'
+					expandMacrosWith: self
+					with: currentNamespace
+					with: newNamespace)! !
 !Kernel.Package categoriesForMethods!
 about!commands!public! !
 aboutBlock!accessing!public! !
@@ -2161,6 +2166,7 @@ variableNames:!private! !
 variables!private!source filing! !
 versionIfRequired!public! !
 vmVersionCheck:!constants!private! !
+warnChangingDefaultNamespaceFrom:to:!helpers!private! !
 !
 
 !Kernel.Package class methodsFor!

--- a/Core/Object Arts/Dolphin/Base/Tests/External.Tests.StructureTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/External.Tests.StructureTest.cls
@@ -100,7 +100,8 @@ testDynamicSelectors
 	self assert: _FPIEEE_RECORD dynamicSelectors single equals: #status.
 	self assert: _FPIEEE_VALUE dynamicSelectors size equals: 0.
 	subject := Structure newAnonymousSubclass.
-	subject initializeTemplate.
+	subject ensureDefined.
+	self assert: subject dynamicSelectors isEmpty.
 	subject
 		beUncompiled;
 		defineField: #writeOnly type: UInt32Field writeOnly;

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.DevelopmentSessionManager.cls
@@ -321,15 +321,56 @@ onUnhandledWarning: aWarning
 	Override the superclass implementation in order to give the user
 	the opportunity to bring up a walkback and go into the debugger."
 
-	| response |
+	| mb description details |
+	description := aWarning description readStream.
+	mb := MessageBox new
+				headline: description nextLine;
+				yourself.
+	details := description upToEnd.
+	details := details notEmpty
+				ifTrue: 
+					[(WriteStream with: details)
+						cr;
+						cr;
+						yourself]
+				ifFalse: [String writeStream].
 	aWarning isSuppressible
-		ifTrue: [aWarning okToContinue ifFalse: [Processor activeProcess terminate]]
+		ifTrue: 
+			[mb
+				isSuppressible: true;
+				uniqueId: aWarning raisingFrame method suppressionId.
+			aWarning isUserResumable
+				ifTrue: 
+					[(mb
+						customButtons: #(#(#ok '&Continue'));
+						detailsText: (details
+									nextPutAll: 'Press Continue to resume execution, disregarding the warning.
+Press Cancel to terminate the process, cancelling the operation.
+
+You can suppress this warning, in which case it will not be shown again. If the warning is suppressed, then it will be ignored on future occurrence, regardless of the choice you make now.';
+									contents);
+						buttonStyle: #okCancel;
+						warning) ~~ #ok
+						ifTrue: [Processor activeProcess terminate]]
+				ifFalse: 
+					["Not resumable"
+					mb errorMsg.
+					Processor activeProcess terminate]]
 		ifFalse: 
-			[response := aWarning abortRetryOrIgnore.
+			[| response |
+			response := mb
+						buttonStyle: #abortRetryIgnore;
+						customButtons: #(#(#abort '&Cancel') #(#retry '&Debug') #(#ignore '&Continue'));
+						detailsText: (details
+									nextPutAll: 'Press Cancel to terminate the process, cancelling the operation.
+Press Debug to open a debugger at the warning site.
+Press Continue to resume execution, disregarding the warning.';
+									contents);
+						warning.
 			response == #retry
 				ifTrue: [self unhandledException: aWarning]
 				ifFalse: [response == #abort ifTrue: [Processor activeProcess terminate]]
-			"ignore - Resume execution"]!
+			"#ignore - Continue execution"]!
 
 onUserBreak
 	"Bring up the Smalltalk debugger (suspending the active process) ..."

--- a/Core/Object Arts/Dolphin/System/Win32/MessageBox/UI.MessageBox.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/MessageBox/UI.MessageBox.cls
@@ -479,7 +479,7 @@ headline: aString
 icon
 	"Answer the receiver's custom icon, if any. Note that the message box may still display an icon, depending on the #iconStyle."
 
-	^icon!
+	^icon ifNil: [#{Graphics.Icon} valueOrNil ifNotNil: [:iconClass | iconClass null]]!
 
 icon: anIcon
 	"Set the receiver's icon to be the argument, anIcon."


### PR DESCRIPTION
Use the new message box to include explanatory text, and change the confusing Abort/Retry/Ignore button labels.