### PR TITLE
Fix browsing of refs/defs to vars broken by recent command query changes

### DIFF
--- a/Core/Contributions/Camp Smalltalk/SUnit/SUnit.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/SUnit.pax
@@ -53,7 +53,7 @@ Core.Object
 	classConstants: {}!
 Core.Object
 	subclass: #'XProgramming.SUnit.TestSuite'
-	instanceVariableNames: 'tests resources name'
+	instanceVariableNames: 'tests resources name dependents'
 	classVariableNames: ''
 	imports: #()
 	classInstanceVariableNames: ''

--- a/Core/Contributions/Camp Smalltalk/SUnit/XProgramming.SUnit.TestSuite.cls
+++ b/Core/Contributions/Camp Smalltalk/SUnit/XProgramming.SUnit.TestSuite.cls
@@ -2,7 +2,7 @@
 
 Core.Object
 	subclass: #'XProgramming.SUnit.TestSuite'
-	instanceVariableNames: 'tests resources name'
+	instanceVariableNames: 'tests resources name dependents'
 	classVariableNames: ''
 	imports: #()
 	classInstanceVariableNames: ''
@@ -29,6 +29,9 @@ defaultResources
 			coll
 				addAll: testCase resources;
 				yourself]!
+
+getDependents
+	^dependents!
 
 name
 	^name!
@@ -63,6 +66,9 @@ run: aResult
 			each run: aResult]]
 		ensure: [aResult duration: (Delay microsecondClockValue - start) microseconds]!
 
+setDependents: aDependentsCollectionOrNil
+	dependents := aDependentsCollectionOrNil!
+
 tests
 	tests isNil ifTrue: [tests := OrderedCollection new].
 	^tests! !
@@ -71,6 +77,7 @@ addDependentToHierachy:!Dependencies!public! !
 addTest:!Accessing!public! !
 addTests:!Accessing!public! !
 defaultResources!Accessing!public! !
+getDependents!dependency!private! !
 name!Accessing!public! !
 name:!Accessing!public! !
 removeDependentFromHierachy:!Dependencies!public! !
@@ -78,6 +85,7 @@ resources!Accessing!public! !
 resources:!Accessing!public! !
 run!public!Running! !
 run:!public!Running! !
+setDependents:!dependency!private! !
 tests!Accessing!public! !
 !
 

--- a/Core/Contributions/Odellsoft/SUnitBrowser/SUnitBrowser.pax
+++ b/Core/Contributions/Odellsoft/SUnitBrowser/SUnitBrowser.pax
@@ -105,7 +105,6 @@ package setPrerequisites: #(
 	'..\..\..\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Text Presenter'
 	'..\..\..\Object Arts\Dolphin\MVP\Icons\Dolphin Text Tile Icons'
 	'..\..\..\Object Arts\Dolphin\MVP\Type Converters\Dolphin Type Converters'
-	'..\..\Refactory\Refactoring Browser\Environments\RBEnvironments'
 	'..\..\Camp Smalltalk\SUnit\SUnit'
 	'SUnitBrowserModelApp').
 

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -2502,7 +2502,7 @@ Core.Object
 	classConstants: {}!
 Core.Object
 	subclass: #'Kernel.CompilationResult'
-	instanceVariableNames: 'method rawTextMap rawTempsMap textMap tempsMap oldMethod package'
+	instanceVariableNames: 'method rawTextMap rawTempsMap flags textMap tempsMap oldMethod package'
 	classVariableNames: ''
 	imports: #()
 	classInstanceVariableNames: ''

--- a/Core/Object Arts/Dolphin/Base/Kernel.CompilationResult.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.CompilationResult.cls
@@ -2,7 +2,7 @@
 
 Core.Object
 	subclass: #'Kernel.CompilationResult'
-	instanceVariableNames: 'method rawTextMap rawTempsMap textMap tempsMap oldMethod package'
+	instanceVariableNames: 'method rawTextMap rawTempsMap flags textMap tempsMap oldMethod package'
 	classVariableNames: ''
 	imports: #()
 	classInstanceVariableNames: ''
