### PR TITLE
Fix #1319: DB Connection buffer classes must be retained on deployment

### DIFF
--- a/Core/Object Arts/Dolphin/Database/DBColAttr.cls
+++ b/Core/Object Arts/Dolphin/Database/DBColAttr.cls
@@ -292,7 +292,7 @@ new
 	^super new initialize! !
 
 !DBColAttr class categoriesForMethods!
-initialize!initializing!private! !
+initialize!initializing!must not strip!private! !
 new!instance creation!public! !
 !
 

--- a/Core/Object Arts/Dolphin/Database/Database Connection Base.pax
+++ b/Core/Object Arts/Dolphin/Database/Database Connection Base.pax
@@ -128,8 +128,7 @@ package globalAliases: (Set new
 package setPrerequisites: #(
 	'..\Base\Dolphin'
 	'..\Base\Dolphin Legacy Date & Time'
-	'..\Registry\Dolphin Registry Access'
-).
+	'..\Registry\Dolphin Registry Access').
 
 package!
 
@@ -377,13 +376,13 @@ Error subclass: #DBError
 
 Notification subclass: #DBWarning
 	instanceVariableNames: ''
-	classVariableNames: ''
+	classVariableNames: 'TraceStream'
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 
 ExternalLibrary subclass: #ODBCLibrary
 	instanceVariableNames: ''
-	classVariableNames: 'TraceStream'
+	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 

--- a/Core/Object Arts/Dolphin/Installation Manager/DolphinBaseProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/DolphinBaseProduct.cls
@@ -80,6 +80,7 @@ contents
 		add: #('Core\Object Arts\Samples\MVP\Sliding Ball Demo\SlidingBallDemo.pax' #plain #imageBased);
 		add: #('Core\Object Arts\Samples\IDE\Dolphin IDE Extension Example.pax' #plain #imageBased);
 		add: #('Core\Object Arts\Samples\MVP\Wordpad\Wordpad.pax' #plain #imageBased);
+		add: #('Core\Object Arts\Samples\Database\DumpTable\DumpTable.pax' #plain #imageBased);
 		yourself.
 
 	"Differences Presenter"

