### PR TITLE
Load IDB IDE Package Backup extension to help avoid loss of work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ DolphinBoot
 hooks
 lfs
 *.exe.WebView2
+Package backups/

--- a/Core/Contributions/IDB/IDB IDE Package Backup.pax
+++ b/Core/Contributions/IDB/IDB IDE Package Backup.pax
@@ -1,4 +1,4 @@
-| package |
+﻿| package |
 package := Package name: 'IDB IDE Package Backup'.
 package paxVersion: 1;
 	basicComment: 'Automatic backup of packages
@@ -12,15 +12,9 @@ Public Domain Freeware
 
 package basicPackageVersion: '6a'.
 
-package basicScriptAt: #postinstall put: 'PackageManager current when: #aboutToSave: send: #onAboutToSavePackage: to: PackageBackup!!'.
-package basicScriptAt: #preuninstall put: 'PackageManager current removeEventsTriggeredFor: PackageBackup!!'.
 
 package classNames
 	add: #PackageBackup;
-	yourself.
-
-package methodNames
-	add: #Package -> #savePACBackupTo:;
 	yourself.
 
 package binaryGlobalNames: (Set new
@@ -29,9 +23,9 @@ package binaryGlobalNames: (Set new
 package globalAliases: (Set new
 	yourself).
 
-package setPrerequisites: (IdentitySet new
-	add: '..\Object Arts\Dolphin\Base\Dolphin';
-	yourself).
+package setPrerequisites: #(
+	'..\..\Object Arts\Dolphin\IDE\Base\Development System'
+	'..\..\Object Arts\Dolphin\Base\Dolphin').
 
 package!
 
@@ -39,7 +33,7 @@ package!
 
 Object subclass: #PackageBackup
 	instanceVariableNames: ''
-	classVariableNames: 'BackupFolder'
+	classVariableNames: 'BackupFolder Instance'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 
@@ -47,21 +41,6 @@ Object subclass: #PackageBackup
 
 
 "Loose Methods"!
-
-!Package methodsFor!
-
-savePACBackupTo: aFolderName 
-	| pathname |
-	#idbAdded.
-	(File exists: self packageFileName) 
-		ifTrue: 
-			[File createDirectory: aFolderName.
-			pathname := File 
-						composePath: aFolderName
-						stem: (File splitStemFrom: self packageFileName) , ' ' , Time now asMilliseconds printString
-						extension: self class packageExtension.
-			File copy: self packageFileName to: pathname]! !
-!Package categoriesFor: #savePACBackupTo:!helpers!idb goodies!public! !
 
 "End of package definition"!
 

--- a/Core/Contributions/IDB/PackageBackup.cls
+++ b/Core/Contributions/IDB/PackageBackup.cls
@@ -1,33 +1,103 @@
-"Filed out from Dolphin Smalltalk X6"!
+﻿"Filed out from Dolphin Smalltalk"!
 
 Object subclass: #PackageBackup
 	instanceVariableNames: ''
-	classVariableNames: 'BackupFolder'
+	classVariableNames: 'BackupFolder Instance'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
-PackageBackup guid: (GUID fromString: '{6F50FCBA-C386-440D-9426-DC697024BF9C}')!
+PackageBackup guid: (GUID fromString: '{6f50fcba-c386-440d-9426-dc697024bf9c}')!
 PackageBackup comment: 'See [DolphinImageFolder]/Idb/Documentation for details
 
 (C) 2005 Ian Bartholomew
 ian@idb.me.uk
 Public Domain Freeware'!
 !PackageBackup categoriesForClass!IDB Goodies! !
+!PackageBackup methodsFor!
+
+backupPackage: aPackage
+	| backupFilename backupFolder packageFilename |
+	packageFilename := aPackage packageFileName.
+	(File exists: packageFilename) ifFalse: [^self].
+	backupFolder := self class backupFolder.
+	File createDirectory: backupFolder.
+	backupFilename := File
+				composePath: backupFolder
+				stem: aPackage name , ' '
+						, (DateAndTime now - ##(DateAndTime year: 2024 day: 1)) asMilliseconds truncated printString
+				extension: aPackage class packageExtension.
+	File copy: packageFilename to: backupFilename!
+
+free
+	PackageManager current removeEventsTriggeredFor: self!
+
+initialize
+	PackageManager current
+		when: #aboutToSave:
+		send: #onAboutToSavePackage:
+		to: self.
+	^self!
+
+onAboutToSavePackage: aPackage
+	self backupPackage: aPackage! !
+!PackageBackup categoriesForMethods!
+backupPackage:!operations!private! !
+free!finalizing!public! !
+initialize!initializing!public! !
+onAboutToSavePackage:!event handling!private! !
+!
+
 !PackageBackup class methodsFor!
 
 backupFolder
 	BackupFolder ifNil: [BackupFolder := self defaultBackupFolder].
 	^BackupFolder!
 
-backupFolder: anObject 
-	BackupFolder := anObject!
+backupFolder: aString
+	BackupFolder := aString!
 
 defaultBackupFolder
 	^FileLocator imageRelative localFileSpecFor: 'Package backups'!
 
-onAboutToSavePackage: aPackage 
-	aPackage savePACBackupTo: self backupFolder! !
-!PackageBackup class categoriesFor: #backupFolder!accessing!public! !
-!PackageBackup class categoriesFor: #backupFolder:!accessing!public! !
-!PackageBackup class categoriesFor: #defaultBackupFolder!accessing!public! !
-!PackageBackup class categoriesFor: #onAboutToSavePackage:!event handling!public! !
+disable
+	Instance ifNil: [^self].
+	Instance free.
+	Instance := nil!
+
+enable
+	Instance ifNil: [Instance := self new initialize]!
+
+icon
+	^PackageManager icon!
+
+initialize
+	Smalltalk developmentSystem registerTool: self.
+	self enable!
+
+isEnabled
+	^Instance notNil!
+
+isEnabled: aBoolean
+	aBoolean ifTrue: [self enable] ifFalse: [self disable]!
+
+publishedAspects
+	^super publishedAspects
+		add: (Aspect boolean: #isEnabled);
+		yourself!
+
+uninitialize
+	self disable.
+	Smalltalk developmentSystem unregisterTool: self! !
+!PackageBackup class categoriesForMethods!
+backupFolder!accessing!public! !
+backupFolder:!accessing!public! !
+defaultBackupFolder!constants!private! !
+disable!operations!public! !
+enable!operations!public! !
+icon!constants!public! !
+initialize!class initialization!public! !
+isEnabled!public!testing! !
+isEnabled:!accessing!public! !
+publishedAspects!constants!public! !
+uninitialize!class hierarchy-removing!public! !
+!
 

--- a/Core/Object Arts/Dolphin/Base/NTLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/NTLibrary.cls
@@ -6,7 +6,7 @@ PermanentLibrary subclass: #NTLibrary
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 NTLibrary guid: (GUID fromString: '{8293e458-7d81-4aba-97a5-c1001c4b2153}')!
-NTLibrary comment: 'NtDllLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''ntdll.dll''.It was generated generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
+NTLibrary comment: 'NtDllLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''ntdll.dll''. It was generated generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
 
 The type library contains the following helpstring For this Module
 	"Windows NT Runtime Library"

--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinBaseProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinBaseProduct.cls
@@ -132,6 +132,7 @@ contents
 		add: #('Core\Contributions\IDB\IDB DeviceIndependentBitmap.pax' #plain #imageBased);
 		add: #('Core\Contributions\IDB\IDB Image Library.pax' #plain #imageBased);
 		add: #('Core\Contributions\IDB\IDB MultipleFileOpenDialog.pax' #plain #imageBased);
+		add: #('Core\Contributions\IDB\IDB IDE Package Backup.pax' #plain #imageBased);
 		yourself.
 
 	"Solutions Software components"

--- a/Core/Object Arts/Dolphin/MVP/Base/ThemeLibrary.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ThemeLibrary.cls
@@ -6,7 +6,7 @@ ExternalLibrary subclass: #ThemeLibrary
 	poolDictionaries: 'ThemeConstants'
 	classInstanceVariableNames: ''!
 ThemeLibrary guid: (GUID fromString: '{fb91df3f-4cb4-48a2-adee-a75b9a4d30a2}')!
-ThemeLibrary comment: 'ThemeLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''UXTHEME.DLL''.It was generated generated from type information in the ''Win32 API (ANSI). Derived from Bruce McKinney´s Hardcore Visual Basic Type Library'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
+ThemeLibrary comment: 'ThemeLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''UXTHEME.DLL''. It was generated generated from type information in the ''Win32 API (ANSI). Derived from Bruce McKinney´s Hardcore Visual Basic Type Library'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
 
 The type library contains the following helpstring for this module
 	"Windows Theme Library. Only available in Windows XP and above."

--- a/Core/Object Arts/Dolphin/Sockets/IpHlpApiLibrary.cls
+++ b/Core/Object Arts/Dolphin/Sockets/IpHlpApiLibrary.cls
@@ -6,7 +6,7 @@ ExternalLibrary subclass: #IPHlpApiLibrary
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 IPHlpApiLibrary guid: (GUID fromString: '{a63698ae-5cef-4f53-bf10-c4a77a8b979a}')!
-IPHlpApiLibrary comment: 'IPHlpApiLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''iphlpapi.DLL''.It was generated generated from type information in the ''Win32 API (ANSI). Derived from Bruce McKinney´s Hardcore Visual Basic Type Library'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
+IPHlpApiLibrary comment: 'IPHlpApiLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''iphlpapi.DLL''. It was generated generated from type information in the ''Win32 API (ANSI). Derived from Bruce McKinney´s Hardcore Visual Basic Type Library'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
 
 The type library contains the following helpstring for this module
 	"IP Helper Library"

--- a/Core/Object Arts/Dolphin/Sockets/WS2_32Library.cls
+++ b/Core/Object Arts/Dolphin/Sockets/WS2_32Library.cls
@@ -6,7 +6,7 @@ ExternalLibrary subclass: #WS2_32Library
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 WS2_32Library guid: (GUID fromString: '{d368efd5-8705-4c18-ada5-9a1e95868480}')!
-WS2_32Library comment: 'WS2_32Library is the <ExternalLibrary> class to represent the dynamic link library, ''WS2_32.dll''.It was generated generated from type information in the ''Windows Sockets 2 Type Library'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
+WS2_32Library comment: 'WS2_32Library is the <ExternalLibrary> class to represent the dynamic link library, ''WS2_32.dll''. It was generated generated from type information in the ''Windows Sockets 2 Type Library'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
 
 This library contains functions pertaining to the use of TCP/IP sockets under Windows through the Sockets 2 (blocking) API.
 

--- a/Core/Object Arts/Dolphin/System/Win32/Crypt32Library.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/Crypt32Library.cls
@@ -6,7 +6,7 @@ ExternalLibrary subclass: #Crypt32Library
 	poolDictionaries: 'WinCryptConstants'
 	classInstanceVariableNames: ''!
 Crypt32Library guid: (GUID fromString: '{02c78993-ba10-47a1-953f-63f60b7693ab}')!
-Crypt32Library comment: 'Crypt32Library is the <ExternalLibrary> class to represent the dynamic link library, ''Crypt32.dll''.It was generated generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
+Crypt32Library comment: 'Crypt32Library is the <ExternalLibrary> class to represent the dynamic link library, ''Crypt32.dll''. It was generated generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
 
 The type library contains the following helpstring for this module
 	"Crypto API"

--- a/Core/Object Arts/Dolphin/System/Win32/HttpApiLibrary.cls
+++ b/Core/Object Arts/Dolphin/System/Win32/HttpApiLibrary.cls
@@ -6,7 +6,7 @@ ExternalLibrary subclass: #HttpApiLibrary
 	poolDictionaries: 'WinHttpServerConsts'
 	classInstanceVariableNames: ''!
 HttpApiLibrary guid: (GUID fromString: '{06475580-47cf-4641-9eb7-96d83f2d2e96}')!
-HttpApiLibrary comment: 'HttpApiLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''HttpApi.dll''.It was generated generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
+HttpApiLibrary comment: 'HttpApiLibrary is the <ExternalLibrary> class to represent the dynamic link library, ''HttpApi.dll''. It was generated generated from type information in the ''Win32 API'' library. It contains methods for each of the functions defined by the corresponding module in that type library.
 
 The type library contains the following helpstring for this module
 	"Windows HTTP Server API"


### PR DESCRIPTION
Modify the base image build to include a simple but useful extension that makes a backup copy of the last .pac file for a package before overwriting it. The files are copied to a 'Package backups' folder under the image root folder with a timestamp encoded in the name for uniqueness. The backups are not managed automatically so they will accumulate until deleted. This shouldn't be too much of a concern these days as the packages are generally not that large, but if this is a problem then there is a PackageBackup icon under Tools/Options/Inspect Options that can be used to disable the backup. Or evaluate `PackageBackup disable`. Some kind of cleanup, perhaps to limit the age of the backups that are kept, could be devised of course.

The motivation to add this now is #1266. This isn't a bug fix, but as I commented on the issue the particular outcome described doesn't correlate with a failure in Dolphin, so there is no actionable bug to address. Nevertheless, having backup copies created of previously saved packages will reduce the changes of losing work from many causes.

The package was originally contributed by Ian Bartholomew and was present in the repo already. It just needed a small fix, and then I enhanced it to make it fit into the IDE options framework.