### PR TITLE
Further changes to complete fix for #1291

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Tests/DelayTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/DelayTest.cls
@@ -22,7 +22,7 @@ expectDelay: expectedDuration for: nowMicroseconds
 	e.g. if the CPU is very busy, this should happen only rarely, and we do not want
 	to tolerate it if it happens all the time as that would indicate an actual bug."
 	self assert: (delta > -1000 and: [delta < 3000])
-		description: ('Expected delay of <1d>ms, got <2d>ms' expandMacrosWith: expectedDuration
+		description: ('Expected delay of <1d>, got <2d>ms' expandMacrosWith: expectedDuration humanReadablePrintString
 				with: (elapsed // 100 / 10 asScaledDecimal: 1))!
 
 setUp

--- a/Core/Object Arts/Dolphin/MVP/Tests/TreeViewTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/Tests/TreeViewTest.cls
@@ -143,7 +143,7 @@ testViewModes
 	canvas := presenter canvas.
 	canvas font: presenter actualFont.
 	"The minimum height is determined by the font height, plus a 1 pixel border, rounded to even"
-	minHeight := canvas textMetrics tmHeight + (2 * dpi // USER_DEFAULT_SCREEN_DPI) roundTo: 2.
+	minHeight := canvas textMetrics tmHeight + 2 roundTo: 2.
 	canvas free.
 	presenter class viewModes keysAndValuesDo: 
 			[:eachKey :eachValue |

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/ListView.cls
@@ -171,12 +171,18 @@ applyImageLists
 	| largeImList smallExt dpi |
 	dpi := self dpi.
 	largeImList := self customImageExtent
-				ifNotNil: [:ext | self thumbnailsImageManager imageListWithExtent: ext * dpi // USER_DEFAULT_SCREEN_DPI]
+				ifNotNil: 
+					[:ext |
+					self thumbnailsImageManager
+						imageListWithExtent: (Icon standardSizeFor: ext * dpi // USER_DEFAULT_SCREEN_DPI)]
 				ifNil: 
 					[thumbnailsImageManager := nil.
 					self imageManager
-						ifNotNil: [:im | im imageListWithExtent: self largeIconExtent * dpi // USER_DEFAULT_SCREEN_DPI]].
-	smallExt := self smallIconExtent * dpi // USER_DEFAULT_SCREEN_DPI.
+						ifNotNil: 
+							[:im |
+							im
+								imageListWithExtent: (Icon standardSizeFor: self largeIconExtent * dpi // USER_DEFAULT_SCREEN_DPI)]].
+	smallExt := Icon standardSizeFor: self smallIconExtent * dpi // USER_DEFAULT_SCREEN_DPI.
 	"The state image list must be set first to avoid a sizing bug in the control, e.g. on certain DPI changes"
 	self hasCheckBoxes
 		ifFalse: 

--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Toolbar.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/Toolbar.cls
@@ -725,7 +725,7 @@ scaledBitmapSize
 
 	| size |
 	size := self actualBitmapSize.
-	^self isScalable ifTrue: [size * self dpi // USER_DEFAULT_SCREEN_DPI] ifFalse: [size]!
+	^self isScalable ifTrue: [Icon standardSizeFor: (size * self dpi // USER_DEFAULT_SCREEN_DPI)] ifFalse: [size]!
 
 scalePadding: anInteger
 	^anInteger * self actualBitmapSize x * self dpi // ##(16 * USER_DEFAULT_SCREEN_DPI)!


### PR DESCRIPTION
- Omitted clamping images to standard sizes in ListView
- Should also constrain toolbar images to standard sizes
- TreeView border for smaller images doesn't actually scale with DPI (test