--- a/Core/Object Arts/Dolphin/Lagoon/Lagoon Tests.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/Lagoon Tests.pax
@@ -24,6 +24,7 @@ package globalAliases: (Set new
 package setPrerequisites: #(
 	'..\Base\Dolphin'
 	'..\Base\Tests\Dolphin Base Tests'
+	'..\..\Samples\Database\DumpTable\DumpTable'
 	'..\..\Samples\MVP\Etch-a-Sketch\Etch-a-Sketch'
 	'..\..\Samples\MVP\Hello World\Hello World'
 	'..\..\Samples\Console\Hello World\Hello World (Console)'

--- a/Core/Object Arts/Dolphin/Lagoon/PackageClosureTests.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/PackageClosureTests.cls
@@ -21,6 +21,15 @@ consoleAppUnimplemented
 
 	^#(#defineTemplate #packages)!
 
+consoleDbAppUnimplemented
+	"Private - Expected missing selectors in a console app using the Database Connection package:
+		- defaultIcon - referenced from RegKeyAbstract and subclasses class icon methods. Icon is referenced from ResourceIdentifier which is part of the base Dolphin package, but which will be removed by actual deployment of a non-GUI app.
+		- defineTemplate - sent by ExternalStructure class>>ensureDefined, but this caller is replaced by an empty stub on actual deployment
+		- packages - sent by PackageRelativeFileLocator>>#package, but class will be removed on actual deployment
+	In practice the only unimplemented message in a simple console DB sample after deployment is #rollback. This is implemented by DBTransaction, which is removed in simple apps that are not using transactions."
+
+	^#(#defaultIcon #defineTemplate #packages)!
+
 environmentForAppDeployment: aCollectionOfPackages
 	| env names devMethods removedClasses |
 	"The in-scope world is drawn from the slice of the classes & methods that are in the requested packages and their pre-reqs"
@@ -78,6 +87,12 @@ testCommandLineHelloWorld
 
 	self verifyPackageClosure: (self environmentForAppDeployment: {CommandLineHelloWorld owningPackage})
 		missing: self consoleAppUnimplemented!
+
+testDumpTable
+	"Tests predicted unimplemented messages of a fairly minimal console application using Database Connection."
+
+	self verifyPackageClosure: (self environmentForAppDeployment: {DumpTable owningPackage})
+		missing: self consoleDbAppUnimplemented!
 
 testEtchASketch
 	"Etch-a-sketch uses STB."
@@ -144,10 +159,12 @@ verifyPackageClosure: aBrowserEnvironment missing: aCollectionOfSymbols
 
 !PackageClosureTests categoriesForMethods!
 consoleAppUnimplemented!constants!private! !
+consoleDbAppUnimplemented!constants!private! !
 environmentForAppDeployment:!helpers!private! !
 environmentForPackageClosure:!helpers!private! !
 simpleGuiAppUnimplementedMessages!constants!private! !
 testCommandLineHelloWorld!public!unit tests! !
+testDumpTable!public!unit tests! !
 testEtchASketch!public!unit tests! !
 testHelloWorld!public!unit tests! !
 testNotepad!public!unit tests! !

--- a/Core/Object Arts/Samples/Database/DumpTable/DumpTable.cls
+++ b/Core/Object Arts/Samples/Database/DumpTable/DumpTable.cls
@@ -1,0 +1,92 @@
+﻿"Filed out from Dolphin Smalltalk"!
+
+ConsoleSessionManager subclass: #DumpTable
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+
+DumpTable guid: (GUID fromString: '{da1a24df-82b3-42ad-b41f-c27e026fb8a3}')!
+
+DumpTable comment: ''!
+
+!DumpTable categoriesForClass!Unclassified! !
+
+!DumpTable methodsFor!
+
+debugTraceStream
+	"Private - We want to dump any ODBC driver warnings to debug output, not stderr, so answer a DebugTraceStream. We need to ensure there is a live reference to the class, to prevent it being removed on deployment."
+
+	^DebugTraceStream current!
+
+dumpTable: tableNameString of: dsnString on: aStream
+	| connection sql query columnNames |
+	connection := DBConnection new.
+	connection dsn: dsnString.
+	connection open.
+	aStream
+		nextPutAll: 'Tables in ';
+		print: connection dataSourceName;
+		cr;
+		cr.
+	connection tables do: 
+			[:each |
+			aStream
+				tab;
+				nextPutAll: each;
+				cr].
+	tableNameString isNil ifTrue: [^self].
+	(tableNameString includes: $") ifTrue: [self usage: -2].
+	sql := 'select * from "<1s>"' << tableNameString.
+	query := connection query: sql.
+	aStream
+		cr;
+		nextPutAll: tableNameString;
+		nextPutAll: ' contains ';
+		flush;
+		print: query size;
+		nextPutAll: ' rows:';
+		cr;
+		cr.
+	columnNames := String streamContents: 
+					[:strm |
+					query columns do: [:each | strm nextPutAll: each name] separatedBy: [strm nextPutAll: ' | ']].
+	aStream
+		nextPutAll: columnNames;
+		cr.
+	columnNames size timesRepeat: [aStream nextPut: $=].
+	aStream cr.
+	query do: 
+			[:eachRow |
+			eachRow contents do: [:each | aStream print: each] separatedBy: [aStream nextPutAll: ' | '].
+			aStream cr].
+	query free.
+	connection close!
+
+main
+	self argc < 2 ifTrue: [self usage: -1].
+	DBWarning traceStream: self debugTraceStream.
+	self
+		dumpTable: (self argc > 2 ifTrue: [self argv third])
+		of: self argv second
+		on: self stdout!
+
+usage: anInteger
+	self stderr
+		nextPutAll: 'Dolphin Smalltalk Dump Table Sample';
+		cr;
+		nextPutAll: 'Copyright © Object Arts Ltd, 2025.';
+		crtab: 1;
+		nextPutAll: 'Usage: ';
+		display: self argv first;
+		nextPutAll: ' <ODBC DSN> [<Table name>]';
+		cr.
+	self primQuit: anInteger! !
+
+!DumpTable categoriesForMethods!
+debugTraceStream!operations-startup!private! !
+dumpTable:of:on:!operations-startup!public! !
+main!operations-startup!public! !
+usage:!operations-startup!public! !
+!
+

--- a/Core/Object Arts/Samples/Database/DumpTable/DumpTable.pax
+++ b/Core/Object Arts/Samples/Database/DumpTable/DumpTable.pax
@@ -1,0 +1,59 @@
+﻿| package |
+package := Package name: 'DumpTable'.
+package paxVersion: 1;
+	basicComment: 'Dolphin Smalltalk Dump Table Sample. 
+Copyright © Object Arts Ltd, 2025.
+
+An application using DBConnection. It is intended primarily for testing app deployment rather than to do anything useful.
+
+## Deployment
+
+Note: When working with  ''Database Connection'', always deploy from a freshly started image as finalization of old statements and connections may cause errors during the deployment. If this happens and the crash dump log shows a faulting call into the ODBCLibrary to free a handle, just restart the image and repeat the deployment.
+
+```
+Smalltalk developmentSystem saveImage.	"Save the image if you don''t want to lose changes"
+(ImageStripper new)
+	rootPackage: DumpTable owningPackage;
+	executableName: ''dumptable.exe'';
+	preserveAspectSetters: false;
+	stripDeprecatedMethods: true;
+	deploy
+``````
+
+And to examine the content: 
+
+```
+"Browse the classes and methods in the deployed application"
+Smalltalk developmentSystem browseDeploymentLog: ''dumptable.xml''.
+"Or just view the log"
+XmlPad filename: ''dumptable.xml''
+```
+'.
+
+package classNames
+	add: #DumpTable;
+	yourself.
+
+package binaryGlobalNames: (Set new
+	yourself).
+
+package globalAliases: (Set new
+	yourself).
+
+package setPrerequisites: #(
+	'..\..\..\Dolphin\Database\Database Connection Base'
+	'..\..\..\Dolphin\System\Trace\Debug Trace Stream'
+	'..\..\..\Dolphin\Base\Dolphin').
+
+package!
+
+"Class Definitions"!
+
+ConsoleSessionManager subclass: #DumpTable
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+
+"End of package definition"!
+


### PR DESCRIPTION
DBColAttr class>>#initialize is the only reference in code to the database buffer classes, and so must not be stripped or the buffer classes will be removed.

A new package closure test is included, but unfortunately the closure test mechanism isn't sophisticated enough to catch this particular fault because it only finds missing code caused by the calculation of the transitive closure of packages required for an application. It does not account for code removed by the deployment process that iteratively removes (supposedly) unreferenced methods and classes, as this is difficult to simulate. It looks possible to create a better test simulation using RB environments than the simplistic approach currently employed, but it is not easy, and in the meantime this corrects the particular case of the apps using Database Connection not working after deployment. I plan to do some further work in this in the Dolphin 8 branch, but I probably won't back port it.