### PR TITLE
Fix for #1319 in Dolphin 8 and some related extras

### DIFF
--- a/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBRefactorings.pax
+++ b/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RBRefactorings.pax
@@ -791,7 +791,7 @@ realClass!public! !
 !Core.Metaclass methodsFor!
 
 classInModel: aRBModel
-	^(instanceClass classInModel: aRBModel) metaclass!
+	^(instanceClass classInModel: aRBModel) ifNotNil: [:modelClass | modelClass metaclass]!
 
 instancesAreClasses
 	^true! !

--- a/Core/Object Arts/Dolphin/Base/Core.Message.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.Message.cls
@@ -30,8 +30,7 @@ argument
 	^args single!
 
 argumentCount
-	"Answer the <integer> number of arguments in the receiver's
-	message."
+	"Answer the <integer> number of arguments in the receiver's message."
 
 	^args size!
 
@@ -52,6 +51,12 @@ asSymbol
 	"Answer the receiver's <selector>."
 
 	^selector!
+
+cull: anObject 
+	^self value: anObject!
+
+cull: arg1 cull: arg2 
+	^self argumentCount == 0 ifTrue: [self cull: arg1] ifFalse: [self value: arg1 value: arg2]!
 
 forwardTo: anObject
 	"Send the receiver Message to anObject for evaluation, 
@@ -146,22 +151,29 @@ selector: aSymbol arguments: argArray
 
 value: anObject
 	"Answer the result of sending the receiver to the object, anObject.
-	Implementation Note: By implementing this selector from the monadic
-	valuable protocol, we enable the substitution of Messages for a
-	large number of parameterization cases where blocks would otherwise
-	be required."
+	Implementation Note: By implementing this selector from the monadic valuable protocol, we enable the substitution of Messages for a large number of parameterization cases where blocks would otherwise be required."
 
 	^anObject perform: selector withArguments: args!
 
 value: receiver value: argument
-	"Answer the result of sending the receiving message to the object, receiver,
-	with the argument, argument.
-	Implementation Note: By implementing this selector from the dyadic
-	valuable protocol, we enable the substitution of Messages for a
-	further set of parameterization cases where blocks would otherwise
-	be required."
+	"Answer the result of sending the receiving message to the object, receiver, with the argument, argument.
+	Implementation Note: By implementing this selector from the dyadic valuable protocol, we enable the substitution of Messages for a further set of parameterization cases where blocks would otherwise be required."
 
 	^receiver perform: selector with: argument!
+
+value: receiver value: arg1 value: arg2
+	"Answer the result of sending the receiving message to the object, receiver, with the arguments, arg1, and arg2."
+
+	^receiver perform: selector with: arg1 with: arg2!
+
+value: receiver value: arg1 value: arg2 value: arg3
+	"Answer the result of sending the receiving message to the object, receiver, with the arguments, arg1, arg2 and arg3."
+
+	^receiver
+		perform: selector
+		with: arg1
+		with: arg2
+		with: arg3!
 
 valueWithArguments: argArray
 	"Evaluate the receiver with an <Array> of arguments in argArray"
@@ -175,6 +187,8 @@ argumentCount!accessing!public! !
 arguments!accessing!public! !
 arguments:!accessing!public! !
 asSymbol!converting!public! !
+cull:!evaluating!public! !
+cull:cull:!evaluating!public! !
 forwardTo:!operations!public! !
 forwardTo:with:!operations!private! !
 forwardTo:withArguments:!operations!private! !
@@ -188,6 +202,8 @@ selector:!accessing!public! !
 selector:arguments:!initializing!private! !
 value:!evaluating!public! !
 value:value:!evaluating!public! !
+value:value:value:!evaluating!public! !
+value:value:value:value:!evaluating!public! !
 valueWithArguments:!evaluating!public! !
 !
 

--- a/Core/Object Arts/Dolphin/Base/Core.MessageSendAbstract.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.MessageSendAbstract.cls
@@ -26,23 +26,23 @@ Athough Message Sends are complete in themselves, they also respond to the valua
 
 	^super = aMessageSend and: [self receiver == aMessageSend receiver]!
 
-cull: arg 
-	^selector numArgs = 0 ifTrue: [self value] ifFalse: [self value: arg]!
+cull: arg
+	^self argumentCount == 0 ifTrue: [self value] ifFalse: [self value: arg]!
 
 cull: arg1 cull: arg2 
-	^selector numArgs < 2 ifTrue: [self cull: arg1] ifFalse: [self value: arg1 value: arg2]!
+	^self argumentCount < 2 ifTrue: [self cull: arg1] ifFalse: [self value: arg1 value: arg2]!
 
-cull: arg1 cull: arg2 cull: arg3 
-	^selector numArgs < 3 
+cull: arg1 cull: arg2 cull: arg3
+	^self argumentCount < 3
 		ifTrue: [self cull: arg1 cull: arg2]
 		ifFalse: 
