### PR TITLE
Walkback on browing RichTextEdit class>>registerClass

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Core.String.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.String.cls
@@ -915,19 +915,24 @@ occurrencesOf: anObject
 		from: 1
 		to: self size!
 
-occurrencesOf: anObject from: startInteger to: endInteger 
-	| current occurrences |
-	current := startInteger.
+occurrencesOf: anObject from: startInteger to: endInteger
+	"Answer how many of the receiver's elements are equal to anObject between the specified code-unit indices. If anObject is not a <Character>, then the answer will be zero. It does not matter if the start of end indices do not correspond to the first and last code-units of complete code-points, but if they do then the incomplete characters of which the indexed code-unit is a part will not be matched, i.e.
+		('🐬a🐬' occurrencesOf: $🐬 from: 2 to: 5) = 0
+		('🐬a🐬' occurrencesOf: $a from: 2 to: 5) = 1
+	"
+
+	| next occurrences |
 	occurrences := 0.
-	[current > endInteger] whileFalse: 
-			[| next |
-			(next := self 
+	next := startInteger.
+	
+	[next > endInteger
+		or: [(next := self
 						nextIndexOf: anObject
-						from: current
-						to: endInteger) == 0 
-				ifTrue: [^occurrences].
-			occurrences := occurrences + 1.
-			current := next + 1].
+						from: next
+						to: endInteger) == 0]]
+			whileFalse: 
+				[occurrences := occurrences + 1.
+				next := next + 1].
 	^occurrences!
 
 prevIndexOf: anObject from: hiInteger to: loInteger

--- a/Core/Object Arts/Dolphin/Base/Core.Symbol.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.Symbol.cls
@@ -8,7 +8,7 @@ Core.Utf8String
 	classInstanceVariableNames: ''
 	classConstants: {
 			'CharClassifications'
-				-> #(nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil #binary nil nil nil #binary #binary nil nil nil #binary #binary #binary #binary nil #binary #digit #digit #digit #digit #digit #digit #digit #digit #digit #digit #colon nil #binary #binary #binary #binary #binary #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic nil #binary nil nil #alphabetic nil #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic nil #binary nil #binary nil)
+				-> #(nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil #binary nil nil nil #binary #binary nil nil nil #binary #binary #binary #binary nil #binary #digit #digit #digit #digit #digit #digit #digit #digit #digit #digit #colon nil #binary #binary #binary #binary #binary #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic nil #binary nil nil #alphabetic nil #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic #alphabetic nil #binary nil #binary nil)
 		}!
 Core.Symbol guid: (Core.GUID fromString: '{87b4c51d-026e-11d3-9fd7-00a0cc3e4a32}')!
 Core.Symbol isNullTerminated: true!
@@ -29,19 +29,22 @@ Symbol complies with the following ANSI protocols:
 argumentCount
 	"Answer the <integer> number of arguments required by a method with the receiver as its selector. The result is undefined if the receiver is not a valid selector."
 
-	| len ch |
+	| len |
 	len := self basicSize.
 	len == 0 ifTrue: [^0].
-	ch := self at: 1.
-	^(ch isEnglishLetter or: [ch == $_])
+	(CharClassifications lookup: (self basicAt: 1)) == #alphabetic
+		ifFalse: 
+			["If valid selector, must be binary"
+			^1].
+	(self at: len) == $:
 		ifTrue: 
-			[(self at: len) == $:
-				ifTrue: [(self
-						occurrencesOf: $:
-						from: 1
-						to: len - 1) + 1]
-				ifFalse: [0]]
-		ifFalse: [1]!
+			["Keyword"
+			^(self
+				occurrencesOf: $:
+				from: 2
+				to: len - 1) + 1].
+	"Unary"
+	^0!
 
 asString
 	"Answer a new <String> containing the characters of the receiver."
@@ -288,12 +291,12 @@ initialize
 	Table isNil ifTrue: [Table := Array new: 3989].
 	empty := #''.
 	VM registryAt: #Symbol put: self.
