### PR TITLE
String>>endsWith: does not work correctly for UTF encoded strings

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Core.AnsiString.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.AnsiString.cls
@@ -27,6 +27,9 @@ _beginsString: aString
 				buf2: self
 				count: size) == 0]!
 
+_endsString: aString
+	^self asUtf8String _endsString: aString!
+
 asAnsiString
 	"Answer an ANSI encoded string representation of the receiver."
 
@@ -118,6 +121,7 @@ urlDecoded
 	^unescaped contents! !
 !Core.AnsiString categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 asAnsiString!converting!public! !
 codePointsDo:!enumerating!public! !
 decodeAt:!encode/decode!private! !

--- a/Core/Object Arts/Dolphin/Base/Core.Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.Character.cls
@@ -55,6 +55,12 @@ At present only byte characters (that are not control characters) have a printab
 _beginsString: aString
 	^aString first = self!
 
+_endsString: aString
+	| i |
+	i := aString size - (aString encodedSizeOf: self) + 1.
+	i < 1 ifTrue: [^false].
+	^(aString decodeAt: i) = self!
+
 _separateSubStringsIn: tokens
 	| start answer size end codeUnits |
 	size := tokens size.
@@ -580,6 +586,7 @@ utf8Length
 	^self error: 'Invalid code point U+' , (t printStringBase: 16)! !
 !Core.Character categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 _separateSubStringsIn:!private!tokenizing! !
 <!comparing!public! !
 <==>!comparing!public! !

--- a/Core/Object Arts/Dolphin/Base/Core.Collection.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.Collection.cls
@@ -16,6 +16,9 @@ Core.Collection comment: ''!
 _beginsString: aString
 	^aString basicBeginsWith: self!
 
+_endsString: aString
+	^aString asArray endsWith: self!
+
 add: newElement
 	"Include the <Object> argument, newElement, as one of the receiver's 
 	elements. Answer newElement."
@@ -579,6 +582,7 @@ union: comperand
 		yourself! !
 !Core.Collection categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 add:!adding!public! !
 addAll:!adding!public! !
 allSatisfy:!enumerating!public! !

--- a/Core/Object Arts/Dolphin/Base/Core.SequenceableCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.SequenceableCollection.cls
@@ -603,13 +603,12 @@ encoding
 endsWith: aCollection
 	"Answer whether the receiver ends with the sequence of objects in the <Collection> argument"
 
-	| i |
-	(i := self size - aCollection size + 1) < 1 ifTrue: [^false].
-	aCollection do: 
-			[:each |
-			(self at: i) = each ifFalse: [^false].
-			i := i + 1].
-	^true!
+	| stream i |
+	i := self size - aCollection size.
+	i < 0 ifTrue: [^false].
+	stream := ReadStream on: self.
+	stream position: i.
+	^aCollection allSatisfy: [:each | stream next = each]!
 
 errorCollectionsOfDifferentSizes
 	^self error: 'collections are of different sizes'!

--- a/Core/Object Arts/Dolphin/Base/Core.String.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.String.cls
@@ -486,6 +486,11 @@ encodeOn: aWriteStream put: aCharacter
 
 	^self subclassResponsibility!
 
+endsWith: anObject
+	"Answer whether the receiver ends with the argument."
+
+	^anObject _endsString: self!
+
 expandMacros
 	"Expand the receiver with replacable arguments.
 	See #expandMacrosWithArguments: for further details."
@@ -1285,6 +1290,7 @@ displayOn:!printing!public! !
 displayString!printing!public! !
 encodedSizeAt:!encode/decode!private! !
 encodeOn:put:!encode/decode!private! !
+endsWith:!comparing!public! !
 expandMacros!printing!public! !
 expandMacrosIn:!double dispatch!private! !
 expandMacrosWith:!printing!public! !

--- a/Core/Object Arts/Dolphin/Base/Core.Utf16String.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.Utf16String.cls
@@ -42,6 +42,13 @@ _beginsString: aString
 				buf2: self
 				count: size * 2) == 0]!
 
+_endsString: aString
+	| i size comparand |
+	comparand := aString asUtf16String.
+	size := comparand size.
+	i := size - self size + 1.
+	^self = (i <= 1 ifTrue: [comparand] ifFalse: [comparand copyFrom: i to: size])!
+
 asUtf16String
 	"Answer a UTF16-encoded equivalent of the receiver."
 
