### PR TITLE
String>>endsWith: does not work correctly for UTF encoded strings

### DIFF
--- a/Core/Object Arts/Dolphin/Base/AnsiString.cls
+++ b/Core/Object Arts/Dolphin/Base/AnsiString.cls
@@ -25,6 +25,9 @@ _beginsString: aString
 				buf2: self
 				count: size) == 0]!
 
+_endsString: aString
+	^self asUtf8String _endsString: aString!
+
 asAnsiString
 	"Answer an ANSI encoded string representation of the receiver."
 
@@ -154,6 +157,7 @@ urlDecoded
 	^unescaped contents! !
 !AnsiString categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 asAnsiString!converting!public! !
 asLowercase!converting!public! !
 asUppercase!converting!public! !

--- a/Core/Object Arts/Dolphin/Base/Character.cls
+++ b/Core/Object Arts/Dolphin/Base/Character.cls
@@ -55,6 +55,12 @@ At present only byte characters (that are not control characters) have a printab
 _beginsString: aString
 	^aString first = self!
 
+_endsString: aString
+	| i |
+	i := aString size - (aString encodedSizeOf: self) + 1.
+	i < 1 ifTrue: [^false].
+	^(aString decodeAt: i) = self!
+
 _separateSubStringsIn: tokens
 	| start answer size end codeUnits |
 	size := tokens size.
@@ -503,6 +509,7 @@ to: aCharacter
 	^(self codePoint to: aCharacter codePoint) collect: [:each | Character codePoint: each]! !
 !Character categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 _separateSubStringsIn:!private!tokenizing! !
 <!comparing!public! !
 =!comparing!public! !

--- a/Core/Object Arts/Dolphin/Base/Collection.cls
+++ b/Core/Object Arts/Dolphin/Base/Collection.cls
@@ -14,6 +14,9 @@ Collection comment: ''!
 _beginsString: aString
 	^aString basicBeginsWith: self!
 
+_endsString: aString
+	^aString asArray endsWith: self!
+
 _indexOfAnyInString: aString startingAt: anInteger 
 	aString from: anInteger keysAndValuesDo: [:i :elem | (self includes: elem) ifTrue: [^i]].
 	^0!
@@ -609,6 +612,7 @@ union: comperand
 ! !
 !Collection categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 _indexOfAnyInString:startingAt:!double dispatch!private!searching! !
 add:!adding!public! !
 addAll:!adding!public! !

--- a/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollection.cls
@@ -612,13 +612,12 @@ encoding
 endsWith: aCollection
 	"Answer whether the receiver ends with the sequence of objects in the <Collection> argument"
 
-	| i |
-	(i := self size - aCollection size + 1) < 1 ifTrue: [^false].
-	aCollection do: 
-			[:each |
-			(self at: i) = each ifFalse: [^false].
-			i := i + 1].
-	^true!
+	| stream i |
+	i := self size - aCollection size.
+	i < 0 ifTrue: [^false].
+	stream := ReadStream on: self.
+	stream position: i.
+	^aCollection allSatisfy: [:each | stream next = each]!
 
 errorCollectionsOfDifferentSizes
 	^self error: 'collections are of different sizes'!