-			[self 
+			[self
 				value: arg1
 				value: arg2
 				value: arg3]!
 
 cull: arg1 cull: arg2 cull: arg3 cull: arg4 
-	^selector numArgs < 4 
+	^self argumentCount < 4 
 		ifTrue: 
 			[self 
 				cull: arg1

--- a/Core/Object Arts/Dolphin/Base/DolphinClasses.st
+++ b/Core/Object Arts/Dolphin/Base/DolphinClasses.st
@@ -4149,7 +4149,7 @@ External.WindowsSystemLibrary
 External.WindowsSystemLibrary
 	subclass: #'OS.UserLibrary'
 	instanceVariableNames: ''
-	classVariableNames: 'DesiredDpiAwarenessContext SystemDpiAwareness'
+	classVariableNames: 'DesiredDpiAwarenessContext DpiAwarenessContext'
 	imports: #(#{OS.MessageBoxConstants private})
 	classInstanceVariableNames: ''
 	classConstants: {}!

--- a/Core/Object Arts/Dolphin/Base/Kernel.EventMessageSend.cls
+++ b/Core/Object Arts/Dolphin/Base/Kernel.EventMessageSend.cls
@@ -18,11 +18,21 @@ When evaluate with extra arguments, an EventMessageSend merges its own argument 
 
 !Kernel.EventMessageSend methodsFor!
 
+argumentCount
+	"Answer the <integer> number of arguments in the receiver's message."
+
+	^expectedArgCount!
+
 asMessageSend
 	^MessageSend
 		receiver: self receiver
 		selector: selector
-		arguments: (Array withAll: self arguments)!
+		arguments: ((Array new: expectedArgCount)
+				replaceFrom: 1
+					to: (expectedArgCount min: args basicSize)
+					with: args
+					startingAt: 1;
+				yourself)!
 
 forwardTo: anObject withArguments: triggerArguments
 	"Private - Send the receiver Message to the <Object>, anObject, with the <Array> of arguments, anArray.	
@@ -85,7 +95,8 @@ value
 				withArguments: (expectedArgCount == args size ifTrue: [args] ifFalse: [self mergeArguments: #()])]! !
 
 !Kernel.EventMessageSend categoriesForMethods!
-asMessageSend!public! !
+argumentCount!accessing!public! !
+asMessageSend!converting!public! !
 forwardTo:withArguments:!evaluating!private! !
 mergeArguments:!evaluating!private! !
 postCopy!copying!public! !

--- a/Core/Object Arts/Dolphin/Base/OS.UserLibrary.cls
+++ b/Core/Object Arts/Dolphin/Base/OS.UserLibrary.cls
@@ -3,7 +3,7 @@
 External.WindowsSystemLibrary
 	subclass: #'OS.UserLibrary'
 	instanceVariableNames: ''
-	classVariableNames: 'DesiredDpiAwarenessContext SystemDpiAwareness'
+	classVariableNames: 'DesiredDpiAwarenessContext DpiAwarenessContext'
 	imports: #(#{OS.MessageBoxConstants private})
 	classInstanceVariableNames: ''
 	classConstants: {}!

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.MessageTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.MessageTest.cls
@@ -14,6 +14,20 @@ Core.Tests.MessageTest comment: ''!
 
 !Core.Tests.MessageTest methodsFor!
 
+testCull
+	| subject |
+	subject := Message selector: #key:value: arguments: #(123 456).
+	self assert: (subject cull: Association) equals: 123 -> 456.
+	subject := Message selector: #isNil.
+	self deny: (subject cull: 1)!
+
+testCullCull
+	| subject |
+	subject := Message selector: #key:value: arguments: #(123 456).
+	self should: [subject cull: Association cull: 'abc'] raise: Error matching: [:ex | ex description = 'Incorrect number of arguments: 1, expected 2'].
+	subject := Message selector: #isNil.
+	self deny: (subject cull: 1 cull: nil)!
+
 testPrintString
 	self assert: (Message selector: #x:y: arguments: #(123 456)) printString
 		equals: 'Message selector: #x:y: arguments: #(123 456)'.
@@ -36,10 +50,27 @@ testSelectorArguments
 	testMethod extraIndex: 0.
 	"Invoke the method directly so we don't need to install it."
 	msg2 := testMethod value: Message withArguments: #(#x:y: #(123 456)).
-	self assert: msg2 equals: msg1! !
+	self assert: msg2 equals: msg1!
+
+testValueColon
+	| subject |
+	subject := Message selector: #key:value: arguments: #(123 456).
+	self assert: (subject value: Association) equals: 123 -> 456.
+	subject := Message selector: #isNil.
+	self deny: (subject value: 1).
+	self assert: (subject value: nil).!
+
+testValueColon2
+	| subject |
+	subject := Message selector: #new: arguments: #(nil).
+	self assert: (subject value: Array value: 2) equals: (Array new: 2).! !
 
 !Core.Tests.MessageTest categoriesForMethods!
+testCull!public!unit tests! !
+testCullCull!public!unit tests! !
 testPrintString!public!unit tests! !
 testSelectorArguments!public!unit tests! !
+testValueColon!public!unit tests! !
+testValueColon2!public!unit tests! !
 !
 

--- a/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.EventMessageSendTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Kernel.Tests.EventMessageSendTest.cls
@@ -16,6 +16,23 @@ Kernel.Tests.EventMessageSendTest comment: ''!
 
 !Kernel.Tests.EventMessageSendTest methodsFor!
 
+testAsMessageSend
+	| subject |
+	subject := EventMessageSend receiver: 1 selector: #yourself.
+	self assert: subject asMessageSend equals: (MessageSend receiver: 1 selector: #yourself).
+	subject := EventMessageSend receiver: Array selector: #with:.
+	self assert: subject asMessageSend
+		equals: (MessageSend
+				receiver: Array
+				selector: #with:
+				argument: nil).
+	subject := EventMessageSend receiver: Array selector: #with:with:.
+	self assert: subject asMessageSend
+		equals: (MessageSend
+				receiver: Array
+				selector: #with:with:
+				arguments: #(nil nil))!
+
 testNoArguments
 	| subject |
 	subject := EventMessageSend receiver: 1 selector: #yourself.
@@ -24,7 +41,11 @@ testNoArguments
 	self assert: (subject value: 2) equals: 1.
 	self assert: (subject valueWithArguments: #(2)) equals: 1.
 	self assert: (subject value: 2 value: 3) equals: 1.
-	self assert: (subject valueWithArguments: #(2 3)) equals: 1!
+	self assert: (subject valueWithArguments: #(2 3)) equals: 1.
+	self assert: (subject cull: 2) equals: 1.
+	self assert: (subject cull: 2 cull: 3) equals: 1.
+	self assert: (subject cull: 2 cull: 3 cull: 4) equals: 1.
+!
 
 testOneArgument
 	| subject |
@@ -38,7 +59,10 @@ testOneArgument
 	self assert: (subject value: 2) equals: #(2).
 	self assert: (subject valueWithArguments: #(2)) equals: #(2).
 	self assert: (subject value: 2 value: 3) equals: #(2).
-	self assert: (subject valueWithArguments: #(2 3)) equals: #(2)!
+	self assert: (subject valueWithArguments: #(2 3)) equals: #(2).
+	self assert: (subject cull: 2) equals: #(2).
+	self assert: (subject cull: 2 cull: 3) equals: #(2).
+	self assert: (subject cull: 2 cull: 3 cull: 4) equals: #(2).!
 
 testOneArgumentWithGC
 	| subject |
@@ -67,6 +91,9 @@ testTwoArguments
 	self assert: (subject valueWithArguments: #(3)) equals: #(3 2).
 	self assert: (subject valueWithArguments: #(3 4)) equals: #(3 4).
 	self assert: (subject valueWithArguments: #(3 4 5)) equals: #(3 4).
+	self assert: (subject cull: 4) equals: #(4 2).
+	self assert: (subject cull: 4 cull: 5) equals: #(4 5).
+	self assert: (subject cull: 4 cull: 5 cull: 6) equals: #(4 5).
 	subject := EventMessageSend
 				receiver: Array
 				selector: #with:with:
@@ -83,6 +110,9 @@ testTwoArguments
 				value: 4)
 		equals: #(2 3).
 	self assert: (subject valueWithArguments: #(2 3 4)) equals: #(2 3).
+	self assert: (subject cull: 4) equals: #(4 nil).
+	self assert: (subject cull: 4 cull: 5) equals: #(4 5).
+	self assert: (subject cull: 4 cull: 5 cull: 6) equals: #(4 5).
 	subject := EventMessageSend
 				receiver: Array
 				selector: #with:with:
@@ -98,9 +128,13 @@ testTwoArguments
 				value: 3
 				value: 4)
 		equals: #(2 3).
-	self assert: (subject valueWithArguments: #(2 3 4)) equals: #(2 3)! !
+	self assert: (subject valueWithArguments: #(2 3 4)) equals: #(2 3).
+	self assert: (subject cull: 2) equals: #(2 nil).
+	self assert: (subject cull: 2 cull: 3) equals: #(2 3).
+	self assert: (subject cull: 2 cull: 3 cull: 4) equals: #(2 3).! !
 
 !Kernel.Tests.EventMessageSendTest categoriesForMethods!
+testAsMessageSend!public!testing! !
 testNoArguments!public!testing! !
 testOneArgument!public!testing! !
 testOneArgumentWithGC!public!testing! !

--- a/Core/Object Arts/Dolphin/Database/Database Connection (Old Names).pax
+++ b/Core/Object Arts/Dolphin/Database/Database Connection (Old Names).pax
@@ -6,7 +6,10 @@ package paxVersion: 2.1;
 
 package setVariableNames: #(
 	#{Smalltalk.DBColAttr}
+	#{Smalltalk.DBConnection}
 	#{Smalltalk.DBError}
+	#{Smalltalk.DBTablesStatement}
+	#{Smalltalk.DBWarning}
 	#{Smalltalk.ODBCDATE}
 	#{Smalltalk.ODBCTIME}
 	#{Smalltalk.ODBCTIMESTAMP}
@@ -14,7 +17,10 @@ package setVariableNames: #(
 
 package setAliasVariableNames: #(
 	#{Smalltalk.DBColAttr}
+	#{Smalltalk.DBConnection}
 	#{Smalltalk.DBError}
+	#{Smalltalk.DBTablesStatement}
+	#{Smalltalk.DBWarning}
 	#{Smalltalk.ODBCDATE}
 	#{Smalltalk.ODBCTIME}
 	#{Smalltalk.ODBCTIMESTAMP}
@@ -30,7 +36,13 @@ package!
 
 Smalltalk.DBColAttr := Database.DBColAttr!
 
+Smalltalk.DBConnection := Database.DBConnection!
+
 Smalltalk.DBError := Database.DBError!
+
+Smalltalk.DBTablesStatement := Database.DBTablesStatement!
+
+Smalltalk.DBWarning := Database.DBWarning!
 
 Smalltalk.ODBCDATE := OS.SQL_DATE_STRUCT!
 

--- a/Core/Object Arts/Dolphin/Database/Database Connection Base.pax
+++ b/Core/Object Arts/Dolphin/Database/Database Connection Base.pax
@@ -1655,7 +1655,7 @@ Core.Object
 Core.Object
 	subclass: #'Database.DBColAttr'
 	instanceVariableNames: 'columnNumber name length sqlType precision scale special bufferClass'
-	classVariableNames: 'BufferClasses'
+	classVariableNames: ''
 	imports: #(#{Database.DBColFlags} #{OS.ODBCTypes} #{OS.ODBCConstants} #{OS.ODBCCTypes})
 	classInstanceVariableNames: ''
 	classConstants: {}!

--- a/Core/Object Arts/Dolphin/Database/Database.DBBoundBuffer.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBBoundBuffer.cls
@@ -20,19 +20,19 @@ This is the normal type of buffer used by the Database Connection as it is more 
 
 !Database.DBBoundBuffer methodsFor!
 
-bind: aDBStatement
+bindColumnsOf: aDBStatement
 	"Private - Bind the receiver's field buffers to columns in the result table."
 
 	| hStmt |
-	hStmt := super bind: aDBStatement.
-	self contents do: [:eachField | eachField bind: aDBStatement].
+	hStmt := super bindColumnsOf: aDBStatement.
+	self contents do: [:eachField | eachField bindColumnOf: aDBStatement].
 	^hStmt!
 
 newFieldForColumn: aDBColAttr
 	^aDBColAttr newBoundField! !
 
 !Database.DBBoundBuffer categoriesForMethods!
-bind:!operations!private! !
+bindColumnsOf:!operations!private! !
 newFieldForColumn:!helpers!private! !
 !
 

--- a/Core/Object Arts/Dolphin/Database/Database.DBBoundField.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBBoundField.cls
@@ -16,10 +16,10 @@ Database.DBBoundField comment: '`DBBoundField` is the class of `DBField`s that p
 
 !Database.DBBoundField methodsFor!
 
-bind: aDBStatement
+bindColumnOf: aDBStatement
 	"Private - Bind the receiver's buffers (data and length) for the <DBStatement> argument, which is assumed to have been executed already."
 
-	^aDBStatement dbCheckException: (OS.ODBCLibrary default
+	^aDBStatement dbCheckException: (OS.Odbc32
 				sqlBindCol: aDBStatement handle
 				columnNumber: column columnNumber
 				targetType: buffer dbInterchangeType
@@ -36,7 +36,7 @@ getData: aDBStatement
 	! !
 
 !Database.DBBoundField categoriesForMethods!
-bind:!operations!private! !
+bindColumnOf:!operations!private! !
 getData:!accessing!private! !
 !
 

--- a/Core/Object Arts/Dolphin/Database/Database.DBColAttr.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBColAttr.cls
@@ -294,7 +294,7 @@ new
 	^super new initialize! !
 
 !Database.DBColAttr class categoriesForMethods!
-initialize!initializing!private! !
+initialize!initializing!must not strip!private! !
 new!instance creation!public! !
 !
 

--- a/Core/Object Arts/Dolphin/Database/Database.DBColAttr.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBColAttr.cls
@@ -3,7 +3,7 @@
 Core.Object
 	subclass: #'Database.DBColAttr'
 	instanceVariableNames: 'columnNumber name length sqlType precision scale special bufferClass'
-	classVariableNames: 'BufferClasses'
+	classVariableNames: ''
 	imports: #(#{Database.DBColFlags} #{OS.ODBCTypes} #{OS.ODBCConstants} #{OS.ODBCCTypes})
 	classInstanceVariableNames: ''
 	classConstants: {}!
@@ -37,6 +37,49 @@ bufferClass
 bufferClass: aClass
 	bufferClass := aClass.
 	length := bufferClass dbTransferOctetLengthForColumn: self!
+
+bufferClasses
+	^##((IdentityDictionary withAll: {SQL_CHAR -> DBCharBuffer.
+						SQL_VARCHAR -> DBVarCharBuffer.
+						SQL_LONGVARCHAR -> DBVarCharBuffer.
+						SQL_WCHAR -> DBWCharBuffer.
+						SQL_WVARCHAR -> DBVarWCharBuffer.
+						SQL_WLONGVARCHAR -> DBVarWCharBuffer.
+						SQL_BINARY -> DBBinaryBuffer.
+						SQL_VARBINARY -> DBVarBinaryBuffer.
+						SQL_LONGVARBINARY -> DBVarBinaryBuffer.
+						SQL_BIT -> External.BOOLEAN.
+						SQL_TINYINT -> External.UInt8.
+						SQL_SMALLINT -> External.Int16.
+						SQL_INTEGER -> External.Int32.
+						SQL_BIGINT -> External.Int64.
+						SQL_NUMERIC -> DBNumericFieldBuffer.
+						SQL_DECIMAL -> DBNumericFieldBuffer.
+						SQL_FLOAT -> External.DOUBLE.
+						SQL_REAL -> External.FLOAT.
+						SQL_DOUBLE -> External.DOUBLE.
+						SQL_TYPE_DATE -> OS.SQL_DATE_STRUCT.
+						SQL_INTERVAL -> OS.SQL_TIME_STRUCT.
+						SQL_TYPE_TIME -> OS.SQL_TIME_STRUCT.
+						SQL_TIMESTAMP -> OS.SQL_TIMESTAMP_STRUCT.
+						SQL_TYPE_TIMESTAMP -> OS.SQL_TIMESTAMP_STRUCT.
+						SQL_GUID -> GUID.
+						SQL_TYPE_NULL -> nil.
+						SQL_INTERVAL_DAY -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_DAY_TO_HOUR -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_DAY_TO_MINUTE -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_DAY_TO_SECOND -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_HOUR -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_HOUR_TO_MINUTE -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_HOUR_TO_SECOND -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_MINUTE -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_MINUTE_TO_SECOND -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_SECOND -> OS.SQL_DAY_SECOND_STRUCT.
+						SQL_INTERVAL_MONTH -> OS.SQL_YEAR_MONTH_STRUCT.
+						SQL_INTERVAL_YEAR -> OS.SQL_YEAR_MONTH_STRUCT.
+						SQL_INTERVAL_YEAR_TO_MONTH -> OS.SQL_YEAR_MONTH_STRUCT.
+						SQL_SS_TIMESTAMPOFFSET -> OS.SQL_SS_TIMESTAMPOFFSET_STRUCT.
+						SQL_SS_TIME2 -> OS.DBTIME2}))!
 
 columnNumber
 	"Answer the instance variable columnNumber"
@@ -190,7 +233,7 @@ type: anInteger
 	"Private - Set the sqlType instance variable to anInteger."
 
 	sqlType := anInteger.
-	self bufferClass: (BufferClasses at: anInteger
+	self bufferClass: (self bufferClasses at: anInteger
 				ifAbsent: [self error: 'Unmarshallable column: ' , self printString])!
 
 updateRuleMask
@@ -209,6 +252,7 @@ updateRuleMask: anInteger
 !Database.DBColAttr categoriesForMethods!
 bufferClass!accessing!public! !
 bufferClass:!initializing!private! !
+bufferClasses!accessing!public! !
 columnNumber!accessing!public! !
 columnNumber:!accessing!private! !
 deleteRuleMask!accessing!public! !
@@ -241,60 +285,12 @@ updateRuleMask:!accessing!private! !
 
 !Database.DBColAttr class methodsFor!
 
-initialize
-	"Private - Initialize the receiver's class variables.
-		self initialize
-	"
-
-	BufferClasses := (IdentityDictionary withAll: {SQL_CHAR -> DBCharBuffer.
-						SQL_VARCHAR -> DBVarCharBuffer.
-						SQL_LONGVARCHAR -> DBVarCharBuffer.
-						SQL_WCHAR -> DBWCharBuffer.
-						SQL_WVARCHAR -> DBVarWCharBuffer.
-						SQL_WLONGVARCHAR -> DBVarWCharBuffer.
-						SQL_BINARY -> DBBinaryBuffer.
-						SQL_VARBINARY -> DBVarBinaryBuffer.
-						SQL_LONGVARBINARY -> DBVarBinaryBuffer.
-						SQL_BIT -> External.BOOLEAN.
-						SQL_TINYINT -> External.UInt8.
-						SQL_SMALLINT -> External.Int16.
-						SQL_INTEGER -> External.Int32.
-						SQL_BIGINT -> External.Int64.
-						SQL_NUMERIC -> DBNumericFieldBuffer.
-						SQL_DECIMAL -> DBNumericFieldBuffer.
-						SQL_FLOAT -> External.DOUBLE.
-						SQL_REAL -> External.FLOAT.
-						SQL_DOUBLE -> External.DOUBLE.
-						SQL_TYPE_DATE -> OS.SQL_DATE_STRUCT.
-						SQL_INTERVAL -> OS.SQL_TIME_STRUCT.
-						SQL_TYPE_TIME -> OS.SQL_TIME_STRUCT.
-						SQL_TIMESTAMP -> OS.SQL_TIMESTAMP_STRUCT.
-						SQL_TYPE_TIMESTAMP -> OS.SQL_TIMESTAMP_STRUCT.
-						SQL_GUID -> GUID.
-						SQL_TYPE_NULL -> nil.
-						SQL_INTERVAL_DAY -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_DAY_TO_HOUR -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_DAY_TO_MINUTE -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_DAY_TO_SECOND -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_HOUR -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_HOUR_TO_MINUTE -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_HOUR_TO_SECOND -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_MINUTE -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_MINUTE_TO_SECOND -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_SECOND -> OS.SQL_DAY_SECOND_STRUCT.
-						SQL_INTERVAL_MONTH -> OS.SQL_YEAR_MONTH_STRUCT.
-						SQL_INTERVAL_YEAR -> OS.SQL_YEAR_MONTH_STRUCT.
-						SQL_INTERVAL_YEAR_TO_MONTH -> OS.SQL_YEAR_MONTH_STRUCT.
-						SQL_SS_TIMESTAMPOFFSET -> OS.SQL_SS_TIMESTAMPOFFSET_STRUCT.
-						SQL_SS_TIME2 -> OS.DBTIME2})!
-
 new
 	"Answer a new initialized instance of the receiver."
 
 	^super new initialize! !
 
 !Database.DBColAttr class categoriesForMethods!
-initialize!initializing!must not strip!private! !
 new!instance creation!public! !
 !
 

--- a/Core/Object Arts/Dolphin/Database/Database.DBField.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBField.cls
@@ -35,17 +35,17 @@ beNull
 
 	self length: OS.ODBCConstants.SQL_NULL_DATA!
 
-bind: aDBStatement
+bindAsParameter: anInteger of: aDBParameterizedStatement
+	"Private - Bind the receiver as the supplier of data for the parameter numbered, anInteger, of aDBParameterizedStatement."
+
+	self subclassResponsibility!
+
+bindColumnOf: aDBStatement
 	"Private - Bind the receiver's buffers (data and length) for the <DBStatement> argument, which is assumed to have been executed already."
 
 	"Unbound by default, so do nothing"
 
 	!
-
-bindAsParameter: anInteger of: aDBParameterizedStatement
-	"Private - Bind the receiver as the supplier of data for the parameter numbered, anInteger, of aDBParameterizedStatement."
-
-	self subclassResponsibility!
 
 bufferClass
 	^column bufferClass!
@@ -134,8 +134,8 @@ value: anObject
 =!comparing!public! !
 allocateBuffer!accessing!private! !
 beNull!accessing!public! !
-bind:!operations!private! !
 bindAsParameter:of:!operations!private! !
+bindColumnOf:!operations!private! !
 bufferClass!accessing!public! !
 column!accessing!private! !
 dbInterchangeType!constants!public! !

--- a/Core/Object Arts/Dolphin/Database/Database.DBFixedSizeField.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBFixedSizeField.cls
@@ -19,7 +19,7 @@ Database.DBFixedSizeField comment: ''!
 bindAsParameter: anInteger of: aDBParameterizedStatement
 	"Private - Bind the receiver as the supplier of data for the parameter numbered, anInteger, of aDBParameterizedStatement. For fixed-sized fields, the buffer is bound directly so that data transfer occurs on exec without the need for SQLPutData calls."
 
-	aDBParameterizedStatement dbCheckException: (OS.ODBCLibrary default
+	aDBParameterizedStatement dbCheckException: (OS.Odbc32
 				sqlBindParameter: aDBParameterizedStatement allocatedHandle
 				parameterNumber: anInteger
 				inputOutputType: column parameterType

--- a/Core/Object Arts/Dolphin/Database/Database.DBLongVarField.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBLongVarField.cls
@@ -20,7 +20,7 @@ bindAsParameter: anInteger of: aDBParameterizedStatement
 	"Private - Bind the receiver as the supplier of data for the parameter numbered, anInteger, of aDBParameterizedStatement. For long variable fields, the partial buffer is not used for output, rather the interchange value is passed directly with a call to SQLPutData after exec. Here we instruct the driver to request the data, using the column number as the correlation value."
 
 	self length: SQL_DATA_AT_EXEC.
-	aDBParameterizedStatement dbCheckException: (OS.ODBCLibrary default
+	aDBParameterizedStatement dbCheckException: (OS.Odbc32
 				sqlBindParameter: aDBParameterizedStatement allocatedHandle
 				parameterNumber: anInteger
 				inputOutputType: column parameterType
@@ -38,11 +38,9 @@ getData: aDBStatement
 
 	"We could potentially retrieve the data lazily (i.e. mark the value as unretrieved here, and query later only if the the value is accessed), but the documentation states 'within a row of data, the value of the Col_or_Param_Num argument in each call to SQLGetData must be greater than or equal to the value of Col_or_Param_Num in the previous call; that is, data must be retrieved in increasing column number order.' Drivers are allowed to relax this restriction, and whether or not that applies can be determined using the SQLGetInfo api and checking for the SQL_GD_ANY_ORDER extension. It doesn't seem worth the complexity of doing this. There is also a restriction that SQLGetData cannot necessarily be called for columns appearing before the last bound column in the query. Since we need to support the use of unbound columns with SQLGetData for varchar(max), etc, we assume that either the driver does not enforce this restriction, or that the SQL query is coded to ensure that the columns are ordered to place the unlimited length ones after all the others. If you run into a problem with this call failing due to column order issues, it should be possible to just reorder the columns in the query to meet the constraint. As one data point, SQL Server doesn't care about the ordering of the bound and unbound columns."
 
-	| ret odbc32 hStmt stream targetType |
+	| ret hStmt stream targetType |
 	hStmt := aDBStatement executedHandle.
-	odbc32 := OS.ODBCLibrary default.
-	"Optimise for the case where the first read succeeds because the data fits in the buffer anyway."
-	ret := odbc32
+	ret := OS.Odbc32
 				sqlGetData: hStmt
 				columnNumber: column columnNumber
 				targetType: (targetType := buffer dbInterchangeType)
@@ -61,7 +59,7 @@ getData: aDBStatement
 	[ret == SQL_SUCCESS_WITH_INFO] whileTrue: 
 			[stream nextPutAll: buffer bytes.
 			"Read the next block"
-			ret := odbc32
+			ret := OS.Odbc32
 						sqlGetData: hStmt
 						columnNumber: column columnNumber
 						targetType: targetType
@@ -77,7 +75,7 @@ getData: aDBStatement
 putData: aDBStatement
 	"Private - Set the data for this long variable length field when used in a parameterised query. The interchange data is not buffered for output. We use the value directly, as for all long column types the data is a byte value (String or ByteArray), or nil for nullable columns. If nil, then SQL_NULL_DATA is passed as the strLenOrInd parameter, which should be interpreted by the driver as indicating a null value."
 
-	aDBStatement dbCheckException: (OS.ODBCLibrary default
+	aDBStatement dbCheckException: (OS.Odbc32
 				sqlPutData: aDBStatement allocatedHandle
 				dataPtr: value
 				strLenOrInd: value dbOctetTransferSize)

--- a/Core/Object Arts/Dolphin/Database/Database.DBResultSet.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBResultSet.cls
@@ -97,19 +97,17 @@ atIndex: anInteger
 
 	^self at: anInteger ifAbsent: nil!
 
-bind
-	"Private - Create and 'bind' (an unbound buffer will not
-	actually do any SQLBindCols, though a bound buffer will)
-	a buffer to hold the all the columns in the result set"
+bindColumns
+	"Private - Create and 'bind' (an unbound buffer will not	actually do any SQLBindCols, though a bound buffer will) a buffer to hold the all the columns in the result set"
 
-	self bind: #()!
+	self bindColumns: #()!
 
-bind: anArrayOfColNums
+bindColumns: anArrayOfColNums
 	"Private - Create and bind a buffer to hold the
 	specified columns (or #() for all columns)
 	as they are fetched from the result set"
 
-	(self allocBuffer: (self describeColumns: anArrayOfColNums)) bind: statement!
+	(self allocBuffer: (self describeColumns: anArrayOfColNums)) bindColumnsOf: statement!
 
 buffer
 	^buffer!
@@ -236,7 +234,7 @@ fetchScroll: orientationInteger offset: offsetInteger
 	DBError exception if an error occurs"
 
 	| ret |
-	buffer ifNil: [self bind].
+	buffer ifNil: [self bindColumns].
 	ret := OS.Odbc32
 				sqlFetchScroll: self statementHandle
 				fetchOrientation: orientationInteger
@@ -458,7 +456,7 @@ rawDo: aZeroArgBlock
 realize
 	"Private - Recreate the result set."
 
-	self bind
+	self bindColumns
 !
 
 resize: anInteger
@@ -568,8 +566,8 @@ at:!accessing!public! !
 at:ifAbsent:!accessing!public! !
 at:put:!accessing!public! !
 atIndex:!accessing!public! !
-bind!binding!private! !
-bind:!binding!private! !
+bindColumns!binding!private! !
+bindColumns:!binding!private! !
 buffer!accessing!private! !
 buffer:!accessing!private! !
 bufferClass!constants!private! !

--- a/Core/Object Arts/Dolphin/Database/Database.DBRowBuffer.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBRowBuffer.cls
@@ -21,12 +21,12 @@ asObject
 
 	^DBRow fromBuffer: self!
 
-bind: aDBStatement 
+bindColumnsOf: aDBStatement
 	"Private - Bind the receiver's field buffers to columns in the result table."
 
 	| hStmt |
 	hStmt := aDBStatement executedHandle.
-	#todo "Will need an array of status values if to fetch a block of rows at a time".
+	#todo.	"Will need an array of status values if to fetch a block of rows at a time"
 	status := ByteArray newFixed: 2.
 	aDBStatement statusArray: status.
 	^hStmt!
@@ -58,7 +58,7 @@ status
 
 !Database.DBRowBuffer categoriesForMethods!
 asObject!converting!private! !
-bind:!operations!private! !
+bindColumnsOf:!operations!private! !
 contents!accessing!public! !
 getContents!helpers!private! !
 getData:!data retrieval!private! !

--- a/Core/Object Arts/Dolphin/Database/Database.DBUnboundField.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.DBUnboundField.cls
@@ -19,7 +19,7 @@ Database.DBUnboundField comment: '`DBBoundField` is the class of `DBField`s that
 getData: aDBStatement
 	"Private - Retrieve the receiver's associated column data from the ODBC result set immediately following a fetch (into the receiver's buffer)."
 
-	aDBStatement dbCheckException: (OS.ODBCLibrary default
+	aDBStatement dbCheckException: (OS.Odbc32
 				sqlGetData: aDBStatement executedHandle
 				columnNumber: column columnNumber
 				targetType: buffer dbInterchangeType
@@ -33,7 +33,7 @@ putData: aDBStatement
 
 	| data |
 	data := buffer bytes.
-	aDBStatement dbCheckException: (OS.ODBCLibrary default
+	aDBStatement dbCheckException: (OS.Odbc32
 				sqlPutData: aDBStatement allocatedHandle
 				dataPtr: data
 				strLenOrInd: data dbOctetTransferSize)

--- a/Core/Object Arts/Dolphin/Database/Database.Tests.MimerSqlNorthwindDB.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.Tests.MimerSqlNorthwindDB.cls
@@ -37,7 +37,7 @@ getOdbcDriver
 	^'MIMER'!
 
 prereqsAvailable
-	^super prereqsAvailable and: [OS.AdvApiLibrary default isServiceRunning: 'MIMER-Mimer']!
+	^super prereqsAvailable and: [OS.AdvApi32 isServiceRunning: 'MIMER-Mimer']!
 
 uid
 	^'SYSADM'! !

--- a/Core/Object Arts/Dolphin/Database/Database.Tests.MySqlNorthwindDB.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.Tests.MySqlNorthwindDB.cls
@@ -69,7 +69,7 @@ options
 prereqsAvailable
 	"The MySQL80 service needs to be installed with ODBC driver, and running. Note that it must also be explicitly configured to utf8mb4 character set, or tests that attempt to insert non-BMP characters will error."
 
-	^super prereqsAvailable and: [OS.AdvApiLibrary default isServiceRunning: 'MySQL80']!
+	^super prereqsAvailable and: [OS.AdvApi32 isServiceRunning: 'MySQL80']!
 
 uid
 	^'root'!

--- a/Core/Object Arts/Dolphin/Database/Database.Tests.OracleNorthwindDB.cls
+++ b/Core/Object Arts/Dolphin/Database/Database.Tests.OracleNorthwindDB.cls
@@ -40,7 +40,7 @@ getOdbcDriver
 prereqsAvailable
 	"Private - Answer whether the pre-reqs for the database resource, e.g. the ODBC driver, are available."
 
-	^OS.AdvApiLibrary default isServiceRunning: 'OracleServiceFREE'!
+	^OS.AdvApi32 isServiceRunning: 'OracleServiceFREE'!
 
 uid
 	^'system'! !

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassBrowserAbstract.cls
@@ -1697,16 +1697,16 @@ packages: aCollection
 parseContext
 	"Answer the {Class. Namespace} scope in who's context methods should be compiled."
 
-	^self method
-		ifNotNil: [:m | (model modelMethodFor: m) parseContext]
-		ifNil: 
-			[self actualClass
-				ifNil: [model defaultParseContext]
+	self method
+		ifNotNil: [:m | (model modelMethodFor: m) ifNotNil: [:modelMethod | ^modelMethod parseContext]].
+	self actualClass
+		ifNotNil: 
+			[:class |
+			(model modelClassFor: class)
 				ifNotNil: 
-					[:class |
-					| modelClass |
-					modelClass := model modelClassFor: class.
-					ParseContext methodClass: modelClass environment: (self namespaceForNewMethodOf: modelClass)]]!
+					[:modelClass |
+					^ParseContext methodClass: modelClass environment: (self namespaceForNewMethodOf: modelClass)]].
+	^model defaultParseContext!
 
 parseTree
 	^methodBrowserPresenter parseTree!

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassHierarchySelector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassHierarchySelector.cls
@@ -25,7 +25,8 @@ createComponents
 customDrawClassTree: anNMTVCUSTOMDRAW
 	"Private - Custom drawing to implement the emphasis in the class hierarchy tree."
 
-	self developmentSystem setCustomDrawAttributes: anNMTVCUSTOMDRAW forClass: anNMTVCUSTOMDRAW item!
+	self developmentSystem setClassCustomDrawAttributes: anNMTVCUSTOMDRAW.
+	self trigger: #classCustomDrawAttributesRequired: with: anNMTVCUSTOMDRAW!
 
 expand: aClass
 	"Expands aClass in the displayed hierarchy"

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassListSelector.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.ClassListSelector.cls
@@ -101,13 +101,12 @@ createSchematicWiring
 		to: self!
 
 customDrawClassList: anNMLVCUSTOMDRAW
-	"Private - Custom drawing to implement the emphasis in the class list. See #customDrawClassTree: for details, although note that the list cannot contain 'included but not defined' classes."
+	"Private - Custom drawing to implement the emphasis in the class list. See #customDrawClassTree: for details, although note that the list should not contain 'included but not defined' classes."
 
-	| class |
-	class := anNMLVCUSTOMDRAW item.
-	(browserEnvironment definesClass: class)
+	(browserEnvironment definesClass: anNMLVCUSTOMDRAW item)
 		ifFalse: [anNMLVCUSTOMDRAW forecolor: ClassBrowserAbstract.LooseMethodColor].
-	self developmentSystem setCustomDrawAttributes: anNMLVCUSTOMDRAW forClass: class!
+	self developmentSystem setClassCustomDrawAttributes: anNMLVCUSTOMDRAW.
+	self trigger: #classCustomDrawAttributesRequired: with: anNMLVCUSTOMDRAW!
 
 customDrawClassTree: anNMTVCUSTOMDRAW
 	"Private - Custom drawing to implement the emphasis in a class or namespace hierarchy tree. 
@@ -126,7 +125,8 @@ customDrawClassTree: anNMTVCUSTOMDRAW
 		ifFalse: 
 			[anNMTVCUSTOMDRAW
 				forecolor: (anNMTVCUSTOMDRAW forecolor fadedBy: ClassBrowserAbstract.GrayedMethodFadeFactor)].
-	self developmentSystem setCustomDrawAttributes: anNMTVCUSTOMDRAW forClass: class!
+	self developmentSystem setClassCustomDrawAttributes: anNMTVCUSTOMDRAW.
+	self trigger: #classCustomDrawAttributesRequired: with: anNMTVCUSTOMDRAW!
 
 deleteItCommand
 	"Private - Answer the command that the context-sensitive 'Browse-It' command would be linked

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowser.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowser.cls
@@ -445,8 +445,8 @@ createSchematicWiring
 customDrawMethodClass: anNMLVCUSTOMDRAW
 	"Private - Custom drawing to implement the emphasis in a method browser's class column."
 
-	self developmentSystem setCustomDrawAttributes: anNMLVCUSTOMDRAW
-		forClass: anNMLVCUSTOMDRAW item methodClass!
+	self developmentSystem setClassCustomDrawAttributes: anNMLVCUSTOMDRAW.
+	self trigger: #classCustomDrawAttributesRequired: with: anNMLVCUSTOMDRAW!
 
 customDrawSelector: anNMLVCUSTOMDRAW
 	"Private - Custom drawing to implement the emphasis in a method browser's selector column."

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.MethodBrowserShell.cls
@@ -117,9 +117,9 @@ onViewOpened
 		ifNotNil: [:item | item model: browserPresenter namespaceModel]!
 
 parseContext
-	^self selectedMethod
-		ifNil: [model defaultParseContext]
-		ifNotNil: [:method | (model modelMethodFor: method) parseContext]!
+	self selectedMethod
+		ifNotNil: [:method | (model modelMethodFor: method) ifNotNil: [:modelMethod | ^modelMethod parseContext]].
+	^model defaultParseContext!
 
 recompileDiffs
 	<commandQuery: #hasMethodSelected>

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.PackageBrowserShell.cls
@@ -486,7 +486,7 @@ createSchematicWiring
 customDrawClassList: anNMLVCUSTOMDRAW
 	"Private - Custom drawing to implement the emphasis in the classes list tree."
 
-	self developmentSystem setCustomDrawAttributes: anNMLVCUSTOMDRAW forClass: anNMLVCUSTOMDRAW subItem!
+	self developmentSystem setClassCustomDrawAttributes: anNMLVCUSTOMDRAW!
 
 defaultHelpId
 	^10807!

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.PluggableEnvironment.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.PluggableEnvironment.cls
@@ -51,10 +51,10 @@ includesSelector: aSelector in: aClass
 selectorsForClass: aClass do: aBlock 
 	"Override for improved performance."
 
-	aClass selectorsAndMethodsDo: 
-			[:eachSelector :eachMethod | 
-			((environment includesSelector: eachSelector in: aClass) and: [filter value: eachMethod]) 
-				ifTrue: [aBlock value: eachSelector]]!
+	aClass methodsDo: 
+			[:each | 
+			((environment includesSelector: each selector in: aClass) and: [filter value: each]) 
+				ifTrue: [aBlock value: each selector]]!
 
 snapshot
 	"Answer a static snapshot of this dynamic method environment."

--- a/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkSystem.cls
+++ b/Core/Object Arts/Dolphin/IDE/Base/Tools.SmalltalkSystem.cls
@@ -930,19 +930,21 @@ browseReferencesToVariable: anAssociation
 	self browseReferencesToLiteral: anAssociation in: self browserEnvironment!
 
 browserEnvFromDom: anIXMLDOMDocument
-	| manifest classes env exeName time model deletedSharedVars retainedSharedVars |
+	| manifest classes env exeName time model deletedSharedVars retainedSharedVars unbound |
 	manifest := anIXMLDOMDocument selectSingleNode: './/Manifest'.
 	classes := manifest selectNodes: 'Classes/Class'.
 	env := SelectorEnvironment new.
 	exeName := File splitFilenameFrom: (anIXMLDOMDocument selectSingleNode: './/Target') text.
 	time := (anIXMLDOMDocument selectSingleNode: './/TimeStamp') text.
 	env label: ('<1s> (<2s>)' expandMacrosWith: exeName with: time).
+	unbound := Set new.
 	classes do: 
 			[:each |
 			| methods className classMethods |
 			className := each getAttribute: 'name'.
 			className asQualifiedReference ifDefined: 
 					[:class |
+					(each getAttribute: 'unbound') = 'true' ifTrue: [unbound add: class].
 					methods := each selectNodes: 'Methods/Method'.
 					env addClass: class selectors: (methods collect: [:eachMethod | eachMethod text asSymbol]).
 					classMethods := each selectNodes: 'ClassMethods/Method'.
@@ -962,6 +964,7 @@ browserEnvFromDom: anIXMLDOMDocument
 			toDelete isEmpty ifFalse: [deletedSharedVars at: each put: toDelete]].
 	deletedSharedVars
 		keysAndValuesDo: [:eachClass :deadVars | deadVars do: [:each | eachClass removeBindingFor: each key]].
+	unbound do: [:each | (each environment classInModel: model) removeBindingFor: each name].
 	^model!
 
 browserEnvironment
@@ -3952,7 +3955,9 @@ sessionManager
 
 	^SessionManager current!
 
-setCustomDrawAttributes: anNMCUSTOMDRAW forClass: aClass
+setClassCustomDrawAttributes: anNMCUSTOMDRAW
+	| aClass |
+	aClass := anNMCUSTOMDRAW subItem.
 	aClass isDeprecated ifTrue: [anNMCUSTOMDRAW font isStruckThrough: true].
 	aClass isVisiblyAbstract ifTrue: [anNMCUSTOMDRAW font isItalic: true]!
 
@@ -4390,7 +4395,7 @@ browseReferencesToInstVar:inHierarchyOf:within:!browsing!private! !
 browseReferencesToInstVars:inHierarchyOf:within:!browsing!private! !
 browseReferencesToLiteral:in:!browsing!public! !
 browseReferencesToVariable:!browsing!public! !
-browserEnvFromDom:!helpers!private! !
+browserEnvFromDom:!public! !
 browserEnvironment!accessing!public! !
 browserEnvironmentForClasses:!browsing!public! !
 browseResourceIdentifier:!operations!public! !
@@ -4687,7 +4692,7 @@ saveImage!commands-actions!public! !
 saveImageAs!commands-actions!public! !
 selectMethods:in:withProgress:!private!searching! !
 sessionManager!accessing!private! !
-setCustomDrawAttributes:forClass:!helpers!private! !
+setClassCustomDrawAttributes:!helpers!private! !
 showPrerequisitesForPackage:!helpers!public! !
 showShellWithHandle:!private! !
 showTranscript!commands-actions!public! !

--- a/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Dolphin Refactoring Browser.pax
@@ -643,7 +643,7 @@ hierarchyDefinesVariable:!public!testing! !
 !Kernel.CompiledMethod methodsFor!
 
 methodInModel: aRBModel
-	^(methodClass classInModel: aRBModel) methodFor: selector! !
+	^(methodClass classInModel: aRBModel) ifNotNil: [:modelClass | modelClass methodFor: selector]! !
 
 !Kernel.CompiledMethod categoriesForMethods!
 methodInModel:!converting!public! !

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.EnvironmentBrowserShell.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.EnvironmentBrowserShell.cls
@@ -58,6 +58,13 @@ createComponents
 	super createComponents.
 	classesPresenter := self add: ClassListSelector new name: 'classes'!
 
+createSchematicWiring
+	super createSchematicWiring.
+	classesPresenter
+		when: #classCustomDrawAttributesRequired:
+		send: #onClassCustomDrawAttributesRequired:
+		to: self!
+
 defaultHelpId
 	^10895!
 
@@ -68,6 +75,15 @@ isMethodVisible: aCompiledMethod
 model: aSystemModel
 	super model: aSystemModel.
 	self browserEnvironment: aSystemModel browserEnvironment!
+
+onClassCustomDrawAttributesRequired: anNMCUSTOMDRAW
+	"Private - Reset the forecolor, as otherwise all classes will be drawn in the 'loose method' colour, which indicates that the class is included but not fully defined. Given that the purpose of the environment browser is to show a filtered view of full set of classes and their methods, it is not terribly useful to show all (or almost all) classes in the highlight colour. Instead we reserve the highlight colour for those classes that are in the hierarchy, but which are not installed in their namespace (i.e. unbound classes). These are also underlined to make them easier to identify."
+
+	anNMCUSTOMDRAW forecolor: anNMCUSTOMDRAW view forecolor ?? Color.WindowText.
+	(anNMCUSTOMDRAW subItem classInModel: model)
+		ifNil: [(anNMCUSTOMDRAW
+				forecolor: LooseMethodColor;
+				font) isUnderlined: true]!
 
 printBasicCaptionOn: aPuttableStream
 	self browserEnvironment displayOn: aPuttableStream!
@@ -110,9 +126,11 @@ browseExecutableManifestFile:!operations!public! !
 browserEnvironment:!initializing!private! !
 browseUnimplemented!commands-actions!public! !
 createComponents!initializing!public! !
+createSchematicWiring!initializing!public! !
 defaultHelpId!constants!public! !
 isMethodVisible:!private!testing! !
 model:!accessing!public! !
+onClassCustomDrawAttributesRequired:!helpers!private! !
 printBasicCaptionOn:!private!updating! !
 printCaptionForClass:on:!private!updating! !
 printCaptionForMethod:on:!private!updating! !

--- a/Core/Object Arts/Dolphin/Installation Manager/Tools.DolphinBaseProduct.cls
+++ b/Core/Object Arts/Dolphin/Installation Manager/Tools.DolphinBaseProduct.cls
@@ -129,7 +129,8 @@ contents
 	"More Samples"
 	contents
 		add: #('Core\Object Arts\Samples\Sockets\Net Examples.pax' #plain #imageBased);
-		add: #('Core\Object Arts\Samples\Sockets\Chat\Chat.pax' #plain #imageBased).
+		add: #('Core\Object Arts\Samples\Sockets\Chat\Chat.pax' #plain #imageBased);
+		add: #('Core\Object Arts\Samples\Database\DumpTable\DumpTable.pax' #plain #imageBased).
 
 	"XmlPad Sample"
 	contents

--- a/Core/Object Arts/Dolphin/Lagoon/Lagoon Tests.pax
+++ b/Core/Object Arts/Dolphin/Lagoon/Lagoon Tests.pax
@@ -20,6 +20,7 @@ package setPrerequisites: #(
 	'..\Base\Dolphin'
 	'..\Base\Tests\Dolphin Base Tests'
 	'..\System\Filer\Dolphin Binary Filer'
+	'..\..\Samples\Database\DumpTable\DumpTable'
 	'..\..\Samples\MVP\Etch-a-Sketch\Etch-a-Sketch'
 	'..\..\Samples\MVP\Hello World\Hello World'
 	'..\..\Samples\Console\Hello World\Hello World (Console)'

--- a/Core/Object Arts/Dolphin/Lagoon/Tools.Tests.PackageClosureTests.cls
+++ b/Core/Object Arts/Dolphin/Lagoon/Tools.Tests.PackageClosureTests.cls
@@ -20,6 +20,15 @@ consoleAppUnimplemented
 
 	^#(#defineTemplate)!
 
+consoleDbAppUnimplemented
+	"Private - Expected missing selectors in a console app using the Database Connection package:
+		- defaultIcon - referenced from RegKeyAbstract and subclasses class icon methods. Icon is referenced from ResourceIdentifier which is part of the base Dolphin package, but which will be removed by actual deployment of a non-GUI app.
+		- defineTemplate - sent by ExternalStructure class>>ensureDefined, but this caller is replaced by an empty stub on actual deployment
+		- version - referenced from DBAbstractStatement class>>stbConvertFrom:. In practice this will be removed if the app does not use STB.
+	In practice the only unimplemented message in a simple console DB sample after deployment is #rollback. This is implemented by DBTransaction, which is removed in simple apps that are not using transactions."
+
+	^#(#defaultIcon #defineTemplate #version)!
+
 simpleGuiAppUnimplementedMessages
 	"Private - Answer the collection of selectors of methods expected to be missing in a simple GUI app with the image stripper:
 		- defineTemplate- sent from ExternalStructure>>ensureDefined, which is replaced with a no-op stub in deployed apps. Should not be in the UnimplementedMessages section of the actual deployment log for GUI apps.
@@ -34,6 +43,13 @@ testCommandLineHelloWorld
 	self verifyPackageClosure: (BrowserEnvironment new
 				forPackagesDeployment: {Smalltalk.CommandLineHelloWorld owningPackage})
 		missing: self consoleAppUnimplemented!
+
+testDumpTable
+	"Tests predicted unimplemented messages of a fairly minimal console application using Database Connection."
+
+	self verifyPackageClosure: (BrowserEnvironment new
+				forPackagesDeployment: {Smalltalk.DumpTable owningPackage})
+		missing: self consoleDbAppUnimplemented!
 
 testEtchASketch
 	"Etch-a-sketch uses STB."
@@ -112,8 +128,10 @@ verifyPackageClosure: aBrowserEnvironment missing: aCollectionOfSymbols
 
 !Tools.Tests.PackageClosureTests categoriesForMethods!
 consoleAppUnimplemented!constants!private! !
+consoleDbAppUnimplemented!constants!private! !
 simpleGuiAppUnimplementedMessages!constants!private! !
 testCommandLineHelloWorld!public!unit tests! !
+testDumpTable!public!unit tests! !
 testEtchASketch!public!unit tests! !
 testHelloWorld!public!unit tests! !
 testNotepad!public!unit tests! !

--- a/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
+++ b/Core/Object Arts/Dolphin/MVP/Base/Dolphin MVP Base.pax
@@ -195,6 +195,7 @@ package setMethodNames: #(
 	#(#{OS.UserLibrary} #drawMenuBar:)
 	#(#{OS.UserLibrary} #emptyClipboard)
 	#(#{OS.UserLibrary} #enableNonClientDpiScaling:)
+	#(#{OS.UserLibrary} #enableNonClientDpiScalingIfNecessary:)
 	#(#{OS.UserLibrary} #enableScrollBar:wSBFlags:wArrows:)
 	#(#{OS.UserLibrary} #endDeferWindowPos:)
 	#(#{OS.UserLibrary} #endPaint:lpPaint:)
@@ -269,6 +270,7 @@ package setMethodNames: #(
 	#(#{OS.UserLibrary} #isForegroundProcess:)
 	#(#{OS.UserLibrary} #isIconic:)
 	#(#{OS.UserLibrary} #isProcessDPIAware)
+	#(#{OS.UserLibrary} #isProcessSystemDpiAware)
 	#(#{OS.UserLibrary} #isValidDpiAwarenessContext:)
 	#(#{OS.UserLibrary} #isWindowUnicode:)
 	#(#{OS.UserLibrary} #isZoomed:)
@@ -343,6 +345,7 @@ package setMethodNames: #(
 	#(#{OS.UserLibrary class} #desiredDpiAwareness)
 	#(#{OS.UserLibrary class} #desiredDpiAwareness:)
 	#(#{OS.UserLibrary class} #dpiAwareness)
+	#(#{OS.UserLibrary class} #dpiAwarenessContext)
 	#(#{UI.ResourceIdentifier} #canShow)
 	#(#{UI.ResourceIdentifier} #fixupIcon)
 	#(#{UI.ResourceIdentifier} #icon)
@@ -3019,6 +3022,13 @@ enableNonClientDpiScaling: hwnd
 	<stdcall: bool EnableNonClientDpiScaling handle>
 	^self invalidCall: _failureCode!
 
+enableNonClientDpiScalingIfNecessary: anExternalHandle
+	"Private - Enable system scaling of non-client window decoration."
+
+	"The [documentation](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enablenonclientdpiscaling) states that it is not necessary to call EnableNonClientScaling for apps running at per monitor V2 awareness level, but as far as I can determine it makes no difference in _any_ mode on Windows 11 as the NC areas are always scaled, regardless of mode and whether this is called or not. It also doesn't have any effect on the bug where at certain DPIs in per-monitor mode menu bars leave small black areas around some edges (i.e. don't paint the entire background)."
+
+	self isProcessSystemDpiAware ifTrue: [self enableNonClientDpiScaling: anExternalHandle]!
+
 enableScrollBar: hwnd wSBFlags: wSBFlags wArrows: wArrows
 	"Invoke the EnableScrollBar() function of the module wrapped by the receiver.
 	Helpstring: Enables or disables scroll bar arrows (see SB_ and ESB_ constants)
@@ -3645,7 +3655,7 @@ initialize
 		- it cannot be changed once set, but the configured context can be changed for the next image restart (so DpiAwarenessContext may not be the system-wide context)
 		- we may not get what we asked for, e.g. in an application with a manifest defined awareness
 		- the result of GetDpiAwarenessContextForProcess will depend on the thread awareness context at the time it is called (!!)"
-	SystemDpiAwareness := UI.DpiAwareness fromHandle: self getThreadDpiAwarenessContext.
+	DpiAwarenessContext := self getThreadDpiAwarenessContext.
 	^self!
 
 insertMenuItem: hMenu uItem: anInteger fByPosition: aBoolean lpmii: aMENUITEMINFOW
@@ -3742,6 +3752,12 @@ isProcessDPIAware
 
 	<stdcall: bool IsProcessDPIAware>
 	^self invalidCall: _failureCode!
+
+isProcessSystemDpiAware
+	"Answer whether the process default Dpi awareness is the 'system' level, i.e. a common high DPI applied to all monitors regardless of their physical DPI, as opposed to per-monitor high DPI."
+
+	^self areDpiAwarenessContextsEqual: DPI_AWARENESS_CONTEXT_SYSTEM_AWARE
+		dpiContextB: DpiAwarenessContext!
 
 isValidDpiAwarenessContext: value
 	"Invoke the IsValidDpiAwarenessContext() function of the module wrapped by the receiver.
@@ -4531,6 +4547,7 @@ drawFrameControl:lprc:uType:uState:!**auto generated**!public!win32 functions-pa
 drawMenuBar:!public!win32 functions-menu! !
 emptyClipboard!public!win32 functions-clipboard! !
 enableNonClientDpiScaling:!**auto generated**!public!win32 functions-high DPI! !
+enableNonClientDpiScalingIfNecessary:!high DPI!public! !
 enableScrollBar:wSBFlags:wArrows:!**auto generated**!public!win32 functions-scroll bar! !
 endDeferWindowPos:!**auto generated**!public! !
 endPaint:lpPaint:!public!win32 functions-painting and drawing! !
@@ -4605,6 +4622,7 @@ isDialogMessage:lpMsg:!public!win32 functions-dialog box! !
 isForegroundProcess:!enquiries!public! !
 isIconic:!public!win32 functions-icon! !
 isProcessDPIAware!**auto generated**!public!win32 functions-high DPI! !
+isProcessSystemDpiAware!high DPI!public!testing! !
 isValidDpiAwarenessContext:!**auto generated**!public!win32 functions-high DPI! !
 isWindowUnicode:!public!win32 functions-window!win32 functions-window procedure! !
 isZoomed:!public!win32 functions-window! !
@@ -4695,12 +4713,18 @@ desiredDpiAwareness: aDpiAwareness
 dpiAwareness
 	"Answer the <DpiAwareness> context established for this Dolphin process. Note that this cannot be changed in a running session, only on restart."
 
-	^SystemDpiAwareness! !
+	^UI.DpiAwareness fromHandle: DpiAwarenessContext!
+
+dpiAwarenessContext
+	"Answer the <integer> dpi awareness context handle established for this Dolphin process. Note that this cannot be changed in a running session, only on restart."
+
+	^DpiAwarenessContext! !
 
 !OS.UserLibrary class categoriesForMethods!
 desiredDpiAwareness!accessing!high DPI!public! !
 desiredDpiAwareness:!accessing!high DPI!public! !
 dpiAwareness!accessing!high DPI!public! !
+dpiAwarenessContext!accessing!public! !
 !
 
 !UI.ResourceIdentifier methodsFor!

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.DisplayMonitor.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.DisplayMonitor.cls
@@ -59,7 +59,11 @@ adjustWindowRect: aRectangle
 
 cacheInfo
 	| monitorInfo |
-	monitorInfo := self infoWithDpiAwareness: UserLibrary dpiAwareness.
+	monitorInfo := MONITORINFOEXW newBuffer.
+	(UserLibrary dpiAwareness inContextDo: [
+		dpi := self effectiveDpi.
+		UserLibrary default getMonitorInfo: handle lpmi: monitorInfo])
+		ifFalse: [Win32Error signal].
 	workArea := monitorInfo workArea.
 	rectangle := monitorInfo rectangle.
 	deviceName := monitorInfo szDevice.
@@ -119,7 +123,8 @@ devices
 dpi
 	"Answer the logical DPI for this monitor. Note that this may not be the same as the physical DPI, depending on the DPI awareness of the application and the OS magnification setting. When DPI unaware, this is always 96. When system DPI aware it is the system-wide DPI, even if different than this monitor's DPI. When per-monitor DPI aware, it is the effective DPI of the monitor (i.e. the monitors's DPI at the configured magnification)."
 
-	^dpi ifNil: [dpi := UserLibrary dpiAwareness inContextDo: [self effectiveDpi]]!
+	dpi ifNil: [self cacheInfo].
+	^dpi!
 
 effectiveDpi
 	"Answer the logical DPI of this monitor as measured in the current thread DPI awareness context. This may be different to #dpi, which is the DPI at the process wide (default) context."

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.DpiAwareness.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.DpiAwareness.cls
@@ -54,14 +54,14 @@ determineName
 	level := self awarenessLevel.
 	level == DPI_AWARENESS_UNAWARE
 		ifTrue: 
-			[^(User32 areDpiAwarenessContextsEqual: handle
-				dpiContextB: DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED) ifTrue: [#gdiScaled] ifFalse: [#unaware]].
+			[^(self isEqualToDpiAwarenessContext: DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED)
+				ifTrue: [#gdiScaled]
+				ifFalse: [#unaware]].
 	level == DPI_AWARENESS_PER_MONITOR_AWARE
 		ifTrue: 
-			[^(User32 areDpiAwarenessContextsEqual: handle
-				dpiContextB: DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
-					ifTrue: [#perMonitor]
-					ifFalse: [#perMonitorV1]].
+			[^(self isEqualToDpiAwarenessContext: DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
+				ifTrue: [#perMonitor]
+				ifFalse: [#perMonitorV1]].
 	^AwarenessLevelNames at: level + 2!
 
 dpi
@@ -90,6 +90,9 @@ isCurrent
 	"Answer whether the receiver is the live DPI awareness context."
 
 	^User32 areDpiAwarenessContextsEqual: User32 getThreadDpiAwarenessContext dpiContextB: handle!
+
+isEqualToDpiAwarenessContext: anInteger
+	^User32 areDpiAwarenessContextsEqual: handle dpiContextB: anInteger!
 
 isPerMonitor
 	^self awarenessLevel == DPI_AWARENESS_PER_MONITOR_AWARE!
@@ -132,6 +135,7 @@ handle:!accessing!private! !
 hash!comparing!public! !
 inContextDo:!operations!public! !
 isCurrent!public!testing! !
+isEqualToDpiAwarenessContext:!comparing!public! !
 isPerMonitor!public!testing! !
 isSystemAware!public!testing! !
 isUnaware!public!testing! !

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.ShellView.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.ShellView.cls
@@ -1141,10 +1141,7 @@ wmNcActivate: message wParam: wParam lParam: lParam
 wmNcCreate: message wParam: wParam lParam: lParam
 	"Private - Default handler for a WM_NCCREATE. "
 
-	"The [documentation](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enablenonclientdpiscaling) states that it is not necessary to call EnableNonClientScaling for apps running at per monitor V2 awareness level, but as far as I can determine it makes no difference in any mode on Windows 11 as the NC areas are always scaled, regardless of mode and whether this is called or not. It also doesn't have any effect on the bug where at certain DPIs in per-monitor mode menu bars leave small black areas around some edges (i.e. don't paint the entire background)."
-
-	UserLibrary dpiAwareness isSystemAware
-			ifTrue: [User32 enableNonClientDpiScaling: handle].
+	User32 enableNonClientDpiScalingIfNecessary: handle.
 	^nil!
 
 wmSetCursor: message wParam: wParam lParam: lParam

--- a/Core/Object Arts/Dolphin/MVP/Base/UI.ViewState.cls
+++ b/Core/Object Arts/Dolphin/MVP/Base/UI.ViewState.cls
@@ -39,7 +39,7 @@ recordStateOf: aView forRecreate: aBoolean
 	view := aView.
 	aBoolean ifTrue: [view setStateRestoring].
 	dpiAwareness := aView dpiAwareness.
-	UserLibrary dpiAwareness = dpiAwareness
+	(dpiAwareness isEqualToDpiAwarenessContext: UserLibrary dpiAwarenessContext)
 		ifTrue: [state := aView state]
 		ifFalse: 
 			["This view has a custom DPI awareness that differs from the system awareness, so we want to restore it with the correct awareness on recreation.

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/Dolphin Common Controls.pax
@@ -910,7 +910,7 @@ OS.NMHDR
 
 OS.NMCUSTOMDRAW
 	subclass: #'OS.NMLVCUSTOMDRAW'
-	instanceVariableNames: 'column'
+	instanceVariableNames: 'column subItem'
 	classVariableNames: ''
 	imports: #()
 	classInstanceVariableNames: ''

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/OS.NMCUSTOMDRAW.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/OS.NMCUSTOMDRAW.cls
@@ -252,6 +252,9 @@ stateMask: anInteger set: aBoolean
 	bytes uint32AtOffset: _OffsetOf_uItemState
 		put: (aBoolean ifTrue: [itemState bitOr: anInteger] ifFalse: [itemState bitAnd: anInteger bitInvert])!
 
+subItem
+	^self item!
+
 uItemState
 	"Answer the <Integer> value of the receiver's 'uItemState' field."
 
@@ -314,6 +317,7 @@ lParam!**compiled accessors**!public! !
 metrics!accessing!public! !
 rc!**compiled accessors**!public! !
 stateMask:set:!private!states-changing! !
+subItem!accessing!public! !
 uItemState!**compiled accessors**!public! !
 uItemState:!**compiled accessors**!public! !
 view!accessing!public! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/OS.NMLVCUSTOMDRAW.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/OS.NMLVCUSTOMDRAW.cls
@@ -2,7 +2,7 @@
 
 OS.NMCUSTOMDRAW
 	subclass: #'OS.NMLVCUSTOMDRAW'
-	instanceVariableNames: 'column'
+	instanceVariableNames: 'column subItem'
 	classVariableNames: ''
 	imports: #()
 	classInstanceVariableNames: ''
@@ -83,6 +83,12 @@ forecolor: aColor
 
 	self clrText: aColor!
 
+getSubItem
+	| row |
+	row := self item.
+	self column ifNotNil: [:col | col getContentsBlock ifNotNil: [:getblock | ^getblock value: row]].
+	^row!
+
 iSubItem
 	"Answer the <Integer> value of the receiver's 'iSubItem' field."
 
@@ -99,10 +105,9 @@ reset
 	self forecolor: self view forecolor ?? Graphics.Color.WindowText!
 
 subItem
-	| row |
-	row := self item.
-	self column ifNotNil: [:col | col getContentsBlock ifNotNil: [:getblock | ^getblock value: row]].
-	^row! !
+	"Answer the object that is being displayed in the list view column associated with this custom draw attributes request."
+
+	^subItem ifNil: [subItem := self getSubItem]! !
 
 !OS.NMLVCUSTOMDRAW categoriesForMethods!
 applyFont!operations!private! !
@@ -116,6 +121,7 @@ column!accessing!public! !
 column:!accessing!private! !
 forecolor!accessing!public! !
 forecolor:!accessing!public! !
+getSubItem!helpers!private! !
 iSubItem!**compiled accessors**!public! !
 itemHandle!accessing!private! !
 reset!public! !

--- a/Core/Object Arts/Dolphin/MVP/Views/Common Controls/UI.ListViewColumn.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Common Controls/UI.ListViewColumn.cls
@@ -235,14 +235,12 @@ infoTipFromRow: item withPrefix: prefixText
 	mode, as otherwise it handles this message itself. This allows for differing behaviour
 	in a view dynamically switchable between modes."
 
-	^getInfoTipBlock isNil 
+	^getInfoTipBlock isNil
 		ifTrue: ['']
-		ifFalse: [ | content |
+		ifFalse: 
+			[| content |
 			content := self contentFromRow: item.
-			(getInfoTipBlock argumentCount > 1
-				ifTrue: [getInfoTipBlock value: content value: prefixText]
-				ifFalse: [getInfoTipBlock value: content]) displayString]
-!
+			(getInfoTipBlock cull: content cull: prefixText) displayString]!
 
 initialize
 	"Private - Initialize the state of the receiever."

--- a/Core/Object Arts/Samples/Database/DumpTable/DumpTable.cls
+++ b/Core/Object Arts/Samples/Database/DumpTable/DumpTable.cls
@@ -1,0 +1,92 @@
+﻿"Filed out from Dolphin Smalltalk"!
+
+ConsoleSessionManager subclass: #DumpTable
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+
+DumpTable guid: (GUID fromString: '{da1a24df-82b3-42ad-b41f-c27e026fb8a3}')!
+
+DumpTable comment: ''!
+
+!DumpTable categoriesForClass!Unclassified! !
+
+!DumpTable methodsFor!
+
+debugTraceStream
+	"Private - We want to dump any ODBC driver warnings to debug output, not stderr, so answer a DebugTraceStream. We need to ensure there is a live reference to the class, to prevent it being removed on deployment."
+
+	^DebugTraceStream current!
+
+dumpTable: tableNameString of: dsnString on: aStream
+	| connection sql query columnNames |
+	connection := DBConnection new.
+	connection dsn: dsnString.
+	connection open.
+	aStream
+		nextPutAll: 'Tables in ';
+		print: connection dataSourceName;
+		cr;
+		cr.
+	connection tables do: 
+			[:each |
+			aStream
+				tab;
+				nextPutAll: each;
+				cr].
+	tableNameString isNil ifTrue: [^self].
+	(tableNameString includes: $") ifTrue: [self usage: -2].
+	sql := 'select * from "<1s>"' << tableNameString.
+	query := connection query: sql.
+	aStream
+		cr;
+		nextPutAll: tableNameString;
+		nextPutAll: ' contains ';
+		flush;
+		print: query size;
+		nextPutAll: ' rows:';
+		cr;
+		cr.
+	columnNames := String streamContents: 
+					[:strm |
+					query columns do: [:each | strm nextPutAll: each name] separatedBy: [strm nextPutAll: ' | ']].
+	aStream
+		nextPutAll: columnNames;
+		cr.
+	columnNames size timesRepeat: [aStream nextPut: $=].
+	aStream cr.
+	query do: 
+			[:eachRow |
+			eachRow contents do: [:each | aStream print: each] separatedBy: [aStream nextPutAll: ' | '].
+			aStream cr].
+	query free.
+	connection close!
+
+main
+	self argc < 2 ifTrue: [self usage: -1].
+	DBWarning traceStream: self debugTraceStream.
+	self
+		dumpTable: (self argc > 2 ifTrue: [self argv third])
+		of: self argv second
+		on: self stdout!
+
+usage: anInteger
+	self stderr
+		nextPutAll: 'Dolphin Smalltalk Dump Table Sample';
+		cr;
+		nextPutAll: 'Copyright © Object Arts Ltd, 2025.';
+		crtab: 1;
+		nextPutAll: 'Usage: ';
+		display: self argv first;
+		nextPutAll: ' <ODBC DSN> [<Table name>]';
+		cr.
+	self primQuit: anInteger! !
+
+!DumpTable categoriesForMethods!
+debugTraceStream!operations-startup!private! !
+dumpTable:of:on:!operations-startup!public! !
+main!operations-startup!public! !
+usage:!operations-startup!public! !
+!
+

--- a/Core/Object Arts/Samples/Database/DumpTable/DumpTable.pax
+++ b/Core/Object Arts/Samples/Database/DumpTable/DumpTable.pax
@@ -1,0 +1,61 @@
+﻿| package |
+package := Package name: 'DumpTable'.
+package paxVersion: 1;
+	basicComment: 'Dolphin Smalltalk Dump Table Sample. 
+Copyright © Object Arts Ltd, 2025.
+
+An application using DBConnection. It is intended primarily for testing app deployment rather than to do anything useful.
+
+## Deployment
+
+Note: When working with  ''Database Connection'', always deploy from a freshly started image as finalization of old statements and connections may cause errors during the deployment. If this happens and the crash dump log shows a faulting call into the ODBCLibrary to free a handle, just restart the image and repeat the deployment.
+
+```
+Smalltalk developmentSystem saveImage.	"Save the image if you don''t want to lose changes"
+(ImageStripper new)
+	rootPackage: DumpTable owningPackage;
+	executableName: ''dumptable.exe'';
+	preserveAspectSetters: false;
+	stripDeprecatedMethods: true;
+	deploy
+``````
+
+And to examine the content: 
+
+```
+"Browse the classes and methods in the deployed application"
+Smalltalk developmentSystem browseDeploymentLog: ''dumptable.xml''.
+"Or just view the log"
+UI.Examples.XmlPad filename: ''dumptable.xml''
+```
+'.
+
+
+package classNames
+	add: #DumpTable;
+	yourself.
+
+package binaryGlobalNames: (Set new
+	yourself).
+
+package globalAliases: (Set new
+	yourself).
+
+package setPrerequisites: #(
+	'..\..\..\Dolphin\Lagoon\Console Application Kit'
+	'..\..\..\Dolphin\Database\Database Connection'
+	'..\..\..\Dolphin\System\Trace\Debug Trace Stream'
+	'..\..\..\Dolphin\Base\Dolphin').
+
+package!
+
+"Class Definitions"!
+
+ConsoleSessionManager subclass: #DumpTable
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+
+"End of package definition"!
+


### PR DESCRIPTION
- Prevents DB buffer classes from being removed from a deployed application
- Environment Browser opened on an app contents (from deployment manifest) will highlight unbound classes to make them easy to see.
- Spotted that DpiAwareness unnecessarily retained in a deployed console app, so fixed that.