### PR TITLE
Fix decoding of last character on page boundary of UTF-8 file with BOM

### DIFF
--- a/Core/Object Arts/Dolphin/Base/File.cls
+++ b/Core/Object Arts/Dolphin/Base/File.cls
@@ -444,6 +444,11 @@ sniffEncoding
 	count := self
 				reset;
 				read: buf.
+	"If it starts with the UTF-8 BOM ( #[16rEF 16rBB 16rBF]), then we can be 99% certain it is UTF-8"
+	((buf at: 1) == 16rEF and: [(buf at: 2) == 16rBB and: [(buf at: 3) == 16rBF]])
+		ifTrue: 
+			[self position: 3.
+			^String.EncodingUtf8].
 	ituResult := (ByteArray newFixed: 4)
 				sdwordAtOffset: 0 put: -1;
 				yourself.
@@ -460,19 +465,13 @@ sniffEncoding
 			[self position: ((ituResult allMask: IS_TEXT_UNICODE_SIGNATURE) ifTrue: [2] ifFalse: [0]).
 			String.EncodingUtf16]
 		ifFalse: 
-			["If it starts with the UTF-8 BOM ( #[16rEF 16rBB 16rBF]), then we can be 99% certain it is UTF-8"
-			(buf beginsWith: Utf8String.Bom)
-				ifTrue: 
-					[self position: 3.
-					String.EncodingUtf8]
-				ifFalse: 
-					[| utf8Stream |
-					self reset.
-					"Do a minimal evaluation of the unknown encoding. If the first 1k reads as UTF-8 (allowing for that fact that we may have truncated the final character) then assume it is UTF-8, otherwise some ANSI code page."
-					utf8Stream := (Utf8String fromByteArray: buf) readStream.
-					((utf8Stream skipTo: Character.Utf8Default) not or: [utf8Stream atEnd])
-						ifTrue: [String.EncodingUtf8]
-						ifFalse: [String.EncodingAnsi]]]!
+			[| utf8Stream |
+			self reset.
+			"Do a minimal evaluation of the unknown encoding. If the first 1k reads as UTF-8 (allowing for that fact that we may have truncated the final character) then assume it is UTF-8, otherwise some ANSI code page."
+			utf8Stream := (Utf8String fromByteArray: buf) readStream.
+			((utf8Stream skipTo: Character.Utf8Default) not or: [utf8Stream atEnd])
+				ifTrue: [String.EncodingUtf8]
+				ifFalse: [String.EncodingAnsi]]!
 
 spec: aString
 	"Private - Set the file path to the <readableString> argument."

--- a/Core/Object Arts/Dolphin/Base/FileStream.cls
+++ b/Core/Object Arts/Dolphin/Base/FileStream.cls
@@ -14,22 +14,31 @@ FileStream addClassConstant: 'LimitsChangedMask' value: 16r1!
 FileStream addClassConstant: 'OwnsFileMask' value: 16r100!
 FileStream addClassConstant: 'PageSize' value: 16r2000!
 
-FileStream comment: 'FileStream is a specialized <ReadWriteStream> for streaming over binary and text files.
+FileStream comment: '`FileStream` is a specialized `ReadWriteStream` for streaming over binary and text files.
 
-The collection instance variable inherited from <Stream> is used to hold a fixed size buffer representing a cached ''page'' of the actual file. This is flushed back to the file either when a new page is loaded, or when explictly requested by #flush or #fullFlush. The readLimit and writeLimit instance variables inherited from <PositionableStream> and <WriteStream> respectively have a different usage in this class than in their defining classes; they are the limits for the current "page" rather than the whole stream. The readLimit will always be equal to the page size, except on the last page of the file. The writeLimit is always equal to the page size. This use of the superclass instance variables allows us to use the stream primitives for every efficient access within the current page, which means that even single character I/O is reasonably fast..
+The collection instance variable inherited from `Stream` is used to hold a fixed size buffer representing a cached ''page'' of the actual file. This is flushed back to the file either when a new page is loaded, or when explictly requested by `flush` or `fullFlush`. The `readLimit` and `writeLimit` instance variables inherited from `PositionableStream` and `WriteStream` respectively have a different usage in this class than in their defining classes; they are the limits for the current "page" rather than the whole stream. The `readLimit` will always be equal to the page size, except on the last page of the file. The `writeLimit` is always equal to the page size. This use of the superclass instance variables allows us to use the stream primitives for very efficient access within the current page, which means that even single character I/O is reasonably fast.
 