@@ -51,6 +51,9 @@ fireSystemUpdateEvent
 		ifTrue: [method methodClass annotationsUpdated: self].
 	Smalltalk trigger: (self isNew ifTrue: [#methodAdded:] ifFalse: [#methodUpdated:]) with: self!
 
+isInteractive
+	^flags allMask: CompilerFlags.Interactive!
+
 isNew
 	^oldMethod isNil!
 
@@ -65,10 +68,11 @@ method: aCompiledMethod
 
 	method := aCompiledMethod!
 
-method: aCompiledMethod rawTextMap: textArray rawTempsMap: tempsArray
+method: aCompiledMethod rawTextMap: textArray rawTempsMap: tempsArray flags: anInteger
 	method := aCompiledMethod.
 	rawTextMap := textArray.
-	rawTempsMap := tempsArray!
+	rawTempsMap := tempsArray.
+	flags := anInteger!
 
 oldMethod
 	^oldMethod!
@@ -112,10 +116,11 @@ affectsAnnotation:!enquiries!public! !
 buildTempsMap!development!private! !
 buildTextMap!development!private! !
 fireSystemUpdateEvent!helpers!private! !
+isInteractive!public!testing! !
 isNew!accessing!public! !
 method!accessing!public! !
 method:!accessing!private! !
-method:rawTextMap:rawTempsMap:!initializing!private! !
+method:rawTextMap:rawTempsMap:flags:!initializing!private! !
 oldMethod!accessing!public! !
 oldMethod:!accessing!public! !
 package!accessing!public! !
@@ -129,13 +134,14 @@ textMap!accessing!development!public! !
 
 !Kernel.CompilationResult class methodsFor!
 
-method: aCompiledMethod rawTextMap: textArray rawTempsMap: tempsArray
+method: aCompiledMethod rawTextMap: textArray rawTempsMap: tempsArray flags: anInteger
 	<primitive: 157>
 	^self new
 		method: aCompiledMethod
 		rawTextMap: textArray
-		rawTempsMap: tempsArray! !
+		rawTempsMap: tempsArray
+		flags: anInteger! !
 !Kernel.CompilationResult class categoriesForMethods!
-method:rawTextMap:rawTempsMap:!instance creation!public! !
+method:rawTextMap:rawTempsMap:flags:!instance creation!public! !
 !
 

--- a/Core/Object Arts/Dolphin/Base/Kernel.Compiler.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.Compiler.cls
@@ -63,7 +63,8 @@ compile: aString in: aClass environment: aNamespaceOrNil flags: anInteger
 	^CompilationResult
 		method: results first
 		rawTextMap: results second
-		rawTempsMap: results third!
+		rawTempsMap: results third
+		flags: anInteger!
 
 compileDebugExpression: aString in: aClass environment: aNamespaceOrNil evaluationPools: anArray
 	^(self
@@ -148,7 +149,8 @@ compileForEvaluation: aString in: aBehaviorOrNil environment: aNamespaceOrNil ev
 	results := CompilationResult
 				method: expression
 				rawTextMap: results second
-				rawTempsMap: results third.
+				rawTempsMap: results third
+				flags: anInteger.
 	expression notNil
 		ifTrue: 
 			[aBehaviorOrNil ifNotNil: [expression methodClass: aBehaviorOrNil].

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.AnnotatedMethodSearch.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.AnnotatedMethodSearch.cls
@@ -11,7 +11,7 @@ Tools.AnnotatedMethodSearch guid: (Core.GUID fromString: '{ba126645-8637-444f-b9
 Tools.AnnotatedMethodSearch comment: ''!
 !Tools.AnnotatedMethodSearch methodsFor!
 
-methodReferenceFilter
+referenceFilter
 	"Private - Answer a <monadicValuable> which can be used to discriminate between <CompiledMethod>s that
 	match this search and those that do not."
 
@@ -20,7 +20,7 @@ methodReferenceFilter
 referencesLabelTag
 	^#annotated! !
 !Tools.AnnotatedMethodSearch categoriesForMethods!
-methodReferenceFilter!helpers!private! !
+referenceFilter!accessing!private! !
 referencesLabelTag!constants!public! !
 !
 

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassSelector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassSelector.cls
@@ -196,7 +196,7 @@ buildAllVariablesMenu: aMenu
 			[self
 				populateVarMenu: aMenu
 				class: class
-				command: #browseReferencesToInstVars:inHierarchyOf:within:
+				command: #browseReferencesToInstVar:inHierarchyOf:within:
 				variables: instVars
 				format: '<1s>.<2s>'
 				abortable: false].
@@ -211,7 +211,7 @@ buildAllVariablesMenu: aMenu
 			[self
 				populateVarMenu: aMenu
 				class: class
-				command: #browseReferencesToClassVars:of:within:
+				command: #browseReferencesToClassVar:of:within:
 				variables: classVars
 				format: '<1s>.<2s>'
 				abortable: false]!
@@ -810,7 +810,7 @@ populateVarMenu: aMenu class: class command: cmdSelector variables: aCollection 
 			msg := MessageSend
 						receiver: self developmentSystem
 						selector: cmdSelector
-						arguments: { { each value }. class. self searchEnvironment }.
+						arguments: { each value. class. self searchEnvironment }.
 			(aMenu addCommand: msg
 				description: (aString expandMacrosWithArguments: { each key name. each value }
 						locale: Locale smalltalk))

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowser.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowser.cls
@@ -970,7 +970,7 @@ saveMethod: aString in: aClass environment: aNamespace categories: aCollection p
 				environment: aNamespace
 				categories: aCollection
 				package: aPackageOrNil
-				extraFlags: (sourcePresenter isAutoParseEnabled ifTrue: [0] ifFalse: [Interactive])]
+				extraFlags: Interactive]
 			on: Compiler notificationClass
 			do: [:cn | sourcePresenter compilerNotification: cn offset: 0].
 	newMethod := change ifNotNil: [change method].

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodSearch.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodSearch.cls
@@ -2,7 +2,7 @@
 
 Core.Object
 	subclass: #'Tools.MethodSearch'
-	instanceVariableNames: 'findDetails regexp literal'
+	instanceVariableNames: 'findDetails regexp literal referenceFilter'
 	classVariableNames: ''
 	imports: #()
 	classInstanceVariableNames: ''
@@ -21,8 +21,21 @@ Class Variables:
 !Tools.MethodSearch categoriesForClass!Kernel-Objects! !
 !Tools.MethodSearch methodsFor!
 
+definitionFilter
+	"Answer a <monadicValuable> which can be used to discriminate between <CompiledMethod>s that
+	match this selector search and those that do not."
+
+	| type |
+	type := self searchMode.
+	^type == #regularExpression
+		ifTrue: [self regexpDefinitionFilter]
+		ifFalse: 
+			[type == #wildcardExpression
+				ifTrue: [self wildcardDefinitionFilter]
+				ifFalse: [self literalDefinitionFilter]]!
+
 definitionsIn: aBrowserEnvironment
-	^(aBrowserEnvironment filterMethods: self methodDefinitionFilter)
+	^(aBrowserEnvironment filterMethods: self definitionFilter)
 		label: (aBrowserEnvironment subEnvironmentLabel: #definitions for: self pattern);
 		search: self;
 		yourself!
@@ -61,32 +74,6 @@ literalSymbolsFilter: matchBlock
 matchesIn: aBrowserEnvironment
 	^{ self definitionsIn: aBrowserEnvironment. self referencesIn: aBrowserEnvironment }!
 
-methodDefinitionFilter
-	"Private - Answer a <monadicValuable> which can be used to discriminate between <CompiledMethod>s that
-	match this selector search and those that do not."
-
-	| type |
-	type := self searchMode.
-	^type == #regularExpression 
-		ifTrue: [self regexpDefinitionFilter]
-		ifFalse: 
-			[type == #wildcardExpression 
-				ifTrue: [self wildcardDefinitionFilter]
-				ifFalse: [self literalDefinitionFilter]]!
-
-methodReferenceFilter
-	"Private - Answer a <monadicValuable> which can be used to discriminate between <CompiledMethod>s that
-	match this selector search and those that do not."
-
-	| type |
-	type := self searchMode.
-	^type == #regularExpression 
-		ifTrue: [self regexpReferenceFilter]
-		ifFalse: 
-			[type == #wildcardExpression 
-				ifTrue: [self wildcardReferenceFilter]
-				ifFalse: [self simpleReferenceFilter]]!
-
 pattern
 	"Answer the receiver's current search pattern <String>. The interpretation of this string is
 	dependant upon the search type mode."
@@ -96,8 +83,22 @@ pattern
 pattern: aString 
 	findDetails pattern: aString!
 
+referenceFilter
+	"Answer a <monadicValuable> which can be used to discriminate between <CompiledMethod>s that match this selector search and those that do not."
+
+	^referenceFilter
+		ifNil: 
+			[| type |
+			type := self searchMode.
+			referenceFilter := type == #regularExpression
+						ifTrue: [self regexpReferenceFilter]
+						ifFalse: 
+							[type == #wildcardExpression
+								ifTrue: [self wildcardReferenceFilter]
+								ifFalse: [self simpleReferenceFilter]]]!
+
 referencesIn: aBrowserEnvironment
-	^(aBrowserEnvironment filterMethods: self methodReferenceFilter)
+	^(aBrowserEnvironment filterMethods: self referenceFilter)
 		label: (aBrowserEnvironment labelFormats at: self referencesLabelTag)
 					<< { self pattern. aBrowserEnvironment. self searchMode asPhrase };
 		search: self;
@@ -188,19 +189,19 @@ wildcardReferenceFilter
 	ignoreCase := findDetails isCaseSensitive not.
 	^self literalSymbolsFilter: [:each | match match: each ignoreCase: ignoreCase]! !
 !Tools.MethodSearch categoriesForMethods!
+definitionFilter!accessing!public! !
 definitionsIn:!enquiries!public! !
 findDetails!accessing!public! !
 findDetails:!accessing!public! !
 initialize!initializing!public! !
-literal!public! !
+literal!accessing!public! !
 literal:!accessing!public! !
 literalDefinitionFilter!helpers!private! !
 literalSymbolsFilter:!helpers!private! !
 matchesIn:!enquiries!public! !
-methodDefinitionFilter!helpers!private! !
-methodReferenceFilter!helpers!private! !
 pattern!accessing!public! !
 pattern:!accessing!public! !
+referenceFilter!accessing!public! !
 referencesIn:!enquiries!public! !
 referencesLabelTag!constants!public! !
 regexpDefinitionFilter!helpers!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodSourceSearch.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodSourceSearch.cls
@@ -15,11 +15,11 @@ Tools.MethodSourceSearch comment: ''!
 methodFilter: aMonadicValuable 
 	^[:each | each getSource ifNil: [false] ifNotNil: [:src | aMonadicValuable value: src]]!
 
-methodReferenceFilter
+referenceFilter
 	"Private - Answer a <monadicValuable> which can be used to discriminate between <CompiledMethod>s that
 	match this search and those that do not."
 
-	^self methodFilter: super methodReferenceFilter!
+	^self methodFilter: super referenceFilter!
 
 referencesLabelTag
 	^#containing!
@@ -58,7 +58,7 @@ wildcardReferenceFilter
 	^[:text | match match: text ignoreCase: ignoreCase]! !
 !Tools.MethodSourceSearch categoriesForMethods!
 methodFilter:!helpers!private! !
-methodReferenceFilter!helpers!private! !
+referenceFilter!accessing!private! !
 referencesLabelTag!constants!public! !
 regexpReferenceFilter!helpers!private! !
 simpleReferenceFilter!helpers!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkSystem.cls
@@ -524,7 +524,7 @@ browseClassVariables: aClass
 	aVariable notNil
 		ifTrue: 
 			[self
-				browseReferencesToClassVars: { aVariable }
+				browseReferencesToClassVar: aVariable
 				of: aClass
 				within: self browserEnvironment]!
 
@@ -642,7 +642,7 @@ browseInstanceVariables: browseClass
 
 	self 
 		browseInstanceVariables: browseClass
-		action: #browseReferencesToInstVars:inHierarchyOf:within:
+		action: #browseReferencesToInstVar:inHierarchyOf:within:
 		in: self browserEnvironment!
 
 browseInstanceVariables: browseClass action: selector in: aBrowserEnvironment
@@ -657,7 +657,7 @@ browseInstanceVariables: browseClass action: selector in: aBrowserEnvironment
 		ifTrue: 
 			[self
 				perform: selector
-				with: { varName }
+				with: varName
 				with: browseClass
 				with: aBrowserEnvironment]!
 
@@ -863,6 +863,14 @@ browseReferencesTo: anObject
 
 	^self browseReferencesToLiteral: anObject in: self browserEnvironment!
 
+browseReferencesToClassVar: aString of: aClass within: aBrowserEnvironment
+	"Private - Open a MethodBrowser on all the methods that reference the class variable named by the <readableString> first argument , in the hierarchy of the <Behavior>, aClass."
+
+	self
+		browseReferencesToClassVars: { aString }
+		of: aClass
+		within: aBrowserEnvironment!
+
 browseReferencesToClassVars: aCollection of: aClass within: aBrowserEnvironment
 	"Private - Open a MethodBrowser on all the methods that reference the class variables in aCollection, in the hierarchy of the <Behavior>, aClass."
 
@@ -882,6 +890,14 @@ browseReferencesToGlobal: aString
 browseReferencesToGlobal: aString in: aBrowserEnvironment 
 	(self promptForReferencesToGlobal: aString in: aBrowserEnvironment) 
 		ifNotNil: [:env | self browseMethodsIn: env]!
+
+browseReferencesToInstVar: aString inHierarchyOf: aBehavior within: aBrowserEnvironment
+	"Private - Open a method browser on all the methods that refer to the instance variable named by <readableString> first argument, in the hierarchy of the <Behavior> 2nd argument, within the <BrowserEnvironment> 3rd argument."
+
+	self
+		browseReferencesToInstVars: { aString }
+		inHierarchyOf: aBehavior
+		within: aBrowserEnvironment!
 
 browseReferencesToInstVars: aCollection inHierarchyOf: aBehavior within: aBrowserEnvironment
 	"Private - Open a method browser on all the methods that refer to the instance variables named by the <collection> of <readableString> argument, in the hierarchy of the <Behavior> argument."
@@ -1436,10 +1452,10 @@ copyClass: aClass
 		in: package!
 
 createClassVariableAccessors: aString in: aClass within: aBrowserEnvironment
-	"Implement the 'Create Variable Accessors' class refactoring on a class variable."
+	"Implement the 'Create Variable Accessors' class refactoring on class variables."
 
 	self
-		createVariableAccessors: {aClass -> aString}
+		createVariableAccessors: { aClass -> aString }
 		classVariables: true
 		within: aBrowserEnvironment!
 
@@ -1626,7 +1642,7 @@ definitionsMatching: aMethodSearch inHierarchyOf: aBehavior within: aBrowserEnvi
 	| class hierarchy |
 	class := aBehavior instanceClass.
 	hierarchy := aBrowserEnvironment forClassHierarchyOf: class.
-	^(hierarchy filterMethods: aMethodSearch methodDefinitionFilter)
+	^(hierarchy filterMethods: aMethodSearch definitionFilter)
 		label: ('Definitions of <1p> in the local hierarchy of <2p>' expandMacrosWith: aMethodSearch pattern
 					with: class);
 		yourself!
@@ -2013,6 +2029,7 @@ installPackage: aString
 		on: Notification
 		do: 
 			[:ex |
+			ex toTrace.
 			self sourceManager logComment: ex description.
 			ex resume]!
 
@@ -2106,7 +2123,7 @@ methodsContainingText: aString in: aBrowserEnvironment prompt: aBoolean
 		ifTrue: [findDetails := self promptForSearchString: findDetails caption: 'Methods Containing…'].
 	(findDetails isNil or: [findDetails pattern isEmpty]) ifTrue: [^nil].
 	search := MethodSourceSearch newFindDetails: findDetails copy.
-	filter := search methodReferenceFilter.
+	filter := search referenceFilter.
 	"Consolidate into a SelectorEnvironment, rather than keeping a dynamic PluggableEnvironment
 	otherwise there is a danger the entire source file may be scanned again"
 	caption := 'Finding Methods Containing <1p>' << search pattern.
@@ -3746,7 +3763,7 @@ renameClassVariable: oldName to: newName in: definingBehavior
 renameClassVariable: aString to: newName in: aClass within: aBrowserEnvironment
 	aClass renameClassVar: aString to: newName.
 	self
-		browseReferencesToClassVars: { newName }
+		browseReferencesToClassVar: newName
 		of: aClass
 		within: aBrowserEnvironment!
 
@@ -3783,7 +3800,7 @@ renameInstanceVariable: oldName to: newName in: definingBehavior
 renameInstanceVariable: aString to: newName in: aClass within: aBrowserEnvironment
 	aClass renameInstVar: aString to: newName.
 	self
-		browseReferencesToInstVars: { newName }
+		browseReferencesToInstVar: newName
 		inHierarchyOf: aClass
 		within: aBrowserEnvironment.
 	^newName!
@@ -4347,9 +4364,11 @@ browsePackages:!browsing!commands!public! !
 browseProtocols!browsing!commands!protocols!public! !
 browseReferencesMatching:in:!browsing!private! !
 browseReferencesTo:!browsing!public! !
+browseReferencesToClassVar:of:within:!browsing!private! !
 browseReferencesToClassVars:of:within:!browsing!private! !
 browseReferencesToGlobal:!browsing!public! !
 browseReferencesToGlobal:in:!browsing!public! !
+browseReferencesToInstVar:inHierarchyOf:within:!browsing!private! !
 browseReferencesToInstVars:inHierarchyOf:within:!browsing!private! !
 browseReferencesToLiteral:in:!browsing!public! !
 browseReferencesToVariable:!browsing!public! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.Tests.MethodSearchTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.Tests.MethodSearchTest.cls
@@ -17,7 +17,7 @@ testNewSelector
 	self assert: subject pattern identicalTo: #testNewSelector.
 	self assert: subject literal identicalTo: #testNewSelector.
 	self assert: subject searchMode identicalTo: #text.
-	filter := subject methodDefinitionFilter.
+	filter := subject definitionFilter.
 	self assert: (filter value: self class >> self selector).
 	self deny: (filter value: Object >> #size)! !
 !Tools.Tests.MethodSearchTest categoriesForMethods!

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.CommandQuery.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.CommandQuery.cls
@@ -290,11 +290,12 @@ new
 validateQueriesIn: aCompilationResult
 	"Private - Validate the commandQuery: annotations in the <CompilationResult>, and return whether the command queries collection should be (lazily) rebuilt because of a valid change."
 
-	| method affectsQueries annotations |
+	| method affectsQueries annotations isInteractive |
 	method := aCompilationResult oldMethod.
 	"If the method previously had commandQuery: annotations, we assume there is a change"
 	affectsQueries := method notNil and: [method hasAnnotation: #commandQuery:].
 	method := aCompilationResult method.
+	isInteractive := aCompilationResult isInteractive.
 	(method notNil and: 
 			[(annotations := method annotations) notNil
 				and: [affectsQueries := annotations includesSelector: #commandQuery:]])
@@ -306,13 +307,16 @@ validateQueriesIn: aCompilationResult
 					[:each |
 					| selector |
 					selector := each first.
-					(self validateQuerySelector: selector in: class)
-						ifFalse: 
-							["As there are validation issues, we want the change to be ignored, rather than used to build an invalid set of command queries"
-							^false]]].
+					(self
+						validateQuerySelector: selector
+						in: class
+						interactive: isInteractive)
+							ifFalse: 
+								["As there are validation issues, we want the change to be ignored, rather than used to build an invalid set of command queries"
+								^false]]].
 	^affectsQueries!
 
-validateQuerySelector: aSymbol in: aClass
+validateQuerySelector: aSymbol in: aClass interactive: aBoolean
 	| argc |
 	argc := aSymbol argumentCount.
 	argc > 1
@@ -320,9 +324,11 @@ validateQuerySelector: aSymbol in: aClass
 			[Warning signal: 'Command query selectors must have at most 1 argument, not the <2d> of <1p>'
 						<< { aSymbol. argc }.
 			^false].
-	(aClass canUnderstand: aSymbol)
+	(aBoolean not or: [aClass canUnderstand: aSymbol])
 		ifFalse: 
-			[Warning signal: '<1p> does not understand the command query selector <2p>' << { aClass. aSymbol }.
+			["If you get this warning, you have defined a commandQuery: annotation with a selector that is not understood by the class.
+			If you proceed (Ignore the warning), the individual commandQuery: will be skipped to avoid it generating an invalid query handler that will cause errors when checking command status. If you cancel at the warning, the rebuild of the command query handlers is aborted entirely. Either action will leave the handlers in a state which is not up-to-date with respect to the code. This will be corrected once you fix the offending commandQuery: annotation(s) and resave the command method. In general it is a good idea to define the handler, at least minimally, before adding a commandQuery: annotation that references it. If you don't you will get the warning and even if ignored you will still need to go back and re-save the command method after adding the command query in order to trigger a rebuild of the handlers. This validation is not performed during a non-interactive compile, e.g. when loading code, to avoid generating misleading warnings that only occur because of load-order."
+			Warning signal: '<1p> does not understand the command query selector <2p>' << { aClass. aSymbol }.
 			^false].
 	^true! !
 !UI.CommandQuery class categoriesForMethods!
@@ -330,6 +336,6 @@ commandDescription:source:!instance creation!public! !
 findQueryHandlersIn:!public! !
 new!instance creation!public! !
 validateQueriesIn:!private! !
-validateQuerySelector:in:!private! !
+validateQuerySelector:in:interactive:!private! !
 !
 


### PR DESCRIPTION
Also, only generate warnings for missing command queries from interactive compile. When loading code, the warnings that commandQuery: annotations refer to handler methods that are not defined by the class owning the command are misleading, since these are likely due to load-order rather than an error. The warning is intended to help avoid creating invalid handler definitions while coding interactively.