### PR TITLE
Drag/drop method over class/instance mode radio button fails

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Base/DragDropSession.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DragDropSession.cls
@@ -80,7 +80,7 @@ defaultScrollInterval
 	"Answers the time (in ms) between the scroll operations while the
 	drop pointer is in the scroll zone"
 
-	^100!
+	^100 milliseconds!
 
 dragObjectClass
 	^self subclassResponsibility!

--- a/Core/Object Arts/Dolphin/MVP/Base/DragDropSession.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/DragDropSession.cls
@@ -77,8 +77,7 @@ defaultScrollInset
 	^15!
 
 defaultScrollInterval
-	"Answers the time (in ms) between the scroll operations while the
-	drop pointer is in the scroll zone"
+	"Answers the <Duration> to wait between the scroll operations while the drop pointer is in the scroll zone"
 
 	^100 milliseconds!
 
@@ -238,6 +237,8 @@ initialize
 	"Private - Initialize the receiver."
 
 	defaultOperation := #move.
+	operationsSupportedByDropTarget := #(#move #copy).
+	inDropTargetScrollZone := false.
 	dragImages := self class defaultDragImages copy.
 	^self!
 
@@ -320,6 +321,16 @@ operationDescriptions
 resetOperation
 	operation := nil!
 
+scrollDelay
+	"Answers the <Duration> of the delay between the drop pointer entering the scroll zone and a scroll operation starting"
+
+	^self defaultScrollDelay!
+
+scrollInterval
+	"Answers the <Duration> to wait between the scroll operations while the drop pointer is in the scroll zone"
+
+	^self defaultScrollInterval!
+
 showDragImage
 	"Show the current drag image. This may be useful to targets wishing to draw some sort of
 	emphasis."
@@ -337,10 +348,10 @@ startScrollProcess
 
 	self stopScrollProcess.
 	scrollProcess := 
-			[self defaultScrollDelay wait.
+			[self scrollDelay wait.
 			
 			[dropTarget ddScroll: self.
-			self defaultScrollInterval wait] repeat]
+			self scrollInterval wait] repeat]
 					forkAt: Processor userBackgroundPriority!
 
 stopScrollProcess
@@ -438,6 +449,8 @@ operation!accessing!public! !
 operation:!accessing!public! !
 operationDescriptions!accessing!public! !
 resetOperation!accessing!public! !
+scrollDelay!accessing!public! !
+scrollInterval!accessing!public! !
 showDragImage!operations!public! !
 solidifyOperation!operations!private! !
 startScrollProcess!operations!private! !

--- a/Core/Object Arts/Dolphin/MVP/Base/View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/View.cls
@@ -3058,17 +3058,8 @@ requestDragObjects: session
 	self presenter trigger: #drag: with: session!
 
 requestDropOperations: aDragDropSession
-	"Update the <DragDropSession>, session, with the set of supported 
-	drag and drop operation symbols (for right-button drags).
-	Implementation Note: Set up some sensible default operations, and then trigger a 
-	#requestDropOperations: event off the receiver's presenter to give its observers an 
-	opportunity to override those defaults."
+	"Provide observers with an opportunity to update the <DragDropSession> argument with the set of supported drag and drop operation symbols (for right-button drags)."
 
-	aDragDropSession supportedOperations isNil 
-		ifTrue: 
-			["Presenter hasn't suggested anything, fill in some defaults"
-
-			aDragDropSession supportedOperations: #(#move #copy)].
 	self presenter trigger: #requestDropOperations: with: aDragDropSession!
 
 requestLayoutExtent: aPointExtent 

--- a/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
+++ b/Core/Object Arts/Dolphin/MVP/Dolphin MVP Tests.pax
@@ -39,6 +39,7 @@ package classNames
 	add: #IconTest;
 	add: #ImageViewAbstractTest;
 	add: #ImageViewTest;
+	add: #InternalDragDropSessionTest;
 	add: #LayoutManagerTest;
 	add: #LinkButtonTest;
 	add: #ListBoxTest;
@@ -235,6 +236,11 @@ DolphinTest subclass: #FolderTest
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 DolphinTest subclass: #IconTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+DolphinTest subclass: #InternalDragDropSessionTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''

--- a/Core/Object Arts/Dolphin/MVP/InternalDragDropSessionTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/InternalDragDropSessionTest.cls
@@ -1,0 +1,33 @@
+﻿"Filed out from Dolphin Smalltalk"!
+
+DolphinTest subclass: #InternalDragDropSessionTest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+InternalDragDropSessionTest guid: (GUID fromString: '{7ad52eea-323b-4bef-a087-a775a45fc039}')!
+InternalDragDropSessionTest comment: ''!
+!InternalDragDropSessionTest categoriesForClass!Unclassified! !
+!InternalDragDropSessionTest methodsFor!
+
+testInitialState
+	| subject |
+	subject := InternalDragDropSession new.
+	self assertIsNil: subject dragSource.
+	self assertIsNil: subject dragPoint.
+	self assertIsNil: subject suggestedSource.
+	self assert: subject dragObjects asArray equals: #().
+	self assert: subject defaultOperation identicalTo: #move.
+	self assertIsNil: subject dropTarget.
+	self assertIsNil: subject suggestedTarget.
+	self assert: subject supportedOperations equals: #(#move #copy).
+	self assertIsNil: subject operation.
+	self deny: subject isInDropTargetScrollZone.
+	self deny: subject isExtendedDrag.
+	self assert: subject operationDescriptions equals: DragDropSession.OperationDescriptions.
+	self assert: subject scrollDelay equals: 1 seconds.
+	self assert: subject scrollInterval equals: 100 milliseconds! !
+!InternalDragDropSessionTest categoriesForMethods!
+testInitialState!public! !
+!
+


### PR DESCRIPTION
Drag/drop of a method over the class/instance mode button can be used to copy/move an instance method to the class side, and vice versa. This fails leaving behind the drag/drop cursor, opening a hidden walkback window. Turns out to be a bug introduced by f20d13948f6a933fc441a9c3fc8440a3b19fb366

Fix cherry-picked from Dolphin 8 commit 8b917af11bdb56ad394767b0ab2ee87066eb00b7