### PR TITLE
FontDialog should not directly modify logFont of its Font value

### DIFF
--- a/Core/Object Arts/Dolphin/MVP/Base/SystemMetrics.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/SystemMetrics.cls
@@ -112,7 +112,12 @@ getIconTitleFont
 	^(self
 		getSysParamForDpi: SPI_GETICONTITLELOGFONT
 		type: LOGFONTW
-		ifError: []) ifNil: [Font system atDpi: self dpi] ifNotNil: [:lf | Font fromLogFont: lf dpi: dpi]!
+		ifError: [])
+			ifNil: [Font system atDpi: self dpi]
+			ifNotNil: 
+				[:lf |
+				lf isImmutable: true.
+				Font fromLogFont: lf dpi: dpi]!
 
 getMetric: anInteger 
 	^UserLibrary default getSystemMetricsForDpi: anInteger dpi: dpi!

--- a/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FontDialog.cls
+++ b/Core/Object Arts/Dolphin/MVP/Dialogs/Common/FontDialog.cls
@@ -48,13 +48,9 @@ model: aValueModel
 	"Note that the LOGFONT we pass to the dialog must be scaled for the current system DPI, regardless of the DPI of the monitor where the dialog is opened."
 	sysmetrics := SystemMetrics current.
 	font := (self value ifNil: [sysmetrics iconTitleFont]) atDpi: sysmetrics dpi.
-	lf := font logFont.
+	lf := font logFont copy.
 	"If the font's height is specified as cell height, ensure translated to character height."
-	lf lfHeight > 0
-		ifTrue: 
-			[lf := lf copy
-						lfHeight: font pixelSize negated;
-						yourself].
+	lf lfHeight > 0 ifTrue: [lf lfHeight: font pixelSize negated].
 	self winStruct logFont: lf!
 
 winStructClass


### PR DESCRIPTION
Fix for a bug introduced by https://github.com/dolphinsmalltalk/Dolphin/commit/d44818d38d6b1cc8d1837c29891b2ec3e8e56a0d as part of the high DPI work, that using the font dialog to alter an existing font aspect modifies the internal LOGFONT structure of the existing font. If that font is a shared item, e.g. the icon title font, then there is the unfortunate global side effect of the shared font becoming modified for all of its uses.