### PR TITLE
Inline expression prompts should offer option to show changes

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
@@ -1199,16 +1199,23 @@ getOptionExtractAssignment: aString
 		confirm!
 
 getOptionInlineExpression: aString
-	^MessageBox new
-		caption: self displayString;
-		headline: 'Inline expression?';
-		text: 'The following expression can be inlined or assigned to a temporary:<n><n><t><1s>?' << aString;
-		customButtons: #(#(#yes '&Inline') #(#no '&Assign Temporary'));
-		defaultButton: 2;
-		detailsText: 'The expression shown is passed as one of the arguments to the method you are inlining. You can safely inline the expression if constant and/or side-effect free, or if it is only referred to once in the inlined method. If not, it should be assigned to a temporary to preserve existing behaviour. If unsure, choose ''Assign Temporary''. You can always inline the temporary later if you wish.';
-		expandLabel: 'Show help';
-		collapseLabel: 'Hide help';
-		confirm!
+	| prompt response |
+	prompt := MessageBox new
+				caption: self displayString;
+				headline: 'Inline expression?';
+				text: 'The following expression can be inlined or assigned to a temporary:<n><n><t><1s>?' << aString;
+				customButtons: #(#(#yes '&Inline') #(#no '&Assign Temporary'));
+				defaultButton: 2;
+				detailsText: 'The expression shown is passed as one of the arguments to the method you are inlining. You can safely inline the expression if constant and/or side-effect free, or if it is only referred to once in the inlined method. If not, it should be assigned to a temporary to preserve existing behaviour. If unsure, choose ''Assign Temporary''. You can always inline the temporary later if you wish.';
+				expandLabel: 'Show help';
+				collapseLabel: 'Hide help';
+				isCancellable: true;
+				checkboxText: SmalltalkSystem current showChangesText;
+				yourself.
+	response := prompt confirmOrCancel.
+	response == #cancel ifTrue: [^self refactoringAborted].
+	prompt isChecked ifTrue: [self shouldShowChanges: true].
+	^response == #yes!
 
 getOptionNewMethodName: aRBMethodName classes: anArray
 	| dialog |

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.RefactoringSmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.RefactoringSmalltalkSystem.cls
@@ -585,16 +585,24 @@ inlineAllSelfSendsOf: aCollectionOfMethods within: aBrowserEnvironment
 	caption := String writeStream.
 	caption nextPutAll: 'Inline self sends of '.
 	^self performRefactoringAction: 
-			[aCollectionOfMethods do: 
+			[| shouldShowChanges |
+			shouldShowChanges := false.
+			aCollectionOfMethods do: 
 					[:each |
-					(InlineAllSendersRefactoring
-						model: namespace
-						sendersOf: each selector
-						in: each methodClass) primitiveExecute.
+					| refactoring |
+					refactoring := InlineAllSendersRefactoring
+								model: namespace
+								sendersOf: each selector
+								in: each methodClass.
+					refactoring shouldShowChanges: shouldShowChanges.
+					refactoring primitiveExecute.
+					shouldShowChanges := refactoring shouldShowChanges.
 					caption display: each]
 				separatedBy: [caption nextPutAll: ', '].
 			namespace name: caption contents.
-			self changeManager performChange: namespace changes.
+			shouldShowChanges
+				ifTrue: [namespace browseChanges]
+				ifFalse: [self changeManager performChange: namespace changes].
 			namespace]!
 
 inlineMessage: aStMessageNode inMethod: aSelector of: aBehavior


### PR DESCRIPTION
Whether or not an expression is inlined or assigned to a temporary affects whether or not an inline operation is a true temporary. Inlining the expression may result in an operation being performed multiple times, which will change behaviour if the operation has side effects. I usually choose to inline, and then inspect the result to see whether to undo or not. An easier option would be to choose to see the proposed changes, and then cancel if inlining the expression wasn't the right choice after all.