### PR TITLE
Fix #1288: High Dpi: Status bars do not resize correctly on change of DPI

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBar.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Control Bars/StatusBar.cls
@@ -408,16 +408,7 @@ updateItem: aStatusBarItem
 
 	self setRightEdges.
 	self setItemText: aStatusBarItem.
-	self invalidateRect: (self rectangleOfItem: aStatusBarItem)!
-
-wmDpiChangedBeforeParent: message wParam: wParam lParam: lParam
-	super
-		wmDpiChangedBeforeParent: message
-		wParam: wParam
-		lParam: lParam.
-	"If not using preferred extent, then rescale the height. If using preferred extent, this will adjust automatically to fit the font/icons as part of layout."
-	self usePreferredExtent ifFalse: [self extent: self extent * self dpi // self topView dpi].
-	^nil! !
+	self invalidateRect: (self rectangleOfItem: aStatusBarItem)! !
 
 !StatusBar categoriesForMethods!
 addItem:!adding!items!public! !
@@ -464,7 +455,6 @@ setWindowText:!accessing!private!win32 bug fix! !
 size!accessing!public! !
 sizeGripWidth!constants!private! !
 updateItem:!private!updating! !
-wmDpiChangedBeforeParent:wParam:lParam:!event handling-win32!private! !
 !
 
 !StatusBar class methodsFor!


### PR DESCRIPTION
Remove StatusBar override of #wmDpiChangedBeforeParent:, which is not necessary since Windows and the superclass implementation do all the rescaling necessary. The override ends up scaling up or down again, causing the bar height to either grow or shrink too much.