--- a/Core/Object Arts/Dolphin/Base/SequenceableCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/SequenceableCollectionTest.cls
@@ -332,7 +332,8 @@ testEndsWith
 	self assert: (sequence endsWith: (self newUnsortedCollection: #($1 $3 $2))) not.
 	self assert: (sequence endsWith: (self newUnsortedCollection: #($1 $2 $4))) not.
 	self assert: (sequence endsWith: (self newUnsortedCollection: #($1 $2 $3 $4))) not.
-	self assert: (sequence endsWith: (self newUnsortedCollection: #($4 $1 $2 $3))) not!
+	self assert: (sequence endsWith: (self newUnsortedCollection: #($4 $1 $2 $3))) not.
+	self assert: (sequence endsWith: (Set with: (self assimilate: $3)))!
 
 testFindFirst
 	| subject matchAll matchNone b c d matchB matchC |

--- a/Core/Object Arts/Dolphin/Base/String.cls
+++ b/Core/Object Arts/Dolphin/Base/String.cls
@@ -477,6 +477,11 @@ encodeOn: aWriteStream put: aCharacter
 
 	^self subclassResponsibility!
 
+endsWith: anObject
+	"Answer whether the receiver ends with the argument."
+
+	^anObject _endsString: self!
+
 expandMacros
 	"Expand the receiver with replacable arguments.
 	See #expandMacrosWithArguments: for further details."
@@ -1242,6 +1247,7 @@ displayOn:!printing!public! !
 displayString!printing!public! !
 encodedSizeAt:!encode/decode!private! !
 encodeOn:put:!encode/decode!private! !
+endsWith:!comparing!public! !
 expandMacros!printing!public! !
 expandMacrosIn:!double dispatch!private! !
 expandMacrosWith:!printing!public! !

--- a/Core/Object Arts/Dolphin/Base/StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/StringTest.cls
@@ -314,6 +314,23 @@ testCopyWithout
 testEmpty
 	self assert: self collectionClass empty class identicalTo: self collectionClass!
 
+testEndsWithEmpty
+	| empty |
+	empty := self collectionClass empty.
+	self deny: (empty endsWith: $d).
+	self deny: (empty endsWith: $\0).
+	self deny: (empty endsWith: $🐬).
+	self deny: (empty endsWith: '🐬' asUtf8String).
+	self deny: (empty endsWith: '🐬' asUtf16String).
+	self deny: (empty endsWith: 'a' asAnsiString).
+	self deny: (empty endsWith: #($a)).
+	self deny: (empty endsWith: #[0]).
+	self assert: (empty endsWith: AnsiString empty).
+	self assert: (empty endsWith: Utf8String empty).
+	self assert: (empty endsWith: Utf16String empty).
+	self assert: (empty endsWith: #()).
+	self assert: (empty endsWith: #[])!
+
 testEquals
 	| abc |
 	self equalityTestCases do: 
@@ -1195,7 +1212,8 @@ testClassReadFrom!public!unit tests! !
 testCopyToComTaskMemory!public!unit tests! !
 testCopyWith!public! !
 testCopyWithout!public! !
-testEmpty!public!testing / accessing! !
+testEmpty!public!unit tests! !
+testEndsWithEmpty!public!unit tests! !
 testEquals!public!unit tests! !
 testExpandMacrosWith!public!unit tests! !
 testExpandMacrosWithArguments!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/Utf16String.cls
+++ b/Core/Object Arts/Dolphin/Base/Utf16String.cls
@@ -36,6 +36,13 @@ _beginsString: aString
 				buf2: self
 				count: size * 2) == 0]!
 
+_endsString: aString
+	| i size comparand |
+	comparand := aString asUtf16String.
+	size := comparand size.
+	i := size - self size + 1.
+	^self = (i <= 1 ifTrue: [comparand] ifFalse: [comparand copyFrom: i to: size])!
+
 asByteString: aClass
 	"Private - Answer a byte-string encoded <String> of the specified class containing the same characters as the receiver."
 
@@ -142,7 +149,7 @@ decodeAt: anInteger
 					Character.Utf8Default]]
 		ifFalse: 
 			[surrogateBits == Character.Utf16TrailMask
-				ifTrue: [self errorIntraCharacterIndex: anInteger]
+				ifTrue: [Character.Utf8Default]
 				ifFalse: [Character utf16Value: leading ifInvalid: [Character.Utf8Default]]]!
 
 decodeNextFrom: aReadStream
@@ -373,6 +380,7 @@ wordAtOffset: anInteger put: anObject
 	^self primitiveFailed: _failureCode! !
 !Utf16String categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 asByteString:!converting!private! !
 asLowercase!converting!public! !
 asUppercase!converting!public! !

--- a/Core/Object Arts/Dolphin/Base/Utf8String.cls
+++ b/Core/Object Arts/Dolphin/Base/Utf8String.cls
@@ -36,6 +36,14 @@ _beginsString: aString
 				buf2: self
 				count: size) == 0]!
 
+_endsString: aString
+	| i size comparand |
+	comparand := aString asUtf8String.
+	size := comparand size.
+	i := size - self size + 1.
+	^self = (i <= 1 ifTrue: [comparand] ifFalse: [comparand copyFrom: i to: size])
+!
+
 asLowercase
 	"Answer a <readableString> which is a copy of the receiver but with the contents converted
 	to lowercase."
@@ -104,7 +112,7 @@ decodeAt: anInteger
 	c < 16rC0
 		ifTrue: 
 			["On a continution byte so in the middle of a character, which is invalid"
-			^self errorIntraCharacterIndex: anInteger].
+			^Character.Utf8Default].
 	"At least 2 byte character"
 	size := self size.
 	anInteger < size ifFalse: [^Character.Utf8Default].
@@ -534,6 +542,7 @@ urlEncoded
 	^encodedStream grabContents! !
 !Utf8String categoriesForMethods!
 _beginsString:!comparing!double dispatch!private! !
+_endsString:!comparing!double dispatch!private! !
 asLowercase!converting!public! !
 asUppercase!converting!public! !
 asUtf8String!converting!public! !

--- a/Core/Object Arts/Dolphin/Base/UtfEncodedStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/UtfEncodedStringTest.cls
@@ -219,7 +219,7 @@ testDecodeAt
 			actual := subject decodeAt: 1.
 			self assert: actual equals: each.
 			"Starting in the middle of a character should always be an error"
-			2 to: subject size do: [:i | self should: [subject decodeAt: i] raise: Error]].
+			2 to: subject size do: [:i | self assert: (subject decodeAt: i) equals: Character replacement]].
 	self decodeInvalidContinuations do: 
 			[:each |
 			| subject actual |
@@ -305,6 +305,41 @@ testEncodeOnPut
 						self assert: actual2 equals: actual.
 						self assert: stream atEnd.
 						self assert: actual equals: each]]!
+
+testEndsWithExtended
+	| chars string |
+	string := self assimilateString: 'abc🐬e'.
+	chars := string asArray.
+	self assert: chars size equals: 5.
+	1 to: 6
+		do: 
+			[:each |
+			| tail |
+			tail := chars copyFrom: each to: chars size.
+			self assert: (string endsWith: tail).
+			self assert: (string endsWith: (Utf8String withAll: tail)).
+			self assert: (string endsWith: (Utf16String withAll: tail)).
+			self deny: (string endsWith: $d).
+			self deny: (string endsWith: $🐬)].
+	self assert: (string endsWith: 'e' asAnsiString).
+	self deny: (string endsWith: 'd' asAnsiString).
+	self deny: (string endsWith: '🐬e' asAnsiString).
+	self deny: (string endsWith: 'c🐬' asUtf16String).
+	self deny: (string endsWith: 'c🐬' asUtf8String).
+	self deny: (string endsWith: '🐬' asUtf16String).
+	self deny: (string endsWith: '🐬' asUtf8String).
+	self deny: (string endsWith: #(101)).
+	self deny: (string endsWith: #[101]).
+	self assert: (string endsWith: $e).
+	self deny: (string endsWith: $d).
+	self deny: (string endsWith: $¬).
+	self deny: (string endsWith: $Ā).
+	self deny: (string endsWith: $ࠀ).
+	self deny: (string endsWith: $🐬).
+	string := string copyFrom: 1 to: string size - 1.
+	self assert: (string endsWith: $🐬).
+	self deny: (string endsWith: $🐭).
+	self deny: (string endsWith: $? asAnsiString)!
 
 testFindFirst
 	| subject index |
@@ -656,6 +691,7 @@ testDecodeAt!public!unit tests! !
 testDecodeNextFrom!constants!public! !
 testDetectIfNoneExtended!public!unit tests! !
 testEncodeOnPut!public!unit tests! !
+testEndsWithExtended!public!unit tests! !
 testFindFirst!public!unit tests! !
 testFindLast!public!unit tests! !
 testFindStringStartingAt!public!unit tests! !


### PR DESCRIPTION
Fixes #1258 for Dolphin 7.1