@@ -320,6 +327,7 @@ uint16AtOffset: anInteger put: anObject
 	^self primitiveFailed: _failureCode! !
 !Core.Utf16String categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 asUtf16String!converting!public! !
 asUtf16StringCopy!converting!public! !
 asUtf8String!converting!public! !

--- a/Core/Object Arts/Dolphin/Base/Core.Utf8String.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.Utf8String.cls
@@ -40,6 +40,13 @@ _beginsString: aString
 				buf2: self
 				count: size) == 0]!
 
+_endsString: aString
+	| i size comparand |
+	comparand := aString asUtf8String.
+	size := comparand size.
+	i := size - self size + 1.
+	^self = (i <= 1 ifTrue: [comparand] ifFalse: [comparand copyFrom: i to: size])!
+
 asUtf8String
 	"Answer a UTF-8 encoded string representation of the receiver."
 
@@ -706,6 +713,7 @@ urlEncoded
 	^encodedStream grabContents! !
 !Core.Utf8String categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 asUtf8String!converting!public! !
 asUtf8StringCopy!converting!public! !
 before:ifAbsent:!public!searching! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.SequenceableCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.SequenceableCollectionTest.cls
@@ -342,7 +342,8 @@ testEndsWith
 	self assert: (sequence endsWith: (self newUnsortedCollection: #($1 $3 $2))) not.
 	self assert: (sequence endsWith: (self newUnsortedCollection: #($1 $2 $4))) not.
 	self assert: (sequence endsWith: (self newUnsortedCollection: #($1 $2 $3 $4))) not.
-	self assert: (sequence endsWith: (self newUnsortedCollection: #($4 $1 $2 $3))) not!
+	self assert: (sequence endsWith: (self newUnsortedCollection: #($4 $1 $2 $3))) not.
+	self assert: (sequence endsWith: (Set with: (self assimilate: $3)))!
 
 testFindFirst
 	| subject matchAll matchNone b c d matchB matchC |

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.StringTest.cls
@@ -362,6 +362,23 @@ testCopyWithout
 testEmpty
 	self assert: self collectionClass empty class identicalTo: self collectionClass!
 
+testEndsWithEmpty
+	| empty |
+	empty := self collectionClass empty.
+	self deny: (empty endsWith: $d).
+	self deny: (empty endsWith: $\0).
+	self deny: (empty endsWith: $🐬).
+	self deny: (empty endsWith: '🐬' asUtf8String).
+	self deny: (empty endsWith: '🐬' asUtf16String).
+	self deny: (empty endsWith: 'a' asAnsiString).
+	self deny: (empty endsWith: #($a)).
+	self deny: (empty endsWith: #[0]).
+	self assert: (empty endsWith: AnsiString empty).
+	self assert: (empty endsWith: Utf8String empty).
+	self assert: (empty endsWith: Utf16String empty).
+	self assert: (empty endsWith: #()).
+	self assert: (empty endsWith: #[])!
+
 testEquals
 	| abc |
 	self equalityTestCases do: 
@@ -1396,6 +1413,7 @@ testCopyToComTaskMemory!public!unit tests! !
 testCopyWith!public! !
 testCopyWithout!public! !
 testEmpty!public!unit tests! !
+testEndsWithEmpty!public!unit tests! !
 testEquals!public!unit tests! !
 testExpandMacrosWith!public!unit tests! !
 testExpandMacrosWithArguments!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.UtfEncodedStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.UtfEncodedStringTest.cls
@@ -512,6 +512,41 @@ testEncodeOnPut
 						self assert: stream atEnd.
 						self assert: actual equals: each]]!
 
+testEndsWithExtended
+	| chars string |
+	string := self assimilateString: 'abc🐬e'.
+	chars := string asArray.
+	self assert: chars size equals: 5.
+	1 to: 6
+		do: 
+			[:each |
+			| tail |
+			tail := chars copyFrom: each to: chars size.
+			self assert: (string endsWith: tail).
+			self assert: (string endsWith: (Utf8String withAll: tail)).
+			self assert: (string endsWith: (Utf16String withAll: tail)).
+			self deny: (string endsWith: $d).
+			self deny: (string endsWith: $🐬)].
+	self assert: (string endsWith: 'e' asAnsiString).
+	self deny: (string endsWith: 'd' asAnsiString).
+	self deny: (string endsWith: '🐬e' asAnsiString).
+	self deny: (string endsWith: 'c🐬' asUtf16String).
+	self deny: (string endsWith: 'c🐬' asUtf8String).
+	self deny: (string endsWith: '🐬' asUtf16String).
+	self deny: (string endsWith: '🐬' asUtf8String).
+	self deny: (string endsWith: #(101)).
+	self deny: (string endsWith: #[101]).
+	self assert: (string endsWith: $e).
+	self deny: (string endsWith: $d).
+	self deny: (string endsWith: $¬).
+	self deny: (string endsWith: $Ā).
+	self deny: (string endsWith: $ࠀ).
+	self deny: (string endsWith: $🐬).
+	string := string copyFrom: 1 to: string size - 1.
+	self assert: (string endsWith: $🐬).
+	self deny: (string endsWith: $🐭).
+	self deny: (string endsWith: $? asAnsiString)!
+
 testFindFirst
 	| subject index |
 	super testFindFirst.
@@ -983,6 +1018,7 @@ testDecodeAt!public!unit tests! !
 testDecodeNextFrom!public!unit tests! !
 testDetectIfNoneExtended!public!unit tests! !
 testEncodeOnPut!public!unit tests! !
+testEndsWithExtended!public!unit tests! !
 testFindFirst!public!unit tests! !
 testFindLast!public!unit tests! !
 testFindStringStartingAt!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/Tests/UI.Tests.RichTextEditTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/Tests/UI.Tests.RichTextEditTest.cls
@@ -73,12 +73,10 @@ testStreamInAnsiText
 	presenter selectLine: 10.
 	actual := presenter selectionRtf.
 	"This test is locale sensitive and may need revision"
-	rtf := '{\rtf1\ansi\ansicpg<1d>\deff0{\fonttbl{\f0\fnil\fcharset0 Segoe UI;}}
-\uc1\pard\lang<2d>\f0\fs20 over the lazy dog}
-'
-				expandMacrosWithArguments: { Character.AnsiCodePage. Locale systemDefault lcid }
-				locale: Locale invariant.
-	self assert: actual equals: rtf.
+	self assert: (actual beginsWith: '{\rtf1\ansi\ansicpg<d>' << Character.AnsiCodePage).
+	self
+		assert: (actual endsWith: '\uc1\pard\lang<d>\f0\fs20 over the lazy dog}
+' << Locale systemDefault lcid).
 
 	"Now stream in the ANSI RTF"
 	rtf := presenter rtfText.
@@ -125,13 +123,12 @@ testStreamInUtfText
 	presenter selectLine: 10.
 	actual := presenter selectionUrtf.
 	"This test is locale sensitive and may need revision"
-	ansi := '{\urtf1\ansi\ansicpg<1d>\deff0{\fonttbl{\f0\fnil\fcharset0 Segoe UI;}{\f1\fnil\fcharset238 Segoe UI;}}
-\uc1\pard\lang<2d>\f0\fs20 ĉṓɲṩḙċ\f1 ť\f0 ᶒțûɾ ấɖḯƥĭṩ\f1 čį\f0 ɳġ ḝ\f1 łį\f0 ʈ}
+	self
+		assert: (actual beginsWith: '{\urtf1\ansi\ansicpg<d>\deff0{\fonttbl{\f0' << Character.AnsiCodePage).
+	self assert: (actual
+				endsWith: '\uc1\pard\lang<d>\f0\fs20 ĉṓɲṩḙċ\f1 ť\f0 ᶒțûɾ ấɖḯƥĭṩ\f1 čį\f0 ɳġ ḝ\f1 łį\f0 ʈ}
 '
-				expandMacrosWithArguments: {Character.AnsiCodePage. Locale systemDefault lcid}
-				locale: Locale invariant.
-	self assert: actual equals: ansi.
-
+						<< Locale systemDefault lcid).
 	"Check round-trip as ANSI RTF (which has an escape syntax to preserve international characters)"
 	presenter text: text.
 	rtf := presenter rtfText.


### PR DESCRIPTION
Fixes #1258