### PR TITLE
Debugger step over does not work after Debug/Continue (Ctrl+F5)

### DIFF
--- a/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/OA SUnit Extensions.pax
@@ -386,6 +386,7 @@ debugCase: aTestCase
 	"Same as runCase:, but must pass out an errors so caught by the debugger"
 
 	| start |
+	aTestCase isDebug: true.
 	start := Delay microsecondClockValue.
 	
 	[aTestCase runCase.

--- a/Core/Contributions/Camp Smalltalk/SUnit/SUnit.pax
+++ b/Core/Contributions/Camp Smalltalk/SUnit/SUnit.pax
@@ -25,11 +25,11 @@ package!
 
 Core.Object
 	subclass: #'XProgramming.SUnit.TestCase'
-	instanceVariableNames: 'testSelector'
+	instanceVariableNames: 'testSelector flags'
 	classVariableNames: ''
 	imports: #()
 	classInstanceVariableNames: ''
-	classConstants: {}!
+	classConstants: { 'DebugMask' -> 16r1 }!
 Core.Object
 	subclass: #'XProgramming.SUnit.TestCaseResult'
 	instanceVariableNames: 'case outcome duration signal stacktrace ip testMethod'

--- a/Core/Contributions/Camp Smalltalk/SUnit/XProgramming.SUnit.TestCase.cls
+++ b/Core/Contributions/Camp Smalltalk/SUnit/XProgramming.SUnit.TestCase.cls
@@ -2,11 +2,11 @@
 
 Core.Object
 	subclass: #'XProgramming.SUnit.TestCase'
-	instanceVariableNames: 'testSelector'
+	instanceVariableNames: 'testSelector flags'
 	classVariableNames: ''
 	imports: #()
 	classInstanceVariableNames: ''
-	classConstants: {}!
+	classConstants: { 'DebugMask' -> 16r1 }!
 XProgramming.SUnit.TestCase guid: (Core.GUID fromString: '{5e96793a-0810-11d4-a876-0050da643bf9}')!
 XProgramming.SUnit.TestCase isNonInstantiable: true!
 XProgramming.SUnit.TestCase comment: ''!
@@ -52,7 +52,11 @@ comparingStringBetween: expectedObject and: actualObject
 
 debug
 	self resources do: [:res | res isAvailable ifFalse: [^res signalInitializationError]].
-	[(self class selector: testSelector) runCase] ensure: [self resources do: [:each | each reset]]!
+	
+	[(self class selector: testSelector)
+		isDebug: true;
+		runCase]
+			ensure: [self resources do: [:each | each reset]]!
 
 debugAsFailure
 	| semaphore |
@@ -61,7 +65,9 @@ debugAsFailure
 	
 	[semaphore wait.
 	self resources do: [:each | each reset]] fork.
-	(self class selector: testSelector) runCaseAsFailure: semaphore!
+	(self class selector: testSelector)
+		isDebug: true;
+		runCaseAsFailure: semaphore!
 
 deny: aBoolean
 	self assert: aBoolean not!
@@ -86,6 +92,12 @@ failureLog
 	
 	^Transcript
 !
+
+isDebug
+	^flags allMask: DebugMask!
+
+isDebug: aBoolean
+	flags := flags mask: DebugMask set: aBoolean!
 
 isLogging
 	^false!
@@ -157,7 +169,8 @@ selector
 	^testSelector!
 
 setTestSelector: aSymbol
-	testSelector := aSymbol!
+	testSelector := aSymbol.
+	flags := 0!
 
 setUp
 	| annotations |
@@ -241,6 +254,8 @@ deny:description:!asserting!public! !
 deny:description:resumable:!asserting!public! !
 fail:!asserting!public! !
 failureLog!Accessing!public! !
+isDebug!public!running! !
+isDebug:!public!running! !
 isLogging!accessing!public! !
 logFailure:!asserting!public! !
 openDebuggerOnFailingTestMethod!public!running! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.HeapsortAlgorithmTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.HeapsortAlgorithmTest.cls
@@ -15,6 +15,8 @@ algorithmToTest
 	^HeapsortAlgorithm!
 
 testBigStringSort
+	<skipIf: #isCiBuild>
+	<knownSlowTest>
 	self bigStringSort! !
 !Kernel.Tests.HeapsortAlgorithmTest categoriesForMethods!
 algorithmToTest!private!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.MergesortAlgorithmTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.MergesortAlgorithmTest.cls
@@ -15,6 +15,7 @@ algorithmToTest
 	^MergesortAlgorithm!
 
 testBigStringSort
+	<knownSlowTest>
 	self bigStringSort!
 
 testTempArrayLargeEnough

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.Debugger.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.Debugger.cls
@@ -147,6 +147,7 @@ beBroken
 
 	flags := flags maskClear: RunMask.	"no longer running"
 	Processor enableInterrupts.
+	breakWhen removeAll.
 	self mainView enable
 
 	!
@@ -191,7 +192,7 @@ break: interruptFrame
 	self suspend
 	"N.B. There must be no further code after this point"!
 
-breakFrame: aStackFrame 
+breakFrame: aStackFrame
 	"Private - Set the frame on which to break."
 
 	self makeDebugFrame: aStackFrame.
@@ -1921,6 +1922,7 @@ userBreak
 
 validateUserInterface
 	super validateUserInterface.
+	self isRunning ifTrue: [^self].
 	sourcePresenter isModified
 		ifTrue: 
 			[sourceInterval

--- a/Core/Object Arts/Dolphin/IDE/Base/UI.TranscriptShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/UI.TranscriptShell.cls
@@ -86,7 +86,7 @@ contents
 cr
 	"Append a line delimiter to the receiver (N.B. For Windows this is a CR-LF sequence)."
 
-	self nextPutAll: String lineDelimiter; flush!
+	self nextPutAll: String.LineDelimiter; flush!
 
 createComponents
 	"Create the presenters contained by the receiver.
@@ -142,7 +142,7 @@ flush
 
 	buffer position == 0 ifTrue: [^self].
 	bufferProtect critical: [self hasOutputWindow ifTrue: [self updateWindow]].
-	(self class flashOnOutput and: [self view isActive not]) ifTrue: [self alertUser]!
+	(FlashOnOutput and: [self view isActive not]) ifTrue: [self alertUser]!
 
 forgetSize
 	"Forget the default size for new instances of this tool."
@@ -304,12 +304,9 @@ tab: tabCount
 	tabCount timesRepeat: [self tab]!
 
 updateWindow
-	| newText length |
-	newText := buffer contents.
-	length := outputWindow textLength.
 	outputWindow
-		caretPosition: length + 1;
-		replaceSelection: newText.
+		appendText: buffer contents;
+		scrollToEnd.
 	^buffer reset!
 
 visit: anObject do: aNiladicValuable

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.UnitTestPlugin.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.UnitTestPlugin.cls
@@ -391,7 +391,7 @@ toggleToTestsClass
 	testClasses := self testClasses.
 	testClasses size == 1 ifFalse: [^nil].
 	testClass := testClasses single.
-	^testClass = self browser actualClass ifTrue: [self classUnderTest] ifFalse: [testClass]!
+	^testClass = self browser selectedClass ifTrue: [self classUnderTest] ifFalse: [testClass]!
 
 toggleToTestsClassDescription
 	^(self toggleToTestsClass ?? TestCase) shortName!

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.ScintillaView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.ScintillaView.cls
@@ -4038,8 +4038,8 @@ modifyText: niladicBlock
 	self isReadOnly
 		ifFalse: [niladicBlock value]
 		ifTrue: 
-			[self isReadOnly: false.
-			niladicBlock ensure: [self isReadOnly: true]]!
+			[self setReadOnly: false.
+			niladicBlock ensure: [self setReadOnly: true]]!
 
 mouseDwellTime
 	"Retrieve the <Duration> that the mouse must sit still to generate a mouse hovering event. Answer nil if this is effectively infinite to indicate that the dwell is not set and no hover events will be generated."

--- a/Core/Object Arts/Dolphin/System/Compiler/Tests/Kernel.Tests.CompilerTest.cls
+++ b/Core/Object Arts/Dolphin/System/Compiler/Tests/Kernel.Tests.CompilerTest.cls
@@ -1064,7 +1064,6 @@ testLiteralStringEncoding
 
 testMapIpWithVoidedEntry
 	| method debugMap textMap debugMethod |
-	self skip. "Work in progress - works with old mapIP:toDebug:, but not replacement yet"
 	method := self getTestMethod: #performOn:.
 	"If the bytecode generation changes, then this test will be inconclusive, so we need to detect that"
 	self assert: method disassembly
@@ -1152,6 +1151,7 @@ testMapIpWithVoidedEntry
 				29 -> (197 to: 378).
 				31 -> (197 to: 378)
 			}.
+	self skip. 'Work in progress - works with old mapIP:toDebug:, but not replacement yet as doesn''t skip voided entry'.
 	"Verify that we can remap every ip in the method to the correct ip in the debug method, although in practice we only need to map bytecodes for the potential break points (mainly sends)."
 	#(#(1 3) #(2 5) #(3 7) #(4 8) #(5 9) #(6 10) #(8 13) #(9 14) #(11 16) #(12 18) #(13 19) #(14 21) #(15 23) #(16 24) #(17 25) #(18 27) #(19 29) #(20 31))
 		do: [:pair | self assert: (method mapIp: pair first toDebug: debugMethod) equals: pair second]!
@@ -1243,6 +1243,40 @@ testOptimizedLoopReadBeforeWritten
 	actual := expr value.
 	self skip: 'Results of actual block evaluation in a loop and optimized loop should be the same - any	read-before-written locals must be reinitialized to nil on each iteration'.
 	self assert: actual equals: expected!
+
+testPopReturn
+	| method debugMap textMap debugMethod |
+	method := self getTestMethod: #appendToStream:.
+	"If the bytecode generation changes, then this test will be inconclusive, so we need to detect that"
+	self assert: method disassembly
+		equals: 'Normal, 1 args, 1 literals
+
+	1	Push Temp[0]
+	2	Push Self
+	3	Send[0]: #nextPut: with 1 args
+	4	Pop; Return self'.
+	textMap := method debugInfo textMap.
+	self assert: textMap equals: { 3 -> (90 to: 117). 4 -> (118 to: 117) }.
+	debugMethod := method asDebugMethod.
+	"Note that the debug method is still 'optimised', as this is necessary so that the text maps (used by the debugger to remap normal frames to debug frames) align.
+	There will be fewer optimisation opportunities due to the Break instructions, in particular macro instructions such as send-to-self, will be split"
+	self assert: debugMethod disassembly
+		equals: 'Normal, 1 args, 1 literals, debug
+
+	1	Push Temp[0]
+	2	Push Self
+	3	*Break
+	4	Send[0]: #nextPut: with 1 args
+	5	Pop
+	6	*Break
+	7	Return self'.
+	debugMap := debugMethod debugInfo textMap.
+	debugMap with: textMap do: [:debug :nondebug | self assert: debug value equals: nondebug value].
+
+	"Verify that we can remap every ip in the method to the correct ip in the debug method, although in practice we only need to map bytecodes for the potential break points (mainly sends)."
+	self skip: 'BUG: Debug IP remap incorrect because of Pop; Return optimisation'.
+	#(#(1 1) #(2 2) #(3 4) #(4 5))
+		do: [:pair | self assert: (method mapIp: pair first toDebug: debugMethod) equals: pair second]!
 
 testQualifiedReference
 	{Array. #(). nil. nil} pairsDo: 
@@ -1354,52 +1388,14 @@ testReturnIfNotNil
 	15	Store Temp[1]
 	16	*Break
 	17	Return'.
+
 	"Verify that we can remap every ip in the method to the correct ip in the debug method, although in practice we only need to map bytecodes for the potential break points (mainly sends)."
 	#(#(1 1) #(2 2) #(3 4) #(4 7) #(5 9) #(6 12) #(7 14))
-		do: [:pair | self assert: (method mapIp: pair first toDebug: debugMethod) equals: pair second]!
+		do: [:pair | self assert: (method mapIp: pair first toDebug: debugMethod) equals: pair second].
 
-testReturnIfNotNilOptimization
-	| method textMap debugMethod |
-	method := self getTestMethod: #associationAt:.
-	"If the bytecode generation changes, then this test will be inconclusive, so we need to detect that"
-	self assert: method disassembly
-		equals: 'Normal, 1 args, 1 stack temps, 3 literals
-
-	1	Push Self; Push Temp[0]
-	2	Push nil
-	3	Send[0]: #associationAt:ifAbsent: with 2 args
-	4	Return If Not Nil
-	5	Push Self; Push Temp[0]
-	6	Send[1]: #errorKeyNotFound: with 1 args
-	7	Return'.
-	textMap := method debugInfo textMap.
-	self assert: textMap
-		equals: { 3 -> (172 to: 212). 4 -> (171 to: 286). 6 -> (226 to: 255). 7 -> (170 to: 286) }.
-	debugMethod := method asDebugMethod.
-	"Note that the debug method is still 'optimised', as this is necessary so that the text maps (used by the debugger to remap normal frames to debug frames) align.
-	There will be fewer optimisation opportunities due to the Break instructions, in particular macro instructions such as send-to-self, will be split"
-	self assert: debugMethod disassembly
-		equals: 'Normal, 1 args, 1 stack temps, 3 literals, debug
-
-	1	Push Self; Push Temp[0]
-	2	Push nil
-	3	*Break
-	4	Send[0]: #associationAt:ifAbsent: with 2 args
-	5	Dup
-	6	*Break
-	7	Jump If Not Nil +6 to 15
-	9	Pop; Push Self
-	10	Push Temp[0]
-	11	*Break
-	12	Send[1]: #errorKeyNotFound: with 1 args
-	13	*Break
-	14	Return
-	15	Store Temp[1]
-	16	*Break
-	17	Return'.
-	"Verify that we can remap every ip in the method to the correct ip in the debug method, although in practice we only need to map bytecodes for the potential break points (mainly sends)."
-	#(#(1 1) #(2 2) #(3 4) #(4 7) #(5 9) #(6 12) #(7 14))
-		do: [:pair | self assert: (method mapIp: pair first toDebug: debugMethod) equals: pair second]!
+	self skip: 'BUG: Text maps are of different sizes. This should never be the case'.
+	debugMap := debugMethod debugInfo textMap.
+	debugMap with: textMap do: [:debug :nondebug | self assert: debug value equals: nondebug value].!
 
 testReturnImmediate
 	"#397"
@@ -2121,11 +2117,11 @@ testNestedCopyingBlocks!public!unit tests! !
 testNestedWhileTrueAtStartOfCleanBlock!public!unit tests! !
 testNotIdentical!public!unit tests! !
 testOptimizedLoopReadBeforeWritten!public!unit tests! !
+testPopReturn!public!unit tests!unit tests-text maps! !
 testQualifiedReference!public!unit tests! !
 testRadixInteger!public!unit tests! !
 testReturnFromOptimizedBlock!public!unit tests! !
 testReturnIfNotNil!public!unit tests!unit tests-text maps! !
-testReturnIfNotNilOptimization!public!unit tests-text maps! !
 testReturnImmediate!exceptions!public!unit tests! !
 testReturnPseudoVar!public!unit tests! !
 testScanningScaledDecimals!public!unit tests! !

--- a/Core/Object Arts/Dolphin/System/Compiler/Tests/Kernel.Tests.DolphinCompilerTestMethods.cls
+++ b/Core/Object Arts/Dolphin/System/Compiler/Tests/Kernel.Tests.DolphinCompilerTestMethods.cls
@@ -18,6 +18,11 @@ Kernel.Tests.DolphinCompilerTestMethods comment: ''!
 == x
 	^super == x!
 
+appendToStream: puttableStream
+	"Packed method with `Pop; Return Self` instruction"
+
+	puttableStream nextPut: self!
+
 associationAt: aString
 	"Answer an <Association> with the specified key and the associated value from the receiver.
 	If the key is not found, raise an exception."
@@ -552,6 +557,7 @@ testWarnUnimplementedAbstractMethod
 !Kernel.Tests.DolphinCompilerTestMethods categoriesForMethods!
 ~~!public!unit tests! !
 ==!public!unit tests! !
+appendToStream:!public!unit tests! !
 associationAt:!accessing!public! !
 basicSize!public!unit tests! !
 ifNil:!public!unit tests! !


### PR DESCRIPTION
The breakWhen condition is left behind from the Debug/Continue, and prevents the debugger stopping on break instructions until cleared, e.g. by doing a single step. This bug is not new - present in D7.1 too.