### PR TITLE
Converting Date to DateAndTime then to asUnixTime results in value that when converted back does not equal original

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Dolphin Legacy Date & Time.pax
+++ b/Core/Object Arts/Dolphin/Base/Dolphin Legacy Date & Time.pax
@@ -58,11 +58,9 @@ Core.Magnitude
 !Core.DateAndTime methodsFor!
 
 asDate
-	"Answer a <Date> representing the date of the receiver. The <Date> will be that at the receiver's offset, so:
-		- if a date in the local timezone is needed, send #asLocal first (i.e. `dateAndTime asLocal asDate`)
-		- if a UTC date is needed, send #asUTC first (i.e. `dateAndTime asUTC asDate`)."
+	"Answer a <Date> representing the date of the receiver. <Date>s are not timezone aware, but we follow the convention that they are assumed to represent a local time. Thefore we first convert the receiver to a local DateAndTime, and then extract the date from that."
 
-	^self dayMonthYearDo: 
+	^self asLocal dayMonthYearDo: 
 			[:d :m :y |
 			Date
 				newDay: d
@@ -70,11 +68,10 @@ asDate
 				year: y]!
 
 asTime
-	"Answer a <Time> representing the local time of the receiver. The <Time> will be that at the receiver's offset, so:
-		- if a time in the local timezone is needed and the DateAndTime, send #asLocal first (i.e. `dateAndTime asLocal asTime`)
-		- if a UTC time is needed, send #asUTC first (i.e. `dateAndTime asUTC asTime`)."
+	"Answer a <Time> representing the local time of the receiver."
 
-	^Time fromSeconds: seconds!
+	^Time fromSeconds: self asLocal seconds
+!
 
 asTimeStamp
 	"Answer a <TimeStamp> representing the local date and time of the receiver. The <TimeStamp> will be that at the receiver's offset, so:

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.DateAndTimeTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.DateAndTimeTest.cls
@@ -33,6 +33,12 @@ julianEpoch
 		second: 0
 		offset: 0 hours!
 
+test1193
+	| today ut |
+	today := Date today.
+	ut := today asDateAndTime asUnixTime.
+	self assert: today equals: (DateAndTime fromUnixTime: ut) asDate!
+
 testAddDuration
 	| subject epochSeconds |
 	subject := DateAndTime
@@ -85,14 +91,13 @@ testAddDuration
 				day: 29)!
 
 testAsDate
-	| subject |
+	| subject utcSeconds |
 	subject := self canonicalInstance.
-	"Note that the offset is ignored - the date is not adjusted to local time"
+	utcSeconds := 1564663499833333333 / 500000000.
+	self assert: (DateAndTime utcSeconds: utcSeconds offset: 0) equals: subject.
+	"#1193: Dates are assumed to be in local time."
 	self assert: subject asDate
-		equals: (Date
-				newDay: 29
-				monthIndex: 2
-				year: 2000)!
+		equals: (Date fromSeconds: utcSeconds + Locale timeZoneInformation offsetSeconds)!
 
 testAsFILETIME
 	| filetime |
@@ -170,10 +175,14 @@ testAsSYSTEMTIMEInvalidMilliseconds
 	self assert: actual wMilliseconds equals: 999!
 
 testAsTime
-	"Offset is ignored - the date is not adjusted to local time"
+	"#1193: A Time representing the local timezone equivalent is expected"
 
-	self assert: self canonicalInstance asTime
-		equals: (Time fromSeconds: (12 * 60 + 59) * 60 + 59 + (666666666 / 1000000000))!
+	| subject utcSeconds |
+	subject := self canonicalInstance.
+	utcSeconds := 1564663499833333333 / 500000000.
+	self assert: (DateAndTime utcSeconds: utcSeconds offset: 0) equals: subject.
+	self assert: subject asTime
+		equals: (Time fromSeconds: utcSeconds + Locale timeZoneInformation offsetSeconds)!
 
 testAsUnixTime
 	| subject |
@@ -804,6 +813,7 @@ testYearMonthDayHourMinuteSecondOffsetErrors
 !Core.Tests.DateAndTimeTest categoriesForMethods!
 canonicalInstance!constants!private! !
 julianEpoch!constants!private! !
+test1193!public!unit tests! !
 testAddDuration!public! !
 testAsDate!public!unit tests! !
 testAsFILETIME!public!unit tests! !


### PR DESCRIPTION
Date and Time in Dolphin are legacy classes for backwards compatibility with Smalltalk-80 Date and Time. They are not timezone aware, which gives rise to conversion issues into and out of DateAndTime. The convention adopted is that Date and Time always represent local time.

Note that this is a breaking change with respect to the behaviour of Dolphin 7.1 which did not convert DateAndTimes to local time before extracting the Date/Time, giving rise to issue #1193. As a breaking change, this is to be fixed in Dolphin 8 only for now.

Fixes #1193