### PR TITLE
Fix #1275: Tree views paint incorrectly when tools are added to an Idea Space

### DIFF
--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.IdeaSpaceShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.IdeaSpaceShell.cls
@@ -79,7 +79,6 @@ breakoutCurrentCard
 	"Break the current card out onto the desktop"
 
 	<commandQuery: #hasCurrentCard>
-	self removeCardMenubarAndAccelerators.
 	self breakoutCard: self currentCard!
 
 canMoveCardLeft
@@ -358,8 +357,8 @@ registerForCardEvents
 removeCard: cardToRemove 
 	| last |
 	last := self removeHistoryForCard: cardToRemove.
-	self removeCardMenubarAndAccelerators.
 	cardsPresenter remove: cardToRemove.
+	self hasCurrentCard ifFalse: [self removeCardMenubarAndAccelerators].
 	^last!
 
 removeCardMenubarAndAccelerators

--- a/Core/Object Arts/Dolphin/IDE/Tools.Tests.IdeaSpaceShellTest.cls
+++ b/Core/Object Arts/Dolphin/IDE/Tools.Tests.IdeaSpaceShellTest.cls
@@ -22,11 +22,7 @@ create: aClassSymbol subclassOf: aClass
 
 createThreeCards
 	| tools |
-	tools := Array new: 3.
-	presenter view noRedrawDo: 
-			[tools at: 1 put: self newInspectorShellCard.
-			tools at: 2 put: self newInspectorShellCard.
-			tools at: 3 put: self newInspectorShellCard].
+	tools := presenter view noRedrawDo: [(1 to: 3) collect: [:i | self newInspectorShellCard]].
 	self assert: presenter cards size equals: 3.
 	tools do: 
 			[:each |

--- a/Core/Object Arts/Dolphin/MVP/Base/External.RECT.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/External.RECT.cls
@@ -47,6 +47,13 @@ bottomRight
 
 	^self right @ self bottom!
 
+bottomRight: aPoint
+	"Set the receiver's bottom right position to the <Point> argument."
+
+	self
+		right: aPoint x;
+		bottom: aPoint y!
+
 center
 	"Answer a <Point> representing the position of the centre of the receiver."
 
@@ -118,11 +125,37 @@ origin
 	^self topLeft
 !
 
+origin: aPoint
+	"Set the Point at the top left corner of the receiver"
+
+	self topLeft: aPoint!
+
+position: aPoint
+	"Move the receiver so that its top-left corner is at the specified position."
+
+	| ext |
+	ext := self extent.
+	self
+		topLeft: aPoint;
+		extent: ext!
+
 right
 	^self subclassResponsibility!
 
 right: anObject
 	self subclassResponsibility!
+
+scaleBy: delta
+	"Scale the receiver in-place by the specified <Point> or <Number> multiplier."
+
+	self
+		topLeft: self topLeft * delta;
+		bottomRight: self bottomRight * delta!
+
+scaledBy: delta
+	"Answer a new <Rectangle> representing the receiver with origin and corner multiplied by delta, where delta is a Point or a Number. Uses the #vertex:vertex: constructor in order to create a normalised rectangle"
+
+	^self species vertex: self origin * delta vertex: self corner * delta!
 
 species
 	^UI.Rectangle!
@@ -137,6 +170,13 @@ topLeft
 	"Answer a Point representing the top left position of the receiver."
 
 	^self left @ self top!
+
+topLeft: aPoint
+	"Set the <Point> representing the top left position of the receiver."
+
+	self
+		left: aPoint x;
+		top: aPoint y!
 
 width
 	"Answer the width of the receiver."
@@ -155,6 +195,7 @@ asRectangle!converting!public! !
 bottom!accessing!public! !
 bottom:!accessing!public! !
 bottomRight!accessing!public! !
+bottomRight:!accessing!public! !
 center!accessing!public! !
 centerRight!public! !
 centerX!accessing!public! !
@@ -168,12 +209,17 @@ height:!accessing!public! !
 left!accessing!public! !
 left:!accessing!public! !
 origin!accessing!public! !
+origin:!accessing!public! !
+position:!public! !
 right!accessing!public! !
 right:!accessing!public! !
+scaleBy:!public!transforming! !
+scaledBy:!public!transforming! !
 species!comparing!public! !
 top!accessing!public! !
 top:!accessing!public! !
 topLeft!accessing!public! !
+topLeft:!accessing!public! !
 width!accessing!public! !
 width:!accessing!public! !
 !

--- a/Core/Object Arts/Dolphin/MVP/Base/Graphics.Rectangle.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/Graphics.Rectangle.cls
@@ -437,10 +437,13 @@ rounded
 
 	^self species origin: origin rounded corner: corner rounded!
 
-scaleBy: delta 
-	"Answer a new <Rectangle> representing the receiver with origin and corner multiplied by
-	delta, where delta is a Point or a Number. Use the #vertex:vertex: constructor in order to
-	create a normalised rectangle"
+scaleBy: delta
+	"Retained for backwards compatibility, but discouraged because the use of the present tense implies that the operation happens in place, but in fact a new instance is answered. #scaledBy: should be used in preference."
+
+	^self scaledBy: delta!
+
+scaledBy: delta
+	"Answer a new <Rectangle> representing the receiver with origin and corner multiplied by delta, where delta is a Point or a Number. Uses the #vertex:vertex: constructor in order to create a normalised rectangle"
 
 	^self species vertex: origin * delta vertex: corner * delta!
 
@@ -615,6 +618,7 @@ rightCenter!accessing!public! !
 rightCenter:!accessing!public! !
 rounded!public!truncation and round off! !
 scaleBy:!public!transforming! !
+scaledBy:!public!transforming! !
 subtract:!public!rectangle functions! !
 top!accessing!public! !
 top:!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/OS.RECTL.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/OS.RECTL.cls
@@ -53,6 +53,13 @@ extent
 	^Graphics.Point x: (bytes int32AtOffset: _OffsetOf_right) - (bytes int32AtOffset: _OffsetOf_left)
 		y: (bytes int32AtOffset: _OffsetOf_bottom) - (bytes int32AtOffset: _OffsetOf_top)!
 
+extent: aPoint
+	"Set the extent of the receiver to the <Point> argument. The origin remains the same and the corner stays in the same quadrant it was in relative to the origin point. If aPoint contains any negative value, the result is undefined."
+
+	bytes
+		int32AtOffset: _OffsetOf_right put: (bytes int32AtOffset: _OffsetOf_left) + aPoint x;
+		int32AtOffset: _OffsetOf_bottom put: (bytes int32AtOffset: _OffsetOf_top) + aPoint y!
+
 height
 	"Answer the height of the receiver."
 
@@ -107,6 +114,7 @@ bottom!**compiled accessors**!public! !
 bottom:!**compiled accessors**!public! !
 bottomRight!accessing!public! !
 extent!accessing!public! !
+extent:!accessing!public! !
 height!accessing!public! !
 left!**compiled accessors**!public! !
 left:!**compiled accessors**!public! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.ShellView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.ShellView.cls
@@ -665,6 +665,9 @@ onPositionChanged: aPositionEvent
 	does not, so we override to invalidate only on resize. This is also a suitable
 	time to revalidate too."
 
+	self isTopView ifFalse: 
+			["May be embedded in some sort of MDI shell, e.g. the Idea Space. If so we do not want to perform the shell-level processing such as revalidating the layout."
+			^super onPositionChanged: aPositionEvent].
 	aPositionEvent isClientAreaChanged ifTrue: [self invalidateLayoutDeeply].
 	(aPositionEvent isHideWindow not and: [self isWindowVisible])
 		ifTrue: 
@@ -679,6 +682,7 @@ onSettingChanged: aSettingsChangeEvent
 	^aSettingsChangeEvent lResult!
 
 onStateRestored
+	self isTopView ifFalse: [^self].
 	self updateMenuBar.
 	self setDefId: defaultButton.
 	self invalidateUserInterface!
@@ -853,31 +857,24 @@ resolutionScaledBy: scale
 !
 
 restorePlacement: aWINDOWPLACEMENT resolution: aPointResolution
-	"Private - Restore the placement for the receiver to aWINDOWPLACEMENT which was measured at
-	a screen resolution of aPointResolution. If the current resolution is different then the
-	placement rectangle will have to be scaled appropriately. Subclasses can override this
-	message to compensate for a resolution change in any other ways required."
+	"Private - Restore the placement for the receiver to aWINDOWPLACEMENT which was measured at a screen resolution of aPointResolution. If the current resolution is different then the placement rectangle will have to be scaled appropriately. Subclasses can override this message to compensate for a resolution change in any other ways required."
 
-	| rect desktopResolution |
-	rect := aWINDOWPLACEMENT rcNormalPosition asRectangle.
+	| rect desktopResolution extent |
+	self isTopView ifFalse: [^super restorePlacement: aWINDOWPLACEMENT resolution: aPointResolution].
+	rect := aWINDOWPLACEMENT rcNormalPosition.
 	desktopResolution := View desktop resolution.
 	aPointResolution = desktopResolution
 		ifFalse: 
 			[| scale |
-			"Resolution is now different so recompute the placement"
 			scale := desktopResolution / aPointResolution.
-			rect := (rect scaleBy: scale) truncated.
+			rect scaleBy: scale.
 			self resolutionScaledBy: scale].
-
-	"If the receiver wants to use a preferred extent, then use that. Otherwise, choose a default
-	extent."
 	self usePreferredExtent
 		ifTrue: 
-			[| extent |
-			extent := self preferredExtent ifNil: [self defaultExtentWithin: creationParent].
-			rect extent: extent].
-	rect position: (self defaultPositionWithin: creationParent forExtent: rect extent).
-	aWINDOWPLACEMENT rcNormalPosition: rect asParameter.
+			[extent := self preferredExtent ifNil: [self defaultExtentWithin: creationParent].
+			rect extent: extent]
+		ifFalse: [extent := rect extent].
+	rect position: (self defaultPositionWithin: creationParent forExtent: extent).
 	self placement: aWINDOWPLACEMENT!
 
 setButtonId: id style: style
@@ -992,6 +989,7 @@ updateIcons
 	"Private - Update the large and small icons of the receiver"
 
 	| actualLargeIcon |
+	self isTopView ifFalse: [^self].
 	actualLargeIcon := largeIcon ifNil: [self presenter icon].
 	self
 		sendMessage: WM_SETICON

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.View.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.View.cls
@@ -3080,27 +3080,23 @@ restoreFromProxy: aViewProxy
 	self handle.
 	self onRestoredFromProxy!
 
-restorePlacement: aWINDOWPLACEMENT resolution: aPointResolution 
+restorePlacement: aWINDOWPLACEMENT resolution: aPointResolution
 	"Private - Restore the placement for the receiver to aWINDOWPLACEMENT which was
 	measured at a screen resolution of aPointResolution. If the current resolution is different
 	then the placement rectangle will have to be scaled appropriately. 
 	Subclasses can override this message to compensate for a resolution change
 	in any other ways required."
 
-	| placement res |
-	placement := aWINDOWPLACEMENT.
+	| res |
 	res := self resolution.
-	aPointResolution = res 
+	aPointResolution = res
 		ifFalse: 
-			["Resolution is now different so recompute the placement"
-
-			| rect scale |
+			[| scale |
+			"Resolution is now different so recompute the placement"
 			scale := res / aPointResolution.
-			rect := placement rcNormalPosition asRectangle.
-			rect := rect scaleBy: scale.
-			placement rcNormalPosition: rect truncated asParameter.
+			aWINDOWPLACEMENT rcNormalPosition scaleBy: scale.
 			self resolutionScaledBy: scale].
-	self placement: placement!
+	self placement: aWINDOWPLACEMENT!
 
 richText: aRichText
 	"Private - Set the text contents of the receiver to the RTF text, aRichText.
@@ -3234,10 +3230,8 @@ setNoRedrawCount: anInteger
 	^self propertyAt: #_noRedrawCount put: anInteger!
 
 setParent: aView
-	| isDesktopParent |
 	self parentView: aView.
-	isDesktopParent := aView == self class desktop.
-	self setWindowStyle: (self getWindowStyle mask: WS_CHILD set: isDesktopParent not).
+	self setWindowStyle: (self getWindowStyle mask: WS_CHILD set: aView ~~ self class desktop).
 	User32 setParent: handle hWndNewParent: aView asParameter!
 
 setRedraw: aBoolean

--- a/Core/Object Arts/Dolphin/MVP/Tests/External.Tests.RECTTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/Tests/External.Tests.RECTTest.cls
@@ -25,9 +25,32 @@ testMarshal
 	self assert: subject equals: rectangle.
 	rectangle2 := subject asRectangle.
 	self assert: rectangle2 isKindOf: UI.Rectangle.
-	self assert: rectangle2 equals: rectangle! !
+	self assert: rectangle2 equals: rectangle!
+
+testScaleBy
+	"Test scaling in-place"
+
+	| rect |
+	rect := self subjectClass marshal: (2 @ 2 corner: 6 @ 4).
+	rect scaleBy: 2.
+	self assert: rect left equals: 4.
+	self assert: rect right equals: 12.
+	self assert: rect top equals: 4.
+	self assert: rect bottom equals: 8.
+	rect := self subjectClass marshal: (2 @ 2 corner: 6 @ 4).
+	rect scaleBy: 1 / 2.
+	self assert: rect left equals: 1.
+	self assert: rect right equals: 3.
+	self assert: rect top equals: 1.
+	self assert: rect bottom equals: 2.
+	rect scaleBy: 0.
+	self assert: rect left equals: 0.
+	self assert: rect right equals: 0.
+	self assert: rect top equals: 0.
+	self assert: rect bottom equals: 0! !
 !External.Tests.RECTTest categoriesForMethods!
 testAsRectangle!public! !
 testMarshal!public! !
+testScaleBy!public!unit tests! !
 !
 

--- a/Core/Object Arts/Dolphin/MVP/Tests/Graphics.Tests.AbstractRectangleTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/Tests/Graphics.Tests.AbstractRectangleTest.cls
@@ -92,12 +92,37 @@ testOriginCorner
 	rect2 := testMethod value: self subjectClass withArguments: {100 @ 200. 300 @ 400}.
 	self assert: rect2 equals: rect!
 
+testPosition
+	| rect ext |
+	rect := self subjectClass origin: 2 @ 1 corner: 6 @ 4.
+	ext := rect extent.
+	rect position: 1 @ 3.
+	self assert: rect origin equals: 1 @ 3.
+	self assert: rect extent equals: ext.
+	self assert: rect corner equals: rect origin + ext!
+
 testRight
 	self assert: desktop right equals: 1280.
 	desktop right: 3072.
 	self assert: desktop right equals: 3072.
 	self assert: desktop width equals: 3072
 !
+
+testScaledBy
+	| rect |
+	rect := 2 @ 2 corner: 6 @ 4.
+	self assert: (rect scaledBy: 2) left equals: 4.
+	self assert: (rect scaledBy: 2) right equals: 12.
+	self assert: (rect scaledBy: 2) top equals: 4.
+	self assert: (rect scaledBy: 2) bottom equals: 8.
+	self assert: (rect scaledBy: 1 / 2) left equals: 1.
+	self assert: (rect scaledBy: 1 / 2) right equals: 3.
+	self assert: (rect scaledBy: 1 / 2) top equals: 1.
+	self assert: (rect scaledBy: 1 / 2) bottom equals: 2.
+	self assert: (rect scaledBy: 0) left equals: 0.
+	self assert: (rect scaledBy: 0) right equals: 0.
+	self assert: (rect scaledBy: 0) top equals: 0.
+	self assert: (rect scaledBy: 0) bottom equals: 0!
 
 testTop
 	self assert: oddDesktop top equals: 2.
@@ -121,7 +146,9 @@ testCopy!public! !
 testHeight!public!unit tests! !
 testLeft!public!unit tests! !
 testOriginCorner!public!unit tests! !
+testPosition!public!unit tests! !
 testRight!public!unit tests! !
+testScaledBy!public!unit tests! !
 testTop!public!unit tests! !
 testWidth!public!unit tests! !
 !


### PR DESCRIPTION
We need to avoid the shell placement/positioning responses when not actually a top-level view. These upset the initial draw-order of the controls to the extent that the tree views are painted but then erased by the nearest parent that doesn't have WS_CLIPCHILDREN set.

There may be some other behaviour of ShellView that is not appropriate in the case where the view is actually being hosted in some kind of MDI wrapper, but this is sufficient for now. It isn't strictly necessary to avoid the attempted addition of a menu bar (which fails silently anyway), nor the setting of Window icons, but both do nothing useful so may as well be skipped.
A better solution might be to adjust the class of the view being created by substituting another through some kind of STB override, or perhaps to have pluggable shell behaviour. Either approach could be used to avoid having a proliferation of #isTopView tests (of which there are already a number, and which is really a "type" test).