### PR TITLE
Fix #1341: `asOrderedCollection` of UTF string can contain partial chars

### DIFF
--- a/Core/Object Arts/Dolphin/Base/Core.UtfEncodedString.cls
+++ b/Core/Object Arts/Dolphin/Base/Core.UtfEncodedString.cls
@@ -103,11 +103,24 @@ asArray
 	"Answer an <Array> whose elements are <Character>s representing the code point sequence of the receiver.
 	Note that this may not be of the same `size` as the receiver as any Characters of the receiver represented by multiple code-unit elements of the receiver will be decoded, including replacing invalid sequences with one or more replacement characters."
 
-	| ch stream chars |
-	chars := Array writeStream: self size.
-	stream := ReadStream on: self.
-	[(ch := stream nextAvailable) isNil] whileFalse: [chars nextPut: ch].
+	| i chars last |
+	chars := Array writeStream: (last := self size).
+	i := 1.
+	[i > last] whileFalse: 
+			[chars nextPut: (self decodeAt: i).
+			i := i + (self encodedSizeAt: i)].
 	^chars grabContents!
+
+asOrderedCollection
+	"Answer an <OrderedCollection> whose elements are <Character>s representing the code point sequence of the receiver."
+
+	| answer i last |
+	answer := OrderedCollection new: (last := self size).
+	i := 1.
+	[i > last] whileFalse: [
+			answer addLast: (self decodeAt: i).
+			i := i + (self encodedSizeAt: i)].
+	^answer!
 
 basicDecodeAt: anInteger 
 	^self subclassResponsibility!
@@ -480,6 +493,7 @@ allButLast:!copying!public! !
 allSatisfy:!enumerating!public! !
 anySatisfy:!enumerating!public! !
 asArray!converting!public! !
+asOrderedCollection!converting!public! !
 basicDecodeAt:!encode/decode!private! !
 before:ifAbsent:!public!searching! !
 codePointAt:!debugger-step through!enumerating!public! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.CollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.CollectionTest.cls
@@ -25,6 +25,10 @@ assimilateElements: aCollection
 collectionClass
 	^self subclassResponsibility!
 
+conversionTestCases
+	^(0 to: 3) collect: [:i |
+		{ self newCollection: (1 to: i). (1 to: i) collect: [:j | self assimilate: j]}]!
+
 newCollection: aCollection
 	^self collectionClass withAll: (self assimilateElements: aCollection)!
 
@@ -110,39 +114,24 @@ testAnySatisfy
 					self assert: visited asArray equals: (subject asArray copyFrom: 1 to: k)]]!
 
 testAsArray
-	| subject ordered |
-	subject := self newCollection: #().
-	ordered := subject asArray.
-	self assert: ordered equals: #().
-	"Test with one, two, more than two elements"
-	1 to: 3
-		do: 
-			[:i |
-			| elems expected |
-			elems := 1 to: i.
-			subject := self newCollection: elems.
-			expected := Array new: i.
-			subject inject: 1 into: [:j :each | expected at: j put: each. j + 1].
-			ordered := subject asArray.
-			self assert: ordered equals: expected]!
+	self conversionTestCases do: 
+			[:each |
+			| array |
+			array := each first asArray.
+			self assert: array class equals: Array.
+			self assert: array size equals: each second size.
+			"For collections in general, the result may not have the same order"
+			self assert: (array noDifference: (each second collect: [:elem | elem value]))]!
 
 testAsOrderedCollection
-	| subject ordered |
-	subject := self newCollection: #().
-	ordered := subject asOrderedCollection.
-	self assert: ordered equals: OrderedCollection new.
-	"Test with one, two, more than two elements"
-	1 to: 3
-		do: 
-			[:i |
-			| elems expected |
-			elems := 1 to: i.
-			subject := self newCollection: elems.
-			expected := OrderedCollection new.
-			subject do: [:each | expected addLast: each].
-			ordered := subject asOrderedCollection.
-			self assert: ordered size equals: i.
-			self assert: ordered equals: expected]!
+	self conversionTestCases do: 
+			[:each |
+			| ordered |
+			ordered := each first asOrderedCollection.
+			self assert: ordered class equals: OrderedCollection.
+			self assert: ordered size equals: each second size.
+			"For collections in general, the result may not have the same order"
+			self assert: (ordered noDifference: (each second collect: [:elem | elem value]))]!
 
 testCopyWith
 	#(#() #($a) #($a $a) #($a $b) #($a $b $a)) do: 
@@ -315,6 +304,7 @@ testStoreOn
 assimilate:!private!unit tests! !
 assimilateElements:!helpers!private! !
 collectionClass!constants!private! !
+conversionTestCases!constants!public! !
 newCollection:!helpers!private! !
 shouldnt:implement:!helpers!private! !
 testAllSatisfy!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.SequenceableCollectionTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.SequenceableCollectionTest.cls
