### PR TITLE
Use menuPopulator: annotations to build drop-down toolbar menus too

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
@@ -296,27 +296,28 @@ browseSystem
 	<commandQuery: #queryBrowseClass:>
 	self developmentSystem browseSystem: self actualClass!
 
-buildHistoryFutureMenu
+buildHistoryFutureMenu: aMenu
 	"Private - Answer a dynamically created future visit menu."
 
-	^(self buildHistoryMenu: history upToEnd command: #historyForward:)
-		text: 'Forward';
-		yourself!
+	super buildHistoryFutureMenu: aMenu.
+	self
+		buildHistoryMenu: aMenu
+		visits: history upToEnd
+		command: #historyForward:!
 
-buildHistoryMenu: visits command: cmdSelector
+buildHistoryMenu: aMenu visits: aSequenceableCollection command: cmdSelector
 	"Private - Answer a dynamically created past visit history menu."
 
-	| popup class subMenu selectors |
-	popup := Menu new.
+	| class subMenu selectors |
 	class := nil.
-	visits keysAndValuesDo: 
+	aSequenceableCollection keysAndValuesDo: 
 			[:i :m |
 			| mclass sel |
 			mclass := m methodClass.
 			mclass = class
 				ifFalse: 
 					[selectors := IdentitySet new.
-					subMenu := popup addSubmenu: mclass name.
+					subMenu := aMenu addSubmenu: mclass name.
 					class := mclass].
 			sel := m selector.
 			"We only want to add each method to the menu once"
@@ -325,22 +326,16 @@ buildHistoryMenu: visits command: cmdSelector
 					[subMenu addCommand: (Message selector: cmdSelector argument: i) description: sel.
 					selectors add: sel].
 			subMenu setDefault: 1].
-	popup setDefault: 1.
-	^popup!
+	aMenu setDefault: 1!
 
-buildHistoryPastMenu
+buildHistoryPastMenu: aMenu
 	"Private - Answer a dynamically created past visit history menu."
 
-	^(self buildHistoryMenu: history past command: #historyBack:)
-		text: 'Past';
-		yourself!
-
-buildPopupForCommand: aSymbol 
-	"Private - Dynamically build an appropriate popup menu for aSymbol command."
-
-	aSymbol == #historyBack ifTrue: [^self buildHistoryPastMenu].
-	aSymbol == #historyForward ifTrue: [^self buildHistoryFutureMenu].
-	^super buildPopupForCommand: aSymbol!
+	super buildHistoryPastMenu: aMenu.
+	self
+		buildHistoryMenu: aMenu
+		visits: history past
+		command: #historyBack:!
 
 canRemoveMethodsInCategory
 	| cat |
@@ -1621,7 +1616,7 @@ onVariableSelected
 onViewOpened
 	"Private - Received when the receiver's view is been connected. "
 
-	| toolbar modifiedModel |
+	| modifiedModel |
 	super onViewOpened.
 	self createPlugins.
 	methodBrowserPresenter beSorted: [:a :b | a selector <= b selector].
@@ -1651,11 +1646,6 @@ onViewOpened
 	modifiedModel
 		when: #valueChanged
 		send: #updateCaption
-		to: self.
-	toolbar := self view viewNamed: 'classBrowserTools'.
-	toolbar presenterConnectionPoint
-		when: #dropDown:
-		send: #onDropDown:
 		to: self.
 
 	"Really a CardContainer view, but we treat as if a presenter"
@@ -2527,10 +2517,9 @@ browseReferencesMatching:in:!helpers!private! !
 browserEnvironment!accessing!public! !
 browseSelectorsInProtocol!commands-actions!private! !
 browseSystem!commands-actions!public! !
-buildHistoryFutureMenu!helpers!menus!private! !
-buildHistoryMenu:command:!helpers!menus!private! !
-buildHistoryPastMenu!helpers!menus!private! !
-buildPopupForCommand:!event handling!private! !
+buildHistoryFutureMenu:!helpers!menus!private! !
+buildHistoryMenu:visits:command:!helpers!menus!private! !
+buildHistoryPastMenu:!helpers!menus!private! !
 canRemoveMethodsInCategory!commands-queries!private! !
 canSaveMethod!private!testing! !
 canSaveState!private!saved state! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodExplorerShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodExplorerShell.cls
@@ -48,27 +48,25 @@ browseMethodsInEnvironments: aCollectionOfBrowserEnvironments
 			ifNotNil: [:first | historyTree selection: first].
 	self setInitialFocus!
 
-buildHistoryFutureMenu
+buildHistoryFutureMenu: aMenu
 	"Private - Answer a dynamically created future visit menu."
 
-	^(self buildHistoryMenu: historyList upToEnd command: #historyForward:)
-		text: 'Forward';
-		yourself!
+	super buildHistoryFutureMenu: aMenu.
+	self buildHistoryMenu: aMenu visits: historyList upToEnd command: #historyForward:!
 
-buildHistoryMenu: visits command: cmdSelector
+buildHistoryMenu: aMenu visits: aSequenceableCollection command: cmdSelector
 	"Private - Answer a dynamically created past visit history menu."
 
-	| popup lastEnv subMenu methods |
-	popup := Menu new.
+	| lastEnv subMenu methods |
 	lastEnv := nil.
-	visits keysAndValuesDo: 
+	aSequenceableCollection keysAndValuesDo: 
 			[:i :each |
 			| env method |
 			env := each key.
 			env == lastEnv
 				ifFalse: 
 					[methods := Set new.
-					subMenu := popup addSubmenu: env displayString.
+					subMenu := aMenu addSubmenu: env displayString.
 					lastEnv := env].
 			method := each value ?? '(none)'.
 			"We only want to add each method to the menu once"
@@ -77,22 +75,16 @@ buildHistoryMenu: visits command: cmdSelector
 					[subMenu addCommand: (Message selector: cmdSelector argument: i) description: method displayString.
 					methods add: method].
 			subMenu setDefault: 1].
-	popup setDefault: 1.
-	^popup!
+	aMenu setDefault: 1!
 
-buildHistoryPastMenu
+buildHistoryPastMenu: aMenu
 	"Private - Answer a dynamically created past visit history menu."
 
-	^(self buildHistoryMenu: historyList past command: #historyBack:)
-		text: 'Past';
-		yourself!
-
-buildPopupForCommand: aSymbol 
-	"Private - Dynamically build an appropriate popup menu for aSymbol command."
-
-	aSymbol == #historyBack ifTrue: [^self buildHistoryPastMenu].
-	aSymbol == #historyForward ifTrue: [^self buildHistoryFutureMenu].
-	^super buildPopupForCommand: aSymbol!
+	super buildHistoryPastMenu: aMenu.
+	self
+		buildHistoryMenu: aMenu
+		visits: historyList past
+		command: #historyBack:!
 
 canSaveState
 	"Private - Answer true if the receiver can successfully have it's state saved by #saveStateOn:. Some
@@ -201,18 +193,6 @@ onTreeSelectionChanged
 			browserPresenter methods: env.
 			self selectFirstMethod]!
 
-onViewOpened
-	"Private - Received when the receiver's view is been connected. "
-
-	| toolbar |
-	super onViewOpened.
-	toolbar := self view viewNamed: 'historyTools'.
-	toolbar presenterConnectionPoint 
-		when: #dropDown:
-		send: #onDropDown:
-		to: self.
-!
-
 pastSize
 	^historyList pastSize!
 
@@ -286,10 +266,9 @@ addSearch:under:!public! !
 addToCommandRoute:!commands!public! !
 browseMethodsIn:!public! !
 browseMethodsInEnvironments:!public! !
-buildHistoryFutureMenu!helpers!menus!private! !
-buildHistoryMenu:command:!helpers!menus!private! !
-buildHistoryPastMenu!helpers!menus!private! !
-buildPopupForCommand:!event handling!private! !
+buildHistoryFutureMenu:!commands-menus!private! !
+buildHistoryMenu:visits:command:!commands-menus!private! !
+buildHistoryPastMenu:!commands-menus!private! !
 canSaveState!private!saved state! !
 createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
@@ -305,7 +284,6 @@ methods:!accessing!public! !
 onMethodSelected!event handling!private! !
 onTimerTick:!event handling!private! !
 onTreeSelectionChanged!event handling!private! !
-onViewOpened!event handling!private! !
 pastSize!accessing!public! !
 queryHistoryBack:!commands!private! !
 queryHistoryForward:!commands!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
@@ -243,12 +243,6 @@ browseVariableReferences
 	<commandQuery: #hasVariableSelected>
 	self model browseSharedVariableReferences: self sharedVariable in: self browserEnvironment!
 
-buildPopupForCommand: aSymbol 
-	"Private - Dynamically build an appropriate popup menu for aSymbol command."
-
-	aSymbol == #viewModeSelect ifTrue: [^classesPresenter view buildViewsPopup].
-	^super buildPopupForCommand: aSymbol!
-
 cacheCurrentCard: aView
 	currentCard := aView name asSymbol!
 
@@ -866,20 +860,12 @@ onViewClosed
 onViewOpened
 	"Private - Received when the receiver's view is been connected. "
 
-	| toolbar |
 	super onViewOpened.
 	(self view viewNamed: 'errors' ifNone: nil)
 		ifNotNil: 
 			[:item |
 			item model: statusModel.
 			scriptTextPresenter errorModel: statusModel].
-
-	"Enable view mode pulldown"
-	toolbar := self view viewNamed: 'viewTools'.
-	toolbar presenterConnectionPoint
-		when: #dropDown:
-		send: #onDropDown:
-		to: self.
 
 	"Really a CardContainer view, but we treat as if a presenter"
 	cardsPresenter := self view viewNamed: 'ownedCards'.
@@ -1289,7 +1275,6 @@ browseReferencesCommand!commands-mappings!private! !
 browseSystem!commands-actions!public! !
 browseVariableClass!commands-actions!public! !
 browseVariableReferences!commands-actions!public! !
-buildPopupForCommand:!event handling!private! !
 cacheCurrentCard:!event handling!private! !
 canSaveState!private!saved state! !
 clearCard:!private!updating! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ResourceBrowser.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ResourceBrowser.cls
@@ -45,20 +45,6 @@ newView
 		ifFalse: [self model openViewComposer]
  !
 
-onViewOpened
-	"Private - Received when the receiver's view is been connected. "
-
-	super onViewOpened.
-
-	"Enable view mode pulldown"
-	(self view viewNamed: 'viewTools' ifNone: nil)
-		ifNotNil: 
-			[:toolbar |
-			toolbar presenterConnectionPoint
-				when: #dropDown:
-				send: #onDropDown:
-				to: resourceToolboxPresenter categoriesPresenter view]!
-
 resource
 	"Answer the selected resource identifier in the receiver or nil if there
 	is none"
@@ -102,7 +88,6 @@ canSaveState!private!saved state! !
 createComponents!**auto generated**!initializing!private! !
 defaultHelpId!public! !
 newView!commands!public! !
-onViewOpened!event handling!private! !
 resource!accessing!public! !
 resource:!accessing!public! !
 resourceToolboxPresenter!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkSystemShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkSystemShell.cls
@@ -172,15 +172,9 @@ onViewModeChanged
 onViewOpened
 	"Private - Received when the receiver's view is been connected. "
 
-	| toolbar |
 	super onViewOpened.
 	systemFolderPresenter selectionByIndex: 1.
-	toolbar := self view viewNamed: 'systemShellTools'.
-	toolbar presenterConnectionPoint 
-		when: #dropDown:
-		send: #onDropDown:
-		to: systemFolderPresenter view.
-	systemFolderPresenter view 
+	systemFolderPresenter view
 		when: #viewModeChanged
 		send: #onViewModeChanged
 		to: self!

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkToolShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkToolShell.cls
@@ -116,9 +116,15 @@ browseTests
 
 	^self developmentSystem testBrowserClass show!
 
-buildPopupForCommand: aSymbol 
-	aSymbol == #newIdeaSpace ifTrue: [^self class buildIdeaSpacePopup].
-	^nil!
+buildHistoryFutureMenu: aMenu
+	aMenu
+		clear;
+		text: '&Forward'!
+
+buildHistoryPastMenu: aMenu
+	aMenu
+		clear;
+		text: '&Back'!
 
 canRefactor
 	"Private - Answer whether the development tools support refactoring (requires that the Refactoring Engine be
@@ -252,6 +258,7 @@ help
 historyBack
 	"Private - Return to the previously visited method."
 
+	<menuPopulator: #buildHistoryPastMenu:>
 	<commandQuery: #queryHistoryBack:>
 	self historyBack: 1!
 
@@ -266,6 +273,7 @@ historyForward
 	"Private - Return to the previously visited class which has been
 	moved back over by a jump back in time."
 
+	<menuPopulator: #buildHistoryFutureMenu:>
 	<commandQuery: #queryHistoryForward:>
 	self historyForward: 1!
 
@@ -316,17 +324,6 @@ isIdeaSpaceCard
 methodBrowserClass
 	^MethodBrowser!
 
-onDropDown: aToolbarButton
-	"Private - The receiver's toolbar has sent a notification that a button's drop-down arrow
-	has been pressed. Generate and pop-up the appropriate menu."
-
-	| popup |
-	popup := self buildPopupForCommand: aToolbarButton command asSymbol.
-	popup isNil ifTrue: [^nil].
-	popup queryAllAlong: self commandPolicy recursive: true.
-	popup showIn: self position: aToolbarButton screenRectangle bottomLeft.
-	^0!
-
 onViewAvailable
 	super onViewAvailable.
 	self applyOptions!
@@ -334,16 +331,7 @@ onViewAvailable
 onViewOpened
 	super onViewOpened.
 	fontSizePresenter model: (ValueAspectAdaptor subject: self aspect: #fontSize).
-	self class defaultSlideyPinsMap ifNotNil: [:map | self slideyPinMap: map].
-
-	"Enable toolbar pulldowns"
-	(self view viewNamed: 'smalltalkTools' ifNone: nil)
-		ifNotNil: 
-			[:toolbar |
-			toolbar presenterConnectionPoint
-				when: #dropDown:
-				send: #onDropDown:
-				to: self]!
+	self class defaultSlideyPinsMap ifNotNil: [:map | self slideyPinMap: map]!
 
 onViewStateRestored
 	super onViewStateRestored.
@@ -590,7 +578,8 @@ browseReferences!commands-actions!public! !
 browseReferencesCommand!commands-mappings!private! !
 browserEnvironment!accessing!public! !
 browseTests!public! !
-buildPopupForCommand:!private! !
+buildHistoryFutureMenu:!commands-menus!private! !
+buildHistoryPastMenu:!commands-menus!private! !
 canRefactor!private!testing! !
 canSaveState!private!saved state! !
 changeManager!accessing!public! !
@@ -624,7 +613,6 @@ inspectItCommand!commands-mappings!private! !
 inspectSystemOptions!commands-actions!public! !
 isIdeaSpaceCard!public! !
 methodBrowserClass!constants!private! !
-onDropDown:!private! !
 onViewAvailable!event handling!public! !
 onViewOpened!private! !
 onViewStateRestored!event handling!public! !
@@ -682,23 +670,6 @@ activeIdeaSpace
 
 applyOptions
 	"Override point for subclases that wish to update instances"!
-
-buildIdeaSpacePopup
-	| popup |
-	popup := Menu new.
-	popup
-		addCommand: (Message selector: #newIdeaSpace) description: 'New IdeaSpace';
-		addCommand: (Message selector: #openIdeaSpace) description: 'Open IdeaSpace from Template…';
-		addSeparator;
-		addCommand: (Message selector: #saveIdeaSpace) description: 'Save IdeaSpace Template';
-		addCommand: (Message selector: #saveIdeaSpaceAs) description: 'Save IdeaSpace Template as…';
-		addCommand: (Message selector: #revertIdeaSpace) description: 'Revert IdeaSpace to Template';
-		addSeparator;
-		addCommand: (Message selector: #addToNewIdeaSpace) description: 'Add to New IdeaSpace';
-		addCommand: (Message selector: #dragToolToIdeaSpace) description: 'Drag to Existing IdeaSpace';
-		addSeparator;
-		addCommand: (Message selector: #breakoutCurrentCard) description: 'Breakout Tool to Desktop'.
-	^popup!
 
 canUseIdeaSpace
 	"Answers true if instances of the receiver can be opened inside an IdeaSpaceShelll
@@ -1076,7 +1047,6 @@ userSettingsRootKey
 !Tools.SmalltalkToolShell class categoriesForMethods!
 activeIdeaSpace!public! !
 applyOptions!accessing!options!private! !
-buildIdeaSpacePopup!private! !
 canUseIdeaSpace!options!public! !
 canUseIdeaSpace:!options!public! !
 canUseIdeaSpaceAspect!private! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspaceDocument.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkWorkspaceDocument.cls
@@ -45,10 +45,6 @@ applyOptions
 areVariableTipsEnabled: aBoolean
 	workspacePresenter areVariableTipsEnabled: aBoolean!
 
-buildPopupForCommand: aSymbol
-	aSymbol == #newIdeaSpace ifTrue: [^SmalltalkToolShell buildIdeaSpacePopup].
-	^nil!
-
 canSaveState
 	"Private - Answer true if the receiver can successfully have it's state saved by #saveStateOn:. Some
 	tools may not be able to save their state and therefore will not be able to be exported as
@@ -177,17 +173,6 @@ isText
 language: aSymbol
 	workspacePresenter view lexer: aSymbol!
 
-onDropDown: aToolbarButton 
-	"Private - The receiver's toolbar has sent a notification that a button's drop-down arrow
-	has been pressed. Generate and pop-up the appropriate menu."
-
-	| popup |
-	popup := self buildPopupForCommand: aToolbarButton command asSymbol.
-	popup isNil ifTrue: [^nil].
-	popup queryAllAlong: self commandPolicy recursive: true.
-	popup showIn: self position: aToolbarButton screenRectangle bottomLeft.
-	^0!
-
 onViewAvailable
 	super onViewAvailable.
 	self applyOptions!
@@ -196,7 +181,7 @@ onViewOpened
 	"Private - Received when the receiver's view has been connected. 
 	Transfer any file contents across to the view"
 
-	| modifiedModel toolbar |
+	| modifiedModel |
 	super onViewOpened.
 	self view acceptDroppedFiles: true.
 	(self view viewNamed: 'errors' ifNone: nil)
@@ -206,12 +191,6 @@ onViewOpened
 	modifiedModel
 		when: #valueChanged
 		send: #updateCaption
-		to: self.
-	"Enable toolbar pulldowns"
-	toolbar := self view viewNamed: 'smalltalkTools'.
-	toolbar presenterConnectionPoint
-		when: #dropDown:
-		send: #onDropDown:
 		to: self.
 	self fileLoad!
 
@@ -308,7 +287,6 @@ workspace
 !Tools.SmalltalkWorkspaceDocument categoriesForMethods!
 applyOptions!options!private! !
 areVariableTipsEnabled:!accessing!options!public! !
-buildPopupForCommand:!commands-menus!private! !
 canSaveState!private!saved state!testing! !
 createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
@@ -335,7 +313,6 @@ isModified!public!testing! !
 isModified:!modes!public! !
 isText!public!testing! !
 language:!options!public! !
-onDropDown:!event handling!private! !
 onViewAvailable!event handling!public! !
 onViewOpened!event handling!private! !
 openWorkspace!commands-actions!public! !

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.ProfessionalSmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.ProfessionalSmalltalkSystem.cls
@@ -44,6 +44,21 @@ browseSystemPackages: aCollection
 		packages: aCollection;
 		yourself!
 
+buildIdeaSpaceDropdownMenu: aMenu
+	aMenu
+		clear;
+		addCommand: #newIdeaSpace description: '&New IdeaSpace';
+		addCommand: #openIdeaSpace description: '&Open IdeaSpace from Template…';
+		addSeparator;
+		addCommand: #saveIdeaSpace description: '&Save IdeaSpace Template';
+		addCommand: #saveIdeaSpaceAs description: 'Save IdeaSpace &Template As…';
+		addCommand: #revertIdeaSpace description: '&Revert IdeaSpace to Template';
+		addSeparator;
+		addCommand: #addToNewIdeaSpace description: '&Add to New IdeaSpace';
+		addCommand: #dragToolToIdeaSpace description: '&Drag to Existing IdeaSpace';
+		addSeparator;
+		addCommand: #breakoutCurrentCard description: '&Breakout Tool to Desktop'!
+
 classBrowserClasses
 	^Set
 		with: self hierarchyBrowserClass
@@ -71,6 +86,7 @@ ideaSpaceClass: toolClass
 	ideaSpaceClass := toolClass!
 
 newIdeaSpace
+	<menuPopulator: #buildIdeaSpaceDropdownMenu:>
 	^self ideaSpaceClass show!
 
 openDeploymentLog: aString
@@ -130,16 +146,17 @@ systemModelFromDeploymentLog: aString
 browseDeployedPackage:!helpers!public! !
 browseDeploymentLog:!helpers!public! !
 browseEnvironment:!browsing!public! !
-browseSources!commands!public! !
+browseSources!commands-actions!public! !
 browseSystemModel:!browsing!public! !
 browseSystemOnMethod:!browsing!public! !
 browseSystemPackages:!browsing!public! !
+buildIdeaSpaceDropdownMenu:!commands-menus!private! !
 classBrowserClasses!accessing!public! !
 classChooserClass!options!public! !
 disassembleMethod:!public! !
 ideaSpaceClass!accessing!public! !
 ideaSpaceClass:!accessing!public! !
-newIdeaSpace!commands!public! !
+newIdeaSpace!commands-actions!public! !
 openDeploymentLog:!helpers!private! !
 packagedResourceIdentifierDialogClass!options!public! !
 packagedResourceIdentifierDialogClass:!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.CommandMenuItem.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.CommandMenuItem.cls
@@ -170,6 +170,16 @@ postCopy
 	commandDescription := commandDescription copy.
 	^self!
 
+printOn: aStream
+	"Appends the receiver to aStream as a representation that a 
+	developer would want to see"
+
+	aStream
+		basicPrint: self;
+		nextPut: $(;
+		print: self description;
+		nextPut: $)!
+
 queryAlong: aCommandPolicy
 	"Answer a <CommandQuery> reflecting the current state of the receiver's command for the
 	specified <commandPolicy>. In this case we want to preconfigure the query with some static
@@ -240,6 +250,7 @@ lastQuery!accessing!private! !
 lastQuery:!accessing!private! !
 populateItemInfo:!private!realizing/unrealizing! !
 postCopy!copying!public! !
+printOn:!printing!public! !
 queryAlong:!operations!public! !
 registerAcceleratorKeyIn:!menus!public! !
 stbSaveOn:!binary filing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.Menu.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.Menu.cls
@@ -545,12 +545,18 @@ postCopy
 	^self!
 
 printOn: aStream
-	"Append, to aStream, a String whose characters are a description of the receiver as a developer
-	would want to see it."
+	"Append, to aStream, a String whose characters are a description of the receiver as a developer would want to see it."
 
 	aStream
 		basicPrint: self;
-		nextPut: $(; display: self text; nextPut: $)!
+		nextPut: $(.
+	self name
+		ifNil: 
+			[| label |
+			label := self text.
+			label isEmpty ifFalse: [aStream print: label]]
+		ifNotNil: [:symbol | aStream print: symbol].
+	aStream nextPut: $)!
 
 queryAllAlong: aCommandPolicy recursive: aBoolean
 	"Private - Query the command status for the receiver and each of its command items and
@@ -587,7 +593,8 @@ queryAllAlong: aCommandPolicy recursive: aBoolean
 										setMenuItemInfo: hMenu
 										uItem: i - 1
 										fByPosition: true
-										lpmii: itemInfo]]]]!
+										lpmii: itemInfo]]]].
+	^menuQuery!
 
 queryAllFromView: aView
 	"Private - Query each menu item along a route from the <View>, aView."

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.MenuItem.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.MenuItem.cls
@@ -139,16 +139,6 @@ populateItemInfo: aMENUITEMINFO
 
 	^self subclassResponsibility!
 
-printOn: aStream
-	"Appends the receiver to aStream as a representation that a 
-	developer would want to see"
-
-	aStream
-		basicPrint: self;
-		nextPut: $(;
-		display: self;
-		nextPut: $)!
-
 registerAcceleratorKeyIn: anAcceleratorTable
 	"Register the accelerator key associated with this menu item, if
 	there is one, in anAcceleratorTable."!
@@ -198,7 +188,6 @@ itemWithId:!accessing!public! !
 menuFromHandle:!accessing!public! !
 name!accessing!public! !
 populateItemInfo:!private!realizing/unrealizing! !
-printOn:!printing!public! !
 registerAcceleratorKeyIn:!menus!public! !
 styleFlags!accessing!private! !
 styleFlags:!accessing!not an aspect!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.ShellView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.ShellView.cls
@@ -1079,9 +1079,7 @@ wmInitMenu: message wParam: wParam lParam: lParam
 	^0 "prevent further processing"!
 
 wmInitMenuPopup: message wParam: wParam lParam: lParam
-	"Private - A sub-menu from the receiver's menu bar is about to be popped.
-	Direct the popup menu indicated, which should be connected to menuBar,
-	to update its items current state for our view."
+	"Private - A sub-menu from the receiver's menu bar is about to be popped. Direct the popup menu indicated, which should be connected to menuBar, to update its items current state for our view."
 
 	| popup |
 	lParam highWord ~~ 0 ifTrue: [^self onAboutToDisplaySystemMenu: wParam].
@@ -1092,10 +1090,9 @@ wmInitMenuPopup: message wParam: wParam lParam: lParam
 				wParam: wParam
 				lParam: lParam].
 
-	"Starting with the focus window, query the command route for the menu and its items,
-	 and enable/disable as appropriate. The menu may also be dynamically updated by
-	 the command target, which is sent a #onAboutToDisplayMenu: event"
+	"Starting with the focus window, query the command route for the menu and its items, and enable/disable as appropriate. The menu may also be dynamically updated by the command target, which is sent a #onAboutToDisplayMenu: event"
 	popup queryAllFromView: self class focus ?? self.
+	"Handled"
 	^0!
 
 wmNcActivate: message wParam: wParam lParam: lParam

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.View.cls
@@ -4041,11 +4041,16 @@ wmInitMenu: message wParam: wParam lParam: lParam
 wmInitMenuPopup: message wParam: wParam lParam: lParam
 	"Private - Context menu or sub-menu can update its state on screen to reflect the current event target."
 
-	| ctxtMenu subMenu |
 	lParam highWord ~~ 0 ifTrue: [^nil	"default processing for system menus"].
-	^((ctxtMenu := self queryContextMenu) notNil
-		and: [(subMenu := ctxtMenu menuFromHandle: wParam) notNil])
-			ifTrue: [subMenu queryAllFromView: self]!
+	^self queryContextMenu
+		ifNotNil: 
+			[:ctxtMenu |
+			(ctxtMenu menuFromHandle: wParam)
+				ifNotNil: 
+					[:subMenu |
+					subMenu queryAllFromView: self.
+					"Handled"
+					0]]!
 
 wmInputLangChange: message wParam: wParam lParam: lParam
 	"Private - Handle the Win32 WM_INPUTLANGCHANGE message.

--- a/Core/Object Arts/Dolphin/MVP/Tests/UI.Tests.MenuTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/Tests/UI.Tests.MenuTest.cls
@@ -23,7 +23,7 @@ exampleStrings
 
 testAllItems
 	self assert: (self exampleMenu allItems collect: [:each | each printString])
-		equals: #('a MenuBar' 'a Menu(&File)' 'a CommandMenuItem(&New)' 'DividerMenuItem break' 'a CommandMenuItem(&Open...)' 'DividerMenuItem separator' 'a CommandMenuItem(E&xit)' 'DividerMenuItem barBreak' 'a CommandMenuItem(F&ire!!)' 'DividerMenuItem break' 'a Menu(&Tools)' 'a CommandMenuItem(&Workspace...)' 'DividerMenuItem separator' 'a Menu(&Options)' 'a CommandMenuItem(Default Font...)' 'a Menu(&Theme)' 'a CommandMenuItem(&Dark)' 'a CommandMenuItem(&Light)')!
+		equals: #('a MenuBar' 'a Menu(''&File'')' 'a CommandMenuItem(''&New'')' 'DividerMenuItem break' 'a CommandMenuItem(''&Open...'')' 'DividerMenuItem separator' 'a CommandMenuItem(''E&xit'')' 'DividerMenuItem barBreak' 'a CommandMenuItem(''F&ire!!'')' 'DividerMenuItem break' 'a Menu(''&Tools'')' 'a CommandMenuItem(''&Workspace...'')' 'DividerMenuItem separator' 'a Menu(''&Options'')' 'a CommandMenuItem(''Default Font...'')' 'a Menu(''&Theme'')' 'a CommandMenuItem(''&Dark'')' 'a CommandMenuItem(''&Light'')')!
 
 testAllMenus
 	self assert: (self exampleMenu allMenus collect: [:each | each text])

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/UI.ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/UI.ListView.cls
@@ -372,18 +372,9 @@ basicUpdateColumn: aListViewColumn
 beSorted: aBlockClosure 
 	self list: (self list asSortedCollection: aBlockClosure)!
 
-buildViewsPopup
-	| popup |
-	popup := Menu new.
-	popup
-		addCommand: (Message selector: #extraLargeIconMode) description: 'Extra large icons';
-		addCommand: (Message selector: #thumbnailsMode) description: 'Thumbnails';
-		addCommand: (Message selector: #tileIconMode) description: 'Tiles';
-		addCommand: (Message selector: #largeIconMode) description: 'Icons';
-		addCommand: (Message selector: #listMode) description: 'List';
-		addCommand: (Message selector: #reportMode) description: 'Details'.
-	popup items do: [:each | each isRadioButtonStyle: true].
-	^popup!
+buildViewsPopup: aMenu
+	#(#extraLargeIconMode 'Extra large icons' #thumbnailsMode 'Thumbnails' #tileIconMode 'Tiles' #largeIconMode 'Icons' #listMode 'List' #reportMode 'Details')
+		pairsDo: [:selector :description | (aMenu addCommand: selector description: description) isRadioButtonStyle: true]!
 
 cancelLabelEdit
 	"Private - Cancel current inline editing."
@@ -1812,17 +1803,6 @@ onDisplayDetailsRequired: anLVITEM
 			[(self stateImageFromRow: rowObject) ifNotNil: [:stateImage | anLVITEM iStateImage: stateImage]].
 	^0	"suppress default processing"!
 
-onDropDown: aToolbarButton 
-	"Private - The receiver's toolbar has sent a notification that a button's drop-down arrow
-	has been pressed. Generate and pop-up the appropriate menu."
-
-	| popup |
-	aToolbarButton command asSymbol == #viewModeSelect ifFalse: [^nil].
-	popup := self buildViewsPopup.
-	popup queryAllAlong: self commandPolicy recursive: true.
-	popup showIn: self position: aToolbarButton screenRectangle bottomLeft.
-	^0!
-
 onEraseRequired: aColorEvent
 	"Handler for erase background. ListView controls manage their own background colours so
 	we pass on erase background requests"
@@ -2064,6 +2044,7 @@ removeColumnAtIndex: columnIndex
 		update!
 
 reportMode
+	<commandQuery: #queryReportMode:>
 	self viewMode: #report!
 
 resetSelection
@@ -2427,8 +2408,9 @@ viewModeChanged
 viewModeSelect
 	"Toggle the view mode of the receiver"
 
-	self 
-		viewMode: (#(#report #extraLargeIcons #thumbnails #tileIcons #largeIcons #smallIcons #list #report) 
+	<menuPopulator: #buildViewsPopup:>
+	self
+		viewMode: (#(#report #extraLargeIcons #thumbnails #tileIcons #largeIcons #smallIcons #list #report)
 				after: self viewMode)!
 
 wantCustomDrawItemNotifications: pNMHDR
@@ -2467,7 +2449,7 @@ basicRemoveColumnAtIndex:!columns!public!removing! !
 basicResetSelection!private!selection! !
 basicUpdateColumn:!columns!private!updating! !
 beSorted:!public!sorting! !
-buildViewsPopup!helpers!private! !
+buildViewsPopup:!commands-menus!private! !
 cancelLabelEdit!operations!private! !
 caretIndex!public!selection! !
 caretIndex:!public!selection! !
@@ -2630,7 +2612,6 @@ nmSelChanged:!event handling-win32!private! !
 notificationClass!constants!private! !
 onButtonPressed:!event handling!private! !
 onDisplayDetailsRequired:!event handling!private! !
-onDropDown:!event handling!private! !
 onEraseRequired:!event handling!public! !
 onItem:removedAtIndex:!event handling!public! !
 onItems:addedAtIndex:!event handling!public! !
@@ -2699,7 +2680,7 @@ updateItem:atIndex:!event handling!public! !
 updateSelectionCache!helpers!private!selection! !
 viewMode!accessing!public! !
 viewModeChanged!helpers!private! !
-viewModeSelect!commands-actions!public! !
+viewModeSelect!commands-actions!commands-menus!public! !
 wantCustomDrawItemNotifications:!helpers!private! !
 !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Dolphin Control Bars.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Dolphin Control Bars.pax
@@ -472,7 +472,7 @@ UI.ControlBarAbstract
 	classConstants: {}!
 UI.ControlBarAbstract
 	subclass: #'UI.Toolbar'
-	instanceVariableNames: 'idMap items bitmapsStart insets tbFlags indent bitmapSize buttonSize _unused27 layoutManager'
+	instanceVariableNames: 'idMap items bitmapsStart insets tbFlags indent bitmapSize buttonSize dropDownMenu layoutManager'
 	classVariableNames: ''
 	imports: #(#{OS.ToolbarConstants})
 	classInstanceVariableNames: ''

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/UI.Toolbar.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/UI.Toolbar.cls
@@ -2,7 +2,7 @@
 
 UI.ControlBarAbstract
 	subclass: #'UI.Toolbar'
-	instanceVariableNames: 'idMap items bitmapsStart insets tbFlags indent bitmapSize buttonSize _unused27 layoutManager'
+	instanceVariableNames: 'idMap items bitmapsStart insets tbFlags indent bitmapSize buttonSize dropDownMenu layoutManager'
 	classVariableNames: ''
 	imports: #(#{OS.ToolbarConstants})
 	classInstanceVariableNames: ''
@@ -494,11 +494,15 @@ nmNotify: pNMHDR
 		ifNotNil: [:action | self perform: action with: pNMHDR]!
 
 onDropDown: aToolbarButton
-	"Private - The receiver's control has sent a notification that a drop-down
-	style buttons drop-down arrow has been pressed. Handle in some
-	application specific manner, and answer zero if handled."
+	"Private - The receiver's control has sent a notification that a drop-down style buttons drop-down arrow has been pressed.  We use the generic command routing and querying mechanism to identify a target that implements and can populate the menu. This works very similarly to standard dynamic menu population, except that the menu is always built completely from scratch. All the boilerplate code that used to be required to handle the #dropDown: event is no longer needed - it is only necessary to implement a menu populator method, and associate that with the drop-down button commands (that should already exist) using #menuPopulator: annotations. For backwards compatibility, if there is no command target on the path prepared to populate the menu, we will then trigger the #dropDown: event that used to be hooked in order to build and show menus for toolbar drop-downs. Otherwise normal menu processing applies, i.e. #onAboutToDisplayMenu: is sent to presenter/view for both the popup itself and any sub-menus that are opened, and the default implementations will trigger the aboutToDisplayMenu: event off the presenter. If a menu is populated through the shared mechanism, then the #dropDown: event is not triggered."
 
-	self presenter trigger: #dropDown: with: aToolbarButton.
+	| emptyMenu |
+	dropDownMenu := Menu new name: aToolbarButton command asSymbol.
+	dropDownMenu showIn: self position: aToolbarButton screenRectangle bottomLeft.
+	emptyMenu := dropDownMenu isEmpty.
+	dropDownMenu := nil.
+	emptyMenu ifTrue: [self presenter trigger: #dropDown: with: aToolbarButton].
+	dropDownMenu := nil.
 	^TBDDRET_DEFAULT!
 
 onEraseRequired: aColorEvent
@@ -979,7 +983,23 @@ wmCreate: message wParam: wParam lParam: lParam
 	^super
 		wmCreate: message
 		wParam: wParam
-		lParam: lParam! !
+		lParam: lParam!
+
+wmInitMenuPopup: message wParam: wParam lParam: lParam
+	"Private - In addition to the normal context menu handling, the toolbar also has drop-down menus associated with drop-down items. These are queried in the normal way, allowing any #menuPopulator: and #commandQuery: methods registered on the command path to populate and update the status of the menu."
+
+	dropDownMenu
+		ifNil: 
+			[^super
+				wmInitMenuPopup: message
+				wParam: wParam
+				lParam: lParam].
+	^(dropDownMenu menuFromHandle: wParam)
+		ifNotNil: 
+			[:subMenu |
+			subMenu queryAllFromView: self.
+			"Handled"
+			0]! !
 !UI.Toolbar categoriesForMethods!
 actualBitmapSize!geometry!public! !
 addBitmap:index:!helpers!private! !
@@ -1092,6 +1112,7 @@ updateSize!operations!private! !
 updateSizePosted!operations!private! !
 validateUserInterface!operations!public! !
 wmCreate:wParam:lParam:!event handling-win32!private! !
+wmInitMenuPopup:wParam:lParam:!event handling-win32!private! !
 !
 
 !UI.Toolbar class methodsFor!

--- a/Core/Object Arts/Samples/ActiveX/Web Browser/OS.COM.Examples.WebBrowserShell.cls
+++ b/Core/Object Arts/Samples/ActiveX/Web Browser/OS.COM.Examples.WebBrowserShell.cls
@@ -52,25 +52,19 @@ Try:
 browserView
 	^browser view!
 
-buildPopupForCommand: aSymbol
-	aSymbol == #settingsMenu ifTrue: [^self buildSettingsPopup].
-	^nil!
-
-buildSettingsPopup
-	| menu submenu |
-	menu := Menu new yourself.
-	"name: #settingsMenu;"
-	menu
+buildSettingsPopup: aMenu
+	| submenu |
+	aMenu
 		addCommand: #toggleEventLogging description: 'Log WebView2 &Events to Transcript';
 		addSeparator.
-	submenu := menu addSubmenu: '&Default WebView2 UI'.
+	submenu := aMenu addSubmenu: '&Default WebView2 UI'.
 	submenu
 		addCommand: #toggleAllowContextMenu description: 'Context &Menus';
 		addCommand: #toggleBrowserAcceleratorKeysEnabled description: '&Accelerator Keys';
 		addCommand: #toggleBuiltinErrorPageEnabled description: '&Error Pages';
 		addCommand: #toggleDefaultScriptDialogsEnabled description: 'Script &Dialogs'.
 	"	name: #defaultWebviewUIEnablement;"
-	menu
+	aMenu
 		addSeparator;
 		addCommand: #toggleAllowExternalDrop description: 'Accept &Dropped Files';
 		addCommand: #toggleDevToolsEnabled description: '&DevTools (F12)';
@@ -80,7 +74,7 @@ buildSettingsPopup
 		addCommand: #toggleSwipeNavigation description: 'S&wipe Navigation';
 		addCommand: #toggleStatusBar description: '&Status Bubbles';
 		addCommand: #toggleZoomControl description: '&Zoom Control'.
-	submenu := (menu addSubmenu: 'Preferred &Color Scheme') yourself.
+	submenu := (aMenu addSubmenu: 'Preferred &Color Scheme') yourself.
 	"name: #colorScheme;"
 	#('&Auto' '&Light' '&Dark') keysAndValuesDo: 
 			[:eachKey :eachValue |
@@ -90,7 +84,7 @@ buildSettingsPopup
 								description: eachValue))
 						isRadioButtonStyle: true;
 						yourself)].
-	menu
+	aMenu
 		addSeparator;
 		addCommand: #toggleGeneralAutofill description: 'General &Autofill';
 		addCommand: #togglePasswordAutosave description: '&Password Autosave';
@@ -98,7 +92,7 @@ buildSettingsPopup
 		addCommand: #toggleJavaScript description: '&JavaScript';
 		addCommand: #toggleInPrivateMode description: 'In Private &Mode';
 		yourself.
-	submenu := (menu addSubmenu: '&Tracking Prevention Level') yourself.
+	submenu := (aMenu addSubmenu: '&Tracking Prevention Level') yourself.
 	"name: #trackingPreventionLevel;"
 	#('&None' '&Basic' 'Ba&lanced' '&Strict') keysAndValuesDo: 
 			[:eachKey :eachValue |
@@ -108,8 +102,7 @@ buildSettingsPopup
 								description: eachValue))
 						isRadioButtonStyle: true;
 						yourself)].
-	menu addCommand: #toggleSmartScreen description: '&SmartScreen'.
-	^menu!
+	aMenu addCommand: #toggleSmartScreen description: '&SmartScreen'!
 
 createComponents
 	"Create the presenters contained by the receiver"
@@ -256,17 +249,6 @@ onDocumentTitleChanged
 
 	self caption: self browserView documentTitle!
 
-onDropDown: aToolbarButton
-	"Private - The receiver's toolbar has sent a notification that a button's drop-down arrow
-	has been pressed. Generate and pop-up the appropriate menu."
-
-	| popup |
-	popup := self buildPopupForCommand: aToolbarButton command asSymbol.
-	popup isNil ifTrue: [^nil].
-	popup queryAllAlong: self commandPolicy recursive: true.
-	popup showIn: self position: aToolbarButton screenRectangle bottomLeft.
-	^0!
-
 onFavIconChanged
 	self webview2 getFavIcon: WebView2.COREWEBVIEW2_FAVICON_IMAGE_FORMAT_PNG
 		thenDo: [:hr :stream | self view smallIcon: (Gdiplus.Bitmap fromIStream: stream) asIcon]!
@@ -311,16 +293,7 @@ onViewOpened
 	statusItem := self view viewNamed: 'zoom'.
 	statusItem model: zoomModel.
 	statusItem := self view viewNamed: 'profile'.
-	statusItem model: profileModel.
-
-	"Enable toolbar pulldowns"
-	(self view viewNamed: 'browserTools' ifNone: nil)
-		ifNotNil: 
-			[:toolbar |
-			toolbar presenterConnectionPoint
-				when: #dropDown:
-				send: #onDropDown:
-				to: self]!
+	statusItem model: profileModel!
 
 onWebResourceRequested: anICoreWebView2WebResourceRequestedEventArgs
 	"Private - Implement web request filter, in this case to block images when that option is enabled by the user."
@@ -524,6 +497,7 @@ refresh
 
 settingsMenu
 	<commandQuery: #hasWebview>
+	<menuPopulator: #buildSettingsPopup:>
 	^self!
 
 toggleAllowContextMenu
@@ -673,8 +647,7 @@ zoomReset
 	browser view zoomFactor: 1! !
 !OS.COM.Examples.WebBrowserShell categoriesForMethods!
 browserView!accessing!public! !
-buildPopupForCommand:!commands-actions!private! !
-buildSettingsPopup!commands-actions!private! !
+buildSettingsPopup:!commands-actions!private! !
 createComponents!initializing!public! !
 createSchematicWiring!initializing!public! !
 displayError:!operations!private! !
@@ -692,7 +665,6 @@ navigate!commands-actions!public! !
 navigateTo:!operations!private! !
 onColorSchemeChanged!private!updating! !
 onDocumentTitleChanged!event handling!private! !
-onDropDown:!event handling!private! !
 onFavIconChanged!event handling!private! !
 onProcessFailed:!event handling!private! !
 onSourceChanged:!event handling!private! !


### PR DESCRIPTION
We can also use the menuPopulator: mechanism to provide a generic implementation to populate and show menus for drop-down toolbar buttons. This removes the need to hook the dropDown: event, to switch on the toolbar button command symbol, and to reproduce the code to show a menu everywhere used.