### PR TITLE
Quit from filed-in script can cause silent nil DNU #setToEnd error

### DIFF
--- a/Core/Object Arts/Dolphin/Base/SourceManager.cls
+++ b/Core/Object Arts/Dolphin/Base/SourceManager.cls
@@ -86,15 +86,16 @@ closeChangesFile
 closeSourceAt: anInteger
 	"Private - Closes the source FileStream SourceFiles at: anInteger and nil it out."
 
-	(SourceFiles at: anInteger) notNil ifTrue: [
-		(SourceFiles at: anInteger) close.
-		SourceFiles at: anInteger put: nil ].
-!
+	(SourceFiles at: anInteger)
+		ifNotNil: 
+			[:file |
+			file close.
+			SourceFiles at: anInteger put: nil]!
 
 closeSources
 	"Private - Closes the changes and the sources files."
 
-	self closeSourcesFile; closeChangesFile!
+	1 to: SourceFiles size do: [:i | self closeSourceAt: i]!
 
 closeSourcesFile
 	"Private - Close the sources FileStream."
@@ -265,7 +266,7 @@ logEvaluate: aString
 onExit
 	"Private - The system is about to exit, close the source files."
 
-	SourceFiles do: [:f | f notNil ifTrue: [f close]]
+	self closeSources
 !
 
 openChangesFile: filePath 


### PR DESCRIPTION
Fix #1184 in release/7.1 by closing and nil'ing SourceFiles.