### PR TITLE
Insecure generic object clipboard format should not be available by default

### DIFF
--- a/Core/Contributions/Solutions Software/Tests/EditableListViewTest.cls
+++ b/Core/Contributions/Solutions Software/Tests/EditableListViewTest.cls
@@ -38,8 +38,6 @@ testPackageClosure
 				forPackagesDeployment: { EditableListViewDemo owningPackage }.
 	missing := Smalltalk developmentSystem unimplementedSelectorsIn: aBrowserEnvironment.	"Use symmetric  difference, as we also want to fix up the test if some missing message is fixed."
 	expected := #(#defineTemplate).
-	#todo. "Temporary STB dependencies caused by Clipboard binary object format, which is to be made opt-in only since it is insecure"
-	expected := expected, #(#binaryStoreBytes #fromBinaryStoreBytes:).
 	self assert: (missing symmetricDifference: expected) asArray sort equals: #()
 	"To debug this, open an env browser on the deployment scope as follows:
 		EnvironmentBrowserShell onEnvironment: aBrowserEnvironment.

--- a/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
+++ b/Core/Object Arts/Dolphin/IDE/Base/Development System.pax
@@ -836,6 +836,7 @@ package setPrerequisites: #(
 	'..\..\MVP\Base\Dolphin Base Dialogs'
 	'..\..\MVP\Base\Dolphin Basic Geometry'
 	'..\..\System\Filer\Dolphin Binary Filer'
+	'..\..\MVP\Base\Dolphin Binary Object Clipboard Format'
 	'..\..\MVP\Presenters\Boolean\Dolphin Boolean Presenter'
 	'Dolphin Browser Environments'
 	'..\..\MVP\Views\Cards\Dolphin Card Containers'

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.AspectInspector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.AspectInspector.cls
@@ -186,20 +186,19 @@ queryCommand: query
 			[query
 				isEnabled: (accessor notNil and: [accessor canReset]);
 				text: (query commandDescription menuText
-							expandMacrosWithArguments: {accessor isNil or: [accessor aspectDescriptor hasDefault not]}
+							expandMacrosWithArguments: { accessor isNil or: [accessor aspectDescriptor hasDefault not] }
 							locale: Locale smalltalk).
 			^true].
 	#pasteAspect == command
 		ifTrue: 