-FileStream can read and write files as binary or text. It supports a number of import text encodings, as follows:
-	#text		- Default text encoding. When reading will attempt to deduce the encoding of the underlying file. When writing a new file, will write UTF-8 with a BOM.
-	#utf8		- UTF-8 encoded text
-	#utf16		- UTF-16 encoded text		(not yet implemented)
-	#utf32		- UTF-32 encoded text		(not yet implemented)
+`FileStream` can read and write files as binary or text. It supports a number of important text encodings, as follows:
+	`#text`		- Default text encoding. When reading will attempt to deduce the encoding of the underlying file. When writing a new file, will write UTF-8 with a BOM.
+	`#ansi`		- ANSI text, assumed encoded per the default Dolphin code page
+	`#utf8`		- UTF-8 encoded text
+	`#utf16le`		- UTF-16 encoded text		(not yet implemented)
+	`#utf32`		- UTF-32 encoded text		(not yet implemented)
 
-Instance Variables:
-	file				The <File> being streamed over.
-	flags			<integer> flags such as whether the page buffer is dirty.
-	pageBase		<integer> offset of the page currently in the buffer. Always a multiple of the page size, plus 1.
-	logicalFileSize	<integer> size of the file. This is cached because it is expensive to determine dynamically.
-'!
+## Instance Variables:
+  `file`			The `File` being streamed over.
+  `flags`			`<integer>` flags such as whether the page buffer is dirty.
+  `pageBase`		`<integer>` offset of the page currently in the buffer. Always a multiple of the page size, plus 1.
+  `logicalFileSize`	`<integer>` size of the file. This is cached because it is expensive to determine dynamically.
+  `offset`			`<integer>` offset of start of text data in a file if it has a BOM
+
+## Class Variables:
+  `BufferClasses`		`IdentityDictionary` mapping from symbolic encodings to the class of byte-object to be used for the page buffer with that encoding
+  `BufferUpdatedMask`	`<integer>` flags set when a write to the page buffer occurs (combines the following two flags)
+  `DirtyBufferMask`		`<integer>` flag set when the page buffer contains updated data that has not yet been written to disk
+  `LimitsChangedMask`	`<integer>` flag set when a write to the page buffer has occurred that has not yet been reflected in the `lastPosition` and/or `readLimit`.
+  `OwnsFileMask`		`<integer>` flag set if the file is owned by a `FileStream` and should be closed by it.
+  `PageSize`			`<integer>` size of the page buffer used to hold part of the file contents in memory - chosen to be a reasonably efficient compromise for serial and random I/O.'!
 
 !FileStream categoriesForClass!Collections-Streams!I/O-Streams! !
 
@@ -44,9 +53,9 @@ absolutePosition
 atEnd
 	"Answer true if the receiver is positioned at its logical end."
 
-	^position >= readLimit and: [pageBase + position > self lastPosition]
-
-!
+	^position >= readLimit and: 
+			[self updateLimits.
+			pageBase + position > logicalFileSize]!
 
 basicNext
 	"Answer the next integer element accessible by the receiver. For a text stream this will be 
@@ -534,14 +543,11 @@ skip: anInteger
 updateLimits
 	"Private - Reconcile the stream position and read limit to include any data written since the last update."
 
-	"The DataWritten flag indicates that some data has been written since the last update to the limits"
-
-	(flags anyMask: LimitsChangedMask)
-		ifTrue: 
-			[| absolute |
-			flags := flags bitAnd: ##(LimitsChangedMask bitInvert).
-			readLimit < position ifTrue: [readLimit := position].
-			logicalFileSize < (absolute := self absolutePosition) ifTrue: [logicalFileSize := absolute]]!
+	| absolute |
+	(flags anyMask: LimitsChangedMask) ifFalse: [^self].
+	flags := flags bitAnd: ##(LimitsChangedMask bitInvert).
+	readLimit < position ifTrue: [readLimit := position].
+	logicalFileSize < (absolute := self absolutePosition) ifTrue: [logicalFileSize := absolute]!
 
 writePage
 	self updateLimits.

--- a/Core/Object Arts/Dolphin/Base/Tests/FileStreamTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/FileStreamTest.cls
@@ -65,6 +65,47 @@ tearDownTempStream
 
 	filestream file free!
 
