### PR TITLE
Serialize Transcript as static var ref in STB/STL6

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.Tests.STBDebuggerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.Tests.STBDebuggerTest.cls
@@ -661,65 +661,69 @@ expectedDump6
 000340         [Core.Utf8String] 47: ''Dolphin''
 000355         [%<45: ''Core.Object''>]
 000359     [%<4: a ProcessorScheduler>]
-000363     [Kernel.STBSingletonProxy;]
-000391         [Kernel.STBClassProxy]
-000395             [Core.Utf8String] 51: ''Dolphin Transcript''
-000421             [Core.Utf8String] 52: ''UI.TranscriptShell''
-000447         [Core.Symbol] 53: #current
-000462     [%<3: Smalltalk>]
-000466     [Core.ByteArray][0] 54: #[]
-000474     [Core.ByteArray][1] 55: #[255]
-000483     [Core.ByteArray][5] 56: #[1 2 3 4 5]
-000496     [Core.OrderedCollection][3]
-000504         [%<28: ''a␀b''>]
-000508         [%<26: #testVersion0>]
-000512         [$d]
-000516     [Kernel.STBSortedCollectionProxy;]
-000555         [Kernel.STBClassProxy]
-000559             [Core.Utf8String] 61: ''Dolphin''
-000574             [Core.Utf8String] 62: ''Core.SortedCollection''
-000603         [Core.Array][4]
-000611             [Core.Utf8String] 64: ''a''
-000620             [Core.Utf8String] 65: ''B''
-000629             [Core.Utf8String] 66: ''b''
-000638             [Core.Utf8String] 67: ''B''
-000647         [Kernel.MergesortAlgorithm;]
-000676             [Kernel.BlockClosure;][0]
-000707                 [%<0: nil>]
-000711                 [Kernel.CompiledMethod;][5]
-000740                     [0]
-000744                     [Kernel.STBMetaclassProxy]
-000748                         [Core.Utf8String] 75: ''Dolphin''
-000763                         [Core.Utf8String] 76: ''Kernel.PluggableSortAlgorithm''
-000800                     [Core.Symbol] 77: #new
-000811                     [<1p>]
-000815                     [Core.ByteArray][10] 78: #[171 100 31 177 97 105 233 1 130 106]
-000833                     [Core.Symbol] 79: #basicNew
-000849                     [Core.Symbol] 80: #setSortBlock:
-000870                     [%<71: [] in nil>]
-000874                     [Core.Symbol] 81: #%<=
-000884                     [Core.Symbol] 82: #yourself
-000900                 [7]
-000904                 [256]
-000908                 [%<0: nil>]
-000912     [Core.LookupTable][2]
-000920         [Core.Utf8String] 84: ''origin''
-000934         [Graphics.Point;]
-000952             [10]
-000956             [20]
-000960         [2]
-000964         [Graphics.Point]
-000968             [100]
-000972             [200]
-000976     [Kernel.FullBindingReference;]
-001011         [Core.Utf8String] 90: ''Core.Object''
-001030         [Core.Array][2]
-001038             [Core.Utf8String] 92: ''Core''
-001050             [Core.Utf8String] 93: ''Object''
-001064         [%<2: false>]
-001068         [%<0: nil>]
-001072         [%<0: nil>]
-End of 83 objects'  << (PluggableSortAlgorithm class >> #new) sourceDescriptor!
+000363     [Kernel.STBStaticVariableProxy;]
+000396         [Kernel.FullBindingReference;]
+000431             [Core.Utf8String] 52: ''Core.Transcript''
+000454             [Core.Array][2]
+000462                 [Core.Utf8String] 54: ''Core''
+000474                 [Core.Utf8String] 55: ''Transcript''
+000492             [%<2: false>]
+000496             [%<0: nil>]
+000500             [%<0: nil>]
+000504     [%<3: Smalltalk>]
+000508     [Core.ByteArray][0] 56: #[]
+000516     [Core.ByteArray][1] 57: #[255]
+000525     [Core.ByteArray][5] 58: #[1 2 3 4 5]
+000538     [Core.OrderedCollection][3]
+000546         [%<28: ''a␀b''>]
+000550         [%<26: #testVersion0>]
+000554         [$d]
+000558     [Kernel.STBSortedCollectionProxy;]
+000597         [Kernel.STBClassProxy]
+000601             [Core.Utf8String] 63: ''Dolphin''
+000616             [Core.Utf8String] 64: ''Core.SortedCollection''
+000645         [Core.Array][4]
+000653             [Core.Utf8String] 66: ''a''
+000662             [Core.Utf8String] 67: ''B''
+000671             [Core.Utf8String] 68: ''b''
+000680             [Core.Utf8String] 69: ''B''
+000689         [Kernel.MergesortAlgorithm;]
+000718             [Kernel.BlockClosure;][0]
+000749                 [%<0: nil>]
+000753                 [Kernel.CompiledMethod;][5]
+000782                     [0]
+000786                     [Kernel.STBMetaclassProxy]
+000790                         [Core.Utf8String] 77: ''Dolphin''
+000805                         [Core.Utf8String] 78: ''Kernel.PluggableSortAlgorithm''
+000842                     [Core.Symbol] 79: #new
+000853                     [<1p>]
+000857                     [Core.ByteArray][10] 80: #[171 100 31 177 97 105 233 1 130 106]
+000875                     [Core.Symbol] 81: #basicNew
+000891                     [Core.Symbol] 82: #setSortBlock:
+000912                     [%<73: [] in nil>]
+000916                     [Core.Symbol] 83: #%<=
+000926                     [Core.Symbol] 84: #yourself
+000942                 [7]
+000946                 [256]
+000950                 [%<0: nil>]
+000954     [Core.LookupTable][2]
+000962         [Core.Utf8String] 86: ''origin''
+000976         [Graphics.Point;]
+000994             [10]
+000998             [20]
+001002         [2]
+001006         [Graphics.Point]
+001010             [100]
+001014             [200]
+001018     [Kernel.FullBindingReference]
+001022         [Core.Utf8String] 91: ''Core.Object''
+001041         [Core.Array][2]
+001049             [Core.Utf8String] 93: ''Core''
+001061             [Core.Utf8String] 94: ''Object''
+001075         [%<2: false>]
+001079         [%<0: nil>]
+001083         [%<0: nil>]
+End of 84 objects' << (PluggableSortAlgorithm class >> #new) sourceDescriptor!
 
 minimumFilerVersion
 	^0!

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.Tests.STLDebuggerTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.Tests.STLDebuggerTest.cls
@@ -313,52 +313,50 @@ expectedDump6
 000045     #{Core.Object}
 000046     #{Core.Object class}
 000047     #{Core.Processor}
-000048     [STBSingletonProxy]
-000050         #{UI.TranscriptShell}
-000051         #current
-000052     #{Smalltalk}
-000053     19: #[]
-000055     20: #[255]
-000057     21: #[1 2 3 4 5]
-000059     [OrderedCollection]
-000062         [%<4: ''a␀b''>]
-000063         #testVersion0
-000064         $d
-000065     [STBSortedCollectionProxy]
-000068         #{Core.SortedCollection}
-000069         [Array]
-000071             27: ''a''
-000073             28: ''B''
-000075             29: ''b''
-000077             30: ''B''
-000079         [MergesortAlgorithm]
-000081             [BlockClosure]
-000085                 nil
-000086                 [CompiledMethod]
-000089                     0
-000090                     #{Kernel.PluggableSortAlgorithm class}
-000091                     #new
-000092                     <1p>
-000093                     37: #[171 100 31 177 97 105 233 1 130 106]
-000095                     #basicNew
-000096                     #setSortBlock:
-000097                     [%<34: [] in nil>]
-000098                     #%<=
-000099                     #yourself
-000100                 7
-000101                 256
-000102                 nil
-000103     [LookupTable]
-000106         2
-000107         [Point]
-000109             100
-000110             200
-000111         42: ''origin''
-000113         [Point]
-000114             10
-000115             20
-000116     44: #{Core.Object}
-End of 77 objects'  << (PluggableSortAlgorithm class >> #new) sourceDescriptor!
+000048     #{Core.Transcript}
+000049     #{Smalltalk}
+000050     17: #[]
+000052     18: #[255]
+000054     19: #[1 2 3 4 5]
+000056     [OrderedCollection]
+000059         [%<4: ''a␀b''>]
+000060         #testVersion0
+000061         $d
+000062     [STBSortedCollectionProxy]
+000065         #{Core.SortedCollection}
+000066         [Array]
+000068             25: ''a''
+000070             26: ''B''
+000072             27: ''b''
+000074             28: ''B''
+000076         [MergesortAlgorithm]
+000078             [BlockClosure]
+000082                 nil
+000083                 [CompiledMethod]
+000086                     0
+000087                     #{Kernel.PluggableSortAlgorithm class}
+000088                     #new
+000089                     <1p>
+000090                     35: #[171 100 31 177 97 105 233 1 130 106]
+000092                     #basicNew
+000093                     #setSortBlock:
+000094                     [%<32: [] in nil>]
+000095                     #%<=
+000096                     #yourself
+000097                 7
+000098                 256
+000099                 nil
+000100     [LookupTable]
+000103         2
+000104         [Point]
+000106             100
+000107             200
+000108         40: ''origin''
+000110         [Point]
+000111             10
+000112             20
+000113     42: #{Core.Object}
+End of 75 objects'  << (PluggableSortAlgorithm class >> #new) sourceDescriptor!
 
 minimumFilerVersion
 	^3!

--- a/Core/Object Arts/Dolphin/IDE/Base/UI.TranscriptShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/UI.TranscriptShell.cls
@@ -278,7 +278,7 @@ space
 stbSaveOn: anSTxOutFiler
 	"Output the singleton receiver to anSTxOutFiler."
 
-	anSTxOutFiler saveObject: self as: (STBSingletonProxy forClass: self class)!
+	anSTxOutFiler saveStatic: #{Core.Transcript} for: self!
 
 tab
 	"Store a tab character as the next element of the receiver."

--- a/Core/Object Arts/Dolphin/System/Filer/Dolphin STx Out Filer Core.pax
+++ b/Core/Object Arts/Dolphin/System/Filer/Dolphin STx Out Filer Core.pax
@@ -419,7 +419,7 @@ stbSaveOn:!binary filing!public! !
 stbSaveOn: anSTxOutFiler
 	"Save out a serialised representation of the receiver to anSTxOutFiler. The receiver is a singleton global, so save as a static reference."
 
-	anSTxOutFiler saveStatic: #{Core.Processor}! !
+	anSTxOutFiler saveStatic: #{Core.Processor} for: self! !
 !Kernel.ProcessorScheduler categoriesForMethods!
 stbSaveOn:!binary filing!public! !
 !

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.STBLegacyOutFiler.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.STBLegacyOutFiler.cls
@@ -37,11 +37,21 @@ saveSet: aSet elements: aCollection
 
 	"In STB prior to 6, Sets were proxied."
 
-	self saveObject: aSet as: (STBCollectionProxy class: aSet class array: aCollection asArray)! !
+	self saveObject: aSet as: (STBCollectionProxy class: aSet class array: aCollection asArray)!
+
+saveStatic: aBindingReference for: anObject
+	"Serialize a static variable reference into the stream."
+
+	"Requires <BindingReference>s, which did not exist at the time of STB 0"
+
+	anObject == #{Transcript} value
+		ifTrue: [self saveObject: anObject as: (STBSingletonProxy forClass: #{UI.TranscriptShell} value)]
+		ifFalse: [self errorStaticVarRefsNotSupported]! !
 !Kernel.STBLegacyOutFiler categoriesForMethods!
 saveCollection:!operations!public! !
 saveLookupTable:!operations!public! !
 saveResourceLibrary:!operations!public! !
 saveSet:elements:!public!serializing! !
+saveStatic:for:!public!serializing! !
 !
 

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.STBOutFiler.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.STBOutFiler.cls
@@ -120,7 +120,12 @@ saveSmallInteger: aSmallInteger
 saveStatic: aBindingReference
 	"Serialize a static variable reference into the stream. "
 
-	self saveObject: aBindingReference
+	self saveObject: (STBStaticVariableProxy reference: aBindingReference asFullyQualifiedReference)!
+
+saveStatic: aBindingReference for: anObject
+	"Serialize a static variable reference into the stream in place of anObject. "
+
+	self saveObject: anObject
 		as: (STBStaticVariableProxy reference: aBindingReference asFullyQualifiedReference)!
 
 saveString: aString
@@ -215,6 +220,7 @@ saveScaledDecimal:!public!serializing! !
 saveSet:elements:!public!serializing! !
 saveSmallInteger:!public!serializing! !
 saveStatic:!public!serializing! !
+saveStatic:for:!public!serializing! !
 saveString:!public!serializing! !
 saveSymbol:!public!serializing! !
 writeByteObject:!operations!private! !

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.STBOutFiler0.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.STBOutFiler0.cls
@@ -120,8 +120,6 @@ saveObject: anObject as: anObjectToSave
 saveStatic: aBindingReference
 	"Serialize a static variable reference into the stream."
 
-	"Requires <BindingReference>s, which did not exist at the time of STB 0"
-
 	self errorStaticVarRefsNotSupported!
 
 saveString: aString

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.STLLegacyOutFiler.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.STLLegacyOutFiler.cls
@@ -40,12 +40,25 @@ saveSet: aSet elements: aCollection
 
 	"In STL 3/4, Sets were proxied. The elements were not sorted, so the resulting source representation could be unstable."
 
-	self saveObject: aSet as: (STBCollectionProxy class: aSet basicClass array: aCollection asArray)! !
+	self saveObject: aSet as: (STBCollectionProxy class: aSet basicClass array: aCollection asArray)!
+
+saveStatic: aBindingReference for: anObject
+	"Serialize a static variable reference into the stream."
+
+	"Requires <BindingReference>s, which did not exist at the time of STB 3, but Processor and Transcript are special cases we need to support."
+
+	anObject == Processor
+		ifTrue: [stream nextPut: aBindingReference value]
+		ifFalse: 
+			[anObject == #{Transcript} value
+				ifTrue: [self saveObject: anObject as: (STBSingletonProxy forClass: #{UI.TranscriptShell} value)]
+				ifFalse: [self errorStaticVarRefsNotSupported]]! !
 !Kernel.STLLegacyOutFiler categoriesForMethods!
 lastPredefined!constants!private! !
 saveCollection:!operations!public! !
 saveLookupTable:!operations!public! !
 saveResourceLibrary:!binary filing!public! !
 saveSet:elements:!public!serializing! !
+saveStatic:for:!public!serializing! !
 !
 

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.STLOutFiler3.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.STLOutFiler3.cls
@@ -166,11 +166,9 @@ saveScaledDecimal: aScaledDecimal
 saveStatic: aBindingReference
 	"Serialize a static variable reference into the stream."
 
-	"Requires <BindingReference>s, which did not exist at the time of STB 3, but Processor is a special case we need to support."
+	"Requires <BindingReference>s, which did not exist at the time of STL 3/4."
 
-	aBindingReference = #{Core.Processor}
-		ifTrue: [stream nextPut: aBindingReference value]
-		ifFalse: [self errorStaticVarRefsNotSupported]!
+	self errorStaticVarRefsNotSupported!
 
 saveString: aString
 	"Serialize a <String> into the object stream."

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.STxOutFiler.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.STxOutFiler.cls
@@ -237,6 +237,11 @@ saveStatic: aBindingReference
 
 	self subclassResponsibility!
 
+saveStatic: aBindingReference for: anObject
+	"Serialize a static variable reference into the stream."
+
+	self saveStatic: aBindingReference!
+
 saveString: aString
 	"Serialize a <String> into the object stream."
 
@@ -369,6 +374,7 @@ saveSingleton:!binary filing!public! !
 saveSingleton:class:name:!binary filing!public! !
 saveSmallInteger:!public!serializing! !
 saveStatic:!public!serializing! !
+saveStatic:for:!public!serializing! !
 saveString:!public!serializing! !
 saveSymbol:!public!serializing! !
 saveVariableBinding:!public!serializing! !

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.Tests.STBTest.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.Tests.STBTest.cls
@@ -304,6 +304,21 @@ testMetaclassProxy0
 	self dumpToTranscriptIfDebug: bytes0.
 	self assert: (self deserialize: bytes0 version: 0) identicalTo: Array class!
 
+testProcessor0
+	"(Array with: Processor with: Processor) binaryStoreBytes"
+	self verifyRoundTripSingleton: Processor version: 0
+		expected: #[33 83 84 66 32 48 32 38 0 5 0 65 114 114 97 121 2 0 0 0 64 0 0 0 64 0 0 0]!
+
+testProcessor1
+	"(Array with: Processor with: Processor) binaryStoreBytes"
+	self verifyRoundTripSingleton: Processor version: 1
+		expected:#[33 83 84 66 32 49 32 98 0 0 0 2 0 0 0 64 0 0 0 64 0 0 0]!
+
+testProcessor3
+	"(Array with: Processor with: Processor) binaryStoreBytes"
+	self verifyRoundTripSingleton: Processor version: 3
+		expected: #[33 83 84 66 32 51 32 98 0 0 0 2 0 0 0 64 0 0 0 64 0 0 0]!
+
 testSmallInteger
 	0 to: STBOutFiler version
 		do: 
@@ -411,6 +426,21 @@ testSymbolsVersion1
 	self assert: rehydrated last identicalTo: #foo.
 	self assert: rehydrated second identicalTo: #bar!
 
+testSymbolsVersion3
+	"Symbols not proxied"
+
+	| rehydrated expectedBytes actualBytes |
+	"#(#foo #bar #foo) binaryStoreBytes"
+	expectedBytes := #[33 83 84 66 32 51 32 98 0 0 0 3 0 0 0 178 0 0 0 3 0 0 0 102 111 111 178 0 0 0 3 0 0 0 98 97 114 160 1 0 0].
+	self dumpToTranscriptIfDebug: expectedBytes.
+	actualBytes := self serialize: #(#foo #bar #foo) version: 3.
+	self assert: actualBytes equals: expectedBytes.
+	rehydrated := self deserialize: actualBytes version: 3.
+	self assert: rehydrated equals: #(#foo #bar #foo).
+	self assert: rehydrated first identicalTo: #foo.
+	self assert: rehydrated last identicalTo: #foo.
+	self assert: rehydrated second identicalTo: #bar!
+
 testSymbolUpgrade
 	| rehydrated dessicated |
 	"Try deserializing an old format stream"
@@ -433,6 +463,30 @@ testSymbolUpgrade
 	self assert: rehydrated identicalTo: #'a†b'.
 	rehydrated := self deserialize: #[33 83 84 66 32 49 32 186 0 0 0 0 0 0 0 82 0 0 0 3 0 0 0 97 134 98] version: 1.
 	self assert: rehydrated identicalTo: #'a†b'.!
+
+testTranscript0
+	"Dolphin 4.x and earlier did not actually serialize Transcript specially, just as any other Presenter instance. They will be able to deserialize this correctly into `(Array with: Transcript with: Transcript)` though."
+
+	self
+		verifyRoundTripSingleton: Transcript
+		version: 0
+		expected: #[33 83 84 66 32 48 32 38 0 5 0 65 114 114 97 121 2 0 0 0 14 2 17 0 83 84 66 83 105 110 103 108 101 116 111 110 80 114 111 120 121 0 0 0 0 78 2 13 0 1 0 0 0 83 84 66 67 108 97 115 115 80 114 111 120 121 0 0 0 0 54 0 6 0 83 116 114 105 110 103 18 0 0 0 68 111 108 112 104 105 110 32 84 114 97 110 115 99 114 105 112 116 178 0 0 0 15 0 0 0 84 114 97 110 115 99 114 105 112 116 83 104 101 108 108 14 1 14 0 83 84 66 83 121 109 98 111 108 80 114 111 120 121 0 0 0 0 178 0 0 0 7 0 0 0 99 117 114 114 101 110 116 128 0 0 0]!
+
+testTranscript1
+	"Dolphin 5.x did not actually serialize Transcript specially, just as any other Presenter instance. They will be able to deserialize this correctly into `(Array with: Transcript with: Transcript)` though."
+
+	self
+		verifyRoundTripSingleton: Transcript
+		version: 1
+		expected: #[33 83 84 66 32 49 32 98 0 0 0 2 0 0 0 14 2 17 0 83 84 66 83 105 110 103 108 101 116 111 110 80 114 111 120 121 0 0 0 0 154 0 0 0 0 0 0 0 82 0 0 0 18 0 0 0 68 111 108 112 104 105 110 32 84 114 97 110 115 99 114 105 112 116 82 0 0 0 15 0 0 0 84 114 97 110 115 99 114 105 112 116 83 104 101 108 108 186 0 0 0 0 0 0 0 82 0 0 0 7 0 0 0 99 117 114 114 101 110 116 176 1 0 0]!
+
+testTranscript3
+	"Dolphin 6.x did serialize Transcript specially using an STBSingletonProxy."
+
+	self
+		verifyRoundTripSingleton: Transcript
+		version: 3
+		expected: #[33 83 84 66 32 51 32 98 0 0 0 2 0 0 0 14 2 17 0 83 84 66 83 105 110 103 108 101 116 111 110 80 114 111 120 121 154 0 0 0 82 0 0 0 18 0 0 0 68 111 108 112 104 105 110 32 84 114 97 110 115 99 114 105 112 116 82 0 0 0 15 0 0 0 84 114 97 110 115 99 114 105 112 116 83 104 101 108 108 178 0 0 0 7 0 0 0 99 117 114 114 101 110 116 176 1 0 0]!
 
 testTruncatedHeader
 	#(#[] #[33] #[33 83 84] #[33 83 84 66] #[33 83 84 66 48] #[33 83 84 66 32] #[33 83 84 66 32 32] #[33 83 84 66 32 48])
@@ -548,6 +602,9 @@ testInvalidStream!public!unit tests! !
 testLargeIntegers0!public!unit tests! !
 testLargeIntegers1to4!public!unit tests! !
 testMetaclassProxy0!public!unit tests! !
+testProcessor0!public!unit tests! !
+testProcessor1!public!unit tests! !
+testProcessor3!public!unit tests! !
 testSmallInteger!public!unit tests! !
 testStringsVersion0!public!unit tests! !
 testStringsVersion1!public!unit tests! !
@@ -556,7 +613,11 @@ testStringsVersion3!public!unit tests! !
 testStringsVersion4!public!unit tests! !
 testSymbolsVersion0!public!unit tests! !
 testSymbolsVersion1!public!unit tests! !
+testSymbolsVersion3!public!unit tests! !
 testSymbolUpgrade!public!unit tests! !
+testTranscript0!public!unit tests! !
+testTranscript1!public!unit tests! !
+testTranscript3!public!unit tests! !
 testTruncatedHeader!public!unit tests! !
 testUnicodeStringUpgrade0!public!unit tests! !
 testUnicodeStringUpgrade3!public!unit tests! !

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.Tests.STBValidatingInFilerTest.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.Tests.STBValidatingInFilerTest.cls
@@ -21,7 +21,10 @@ initializeLocator: anInteger
 		ifNil: 
 			[locator := RestrictedClassLocator forClasses: (anInteger < 4
 								ifTrue: 
-									[#(#{Core.ByteArray} #{Core.String} #{Core.AnsiString}#{Smalltalk.STBSymbolProxy} #{Core.Array})]
+									[anInteger < 2
+										ifTrue: 
+											[#(#{Core.ByteArray} #{Core.String} #{Core.AnsiString} #{Smalltalk.STBSymbolProxy} #{Core.Array})]
+										ifFalse: [#(#{Core.ByteArray} #{Core.String} #{Core.AnsiString} #{Core.Symbol} #{Core.Array})]]
 								ifFalse: [#(#{Core.ByteArray} #{Core.Utf8String} #{Core.Array} #{Core.Symbol} #{Core.AnsiString})])]!
 
 newInFilerOn: aByteArray
@@ -298,14 +301,27 @@ verifyResourceLibraryAtVersion: anInteger
 	super verifyResourceLibraryAtVersion: anInteger!
 
 verifyRoundTripSingleton: anObject version: anInteger
+	self
+		verifyRoundTripSingleton: anObject
+		version: anInteger
+		expected: (self serialize: { anObject. anObject } version: anInteger)!
+
+verifyRoundTripSingleton: anObject version: anInteger expected: aByteArray
 	self initializeLocator: anInteger.
 	locator includeClass: anObject class.
-	anInteger < 2
+	anInteger >= 6
 		ifTrue: 
 			[locator
-				includeClass: String;
-				includeClass: Smalltalk.STBSymbolProxy].
-	super verifyRoundTripSingleton: anObject version: anInteger!
+				includeClass: STBStaticVariableProxy;
+				includeClass: Kernel.FullBindingReference]
+		ifFalse: 
+			[locator
+				includeClass: STBSingletonProxy;
+				includeClass: STBClassProxy].
+	super
+		verifyRoundTripSingleton: anObject
+		version: anInteger
+		expected: aByteArray!
 
 verifySaveStaticVariableReferenceAtVersion: anInteger
 	self initializeLocator: anInteger.
@@ -342,6 +358,10 @@ verifySymbolsAtVersion: anInteger
 	self newLocator: anInteger.
 	anInteger > 1 ifTrue: [locator includeClass: Symbol].
 	super verifySymbolsAtVersion: anInteger!
+
+verifyTranscriptRoundTripAtVersion: anInteger 
+	self newLocator: anInteger.
+	^super verifyTranscriptRoundTripAtVersion: anInteger!
 
 verifyVariableBindingsAtVersion: anInteger
 	self newLocator: anInteger.
@@ -394,11 +414,13 @@ verifyLookupTablesAtVersion:!helpers!private! !
 verifyOrderedCollectionsAtVersion:!helpers!private! !
 verifyResourceLibraryAtVersion:!helpers!private! !
 verifyRoundTripSingleton:version:!helpers!private! !
+verifyRoundTripSingleton:version:expected:!helpers!private! !
 verifySaveStaticVariableReferenceAtVersion:!helpers!private! !
 verifyScaledDecimalsAtVersion:!helpers!private! !
 verifySetsAtVersion:!helpers!private! !
 verifyStrings:atVersion:!helpers!private! !
 verifySymbolsAtVersion:!helpers!private! !
+verifyTranscriptRoundTripAtVersion:!public! !
 verifyVariableBindingsAtVersion:!helpers!private! !
 !
 

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.Tests.STLFilerTest.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.Tests.STLFilerTest.cls
@@ -345,14 +345,25 @@ testInvalidStream
 	self should: [STLInFiler on: #('') readStream] raise: STBError.
 	self should: [STLInFiler on: #(#[]) readStream] raise: STBError!
 
-testProcessor
+testProcessor3
+	"(Array with: Processor with: Processor) literalStoreArray"
+
+	self
+		verifyRoundTripSingleton: Processor
+		version: 3
+		expected: '(Object fromLiteralStoreArray: #(#''!!STL'' 3 98 2 64 64 ))'!
+
+testProcessor4
+	"(Array with: Processor with: Processor) literalStoreArray"
+
+	self
+		verifyRoundTripSingleton: Processor
+		version: 4
+		expected: '(Object fromLiteralStoreArray: #(#''!!STL'' 4 8 #(##(Smalltalk.Processor) ##(Smalltalk.Processor)) ))'!
+
+testProcessor5plus
 	"Special case global variable"
 
-	super testProcessor.
-	self assert: (self serialize: Processor version: 3)
-		equals: '(Object fromLiteralStoreArray: #(#''!!STL'' 3 64 ))'.
-	self assert: (self serialize: Processor version: 4)
-		equals: '(Object fromLiteralStoreArray: #(#''!!STL'' 4 ##(Smalltalk.Processor) ))'.
 	5 to: self outfilerClass version
 		do: 
 			[:ver |
@@ -546,6 +557,18 @@ testSymbolReadWrite
 		by: -1
 		do: [:ver | self verifySymbolReadWriteAtVersion: ver]!
 
+testTranscript3
+	self
+		verifyRoundTripSingleton: Transcript
+		version: 3
+		expected: '(Object fromLiteralStoreArray: #(#''!!STL'' 3 98 2 1114638 ##(Smalltalk.STBSingletonProxy) 8 ##(Smalltalk.TranscriptShell) 8 #current 432 ))'!
+
+testTranscript4
+	self
+		verifyRoundTripSingleton: Transcript
+		version: 4
+		expected: '(Object fromLiteralStoreArray: #(#''!!STL'' 4 34 2 1114638 ##(Smalltalk.STBSingletonProxy) ##(Smalltalk.TranscriptShell) #current 432 ))'!
+
 testVariableBindingsVersion4
 	self
 		verifyVariableBindings: '(Object fromLiteralStoreArray: #(#''!!STL'' 4 34 3 983558 ##(Smalltalk.VariableBinding) #Object ##(Smalltalk.Object) 418 8 ''PageSize'' 16385 418 #Processor ##(Smalltalk.Processor) ))'
@@ -659,8 +682,8 @@ verifyIntegerReadWriteAtVersion: anInteger
 verifyRehydrateNonExistantClass: dessicated
 	self should: [self deserialize: dessicated version: self outfilerClass version] raise: NotFoundError!
 
-verifyRoundTripSingleton: anObject version: anInteger
-	super verifyRoundTripSingleton: anObject version: anInteger.
+verifyRoundTripSingleton: anObject version: anInteger expected: aString
+	super verifyRoundTripSingleton: anObject version: anInteger expected: aString.
 	self assert: (Object fromLiteralStoreArray: anObject literalStoreArray) identicalTo: anObject!
 
 verifyStringsAtPreUnicodeVersion: anInteger
@@ -722,7 +745,9 @@ testInvalidClassReference!public!unit tests! !
 testInvalidObjectReference!public!unit tests! !
 testInvalidPredefinedClass!public!unit tests! !
 testInvalidStream!public!unit tests! !
-testProcessor!public!unit tests! !
+testProcessor3!public!unit tests! !
+testProcessor4!public!unit tests! !
+testProcessor5plus!public!unit tests! !
 testSmalltalk!public! !
 testStl3ExtendedChar!public!unit tests! !
 testStl3Literals!public!unit tests! !
@@ -731,6 +756,8 @@ testStl5Literals!public!unit tests! !
 testStl6Literals!public!unit tests! !
 testStringsVersion4!public!unit tests! !
 testSymbolReadWrite!public!unit tests! !
+testTranscript3!public!unit tests! !
+testTranscript4!public!unit tests! !
 testVariableBindingsVersion4!public!unit tests! !
 testVariableBindingsVersion5!public!unit tests! !
 verifyArrayOfAtomicsAtVersion:!helpers!private! !
@@ -740,7 +767,7 @@ verifyBlockReadWriteAtVersion:!helpers!private! !
 verifyClassReadWriteAtVersion:!helpers!private! !
 verifyIntegerReadWriteAtVersion:!helpers!private! !
 verifyRehydrateNonExistantClass:!helpers!private! !
-verifyRoundTripSingleton:version:!helpers!private! !
+verifyRoundTripSingleton:version:expected:!helpers!private! !
 verifyStringsAtPreUnicodeVersion:!helpers!private! !
 verifySymbolReadWriteAtVersion:!helpers!private! !
 !

--- a/Core/Object Arts/Dolphin/System/Filer/Kernel.Tests.STxFilerTest.cls
+++ b/Core/Object Arts/Dolphin/System/Filer/Kernel.Tests.STxFilerTest.cls
@@ -170,7 +170,7 @@ testPoolDictionary
 		do: [:ver | self verifyDictionaries: PoolDictionary atVersion: ver]!
 
 testProcessor
-	"Special case global variable"
+	"Special case global variable that has a pre-allocated reference index in STB (and STL prior to v6)."
 
 	self minimumFilerVersion to: self outfilerClass version
 		do: [:ver | self verifyRoundTripSingleton: Processor version: ver]!
@@ -259,7 +259,7 @@ testSystemDictionary
 testTranscript
 	self outfilerClass version to: self minimumFilerVersion
 		by: -1
-		do: [:ver | self verifyRoundTripSingleton: Transcript version: ver]!
+		do: [:ver | self verifyTranscriptRoundTripAtVersion: ver]!
 
 testVariableBinding
 	self outfilerClass version to: self minimumFilerVersion
@@ -395,16 +395,20 @@ verifyResourceLibraryAtVersion: anInteger
 	self assert: rehydrated asIdentitySet single identicalTo: lib2!
 
 verifyRoundTripSingleton: anObject version: anInteger
+	self
+		verifyRoundTripSingleton: anObject
+		version: anInteger
+		expected: (self serialize: { anObject. anObject } version: anInteger)!
+
+verifyRoundTripSingleton: anObject version: anInteger expected: aByteArray
 	| dessicated array rehydrated |
-	dessicated := self serialize: anObject version: anInteger.
-	rehydrated := self deserialize: dessicated version: anInteger.
-	self assert: rehydrated identicalTo: anObject.
+	rehydrated := self deserialize: aByteArray version: anInteger.
 	array := { anObject. anObject }.
-	dessicated := self serialize: array version: anInteger.
-	rehydrated := self deserialize: dessicated version: anInteger.
 	self assert: rehydrated equals: array.
 	self assert: rehydrated first identicalTo: anObject.
-	self assert: rehydrated second identicalTo: anObject!
+	self assert: rehydrated second identicalTo: anObject.
+	dessicated := self serialize: array version: anInteger.
+	self assert: dessicated equals: aByteArray!
 
 verifySaveStaticVariableReferenceAtVersion: ver
 	| serialised filer |
@@ -486,6 +490,9 @@ verifySymbolsAtVersion: anInteger
 	self assert: (rehydrated at: 5) identicalTo: sym.
 	self assert: (rehydrated at: 2) identicalTo: (rehydrated at: 4).
 	^self assert: (rehydrated at: 6) identicalTo: s asSymbol!
+
+verifyTranscriptRoundTripAtVersion: anInteger
+	^self verifyRoundTripSingleton: Transcript version: anInteger!
 
 verifyVariableBindings: expected version: anInteger
 	| actual rehydrated array var |
@@ -575,6 +582,7 @@ verifyOrderedCollectionsAtVersion:!helpers!private! !
 verifyRehydrateNonExistantClass:!helpers!private! !
 verifyResourceLibraryAtVersion:!helpers!private! !
 verifyRoundTripSingleton:version:!helpers!private! !
+verifyRoundTripSingleton:version:expected:!helpers!private! !
 verifySaveStaticVariableReferenceAtVersion:!helpers!private! !
 verifyScaledDecimalsAtVersion:!helpers!private! !
 verifySetsAtVersion:!helpers!private! !
@@ -583,6 +591,7 @@ verifyStrings:atVersion:!helpers!private! !
 verifyStringsAtPreUnicodeVersion:!helpers!private! !
 verifyStringsAtVersion:!helpers!private! !
 verifySymbolsAtVersion:!helpers!private! !
+verifyTranscriptRoundTripAtVersion:!public!unit tests! !
 verifyVariableBindings:version:!helpers!private! !
 verifyVariableBindingsAtVersion:!helpers!private! !
 !


### PR DESCRIPTION
Rather than saving a singleton proxy to TranscriptShell class>>#current, save as a variable ref so can resolve to whatever stream is assigned to transcript in the loading image (e.g. stdout).