### PR TITLE
Avoid startup dependency on AXHost DLL

### DIFF
--- a/Core/Object Arts/Dolphin/ActiveX/OCX/UI.AXControlSite.cls
+++ b/Core/Object Arts/Dolphin/ActiveX/OCX/UI.AXControlSite.cls
@@ -603,6 +603,9 @@ observePropertyNotifications
 
 	^self firesPropertyNotifications!
 
+onAboutToCreate
+	WM_ATLGETHOST ifNil: [self class initializeAxHost]!
+
 OnChanged: dispid
 	"Private - Implement the IPropertyNotifySink::OnChanged() method.
 	The property with <integer> id, dispid, has changed, trigger an event
@@ -958,6 +961,7 @@ isWindowless!public!testing! !
 licenseKey!accessing!public! !
 licenseKey:!accessing!public! !
 observePropertyNotifications!helpers!private! !
+onAboutToCreate!event handling!public! !
 OnChanged:!event handling!private! !
 onDestroyed!event handling!private! !
 OnRequestEdit:!event handling!private! !
@@ -1230,12 +1234,14 @@ initialize
 				shrink;
 				yourself)!
 
-onStartup
-	"The system is starting: Initialize the host window class and register the window message
-	used for communicating with it."
-
+initializeAxHost
 	AXHostLibrary default axWinInit.
 	WM_ATLGETHOST := User32 registerWindowMessage: 'WM_ATLGETHOST'!
+
+onStartup
+	"Private - In a new session we will need to reinitialize the AX host and register the message for fetching its IUnknown, but we do that lazily."
+
+	WM_ATLGETHOST := nil!
 
 progId: aString 
 	"Answer a new instance of the receiver hosting the OCX with the specified prog id (which may also be 
@@ -1284,6 +1290,7 @@ example3!examples!public! !
 getHostMsg!initializing!public! !
 icon!constants!public! !
 initialize!initializing!public! !
+initializeAxHost!initializing!private! !
 onStartup!events-session!public! !
 progId:!accessing!instance creation!public! !
 resource_Default_view!public!resources-views! !

--- a/Core/Object Arts/Dolphin/IDE/Professional/Tools.RewriteChangesBrowser.cls
+++ b/Core/Object Arts/Dolphin/IDE/Professional/Tools.RewriteChangesBrowser.cls
@@ -164,7 +164,7 @@ queryChangesCommand: aCommandQuery
 	changes isEmpty ifTrue: [^self].
 	aCommandQuery
 		beEnabled;
-		text: aCommandQuery description << changes size = 1!
+		text: aCommandQuery description << (changes size = 1)!
 
 refresh
 	self createChangesTree.

--- a/Core/Object Arts/Dolphin/MVP/Graphics/Graphics.AbstractFont.cls
+++ b/Core/Object Arts/Dolphin/MVP/Graphics/Graphics.AbstractFont.cls
@@ -198,14 +198,15 @@ styleChanged
 	series := nil!
 
 textMetrics
-	| tm dc |
+	| dc |
 	dc := User32 getDC: nil.
-	
-	[Gdi32 selectObject: dc hgdiobj: self handle.
+	^
+	[| tm |
+	Gdi32 selectObject: dc hgdiobj: self handle.
 	tm := TEXTMETRICW newBuffer.
-	Gdi32 getTextMetrics: dc lptm: tm]
-			ensure: [User32 releaseDC: nil hDC: dc].
-	^tm!
+	Gdi32 getTextMetrics: dc lptm: tm.
+	tm]
+			ensure: [User32 releaseDC: nil hDC: dc]!
 
 unstyledCopy
 	"Answer a new <Font> that is the same as the receiver, but without any styling (i.e. without italics, bold, or underlining)."

--- a/Core/Object Arts/Dolphin/MVP/Graphics/Tests/Graphics.Tests.AbstractFontTest.cls
+++ b/Core/Object Arts/Dolphin/MVP/Graphics/Tests/Graphics.Tests.AbstractFontTest.cls
@@ -37,6 +37,15 @@ testStbRoundTrip
 testStlRoundTrip
 	self verifyStxRoundTrip: self stlRoundTripBlock!
 
+testTextMetrics
+	| tm subject |
+	subject := self canonicalSubject.
+	tm := subject textMetrics.
+	"This is a bit of a kick-the-tyres test. We are just checking we get back some valid looking metrics really, since the values may obviously vary according to the test font."
+	self assert: tm tmBreakChar isSeparator.
+	self assert: tm tmDigitizedAspectX equals: tm tmDigitizedAspectY.
+	self assert: tm tmHeight equals: tm tmAscent + tm tmDescent!
+
 verifyStxRoundTrip: aMonadicValuable
 	| array deserialized subject150 subject original |
 	subject := self canonicalSubject.
@@ -59,6 +68,7 @@ testAtDpi!public!unit tests! !
 testComparing!public!unit tests! !
 testStbRoundTrip!public!unit tests! !
 testStlRoundTrip!public!unit tests! !
+testTextMetrics!public!unit tests! !
 verifyStxRoundTrip:!helpers!private! !
 !
 

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.KeyBinding.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.KeyBinding.cls
@@ -109,6 +109,7 @@ Core.Object
 								16r997 -> #copyLine.
 								16r9A5 -> #duplicateSelection.
 								16r9D6 -> #deleteToEndOfWord.
+								16r9D7 -> #basicCopySelectionOrLine.
 								16rA3B -> #centerCurrentLine.
 								16rA3C -> #moveSelectedLinesUp.
 								16rA3D -> #moveSelectedLinesDown.
@@ -116,6 +117,9 @@ Core.Object
 								16rA45 -> #scrollToEnd.
 								16rA5C -> #moveToVcStartOfDisplayLine.
 								16rA5D -> #extendToStartOfVcDisplayLine.
+								16rAFA -> #basicCutSelectionOrLine.
+								16rAFD -> #indentLines.
+								16rAFE -> #unindentLines.
 								16rBB9 -> #startRecording.
 								16rBBA -> #stopRecording
 							}).

--- a/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.ScintillaLibrary.cls
+++ b/Core/Object Arts/Dolphin/MVP/Views/Scintilla/UI.Scintilla.ScintillaLibrary.cls
@@ -71,7 +71,7 @@ fileName
 versionString
 	"Answer the version of the Scintilla control for which this library was generated."
 
-	^'5.5.3'! !
+	^'5.5.4'! !
 
 !UI.Scintilla.ScintillaLibrary class categoriesForMethods!
 closeDefault!private!realizing/unrealizing! !

--- a/Lexilla.dll
+++ b/Lexilla.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7b36cabe4495ca27ca368205c830ed248122d96eb0a41e21e99f972721f1f53
-size 1039360
+oid sha256:f862562dc921ec653fefc94514b8fc7966448d1af640faabddee527ac1c4fc7a
+size 1047040

--- a/Scintilla.dll
+++ b/Scintilla.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fda9c5055b5eeffdb40d47ccff172d6a08ef735143079f8c8816ba5e1f9df15
-size 802304
+oid sha256:b2a520138fa7972dbcd779e80d99c9a534ecabcaf31e29af23942db8dff9e161
+size 801280


### PR DESCRIPTION
The AXHost DLL is optional and its absence should only cause a failure if an attempt is made to actually use it.

This mitigates #1323. Although the DLL should be added to the setup, this should prevent failure on initial startup following installation.

Contains a few other small low-impact changes. Often the Scintilla upgrades are impactful, but in this case there is no API change.