+testAtEndWithUtf8Bom
+	(0 to: 1) , (FileStream.PageSize - Utf8String.Bom size - 3 to: FileStream.PageSize + 1)
+		, (FileStream.PageSize * 2 - Utf8String.Bom size - 3 to: FileStream.PageSize * 2 + 1) do: 
+				[:each |
+				| subject |
+				subject := self tempWriteStream: #utf8.
+				subject
+					position: each;
+					nextPut: $£.
+				self assert: subject position equals: each + 2.
+				self assert: subject atEnd.
+				subject position: each.
+				self assert: subject position equals: each.
+				self deny: subject atEnd.
+				self assert: subject basicNext equals: 194.
+				self assert: subject position equals: each + 1.
+				self deny: subject atEnd.
+				self assert: subject basicNext equals: 163.
+				self assert: subject position equals: each + 2.
+				self assert: subject atEnd.
+				subject position: each.
+				self deny: subject atEnd.
+				self assert: subject next equals: $£.
+				self assert: subject atEnd.
+				subject close.
+				subject := self tempReadStream.
+				subject position: each.
+				self assert: subject position equals: each.
+				self deny: subject atEnd.
+				self assert: subject basicNext equals: 194.
+				self assert: subject position equals: each + 1.
+				self deny: subject atEnd.
+				self assert: subject basicNext equals: 163.
+				self assert: subject position equals: each + 2.
+				self assert: subject atEnd.
+				subject position: each.
+				self deny: subject atEnd.
+				self assert: subject next equals: $£.
+				self assert: subject atEnd.
+				subject close]!
+
 testFileTimes
 	"Tests that file accesor exists and that #lastWriteTime works (for patch #1397)"
 
@@ -228,6 +269,48 @@ testSingleByteOverflow
 	self assert: filestream next equals: $3.
 	filestream close!
 
+testUtf8StraddlingPageBoundary
+	"Test writing and then reading a multi-byte UTF-8 character that is straddling a page boundary"
+
+	| offset string subject allText |
+	subject := self tempWriteStream: #utf8.
+	self assert: subject atEnd.
+	offset := Utf8String.Bom size.
+	"Fill the first page up to the penultimate byte"
+	string := String new: FileStream.PageSize - offset - 1 withAll: $X.
+	subject nextPutAll: string.
+	self assert: subject atEnd.
+	subject nextPut: Character dolphin.
+	self assert: subject atEnd.
+	subject close.
+	allText := string copyWith: Character dolphin.
+	self assert: (File readAllText: tempFileName) equals: allText.
+	subject := self tempReadStream.
+	self deny: subject atEnd.
+	self assert: subject encoding equals: #utf8.
+	self assert: subject upToEnd equals: allText.
+	subject reset.
+	self assert: (subject next: string size) equals: string.
+	subject reset.
+	1 to: string size
+		do: 
+			[:each |
+			self assert: subject next equals: $X.
+			self deny: subject atEnd].
+	"The emoji straddles the page boundary"
+	self assert: subject next equals: Character dolphin.
+	self assert: subject atEnd.
+	subject reset.
+	subject position: string size.
+	self deny: subject atEnd.
+	self assert: subject nextAvailable equals: Character dolphin.
+	subject position: string size.
+	Character dolphin asUtf8String asByteArray do: 
+			[:each |
+			self deny: subject atEnd.
+			self assert: subject basicNext equals: each].
+	self assert: subject atEnd!
+
 testVeryLargeSparseFile
 	| empty max |
 	filestream := self tempWriteStream.
@@ -290,11 +373,13 @@ streamClass!helpers!private! !
 streamOn:!helpers!private! !
 streamOnFile:type:!helpers!private! !
 tearDownTempStream!helpers!private! !
+testAtEndWithUtf8Bom!public!unit tests! !
 testFileTimes!public!unit tests! !
 testNextAvailableColonWithPaging!public!unit tests! !
 testNextPutAll!public!unit tests! !
 testOwnsFile!public! !
 testSingleByteOverflow!public!unit tests! !
+testUtf8StraddlingPageBoundary!public!unit tests! !
 testVeryLargeSparseFile!public!unit tests! !
 testWritePastEnd!public!unit tests! !
 !

--- a/Core/Object Arts/Dolphin/Base/Tests/FileTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/FileTest.cls
@@ -594,13 +594,12 @@ testSniffEncodingUtf8
 	"The sniffing will regard short sequences as most likely to be UTF-8 if they can be decoded as UTF-8, even if they in fact ANSI text. If the content is pure ASCII, then it makes no difference anyway as both UTF-8 and ANSI encodings (with any code page) are the same for this case."
 
 	tempFile := File temporary.
-	{
-		Utf8String.Bom.
+	{Utf8String.Bom.
 		Utf8String.Bom , $£ asAnsiString asByteArray.
 		'a b c ' asByteArray.
 		$£ asUtf8String asByteArray.
-		'a 🐬' asUtf8String asByteArray
-	} do: 
+		'a 🐬' asUtf8String asByteArray.
+		Utf8String.Bom, #[0 194 163]} do: 
 				[:each |
 				tempFile
 					size: 0;


### PR DESCRIPTION
Bug is in `FileStream>>#atEnd`, which does not account for the BOM offset.

Fixes #1337 in Dolphin 7.2