-	classificationTable := Array new: 128.
+	classificationTable := Array new: 127.
 	'_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-		do: [:alpha | classificationTable at: alpha codePoint + 1 put: #alphabetic].
-	'01234567890' do: [:digit | classificationTable at: digit codePoint + 1 put: #digit].
-	'!!%&*+,-/<=>?@\~|' do: [:binary | classificationTable at: binary codePoint + 1 put: #binary].
-	classificationTable at: $: codePoint + 1 put: #colon.
+		do: [:alpha | classificationTable at: alpha codePoint put: #alphabetic].
+	'01234567890' do: [:digit | classificationTable at: digit codePoint put: #digit].
+	'!!%&*+,-/<=>?@\~|' do: [:binary | classificationTable at: binary codePoint put: #binary].
+	classificationTable at: $: codePoint put: #colon.
 	self addClassConstant: 'CharClassifications' value: classificationTable!
 
 intern: aString
@@ -320,11 +323,11 @@ isLiteralSymbol: aSymbol
 	| size class |
 	size := aSymbol basicSize.
 	size == 0 ifTrue: [^false].
-	class := CharClassifications lookup: (aSymbol basicAt: 1) + 1.
+	class := CharClassifications lookup: (aSymbol basicAt: 1).
 	class == #binary
 		ifTrue: 
 			[2 to: size
-				do: [:i | (CharClassifications lookup: (aSymbol basicAt: i) + 1) == #binary ifFalse: [^false]]]
+				do: [:i | (CharClassifications lookup: (aSymbol basicAt: i)) == #binary ifFalse: [^false]]]
 		ifFalse: 
 			[| includesColon initial |
 			class == #alphabetic ifFalse: [^false].
@@ -333,7 +336,7 @@ isLiteralSymbol: aSymbol
 			2 to: size
 				do: 
 					[:i |
-					class := CharClassifications lookup: (aSymbol basicAt: i) + 1.
+					class := CharClassifications lookup: (aSymbol basicAt: i).
 					initial
 						ifTrue: 
 							[class == #alphabetic ifFalse: [^false].

--- a/Core/Object Arts/Dolphin/Base/External.DynamicLinkLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/External.DynamicLinkLibrary.cls
@@ -407,10 +407,9 @@ default: anExternalLibrary
 	self setDefault: anExternalLibrary!
 
 fileName
-	"Answer the host system file name for the external library the 
-	receiver represents."
+	"Answer the host system file name for the external library the receiver represents."
 
-	^self error: 'Cannot open anonymous library'!
+	^nil!
 
 fromHandle: aHandle
 	"Answers an instance of ExternalLibrary attached to aHandle."

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.SymbolTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.SymbolTest.cls
@@ -33,14 +33,23 @@ newEmptyCollection: anInteger
 	^Symbol intern: (String new: anInteger)!
 
 testArgumentCount
+	self assert: #'' argumentCount equals: 0.
 	self assert: #< argumentCount equals: 1.
+	self assert: #<= argumentCount equals: 1.
 	self assert: #<==> argumentCount equals: 1.
+	self assert: #a argumentCount equals: 0.
 	self assert: #a: argumentCount equals: 1.
-	self assert: #size argumentCount equals: 0.
-	self assert: #_dup: argumentCount equals: 1.
 	self assert: #a:b: argumentCount equals: 2.
 	self assert: #a:r:g:b: argumentCount equals: 4.
-	self assert: #ab:c:def: argumentCount equals: 3!
+	self assert: #ab:c:def: argumentCount equals: 3.
+	self assert: #size argumentCount equals: 0.
+	self assert: #_dup: argumentCount equals: 1.
+	self assert: #_ argumentCount equals: 0.
+	self assert: #_: argumentCount equals: 1.
+	self assert: #_:_: argumentCount equals: 2.
+
+	"Result for non-selectors is undefined, but should not fail"
+	#(#'123' #'🐬' #'a:🐬:') do: [:each | self shouldnt: [each argumentCount] raise: Error]!
 
 testAsString
 	#('abc ' '£' '€' '🐬' '你好') do: 

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.UtfEncodedStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.UtfEncodedStringTest.cls
@@ -849,12 +849,52 @@ testNewWithAll
 
 testOccurrencesOf
 	| subject |
-	subject := self assimilateString: '🐬a£文🐬Ā🍺'.
-	self assert: (subject occurrencesOf: Character dolphin) equals: 2.
+	subject := self assimilateString: '🐬a£文🐬Ā🍺Ā'.
+	self assert: (subject occurrencesOf: $🐬) equals: 2.
 	self assert: (subject occurrencesOf: $£) equals: 1.
+	self assert: (subject occurrencesOf: $文) equals: 1.
 	self assert: (subject occurrencesOf: $ð) equals: 0.
+	self assert: (subject occurrencesOf: $Ā) equals: 2.
 	subject := self collectionClass empty.
-	self assert: (subject occurrencesOf: Character dolphin) equals: 0!
+	self assert: (subject occurrencesOf: $🐬) equals: 0!
+
+testOccurrencesOfFromTo
+	| subject |
+	subject := self assimilateString: '🐬a£文a🐬Ā🍺'.
+	self assert: (subject
+				occurrencesOf: $🐬
+				from: 1
+				to: subject size - 1)
+		equals: 2.
+	2 to: 6
+		do: 
+			[:i |
+			self assert: (subject
+						occurrencesOf: $🐬
+						from: i
+						to: subject size - 1)
+				equals: 1].
+	self assert: (subject
+				occurrencesOf: $a
+				from: 2
+				to: subject size - 1)
+		equals: 2.
+	self assert: (subject
+				occurrencesOf: $🍺
+				from: 2
+				to: subject size)
+		equals: 1.
+	self assert: (subject
+				occurrencesOf: $🍺
+				from: 2
+				to: subject size - 1)
+		equals: 0.
+	subject := self collectionClass empty.
+	self assert: (subject
+				occurrencesOf: $🐬
+				from: 1
+				to: subject size)
+		equals: 0!
 
 testPairsDo
 	| subject pairs |
@@ -1040,6 +1080,7 @@ testMatchExtended!public! !
 testMidString!public!unit tests! !
 testNewWithAll!public! !
 testOccurrencesOf!public!unit tests! !
+testOccurrencesOfFromTo!public!unit tests! !
 testPairsDo!public!unit tests! !
 testReject!public!unit tests! !
 testReverseComposites!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/Tests/External.Tests.DynamicLinkLibraryTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/External.Tests.DynamicLinkLibraryTest.cls
@@ -16,6 +16,14 @@ makeTestMethodFrom: anExternalMethod overlapped: aBoolean
 		ifTrue: [anExternalMethod copy extraIndex: 48; yourself]
 		ifFalse: [anExternalMethod]!
 
+testClosedBaseInstance
+	"Verify that the correct culprit is identified for bad call-outs"
+
+	| subject |
+	subject := DynamicLinkLibrary open: 'kernel32'.
+	subject close.
+	self assert: subject printString equals: 'a DynamicLinkLibrary(NULL - nil)'!
+
 testInvalidCallArguments
 	"Verify that the correct culprit is identified for bad call-outs"
 
@@ -86,6 +94,7 @@ verifyInvalidCallArguments: aBoolean
 		matching: [:ex | ex hresult = (HRESULT fromPrimitiveFailureCode: _PrimitiveFailureCode.InvalidParameter)]! !
 !External.Tests.DynamicLinkLibraryTest categoriesForMethods!
 makeTestMethodFrom:overlapped:!helpers!private! !
+testClosedBaseInstance!public!unit tests! !
 testInvalidCallArguments!public!unit tests! !
 testInvalidOverlappedCallArguments!public!unit tests! !
 testSingletonSerialisationToStb!public!unit tests! !

--- a/Core/Object Arts/Dolphin/IDE/Tools.Tests.IdeaSpaceShellTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Tools.Tests.IdeaSpaceShellTest.cls
@@ -232,11 +232,11 @@ testHistoryRemove
 	self assert: hist isEmpty!
 
 testRemoveCard
-	| sb |
-	sb := self newSystemBrowserCard.
-	self newClassBrowserCard.
+	| card1 |
+	card1 := self newInspectorShellCard.
+	self newInspectorShellCard.
 	super assert: presenter cards size = 2.
-	sb exit.
+	card1 exit.
 	super assert: presenter cards size = 1.
 	presenter closeCard.
 	super assert: presenter cards isEmpty!

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -1303,8 +1303,10 @@ Core.Object
 	classInstanceVariableNames: ''
 	classConstants: {
 			'DefaultMask' -> 16r1.
+			'MaximumId' -> 16r7FFF.
 			'ModalMask' -> 16r2.
 			'NotAbortableMask' -> 16r4.
+			'StartingId' -> 16rFA0.
 			'TextSubstitutionsMask' -> 16r8
 		}!
 Core.Object

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.CommandDescription.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.CommandDescription.cls
@@ -8,8 +8,10 @@ Core.Object
 	classInstanceVariableNames: ''
 	classConstants: {
 			'DefaultMask' -> 16r1.
+			'MaximumId' -> 16r7FFF.
 			'ModalMask' -> 16r2.
 			'NotAbortableMask' -> 16r4.
+			'StartingId' -> 16rFA0.
 			'TextSubstitutionsMask' -> 16r8
 		}!
 UI.CommandDescription guid: (Core.GUID fromString: '{87b4c469-026e-11d3-9fd7-00a0cc3e4a32}')!
@@ -319,16 +321,11 @@ initialize
 	CommandDescriptionRegistry isNil
 		ifTrue: 
 			[CommandDescriptionRegistry := WeakIdentityDictionary newWithWeakKeys: 150.
-			CurrentId := self startingId]
+			CurrentId := StartingId]
 		ifFalse: 
 			[CommandDescriptionRegistry
 				haveStrongValues;
 				haveWeakKeys]!
-
-maximumId
-	"Private - Answer the maximum id that we have available."
-
-	^32767!
 
 new
 	"Instances of the receiver must have a command selector specified."
@@ -338,20 +335,17 @@ new
 nextId
 	"Private - Answer the next <SmallInteger> id to use."
 
-	| wrapped max |
+	| wrapped |
 	wrapped := false.
-	max := self maximumId.
-	[ 	(CurrentId := CurrentId + 1) > max ifTrue: [
-			wrapped ifTrue: [^self error: 'There are no unused command ids available.'].
+	
+	[(CurrentId := CurrentId + 1) > MaximumId
+		ifTrue: 
+			[wrapped ifTrue: [^self error: 'There are no unused command ids available. Try closing some windows.'].
 			wrapped := true.
-			CurrentId := self startingId].
-		CommandDescriptionRegistry identityIncludes: CurrentId] whileTrue.
+			CurrentId := StartingId].
+	CommandDescriptionRegistry identityIncludes: CurrentId]
+			whileTrue.
 	^CurrentId!
-
-startingId
-	"Private - Answer the first id which we can safely use."
-
-	^4000!
 
 stbConvertFrom: anSTBClassFormat
 	"Convert from earlier CommandDescription versions."
@@ -420,10 +414,8 @@ command:description:!instance creation!public! !
 command:description:image:!instance creation!public! !
 idFor:!command registry!private! !
 initialize!development!initializing!private! !
-maximumId!command registry!private! !
 new!instance creation!public! !
 nextId!command registry!private! !
-startingId!command registry!private! !
 stbConvertFrom:!binary filing!public! !
 stbConvertFromVersion1:!binary filing!public! !
 stbConvertFromVersion3:!binary filing!public! !


### PR DESCRIPTION
Closed DynamicLinkLibrary instance throws an error from its `printOn:`

Also speed up IdeaSpaceShellTest>>testRemoveCard which is frequently reported as slow