@@ -37,6 +37,15 @@ newNumericArray: anInteger
 newUnsortedCollection: aCollection
 	^self unsortedCollectionClass withAll: (self assimilateElements: aCollection)!
 
+testAsArray
+	self conversionTestCases do: 
+			[:each |
+			| ordered |
+			ordered := each first asArray.
+			self assert: ordered class equals: Array.
+			"For sequenceable collections the order should be maintained"
+			self assert: ordered equals: each second]!
+
 testAsByteArray
 	| sequence |
 	sequence := #().
@@ -54,6 +63,15 @@ testAsByteArray
 	sequence := #(65 66 67 68).
 	self assert: (self newCollection: sequence) asByteArray
 		equals: (self byteArrayForSequence: sequence)!
+
+testAsOrderedCollection
+	self conversionTestCases do: 
+			[:each |
+			| ordered |
+			ordered := each first asOrderedCollection.
+			self assert: ordered class equals: OrderedCollection.
+			"For sequenceable collections the order should be maintained"
+			self assert: ordered equals: (OrderedCollection withAll: each second)]!
 
 testAssociations
 	#(#() #(65) #(65 66) #(65 66 67) #(65 66 67 68)) do: 
@@ -892,7 +910,9 @@ newCopy:!helpers!private! !
 newEmptyCollection:!helpers!private! !
 newNumericArray:!helpers!private! !
 newUnsortedCollection:!helpers!private! !
+testAsArray!public!unit tests! !
 testAsByteArray!public!unit tests! !
+testAsOrderedCollection!public!unit tests! !
 testAssociations!public!unit tests! !
 testAt!public!unit tests! !
 testBeginsWith!public!unit tests! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.StringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.StringTest.cls
@@ -37,6 +37,10 @@ caseInsensitiveEqualCases
 caseInsensitiveLessThanCases
 	^#(#('' 'i') #('i' 'j') #('i' 'J') #('i' 'ij') #('ij' 'j') #('I' 'j') #('i$' 'i£') #('I$' 'i£') #('i$' 'I£') #('I$' 'I£') #('£' '€'))!
 
+conversionTestCases
+	^#(#('' #()) #('a' #($a)) #('ab' #($a $b)) #('oña' #($o $ñ $a)) #('£€' #($£ $€)))
+		collect: [:each | { self assimilateString: each first. each second }]!
+
 copyClass
 	^self collectionClass!
 
@@ -1417,6 +1421,7 @@ beforeTestCases!constants!private! !
 caseConversionCases!constants!private! !
 caseInsensitiveEqualCases!constants!private! !
 caseInsensitiveLessThanCases!constants!private! !
+conversionTestCases!constants!private! !
 copyClass!constants!private! !
 equalityTestCases!constants!private! !
 findActualIndicesOf:in:!helpers!private! !

--- a/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.UtfEncodedStringTest.cls
+++ b/Core/Object Arts/Dolphin/Base/Tests/Core.Tests.UtfEncodedStringTest.cls
@@ -36,6 +36,11 @@ caseInsensitiveLessThanCases
 	^super caseInsensitiveLessThanCases
 		, #(#('' '🐬') #('🐬' '🐬a') #('a🐬' 'b🐬') #('a' '🐬') #('A' '🐬'))!
 
+conversionTestCases
+	^super conversionTestCases
+		, (#(#('a 🍺' #($a $\x20 $🍺)) #('文字化け' #($文 $字 $化 $け)) #('aáeéñ' #($a $á $e $é $ñ)) #('ᚠ' #($ᚠ)) #('Приве́т' #($П $р $и $в $е $́ $т)) #('नमस्ते' #($न $म $स $् $त $े)) #('🐬🍺ö' #($🐬 $🍺 $o $̈)) #('👨🏻‍🍳' #($👨 $🏻 $\x200D $🍳)))
+				collect: [:each | { self assimilateString: each first. each second }])!
+
 decodeIncompleteContinuations
 	^self subclassResponsibility!
 
@@ -1027,6 +1032,7 @@ beforeTestCases!constants!private! !
 caseConversionCases!constants!private! !
 caseInsensitiveEqualCases!constants!private! !
 caseInsensitiveLessThanCases!constants!private! !
+conversionTestCases!constants!private! !
 decodeIncompleteContinuations!constants!private! !
 decodeInvalidCharacters!constants!private! !
 decodeInvalidContinuations!constants!private! !


### PR DESCRIPTION
Dolphin 8 has a bug that it is converting the string to a sequence of Characters representing the code units of the UTF-8 encoding. The bug was introduced by f94156b. The tests accompanying the change don't properly cover UTF encoding strings. Here we fix the conversion and improve the tests.