-			[| text |
+			[| text class |
 			text := 'nil'.
-			Clipboard current isObjectAvailable
+			(Clipboard current isObjectAvailable
+				and: [(class := Clipboard current getObjectClassIfNone: nil) notNil])
 				ifTrue: 
-					[| class |
-					class := Clipboard current getObjectClass.
-					text := class printString.
+					[text := class printString.
 					query isEnabled: accessor notNil].
-			query text: (query commandDescription description expandMacrosWithArguments: {text}
+			query text: (query commandDescription description expandMacrosWithArguments: { text }
 						locale: Locale smalltalk).
 			^true].
 	^super queryCommand: query!

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.DevelopmentSessionManager.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.DevelopmentSessionManager.cls
@@ -704,11 +704,11 @@ tertiaryStartup
 	SmalltalkSystemShell is available)."
 
 	"Invalidate options before restoring window state"
+
 	SmalltalkToolShell invalidateOptions.
-
 	super tertiaryStartup.
-
 	self disableWindowGhosting.
+	ClipboardBinaryObjectTypeConverter current beUnrestricted.
 	"Flush any output accumulated in the transcript buffer during startup."
 	TranscriptShell current flush.
 	self mainShellClass onStartup.

--- a/Core/Object Arts/Dolphin/Installation Manager/Tools.DolphinCoreProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/Tools.DolphinCoreProduct.cls
@@ -20,14 +20,18 @@ contents
 
 	"Base"
 	contents
+		add: #('Core\Object Arts\Dolphin\MVP\Base\Dolphin Binary Object Clipboard Format.pax' #plain #imageBased);
 		add: #('Core\Object Arts\Dolphin\MVP\Presenters\Text\Dolphin Rich Text Presenter.pax' #plain #imageBased);
 		add: #('Core\Object Arts\Dolphin\MVP\Views\Path\Dolphin StaticPath Control.pax' #encrypted #imageBased);
 		add: #('Core\Object Arts\Dolphin\MVP\Views\SysLink\Dolphin SysLink Control.pax' #encrypted #imageBased);
 		add: #('Core\Contributions\Refactory\Refactoring Browser\Formatters\RBFormatters.pax' #plain #imageBased);
 		add: #('Core\Object Arts\Dolphin\System\Announcements\Dolphin Announcements.pax' #plain #imageBased);
 		
-		"##(self paxesUnder: 'Core\Object Arts\Dolphin\MVP\Presenters\Prompters' encrypted: false) asArray"
-		addAll: #(#('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Choice Prompter.pax' #plain #imageBased) #('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin In-place Text Editor.pax' #plain #imageBased) #('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Integer Prompter.pax' #plain #imageBased) #('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Key-Value Prompter.pax' #plain #imageBased) #('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Prompter.pax' #plain #imageBased));
+		add: #('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Choice Prompter.pax' #plain #imageBased);
+		add: #('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin In-place Text Editor.pax' #plain #imageBased);
+		add: #('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Integer Prompter.pax' #plain #imageBased);
+		add: #('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Key-Value Prompter.pax' #plain #imageBased);
+		add: #('Core\Object Arts\Dolphin\MVP\Presenters\Prompters\Dolphin Prompter.pax' #plain #imageBased);
 
 		add: #('Core\Object Arts\Dolphin\ActiveX\COM\OLE COM.pax' #plain #imageBased);
 		add: #('Core\Object Arts\Dolphin\ActiveX\COM\OLE COM (Old Names).pax' #plain #imageBased);

--- a/Core/Object Arts/Dolphin/Lagoon/Tools.Tests.PackageClosureTests.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/Tools.Tests.PackageClosureTests.cls
@@ -23,9 +23,7 @@ simpleGuiAppUnimplementedMessages
 		- ttmRelayEvent: - only sent (from MVP base) if the Dolphin ToolTips package is loaded. This may show up in the UnimplementedMessages section of the actual deployment log for GUI apps.
 		- #isStable, #override:with: #removeOverrideFor: #saveObject: #saveObject:as: #saveSingleton: #saveSingleton:class:name: #saveSingleton:name: - STBOutFiler methods sent by stbSaveOn:'s, which will be removed on deployment if the STB/STLOutFilers are not part of the app. However as STBOutFiler is no longer part of the base Dolphin package, it will be missing in any application that does not use STB, causing these methods to have no implementation in the dummy deployment environment. An app such as Etch-A-Sketch does use STB to save documents, so it won't be missing these in the deployment environment, but most of the test apps will as they don't use STB for writing, only STL for reading view resources."
 
-	#todo.	"Extra STBOutFiler messages from Clipboard, to be removed"
-	^#(#ttmRelayEvent: #defineTemplate #isStable #override:with: #removeOverrideFor: #saveObject: #saveObject:as: #saveSingleton: #saveSingleton:class:name:)
-		, #(#binaryStoreBytes #fromBinaryStoreBytes:)!
+	^#(#ttmRelayEvent: #defineTemplate #isStable #override:with: #removeOverrideFor: #saveObject: #saveObject:as: #saveSingleton: #saveSingleton:class:name:)!
 
 testCommandLineHelloWorld
 	"Tests predicted unimplemented messages of a minimal console application. Note that the actual set will be less and can be determined by deploying the application with deployment logging enabled, and looking at the UnimplementedMesages element in the resulting log. In the case of 'Hello World' the unimplemented message set should actually be empty when deploying."

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin Binary Object Clipboard Format.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin Binary Object Clipboard Format.pax
@@ -1,0 +1,76 @@
+﻿| package |
+package := Package name: 'Dolphin Binary Object Clipboard Format'.
+package paxVersion: 2.1;
+	basicComment: 'Dolphin 🐬 Smalltalk Generic Object Clipboard Format
+Copyright © Object Arts Ltd. 1997-2023.
+
+Supports copy and paste of generic object graphs via the Windows clipboard. The STB serialization mechanism is used.
+
+Note: STB is insecure in that it can be used to transport arbitrary objects including code. This package has been split from the standard clipboard support in order that the Object format is not included in applications unless explicitly linked in by explicitly declaring a manual package dependency.'.
+
+
+package setClassNames: #(
+	#{UI.ClipboardBinaryObjectTypeConverter}
+).
+
+package setMethodNames: #(
+	#(#{UI.Clipboard} #getObject)
+	#(#{UI.Clipboard} #getObjectClass)
+	#(#{UI.Clipboard} #getObjectClassIfNone:)
+	#(#{UI.Clipboard} #getObjectIfNone:)
+).
+
+package setPrerequisites: #(
+	'..\..\Base\Dolphin'
+	'Dolphin MVP Base'
+	'..\Type Converters\Dolphin Type Converters'
+	'..\..\System\Filer\Dolphin Validating Binary Filer'
+).
+
+package!
+
+"Class Definitions"!
+
+UI.TypeConverter
+	subclass: #'UI.ClipboardBinaryObjectTypeConverter'
+	instanceVariableNames: 'classLocator'
+	classVariableNames: 'Current'
+	imports: #()
+	classInstanceVariableNames: ''
+	classConstants: {}!
+
+"Loose Methods"!
+
+!UI.Clipboard methodsFor!
+
+getObject
+	"Answer the <Object> stored on the clipboard or raise an error if none."
+
+	^self getObjectIfNone: [self errorFormatNotAvailable: #Object]!
+
+getObjectClass
+        "Answer the <Class> for the <Object> stored on the clipboard or raise an error if there is
+	none."
+
+	^self getObjectClassIfNone: [self errorFormatNotAvailable: #ObjectClass]!
+
+getObjectClassIfNone: exceptionHandler
+	"Answer the <Class> of the <Object> stored on the clipboard. If no object is currently
+	available, the answers the result of evaluating the <niladicValuable> exceptionHandler."
+
+	^self getRegisteredFormat: #ObjectClass ifNone: exceptionHandler!
+
+getObjectIfNone: exceptionHandler
+	"Answer the <object> stored on the clipboard. If no object is currently available, the
+	answers the result of evaluating the <niladicValuable> exceptionHandler."
+
+	^self getRegisteredFormat: #Object ifNone: exceptionHandler! !
+!UI.Clipboard categoriesForMethods!
+getObject!accessing!public! !
+getObjectClass!accessing!public! !
+getObjectClassIfNone:!accessing!public! !
+getObjectIfNone:!accessing!public! !
+!
+
+"End of package definition"!
+

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.Clipboard.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.Clipboard.cls
@@ -129,34 +129,8 @@ getFormatName: format
 				cchMaxCount: name size.
 	^len == 0 ifFalse: [(name resize: len) asUtf8String]!
 
-getObject
-	"Answer the <Object> stored on the clipboard or raise an error if none."
-
-	^self getObjectIfNone: [self errorFormatNotAvailable: #Object]!
-
-getObjectClass
-        "Answer the <Class> for the <Object> stored on the clipboard or raise an error if there is
-	none."
-
-	^self getObjectClassIfNone: [self errorFormatNotAvailable: #ObjectClass]!
-
-getObjectClassIfNone: exceptionHandler
-	"Answer the <Class> of the <Object> stored on the clipboard. If no object is currently
-	available, the answers the result of evaluating the <niladicValuable> exceptionHandler."
-
-	^self getRegisteredFormat: #ObjectClass ifNone: exceptionHandler!
-
-getObjectIfNone: exceptionHandler
-	"Answer the <object> stored on the clipboard. If no object is currently available, the
-	answers the result of evaluating the <niladicValuable> exceptionHandler."
-
-	^self getRegisteredFormat: #Object ifNone: exceptionHandler!
-
 getRegisteredFormat: name ifNone: exceptionHandler
-	"Answer an <Object> representing the contents of the clipboard of the named pre-registered
-	format translated to an appropriate Smalltalk object using the right-to-left conversion of
-	the type converter registered for that format. If the format is not currently available, the
-	answers the result of evaluating the <niladicValuable> exceptionHandler."
+	"Answer an <Object> representing the contents of the clipboard of the named pre-registered format translated to an appropriate Smalltalk object using the right-to-left conversion of the type converter registered for that format. If the format is not currently available or the data cannot be read, then answers the result of evaluating the <niladicValuable> exceptionHandler."
 
 	| formatId |
 	formatId := registeredFormats at: name.
@@ -164,7 +138,7 @@ getRegisteredFormat: name ifNone: exceptionHandler
 			[| handle |
 			handle := User32 getClipboardData: formatId first.
 			handle isNull ifTrue: [^exceptionHandler value].
-			formatId last rightToLeft: handle]!
+			[formatId second rightToLeft: handle] on: Error do: [:ex | exceptionHandler value]]!
 
 getText
 	"Answer a <readableString> containing the CF_UNICODETEXT contents 
@@ -186,25 +160,17 @@ initialize
 		Clipboard current initialize
 	"
 
-	| nullConversion objectConverter |
+	| nullConversion |
 	isOpen := false.
 	registeredFormats := IdentityDictionary new.
 	idToName := IdentityDictionary new.
 	nullConversion := NullConverter new.
-	objectConverter := PluggableTypeConverter
-				leftToRight: [:obj | External.Memory copyBytesToGlobalHeap: obj binaryStoreBytes]
-				rightToLeft: [:handle | Object fromBinaryStoreBytes: (ByteArray fromGlobalHandle: handle)].
 	self
 		addRegisteredFormat: #String
 			id: CF_UNICODETEXT
 			converter: (PluggableTypeConverter
-					leftToRight: [:obj | External.Memory copyBytesToGlobalHeap: obj asString asUtf16String]
+					leftToRight: [:obj | External.Memory copyBytesToGlobalHeap: obj asUtf16String]
 					rightToLeft: [:handle | Utf16String fromGlobalHandle: handle]);
-		addRegisteredFormat: #AnsiString
-			id: CF_TEXT
-			converter: (PluggableTypeConverter
-					leftToRight: [:obj | External.Memory copyBytesToGlobalHeap: obj asString asAnsiString]
-					rightToLeft: [:handle | AnsiString fromGlobalHandle: handle]);
 		addRegisteredFormat: #Bitmap
 			id: CF_BITMAP
 			converter: (PluggableTypeConverter leftToRight: [:bmp | bmp copy detachHandle]
@@ -218,13 +184,7 @@ initialize
 		addRegisteredFormat: #DIBSection
 			id: CF_DIB
 			converter: (PluggableTypeConverter leftToRight: [:ds | ds copyToGlobalHeap]
-					rightToLeft: [:handle | DIBSection fromGlobalHandle: handle]);
-		addRegisteredFormat: #Object
-			id: (User32 registerClipboardFormat: 'Smalltalk Object Format')
-			converter: objectConverter;
-		addRegisteredFormat: #ObjectClass
-			id: (User32 registerClipboardFormat: 'Smalltalk Object Class Format')
-			converter: objectConverter!
+					rightToLeft: [:handle | DIBSection fromGlobalHandle: handle])!
 
 isBitmapAvailable
 	"Answer whether the clipboard contains a bitmap."
@@ -353,10 +313,6 @@ getBitmapIfNone:!accessing!public! !
 getDIBSection!accessing!public! !
 getDIBSectionIfNone:!accessing!public! !
 getFormatName:!accessing!public! !
-getObject!accessing!public! !
-getObjectClass!accessing!public! !
-getObjectClassIfNone:!accessing!public! !
-getObjectIfNone:!accessing!public! !
 getRegisteredFormat:ifNone:!accessing!public! !
 getText!accessing!public! !
 getTextIfNone:!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.ClipboardBinaryObjectTypeConverter.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.ClipboardBinaryObjectTypeConverter.cls
@@ -1,0 +1,86 @@
+﻿"Filed out from Dolphin Smalltalk"!
+
+UI.TypeConverter
+	subclass: #'UI.ClipboardBinaryObjectTypeConverter'
+	instanceVariableNames: 'classLocator'
+	classVariableNames: 'Current'
+	imports: #()
+	classInstanceVariableNames: ''
+	classConstants: {}!
+UI.ClipboardBinaryObjectTypeConverter guid: (Core.GUID fromString: '{62288e60-a337-4d21-b14d-615407c58023}')!
+UI.ClipboardBinaryObjectTypeConverter comment: ''!
+!UI.ClipboardBinaryObjectTypeConverter methodsFor!
+
+beUnrestricted
+	classLocator := ClassLocator new!
+
+classLocator
+	"Answer the <ClassLocator> used for resolving classes in the serialized data stream being copied from the clipboard. Usually this will be an instance of <RestrictedClassLocator>, allowing selective enablement/disablement of copy & paste of particular classes of object to/from the clipboard. In a development environment this will be a standard <ClassLocator>, in which case any type of object can be transferred through the clipboard. Note that there are security implications to this since this allows arbitrary code to be transferred and executed."
+
+	^classLocator!
+
+classLocator: aClassLocator
+	"Set the <ClassLocator> used for resolving classes in the serialized data stream being copied from the clipboard.
+	For security reasons, a restricted class locator should be used that in some way limits the types of objects that can be instantiated. See ValidatingClassLocator and RestrictedClassLocator.
+	In order to be secure by default, a RestrictedClassLocator is used that excludes all but a few basic types (see the #initialize method for details). This will mean that very little data in Object format can be pasted from the clipboard unless at least some relevant classes are explicitly included."
+
+	classLocator := aClassLocator!
+
+initialize
+	"Private - Initialize the receiver
+		self current initialize
+	"
+
+	classLocator := RestrictedClassLocator new.
+	"Restricted class locators exclude all classes by default except UndefinedObject, SmallInteger, True and False. Everything else must be explicitly added, even basic types like Array, String, Symbol, etc"
+	classLocator
+		includeClasses: #(#{Kernel.STBClassProxy} #{Core.Utf8String} #{Core.Array} #{Core.OrderedCollection} #{Core.Symbol} #{Core.LargeInteger} #{Core.Float} #{Core.ScaledDecimal} #{Core.Fraction} #{Core.True} #{Core.False} #{Core.SmallInteger} #{Core.UndefinedObject})!
+
+leftToRight: anObject
+	"Private - Answers a Windows global memory handle that can be put on the clipboard, and which contains an STB serialised representation of the <Object> argument."
+
+	^External.Memory copyBytesToGlobalHeap: anObject binaryStoreBytes!
+
+register
+	Clipboard current
+		addRegisteredFormat: #Object
+			id: (User32 registerClipboardFormat: 'Smalltalk Object Format')
+			converter: self;
+		addRegisteredFormat: #ObjectClass
+			id: (User32 registerClipboardFormat: 'Smalltalk Object Class Format')
+			converter: self!
+
+rightToLeft: aHandle
+	"Private - Answers an <Object> reconstituted from the STB serialised data in the specified global memory block, e.g. from the Clipboard."
+
+	^(STBValidatingInFiler on: (ByteArray fromGlobalHandle: aHandle) readStream
+		classLocator: classLocator) next! !
+!UI.ClipboardBinaryObjectTypeConverter categoriesForMethods!
+beUnrestricted!modes!public! !
+classLocator!accessing!public! !
+classLocator:!accessing!public! !
+initialize!initializing!private! !
+leftToRight:!operations!private! !
+register!initializing!private! !
+rightToLeft:!operations!private! !
+!
+
+!UI.ClipboardBinaryObjectTypeConverter class methodsFor!
+
+current
+	^Current ifNil: [Current := self new]!
+
+onPreStripImage
+	"Private -  Assist in the image stripping process by clearing down any
+	lazily initialized variables held by the receiver."
+
+	Current := nil!
+
+onStartup
+	self current register! !
+!UI.ClipboardBinaryObjectTypeConverter class categoriesForMethods!
+current!public! !
+onPreStripImage!class hierarchy-removing!private! !
+onStartup!public! !
+!
+

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.GUISessionManager.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.GUISessionManager.cls
@@ -8,6 +8,7 @@ Core.SessionManager
 	classInstanceVariableNames: ''
 	classConstants: { 'NoSplashMask' -> 16r2. 'UnattendedMask' -> 16r4 }!
 UI.GUISessionManager guid: (Core.GUID fromString: '{81bc839c-bcd6-4502-a491-418ed5a109e6}')!
+UI.GUISessionManager isNonInstantiable: true!
 UI.GUISessionManager comment: 'GUISessionManager is the class of <SessionManager>s used to manage the life-cycle of a graphical (as opposed to command line, or console) application.
 
 Note that Dolphin GUI applications can access the console and standard I/O streams, but a separate console window will be opened.
@@ -199,7 +200,7 @@ windowSystemShutdown
 windowSystemStartup
 	"Private - Perform window system startup operations."
 
-	#(#{Canvas} #{GraphicsTool} #{Clipboard} #{View} #{ToolbarIconButton} #{Command})
+	#(#{Canvas} #{GraphicsTool} #{Clipboard} #{ClipboardBinaryObjectTypeConverter} #{View} #{ToolbarIconButton} #{Command})
 		do: [:s | s ifDefined: [:c | c onStartup]]! !
 !UI.GUISessionManager categoriesForMethods!
 allocConsole!operations!private! !

--- a/Core/Object Arts/Dolphin/MVP/Tests/UI.Tests.ClipboardTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/Tests/UI.Tests.ClipboardTest.cls
@@ -15,7 +15,9 @@ isUnattendedSession
 	^SessionManager current isUnattended!
 
 sampleAnsiString
-	^Character byteCharacterSet copyFrom: 2!
+	"Note that this starts with a null terminator, but should still round-trip through the clipboard"
+
+	^Character byteCharacterSet!
 
 sampleBitmap
 	^Bitmap fromFile: 'Resources\Beach ball.bmp' usingLocator: FileLocator installRelative!
@@ -37,13 +39,15 @@ tearDown
 	Clipboard current empty!
 
 testAnsiString
+	"We no longer deal with CF_TEXT as it is largely obsolete, and these get copied/pasted as CF_UNICODETEXT instead. The system will make CF_TEXT available to any other application that might still need it."
+
 	| actual expected |
 	expected := self sampleAnsiString.
 	expected copyToClipboard.
 	self assert: (Clipboard current isFormatAvailable: #String).
-	self assert: (Clipboard current isFormatAvailable: #AnsiString).
-	actual := Clipboard current getRegisteredFormat: #AnsiString ifNone: [''].
-	self assert: actual isKindOf: AnsiString.
+	self assert: (Clipboard current isFormatIdAvailable: Win32Constants.CF_TEXT).
+	self assert: (Clipboard current isFormatIdAvailable: Win32Constants.CF_LOCALE).
+	actual := Clipboard current getRegisteredFormat: #String ifNone: ''.
 	self assert: actual equals: expected!
 
 testAvailableFormatsBitmaps
@@ -57,14 +61,22 @@ testAvailableFormatsBitmaps
 	self assert: actual equals: #(#DIBSection #Bitmap)!
 
 testAvailableFormatsStrings
-	| actual |
+	| actual expected |
 	self sampleUnicodeString copyToClipboard.
-	actual := Clipboard current availableFormats.
+	actual := Clipboard current availableFormatIds.
 	"For strings, we will always get both unicode and ansi string formats because Windows will convert, but the native format should be first"
-	self assert: actual equals: #(#String #AnsiString).
+	expected := {
+				Win32Constants.CF_UNICODETEXT.
+				Win32Constants.CF_LOCALE.
+				Win32Constants.CF_TEXT.
+				Win32Constants.CF_OEMTEXT
+			}.
+	self assert: actual equals: expected.
+	self assert: Clipboard current availableFormats equals: #(#String).
 	self sampleAnsiString copyToClipboard.
-	actual := Clipboard current availableFormats.
-	self assert: actual equals: #(#AnsiString #String).
+	actual := Clipboard current availableFormatIds.
+	self assert: actual equals: expected.
+	self assert: Clipboard current availableFormats equals: #(#String).
 	"But Windows will not convert RTF to strings or vice versa"
 	self sampleRichText copyToClipboard.
 	actual := Clipboard current availableFormats.
@@ -94,7 +106,7 @@ testRichText
 	richText copyToClipboard.
 	self assert: (Clipboard current isFormatAvailable: #RichText).
 	self deny: (Clipboard current isFormatAvailable: #String).
-	self deny: (Clipboard current isFormatAvailable: #AnsiString).
+	self deny: (Clipboard current isFormatIdAvailable: Win32Constants.CF_TEXT).
 	actual := Clipboard current getRegisteredFormat: #RichText ifNone: [''].
 	self assert: actual equals: richText.
 	self assert: richText asString equals: self sampleUnicodeString!
@@ -104,8 +116,10 @@ testUtf16String
 	utf16 := self sampleUnicodeString asUtf16String.
 	utf16 copyToClipboard.
 	self assert: (Clipboard current isFormatAvailable: #String).
-	self assert: (Clipboard current isFormatAvailable: #AnsiString).
+	self assert: (Clipboard current isFormatIdAvailable: Win32Constants.CF_TEXT).
+	self assert: (Clipboard current isFormatIdAvailable: Win32Constants.CF_LOCALE).
 	actual := Clipboard current getText.
+	self assert: actual encoding equals: #utf16le.
 	self assert: actual equals: utf16!
 
 testUtf8String
@@ -113,9 +127,11 @@ testUtf8String
 	utf8 := self sampleUnicodeString asUtf8String.
 	utf8 copyToClipboard.
 	self assert: (Clipboard current isFormatAvailable: #String).
-	self assert: (Clipboard current isFormatAvailable: #AnsiString).
+	self assert: (Clipboard current isFormatIdAvailable: Win32Constants.CF_TEXT).
+	self assert: (Clipboard current isFormatIdAvailable: Win32Constants.CF_LOCALE).
 	"We'll get back UTF-16, but the content should be the same."
 	actual := Clipboard current getText.
+	self assert: actual encoding equals: #utf16le.
 	self assert: actual equals: utf8! !
 !UI.Tests.ClipboardTest categoriesForMethods!
 isUnattendedSession!private!testing! !


### PR DESCRIPTION
Make generic object transfer via the clipboard  an opt-in feature (the IDE is opted-in) because it uses STB and is therefore insecure. A validating filer can also be used to constrain the objects that can be copied and pasted via the clipboard.