### PR TITLE
Fix #1275: Tree views paint incorrectly when tools are added to Idea …

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/ShellView.cls
@@ -660,6 +660,9 @@ onPositionChanged: aPositionEvent
 	does not, so we override to invalidate only on resize. This is also a suitable
 	time to revalidate too."
 
+	self isTopView ifFalse:
+			["May be embedded in some sort of MDI shell, e.g. the Idea Space. If so we do not want to perform the shell-level processing, especially revalidating the layout as this can cause the view to paint incorrectly."
+			"^super onPositionChanged: aPositionEvent"].
 	aPositionEvent isClientAreaChanged ifTrue: [self invalidateLayoutDeeply].
 	(aPositionEvent isHideWindow not and: [self isWindowVisible])
 		ifTrue: 
@@ -689,6 +692,7 @@ onSettingChanged: aSettingsChangeEvent
 	^aSettingsChangeEvent lResult!
 
 onStateRestored
+	self isTopView ifFalse: [^self].
 	self updateMenuBar.
 	self setDefId: defaultButton.
 	self invalidateUserInterface!
@@ -872,6 +876,7 @@ restorePlacement: aWINDOWPLACEMENT resolution: aPointResolution
 	message to compensate for a resolution change in any other ways required."
 
 	| rect desktopResolution |
+	self isTopView ifFalse: [^super restorePlacement: aWINDOWPLACEMENT resolution: aPointResolution].
 	rect := aWINDOWPLACEMENT rcNormalPosition asRectangle.
 	desktopResolution := View desktop resolution.
 	aPointResolution = desktopResolution
@@ -1005,6 +1010,7 @@ updateIcons
 	"Private - Update the large and small icons of the receiver"
 
 	| actualLargeIcon |
+	self isTopView ifFalse: [^self].
 	actualLargeIcon := largeIcon notNil ifTrue: [largeIcon] ifFalse: [self presenter icon].
 	self
 		sendMessage: WM_SETICON


### PR DESCRIPTION
…Space

We need to avoid the shell placement/positioning responses when not actually a top-level view. These upset the initial draw-order of the controls to the extent that the tree views are painted but then erased by the nearest parent that doesn't have WS_CLIPCHILDREN set.

There may be some other behaviour of ShellView
that is not appropriate in the case where the view is actually being hosted in some kind of MDI wrapper, but this is sufficient for now. It isn't strictly necessary to avoid the attempted addition of a menu bar (which fails silently anyway), nor the setting of Window icons, but both do nothing useful so may as well be skipped.
A better solution might be to adjust the class of the view being created by substituting another through some kind of STB override, or perhaps to have pluggable shell behaviour. Either approache could be used to avoid having a proliferation of #isTopView tests (of which there are already a number, and which is really a "type" test).